### PR TITLE
Link to external Azure IoT Hub component - iothub-react

### DIFF
--- a/docs/src/main/paradox/external-connectors.md
+++ b/docs/src/main/paradox/external-connectors.md
@@ -26,3 +26,7 @@ TODO: Add links to more connectors. [Contributions](https://github.com/akka/alpa
 [Streaming TCP Java documentation](http://doc.akka.io/docs/akka/2.4/java/stream/stream-io.html#Streaming_TCP)
 
 [Streaming TCP Scala documentation](http://doc.akka.io/docs/akka/2.4/scala/stream/stream-io.html#Streaming_TCP)
+
+## Azure
+
+[Streaming IoT messages using Azure IoT Hub](https://github.com/Azure/toketi-iothubreact)


### PR DESCRIPTION
I'd like to add "iothub-react" to Alpakka, it's a component to stream messages from/to IoT devices using Microsoft Azure IoT Hub. 

Source code and documentation are available here https://github.com/Azure/toketi-iothubreact and the project is also linked here https://azure.github.io/projects/sdks . 

I tested the page rendering locally (thanks @johanandren for the instructions)

Please let me know if there's anything we can do to improve :-)