### PR TITLE
journal-writer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val alpakka = project
   .in(file("."))
-  .aggregate(amqp, cassandra, docs, mqtt)
+  .aggregate(amqp, cassandra, docs, mqtt, journalWriter)
   .settings(
     publishArtifact := false,
     unidocSettings
@@ -33,6 +33,16 @@ lazy val mqtt = project
     // Make it not step on each other by running Scala and Java tests sequentially.
     parallelExecution in Test := false
   )
+
+lazy val journalWriter = project
+    .in(file("journal-writer"))
+    .enablePlugins(AutomateHeaderPlugin)
+    .settings(
+      name := "akka-stream-alpakka-journal-writer",
+      Dependencies.AkkaPersistenceWriter,
+      fork in Test := true,
+      parallelExecution in Test := false
+    )
 
 lazy val docs = project
   .in(file("docs"))

--- a/docs/src/main/paradox/connectors.md
+++ b/docs/src/main/paradox/connectors.md
@@ -6,6 +6,7 @@
 * [Cassandra Connector](cassandra.md)
 * [MQTT Connector](mqtt.md)
 * [External Connectors](external-connectors.md)
+* [Akka Persistence Journal Writer](journal-writer.md)
 
 @@@
 

--- a/docs/src/main/paradox/journal-writer.md
+++ b/docs/src/main/paradox/journal-writer.md
@@ -66,30 +66,30 @@ The solution is the configuration of the event-adapters on the write-plugins lik
 
 ```
 inmemory-journal {
- event-adapters {
-   adapter-a = "com.github.dnvriend.EventAdapterA"
- }
- event-adapter-bindings {
-   "com.github.dnvriend.MyMessage" = adapter-a
- }
+  event-adapters {
+    adapter-a = "akka.stream.alpakka.persistence.writer.EventAdapterA"
+  }
+  event-adapter-bindings {
+    "akka.stream.alpakka.persistence.writer.MyMessage" = adapter-a
+  }
 }
 
 inmemory-read-journal {
- write-plugin = "inmemory-journal"
+  write-plugin = "inmemory-journal"
 }
 
 akka.persistence.journal.leveldb {
- dir = "target/journal"
- event-adapters {
-   adapter-b = "com.github.dnvriend.EventAdapterB"
- }
- event-adapter-bindings {
-   "com.github.dnvriend.MyMessage" = adapter-b
- }
+  dir = "target/journal"
+  event-adapters {
+    adapter-b = "akka.stream.alpakka.persistence.writer.EventAdapterB"
+  }
+  event-adapter-bindings {
+    "akka.stream.alpakka.persistence.writer.MyMessage" = adapter-b
+  }
 }
 
 akka.persistence.query.journal.leveldb {
- write-plugin = "akka.persistence.journal.leveldb"
+  write-plugin = "akka.persistence.journal.leveldb"
 }
 ```
 

--- a/docs/src/main/paradox/journal-writer.md
+++ b/docs/src/main/paradox/journal-writer.md
@@ -1,0 +1,142 @@
+# Akka Persistence Journal Writer Connector
+
+The Akka Persistence Journal Writer connector consists of an akka-streams Flow and Sink that makes it possible to write EventEnvelope , Seq[EventEnvelope], EventEnvelope2 or Seq[EventEnvelope2] to any akka-persistence jounal. It does this by sending messages directly to the journal plugin itself.
+
+## Artifacts
+
+sbt
+:   @@@vars
+    ```scala
+    libraryDependencies += "com.typesafe.akka" %% "akka-stream-alpakka-journal-writer" % "$version$"
+    ```
+    @@@
+
+Maven
+:   @@@vars
+    ```xml
+    <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-stream-alpakka-journal-writer_$scala.binaryVersion$</artifactId>
+      <version>$version$</version>
+    </dependency>
+    ```
+    @@@
+
+Gradle
+:   @@@vars
+    ```gradle
+    dependencies {
+      compile group: "com.typesafe.akka", name: "akka-stream-alpakka-journal-writer_$scala.binaryVersion$", version: "$version$"
+    }
+    ```
+    @@@
+
+## Basic Usage
+
+The akka-persistence-journal-writer lets you write events to any journal. It accepts only two types of messages:
+
+akka.persistence.query.EventEnvelope
+akka.persistence.query.EventEnvelope2
+Of course, you can send immutable.Seq[EventEnvelope] or immutable.Seq[EventEnvelope2] of those too for bulk loading.
+
+The basic use case would be loading one event store into another. In this example we will be loading events from the inmemory-journal, using akka-persistence-query and loading the events into the level-db journal:
+
+Scala
+:   ```
+import akka.stream.scaladsl._
+import akka.persistence.query._
+import akka.persistence.query.scaladsl._
+
+val inMemoryReadJournal = PersistenceQuery(system).readJournalFor("inmemory-read-journal")
+ .asInstanceOf[ReadJournal with CurrentPersistenceIdsQuery with CurrentEventsByPersistenceIdQuery]
+
+val result: Future[Done] =
+ inMemoryReadJournal.currentPersistenceIds().flatMapConcat { pid =>
+  inMemoryReadJournal.currentEventsByPersistenceId(pid, 0, Long.MaxValue)
+ }.grouped(100).runWith(JournalWriter.sink("akka.persistence.journal.leveldb"))
+```
+
+The fragment above reads all events from all persistenceIds from the inmemory-journal using akka-persistence-query and writes them directly into an empty level-db journal. Of course, any journal will work.
+
+## Converting serialization strategy
+
+Some akka-persistence-query compatible plugins support using the event-adapters from the write-plugin, therefor converting the journal's data-model to the application-model when querying the journal. Say for example that you have a journal that uses the Java-serialization strategy to store events and you would like to convert all those event using another serialization strategy, say Protobuf, then you can just configure some event adapters on the other write-plugin, say the level-db plugin and just load events from the in-memory plugin and store them into the level-db plugin. Akka-persistence will do all the work for you because you have configured the event-adapters on the plugin to do the serialization.
+
+The solution is the configuration of the event-adapters on the write-plugins like eg:
+
+```
+inmemory-journal {
+ event-adapters {
+   adapter-a = "com.github.dnvriend.EventAdapterA"
+ }
+ event-adapter-bindings {
+   "com.github.dnvriend.MyMessage" = adapter-a
+ }
+}
+
+inmemory-read-journal {
+ write-plugin = "inmemory-journal"
+}
+
+akka.persistence.journal.leveldb {
+ dir = "target/journal"
+ event-adapters {
+   adapter-b = "com.github.dnvriend.EventAdapterB"
+ }
+ event-adapter-bindings {
+   "com.github.dnvriend.MyMessage" = adapter-b
+ }
+}
+
+akka.persistence.query.journal.leveldb {
+ write-plugin = "akka.persistence.journal.leveldb"
+}
+```
+
+In the example above, all events will be written to the in-memory journal using the event-adapter AdapterA. The inmemory-read-journal has been configured to use the event-adapters as configured from the inmemory-journal so when reading events using akka-persistence-query it should return application-domain events and not the java-serialized byte arrays.
+
+When asking the akka-persistence-journal-writer (JournalWriter) to write events to a write plugin with a certain journalPluginId, eg. the level-db plugin, that plugin has been configured with certain event-adapters. Imagine that those event adapters will convert application-domain events to Protobuf types, then the protobuf serializer will serialize events to byte arrays and store those events in the level-db journal.
+
+Of course, all events in the inmemory-journal will stay untouched. All events in the level-db journal will be protobuf-encoded.
+
+## Bulk loading events
+
+Say for a moment, that you have some business level entity with a stable identifier, and you have a lot of those. But those entities do not yet exist. They will exist only when they are created in the journal; ie. they have an initial state and a persistenceId of course.
+
+Also imagine that the initial state is in some very large CSV file or JSON file that has been provided to you by an Apache Spark job for example.
+
+You _could_ do the following:
+
+- read each record,
+- convert to an event,
+- send events to shard,
+- persistent actor will be recovered,
+- event will be stored,
+- persistent actor will be passified,
+- actor will be unloaded from memory.
+- This is in the book...
+
+You could also do the following:
+
+- read each record with a FileIO source
+- convert the CSV to a the known event, wrap into a Seq[EventEnvelope]
+- directly store these events in the journal
+- This will have no persistent-actor life cycle overhead and will be much faster.
+
+Its only applicable in some use cases of course.
+
+### Running the example code
+
+The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
+
+Scala
+:   ```
+    sbt
+    > journalWriter/test
+    ```
+
+Java
+:   ```
+    sbt
+    > journalWriter/test
+    ```

--- a/journal-writer/src/main/scala/akka/persistence/journal/writer/WriteJournalAdapterCameo.scala
+++ b/journal-writer/src/main/scala/akka/persistence/journal/writer/WriteJournalAdapterCameo.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.persistence.journal.writer
+
+import akka.actor.{ Actor, ActorRef }
+import akka.persistence.JournalProtocol._
+import akka.persistence.query.EventEnvelope
+import akka.stream.alpakka.persistence.writer._
+
+import scala.collection.immutable.Seq
+
+object WriteJournalAdapterCameo {
+  def writeMessages(xs: Seq[EventEnvelope], writerJournalAdapter: ActorRef): WriteMessages =
+    WriteMessages(toAtomicWrite(xs), writerJournalAdapter, 1)
+}
+
+class WriteJournalAdapterCameo(writePlugin: ActorRef, replyTo: ActorRef, messages: Seq[EventEnvelope]) extends Actor {
+  import WriteJournalAdapterCameo._
+  override def preStart(): Unit = {
+    if (messages.isEmpty)
+      replyWithSuccess(replyTo)
+    else
+      writePlugin ! writeMessages(messages, self)
+  }
+
+  override def receive: Receive = {
+    case msg: WriteMessageSuccess =>
+      replyWithSuccess(replyTo)
+    case WriteMessagesSuccessful =>
+      replyWithSuccess(replyTo)
+    case WriteMessagesFailed(cause) =>
+      replyWithFailure(replyTo, cause)
+    case WriteMessageRejected(_, cause, _) =>
+      replyWithFailure(replyTo, cause)
+    case WriteMessageFailure(_, cause, _) =>
+      replyWithFailure(replyTo, cause)
+  }
+}

--- a/journal-writer/src/main/scala/akka/stream/alpakka/persistence/writer/JournalWriter.scala
+++ b/journal-writer/src/main/scala/akka/stream/alpakka/persistence/writer/JournalWriter.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.persistence.writer
+
+import akka.actor.{ Actor, ActorRef, ActorSystem, Props }
+import akka.pattern.ask
+import akka.persistence.Persistence
+import akka.persistence.journal.writer.WriteJournalAdapterCameo
+import akka.persistence.query.{ EventEnvelope, EventEnvelope2 }
+import akka.stream.scaladsl._
+import akka.util.Timeout
+import akka.{ Done, NotUsed }
+
+import scala.collection.immutable._
+import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.reflect.ClassTag
+
+class WriteJournalAdapter(writePlugin: ActorRef) extends Actor {
+  def cameo(replyTo: ActorRef, writePlugin: ActorRef, messages: Seq[EventEnvelope]): ActorRef =
+    context.actorOf(Props(new WriteJournalAdapterCameo(writePlugin, replyTo, messages)))
+
+  override def receive: Receive = {
+    case messages: Seq[_] if messages.isEmpty =>
+      cameo(sender(), writePlugin, Seq.empty[EventEnvelope])
+    case messages: Seq[_] if messages.is[EventEnvelope] =>
+      cameo(sender(), writePlugin, messages.as[EventEnvelope])
+    case messages: Seq[_] if messages.is[EventEnvelope2] =>
+      cameo(sender(), writePlugin, messages.as[EventEnvelope2].map(toEventEnvelope))
+    case msg: EventEnvelope =>
+      cameo(sender(), writePlugin, Seq(msg))
+    case msg: EventEnvelope2 =>
+      cameo(sender(), writePlugin, Seq(toEventEnvelope(msg)))
+    case _ =>
+      replyWithFailure(sender(), unsupported)
+  }
+}
+
+object JournalWriter {
+  def flow[A](journalPluginId: String, parallelism: Int = 1)(implicit system: ActorSystem, ec: ExecutionContext, ct: ClassTag[A], timeout: Timeout = Timeout(1.minute)): Flow[A, A, NotUsed] = {
+    assert(ct.runtimeClass == classOf[EventEnvelope] || ct.runtimeClass == classOf[EventEnvelope2] || ct.runtimeClass == classOf[Seq[EventEnvelope]] || ct.runtimeClass == classOf[Seq[EventEnvelope2]], s"element must be of type EventEnvelope, EventEnvelope2, immutable.Seq[EventEnvelope] or immutable.Seq[EventEnvelope2], type is: '${ct.runtimeClass}'")
+    val journal: ActorRef = Persistence(system).journalFor(journalPluginId)
+    val journalAdapter: ActorRef = system.actorOf(Props(new WriteJournalAdapter(journal)))
+    Flow[A].mapAsync(parallelism)(element => (journalAdapter ? element).map(_ => element))
+  }
+
+  def sink[A: ClassTag](journalPluginId: String, parallelism: Int = 1)(implicit system: ActorSystem, ec: ExecutionContext, timeout: Timeout = Timeout(1.minute)): Sink[A, Future[Done]] =
+    flow(journalPluginId, parallelism).toMat(Sink.ignore)(Keep.right)
+}

--- a/journal-writer/src/main/scala/akka/stream/alpakka/persistence/writer/package.scala
+++ b/journal-writer/src/main/scala/akka/stream/alpakka/persistence/writer/package.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.persistence
+
+import akka.actor.{ ActorContext, ActorRef }
+import akka.persistence.query.{ EventEnvelope, EventEnvelope2 }
+import akka.persistence.{ AtomicWrite, PersistentRepr }
+
+import scala.collection.immutable.{ Map, Seq }
+import scala.reflect.ClassTag
+
+package object writer {
+  val unsupported: Throwable = new IllegalArgumentException("JournalWriter only accepts EventEnvelope, immutable.Seq[EventEnvelope], EventEnvelope2 and immutable.Seq[EventEnvelope2]")
+
+  def replyWithFailure(replyTo: ActorRef, cause: Throwable = unsupported)(implicit ctx: ActorContext, self: ActorRef): Unit = {
+    replyTo ! akka.actor.Status.Failure(cause)
+    ctx.stop(self)
+  }
+
+  def replyWithSuccess(replyTo: ActorRef, msg: String = "ack")(implicit ctx: ActorContext, self: ActorRef): Unit = {
+    replyTo ! msg
+    ctx.stop(self)
+  }
+
+  implicit class SeqOps(val that: Seq[_]) extends AnyVal {
+    def is[A](implicit ct: ClassTag[A]): Boolean =
+      that.nonEmpty && that.forall(_.getClass == ct.runtimeClass)
+    def as[A: ClassTag]: Seq[A] = that.map(_.asInstanceOf[A])
+  }
+
+  def toPersistentRepr(env: EventEnvelope): PersistentRepr =
+    PersistentRepr(
+      payload = env.event,
+      sequenceNr = env.sequenceNr,
+      persistenceId = env.persistenceId
+    )
+
+  def listOfEnvelopeToRepr(xs: Seq[EventEnvelope]): Seq[PersistentRepr] =
+    xs.map(toPersistentRepr)
+
+  def listOfReprToAtomicWrite(xs: Seq[PersistentRepr]): AtomicWrite =
+    AtomicWrite(xs)
+
+  def toAtomicWrite(xs: Seq[EventEnvelope]): Seq[AtomicWrite] = {
+    val groupedByPid: Map[String, AtomicWrite] =
+      xs.groupBy(_.persistenceId)
+        .mapValues(listOfEnvelopeToRepr)
+        .mapValues(listOfReprToAtomicWrite)
+    Seq(groupedByPid.values.toList: _*)
+  }
+
+  def toEventEnvelope(x: EventEnvelope2): EventEnvelope =
+    EventEnvelope(0L, x.persistenceId, x.sequenceNr, x.event)
+}

--- a/journal-writer/src/test/resources/application.conf
+++ b/journal-writer/src/test/resources/application.conf
@@ -1,0 +1,68 @@
+# Copyright 2016 Dennis Vriend
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+akka {
+  stdout-loglevel = off // defaults to WARNING can be disabled with off. The stdout-loglevel is only in effect during system startup and shutdown
+  log-dead-letters-during-shutdown = off
+  loglevel = off
+  log-dead-letters = off
+  log-config-on-start = off // Log the complete configuration at INFO level when the actor system is started
+
+  actor {
+    serialize-messages = off // when on, the akka framework will determine whether or not messages can be serialized, else the plugin
+
+    debug {
+      receive = on // log all messages sent to an actor if that actors receive method is a LoggingReceive
+      autoreceive = off // log all special messages like Kill, PoisoffPill etc sent to all actors
+      lifecycle = off // log all actor lifecycle events of all actors
+      fsm = off // enable logging of all events, transitioffs and timers of FSM Actors that extend LoggingFSM
+      event-stream = off // enable logging of subscriptions (subscribe/unsubscribe) on the ActorSystem.eventStream
+    }
+  }
+
+  persistence {
+    journal.plugin = "inmemory-journal"
+    snapshot-store.plugin = "inmemory-snapshot-store"
+  }
+}
+
+inmemory-journal {
+  event-adapters {
+    adapter-a = "akka.stream.alpakka.persistence.writer.EventAdapterA"
+  }
+  event-adapter-bindings {
+    "akka.stream.alpakka.persistence.writer.MyMessage" = adapter-a
+  }
+}
+
+inmemory-read-journal {
+  # use the event adapters from inmemory-journal as this plugin will write events
+  write-plugin = "inmemory-journal"
+}
+
+akka.persistence.journal.leveldb {
+  dir = "target/journal"
+  event-adapters {
+    adapter-b = "akka.stream.alpakka.persistence.writer.EventAdapterB"
+  }
+  event-adapter-bindings {
+    "akka.stream.alpakka.persistence.writer.MyMessage" = adapter-b
+  }
+}
+
+akka.persistence.query.journal.leveldb {
+  # use the event adapters from leveldb-journal as this plugin will write events
+  write-plugin = "akka.persistence.journal.leveldb"
+}
+

--- a/journal-writer/src/test/resources/application.conf
+++ b/journal-writer/src/test/resources/application.conf
@@ -1,17 +1,3 @@
-# Copyright 2016 Dennis Vriend
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 akka {
   stdout-loglevel = off // defaults to WARNING can be disabled with off. The stdout-loglevel is only in effect during system startup and shutdown
   log-dead-letters-during-shutdown = off

--- a/journal-writer/src/test/resources/logback.xml
+++ b/journal-writer/src/test/resources/logback.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration debug="false">
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>debug</level>
+        </filter>
+        <encoder>
+            <pattern>%date{ISO8601} - %logger -> %-5level[%thread] %logger{0} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+
+    <!--<logger name="akka" level="debug"/>-->
+    <!--<logger name="akka.persistence" level="debug"/>-->
+
+    <root level="error">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/journal-writer/src/test/scala/akka/persistence/journal/writer/WriteJournalAdapterTest.scala
+++ b/journal-writer/src/test/scala/akka/persistence/journal/writer/WriteJournalAdapterTest.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.persistence.journal.writer
+
+import akka.actor.{ ActorRef, Props }
+import akka.persistence.JournalProtocol._
+import akka.persistence.journal.writer.WriteJournalAdapterCameo._
+import akka.persistence.query.{ EventEnvelope, EventEnvelope2, NoOffset }
+import akka.persistence.{ AtomicWrite, PersistentImpl, PersistentRepr }
+import akka.stream.alpakka.persistence.writer._
+import akka.testkit.TestProbe
+
+import scala.collection.immutable._
+import scala.concurrent.duration._
+
+class WriteJournalAdapterTest extends TestSpec {
+
+  def validateAtomicWrite(aw: AtomicWrite, persistenceId: String): Unit = {
+    aw.persistenceId shouldBe persistenceId
+    aw.payload.size shouldBe 1
+    aw.payload.head.persistenceId shouldBe persistenceId
+  }
+
+  it should "map a Seq[EventEnvelope] to a WriteMessages that has two persistenceIds" in {
+    val write: WriteMessages = writeMessages(Seq(
+      EventEnvelope(0, "pid1", 1L, "foo"),
+      EventEnvelope(0, "pid2", 1L, "foo")
+    ), null)
+    write.messages.size shouldBe 2 // there are two atomic writes
+    val aw1 = write.messages.map(_.asInstanceOf[AtomicWrite]).filter(_.persistenceId == "pid1").head
+    validateAtomicWrite(aw1, "pid1")
+    val aw2 = write.messages.map(_.asInstanceOf[AtomicWrite]).filter(_.persistenceId == "pid2").head
+    validateAtomicWrite(aw2, "pid2")
+  }
+
+  def withJournal(f: TestProbe => TestProbe => ActorRef => Unit): Unit = {
+    val sink = TestProbe()
+    val journal = TestProbe()
+    val adapter = system.actorOf(Props(new WriteJournalAdapter(journal.ref)))
+    try f(sink)(journal)(adapter) finally killActors(adapter)
+  }
+
+  it should "send no instructions to write an empty Seq" in withJournal { sink => journal => adapter =>
+    sink.send(adapter, Seq.empty[EventEnvelope])
+    journal.expectNoMsg(100.millis)
+    sink.expectMsg("ack")
+  }
+
+  it should "send instructions to write an EventEnvelope" in withJournal { sink => journal => adapter =>
+    sink.send(adapter, EventEnvelope(0L, "pid1", 1L, "foo"))
+    journal.expectMsgPF() { case WriteMessages(List(AtomicWrite(List(PersistentImpl("foo", 1L, "pid1", _, _, _, _)))), _, _) => }
+    journal.reply(WriteMessagesSuccessful)
+    sink.expectMsg("ack")
+  }
+
+  it should "send instructions to write a Seq[EventEnvelope]" in withJournal { sink => journal => adapter =>
+    sink.send(adapter, Seq(EventEnvelope(0L, "pid1", 1L, "foo")))
+    journal.expectMsgPF() { case WriteMessages(Seq(AtomicWrite(Seq(PersistentRepr("foo", 1L)))), _, _) => }
+    journal.reply(WriteMessagesSuccessful)
+    sink.expectMsg("ack")
+
+    sink.send(adapter, Seq(EventEnvelope(0L, "pid1", 1L, "foo"), EventEnvelope(0L, "pid1", 2L, "bar")))
+    journal.expectMsgPF() { case WriteMessages(Seq(AtomicWrite(Seq(PersistentImpl("foo", 1L, "pid1", _, _, _, _), PersistentImpl("bar", 2L, "pid1", _, _, _, _)))), _, _) => }
+    journal.reply(WriteMessagesSuccessful)
+    sink.expectMsg("ack")
+  }
+
+  it should "send instructions to write an EventEnvelope2" in withJournal { sink => journal => adapter =>
+    sink.send(adapter, EventEnvelope2(NoOffset, "pid2", 1L, "foo"))
+    journal.expectMsgPF() { case WriteMessages(List(AtomicWrite(List(PersistentImpl("foo", 1L, "pid2", _, _, _, _)))), _, _) => }
+    journal.reply(WriteMessagesSuccessful)
+    sink.expectMsg("ack")
+  }
+
+  it should "send instructions to write a Seq[EventEnvelope2]" in withJournal { sink => journal => adapter =>
+    sink.send(adapter, Seq(EventEnvelope2(NoOffset, "pid2", 1L, "foo")))
+    journal.expectMsgPF() { case WriteMessages(Seq(AtomicWrite(Seq(PersistentImpl("foo", 1L, "pid2", _, _, _, _)))), _, _) => }
+    journal.reply(WriteMessagesSuccessful)
+    sink.expectMsg("ack")
+
+    sink.send(adapter, Seq(EventEnvelope2(NoOffset, "pid2", 1L, "foo"), EventEnvelope2(NoOffset, "pid2", 2L, "bar")))
+    journal.expectMsgPF() { case WriteMessages(Seq(AtomicWrite(Seq(PersistentImpl("foo", 1L, "pid2", _, _, _, _), PersistentImpl("bar", 2L, "pid2", _, _, _, _)))), _, _) => }
+    journal.reply(WriteMessagesSuccessful)
+    sink.expectMsg("ack")
+  }
+
+  it should "fail on all other messages" in withJournal { sink => journal => adapter =>
+    sink.send(adapter, "foo")
+    journal.expectNoMsg(100.millis)
+    sink.expectMsg(akka.actor.Status.Failure(unsupported))
+  }
+
+  it should "fail the sink when journal fails writing messages" in withJournal { sink => journal => adapter =>
+    sink.send(adapter, EventEnvelope(0L, "pid1", 1L, "foo"))
+    journal.expectMsgPF() { case WriteMessages(List(AtomicWrite(List(PersistentImpl("foo", 1L, "pid1", _, _, _, _)))), _, _) => }
+    journal.reply(WriteMessagesFailed(mockFailure))
+    sink.expectMsg(akka.actor.Status.Failure(mockFailure))
+  }
+
+  it should "fail the sink when journal fails writing a message" in withJournal { sink => journal => adapter =>
+    sink.send(adapter, EventEnvelope(0L, "pid1", 1L, "foo"))
+    journal.expectMsgPF() { case WriteMessages(List(AtomicWrite(List(PersistentImpl("foo", 1L, "pid1", _, _, _, _)))), _, _) => }
+    journal.reply(WriteMessageFailure(null, mockFailure, 1))
+    sink.expectMsg(akka.actor.Status.Failure(mockFailure))
+  }
+
+  it should "fail the sink when journal rejects a message" in withJournal { sink => journal => adapter =>
+    sink.send(adapter, EventEnvelope(0L, "pid1", 1L, "foo"))
+    journal.expectMsgPF() { case WriteMessages(List(AtomicWrite(List(PersistentImpl("foo", 1L, "pid1", _, _, _, _)))), _, _) => }
+    journal.reply(WriteMessageRejected(null, mockFailure, 1))
+    sink.expectMsg(akka.actor.Status.Failure(mockFailure))
+  }
+}

--- a/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/EventAdapterA.scala
+++ b/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/EventAdapterA.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.persistence.writer
+
+import akka.actor.ExtendedActorSystem
+import akka.persistence.journal.{ EventAdapter, EventSeq }
+
+class EventAdapterA(system: ExtendedActorSystem) extends EventAdapter {
+  override def manifest(event: Any): String = ""
+
+  override def fromJournal(event: Any, manifest: String): EventSeq =
+    EventSeq(event)
+
+  override def toJournal(event: Any): Any = event match {
+    case MyMessage(str) => MyMessage(s"$str - a")
+  }
+}

--- a/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/EventAdapterB.scala
+++ b/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/EventAdapterB.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.persistence.writer
+
+import akka.actor.ExtendedActorSystem
+import akka.persistence.journal.{ EventAdapter, EventSeq }
+
+class EventAdapterB(system: ExtendedActorSystem) extends EventAdapter {
+  override def manifest(event: Any): String = ""
+
+  override def fromJournal(event: Any, manifest: String): EventSeq =
+    EventSeq(event)
+
+  override def toJournal(event: Any): Any = event match {
+    case MyMessage(str) => MyMessage(s"$str - b")
+  }
+}

--- a/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/InMemoryCleanup.scala
+++ b/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/InMemoryCleanup.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.persistence.writer
+
+import akka.pattern.ask
+import akka.persistence.inmemory.extension.InMemoryJournalStorage.ClearJournal
+import akka.persistence.inmemory.extension.StorageExtension
+import org.scalatest.BeforeAndAfterEach
+
+trait InMemoryCleanup { _: TestSpec with BeforeAndAfterEach =>
+  override protected def beforeEach(): Unit = {
+    (StorageExtension(system).journalStorage ? ClearJournal).toTry should be a 'success
+  }
+}

--- a/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/JournalWriterTest.scala
+++ b/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/JournalWriterTest.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.persistence.writer
+
+import akka.actor.{ ActorRef, Props }
+import akka.persistence.query.{ EventEnvelope, EventEnvelope2, NoOffset }
+import akka.stream.scaladsl.Source
+import akka.testkit.TestProbe
+
+class JournalWriterTest extends TestSpec {
+  def withPid(pid: String = "pid1", pluginId: JournalIds => JournalIds = identity[JournalIds])(f: TestProbe => ActorRef => Unit): Unit = {
+    val tp = TestProbe()
+    val ref = system.actorOf(Props(new Messenger(pid, pluginId(JournalIds().InMemory).id)))
+    try f(tp)(ref) finally killActors(ref)
+  }
+
+  it should "store events in store" in {
+    withPid("pid1") { tp => ref =>
+      tp.send(ref, "foo")
+      tp.expectMsg("ack")
+    }
+
+    withPid("pid1") { tp => ref =>
+      tp.send(ref, "state")
+      tp.expectMsg(Seq(MyMessage("foo - a")))
+    }
+
+    inMemoryReadJournal.currentEventsByPersistenceId("pid1", 0, Long.MaxValue).withTestProbe { tp =>
+      tp.request(Long.MaxValue)
+      tp.expectNext(EventEnvelope(1, "pid1", 1, MyMessage("foo - a")))
+      tp.expectComplete()
+    }
+
+    withPid("pid1") { tp => ref =>
+      tp.send(ref, "bar")
+      tp.expectMsg("ack")
+    }
+
+    inMemoryReadJournal.currentEventsByPersistenceId("pid1", 0, Long.MaxValue).withTestProbe { tp =>
+      tp.request(Long.MaxValue)
+      tp.expectNext(EventEnvelope(1, "pid1", 1, MyMessage("foo - a")))
+      tp.expectNext(EventEnvelope(2, "pid1", 2, MyMessage("bar - a")))
+      tp.expectComplete()
+    }
+  }
+
+  it should "write events into the event store using EventEnvelope" in {
+    Source(List(
+      EventEnvelope(0L, "pid1", 1, MyMessage("baz")),
+      EventEnvelope(0L, "pid1", 2, MyMessage("quz"))
+    )).runWith(JournalWriter.sink(JournalIds().InMemory.id)).toTry should be a 'success
+
+    withPid("pid1") { tp => ref =>
+      tp.send(ref, "state")
+      tp.expectMsg(Seq(MyMessage("baz - a"), MyMessage("quz - a")))
+    }
+  }
+
+  it should "write events into the event store using Seq[EventEnvelope]" in {
+    Source(List(
+      EventEnvelope(0L, "pid1", 1, MyMessage("baz")),
+      EventEnvelope(0L, "pid1", 2, MyMessage("quz"))
+    )).grouped(2).runWith(JournalWriter.sink(JournalIds().InMemory.id)).toTry should be a 'success
+
+    withPid("pid1") { tp => ref =>
+      tp.send(ref, "state")
+      tp.expectMsg(Seq(MyMessage("baz - a"), MyMessage("quz - a")))
+    }
+  }
+
+  it should "write events into the event store using EventEnvelope2" in {
+    Source(List(
+      EventEnvelope2(NoOffset, "pid1", 1, MyMessage("baz")),
+      EventEnvelope2(NoOffset, "pid1", 2, MyMessage("quz"))
+    )).runWith(JournalWriter.sink(JournalIds().InMemory.id)).toTry should be a 'success
+
+    withPid("pid1") { tp => ref =>
+      tp.send(ref, "state")
+      tp.expectMsg(Seq(MyMessage("baz - a"), MyMessage("quz - a")))
+    }
+  }
+
+  it should "write events into the event store using Seq[EventEnvelope2]" in {
+    Source(List(
+      EventEnvelope2(NoOffset, "pid1", 1, MyMessage("baz")),
+      EventEnvelope2(NoOffset, "pid1", 2, MyMessage("quz"))
+    )).grouped(2).runWith(JournalWriter.sink(JournalIds().InMemory.id)).toTry should be a 'success
+
+    withPid("pid1") { tp => ref =>
+      tp.send(ref, "state")
+      tp.expectMsg(Seq(MyMessage("baz - a"), MyMessage("quz - a")))
+    }
+  }
+
+  it should "write events to leveldb and read from leveldb" in {
+    Source(List(
+      EventEnvelope(0L, "foo1", 1, MyMessage("foo")),
+      EventEnvelope(0L, "foo1", 2, MyMessage("bar")),
+      EventEnvelope(0L, "foo2", 1, MyMessage("baz")),
+      EventEnvelope(0L, "foo2", 2, MyMessage("qux")),
+      EventEnvelope(0L, "foo2", 3, MyMessage("quz")),
+      EventEnvelope(0L, "foo3", 1, MyMessage("zuul"))
+    )).runWith(JournalWriter.sink(JournalIds().LevelDb.id)).toTry should be a 'success
+
+    withPid("foo1", _.LevelDb) { tp => ref =>
+      tp.send(ref, "state")
+      tp.expectMsg(Seq(MyMessage("foo - b"), MyMessage("bar - b")))
+    }
+
+    withPid("foo2", _.LevelDb) { tp => ref =>
+      tp.send(ref, "state")
+      tp.expectMsg(Seq(MyMessage("baz - b"), MyMessage("qux - b"), MyMessage("quz - b")))
+    }
+
+    withPid("foo3", _.LevelDb) { tp => ref =>
+      tp.send(ref, "state")
+      tp.expectMsg(Seq(MyMessage("zuul - b")))
+    }
+  }
+
+  it should "read events from one store and write into another EventEnvelope" in {
+    Source(List(
+      EventEnvelope(0L, "pid1", 1, MyMessage("foo")),
+      EventEnvelope(0L, "pid2", 1, MyMessage("bar")),
+      EventEnvelope(0L, "pid3", 1, MyMessage("baz"))
+    )).runWith(JournalWriter.sink(JournalIds().InMemory.id)).toTry should be a 'success
+
+    // read events from inMemory and write to LevelDb
+    inMemoryReadJournal.currentPersistenceIds().flatMapConcat(pid =>
+      inMemoryReadJournal.currentEventsByPersistenceId(pid, 0, Long.MaxValue)).runWith(JournalWriter.sink(JournalIds().LevelDb.id)).toTry should be a 'success
+
+    withPid("pid1", _.LevelDb) { tp => ref =>
+      tp.send(ref, "state")
+      tp.expectMsg(Seq(MyMessage("foo - a - b")))
+    }
+
+    withPid("pid2", _.LevelDb) { tp => ref =>
+      tp.send(ref, "state")
+      tp.expectMsg(Seq(MyMessage("bar - a - b")))
+    }
+
+    withPid("pid3", _.LevelDb) { tp => ref =>
+      tp.send(ref, "state")
+      tp.expectMsg(Seq(MyMessage("baz - a - b")))
+    }
+  }
+
+  it should "read events from one store and write into another grouped" in {
+    Source(List(
+      EventEnvelope(0L, "pid10", 1, MyMessage("foof")),
+      EventEnvelope(0L, "pid10", 2, MyMessage("boof")),
+      EventEnvelope(0L, "pid10", 3, MyMessage("doof")),
+      EventEnvelope(0L, "pid11", 1, MyMessage("barf")),
+      EventEnvelope(0L, "pid12", 1, MyMessage("bazf"))
+    )).runWith(JournalWriter.sink(JournalIds().InMemory.id)).toTry should be a 'success
+
+    // read events from inMemory and write to LevelDb
+    inMemoryReadJournal.currentPersistenceIds().flatMapConcat(pid =>
+      inMemoryReadJournal.currentEventsByPersistenceId(pid, 0, Long.MaxValue)).grouped(2).runWith(JournalWriter.sink(JournalIds().LevelDb.id)).toTry should be a 'success
+
+    withPid("pid10", _.LevelDb) { tp => ref =>
+      tp.send(ref, "state")
+      tp.expectMsg(Seq(MyMessage("foof - a - b"), MyMessage("boof - a - b"), MyMessage("doof - a - b")))
+    }
+
+    withPid("pid11", _.LevelDb) { tp => ref =>
+      tp.send(ref, "state")
+      tp.expectMsg(Seq(MyMessage("barf - a - b")))
+    }
+
+    withPid("pid12", _.LevelDb) { tp => ref =>
+      tp.send(ref, "state")
+      tp.expectMsg(Seq(MyMessage("bazf - a - b")))
+    }
+  }
+
+  it should "not send unknown types like eg. String" in {
+    intercept[AssertionError] {
+      Source.single("foo").runWith(JournalWriter.sink(JournalIds().LevelDb.id)).toTry should be a 'success
+    }
+  }
+}

--- a/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/LevelDbCleanup.scala
+++ b/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/LevelDbCleanup.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.persistence.writer
+
+import java.io.File
+
+import org.apache.commons.io.FileUtils
+import org.scalatest.BeforeAndAfterAll
+
+trait LevelDbCleanup { _: TestSpec with BeforeAndAfterAll =>
+  def storageLocations = List(
+    "akka.persistence.journal.leveldb.dir"
+  ).map(s => new File(system.settings.config.getString(s)))
+
+  override protected def beforeAll(): Unit = {
+    storageLocations.foreach(FileUtils.deleteDirectory)
+  }
+}

--- a/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/Messenger.scala
+++ b/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/Messenger.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.persistence.writer
+
+import akka.persistence.PersistentActor
+
+class Messenger(val persistenceId: String, override val journalPluginId: String = "") extends PersistentActor {
+  var events: Seq[Any] = Seq.empty[Any]
+  override def receiveRecover: Receive = {
+    case event: MyMessage => events :+= event
+    case event            =>
+  }
+
+  override def receiveCommand: Receive = {
+    case "state" =>
+      sender() ! events
+    case str: String => persist(MyMessage(str)) { _ =>
+      sender() ! "ack"
+    }
+  }
+}

--- a/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/MyMessage.scala
+++ b/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/MyMessage.scala
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.persistence.writer
+
+final case class MyMessage(msg: String)

--- a/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/TestSpec.scala
+++ b/journal-writer/src/test/scala/akka/stream/alpakka/persistence/writer/TestSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.persistence.writer
+
+import akka.actor.{ ActorRef, ActorSystem, PoisonPill }
+import akka.persistence.query.PersistenceQuery
+import akka.persistence.query.scaladsl.{ CurrentEventsByPersistenceIdQuery, CurrentPersistenceIdsQuery, ReadJournal }
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.TestSubscriber
+import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.{ ActorMaterializer, Materializer }
+import akka.testkit.TestProbe
+import akka.util.Timeout
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers }
+
+import scala.collection.immutable._
+import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.Try
+
+case class JournalIds(id: String = "") {
+  def InMemory = this.copy(id = "inmemory-journal")
+  def LevelDb = this.copy(id = "akka.persistence.journal.leveldb")
+}
+
+case class ReadJournalIds(id: String = "") {
+  def InMemory = this.copy(id = "inmemory-read-journal")
+  def LevelDb = this.copy(id = "akka.persistence.query.journal.leveldb")
+}
+
+abstract class TestSpec extends FlatSpec with Matchers with ScalaFutures with BeforeAndAfterAll with BeforeAndAfterEach with LevelDbCleanup with InMemoryCleanup {
+  implicit val system: ActorSystem = ActorSystem()
+  implicit val mat: Materializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
+  implicit val pc: PatienceConfig = PatienceConfig(timeout = 3.seconds)
+  implicit val timeout = Timeout(30.seconds)
+
+  def readJournal(pluginId: ReadJournalIds => ReadJournalIds) = PersistenceQuery(system).readJournalFor(pluginId(ReadJournalIds()).id)
+    .asInstanceOf[ReadJournal with CurrentPersistenceIdsQuery with CurrentEventsByPersistenceIdQuery]
+
+  val inMemoryReadJournal = readJournal(_.InMemory)
+  val levelDbReadJournal = readJournal(_.LevelDb)
+
+  val mockFailure: Throwable = new RuntimeException("Mock failure")
+
+  def withEnvelopes[A](xs: Seq[A])(f: Source[A, _] => Unit): Unit =
+    f(Source(xs))
+
+  def killActors(actors: ActorRef*): Unit = {
+    val tp = TestProbe()
+    actors.foreach { (actor: ActorRef) =>
+      tp watch actor
+      actor ! PoisonPill
+      tp.expectTerminated(actor)
+    }
+  }
+
+  implicit class SourceOps[A](that: Source[A, _])(implicit system: ActorSystem) {
+    def withTestProbe(f: TestSubscriber.Probe[A] => Unit): Unit =
+      f(that.runWith(TestSink.probe(system)))
+  }
+
+  implicit class PimpedFuture[T](self: Future[T]) {
+    def toTry: Try[T] = Try(self.futureValue)
+  }
+
+  override protected def afterAll(): Unit = {
+    system.terminate().toTry should be a 'success
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._, Keys._
 object Dependencies {
 
   val ScalaVersions = Seq("2.11.8", "2.12.0-RC2")
-  val AkkaVersion = "2.4.11"
+  val AkkaVersion = "2.4.12"
 
   val Common = Seq(
     libraryDependencies ++= Seq(
@@ -33,5 +33,20 @@ object Dependencies {
       "io.moquette"      % "moquette-broker"                % "0.8.1" % Test // ApacheV2
     ),
     resolvers += "moquette" at "http://dl.bintray.com/andsel/maven/"
+  )
+
+  val AkkaPersistenceWriter = Seq(
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-persistence" % AkkaVersion,
+      "com.typesafe.akka" %% "akka-persistence-query-experimental" % AkkaVersion,
+      "com.github.dnvriend" %% "akka-persistence-inmemory" % "1.3.13" % Test,
+      "commons-io" % "commons-io" % "2.5" % Test,
+      "org.iq80.leveldb" % "leveldb" % "0.7" % Test,
+      "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8" % Test
+    ),
+    libraryDependencies --= Seq(
+      "com.novocode"       % "junit-interface"     % "0.11"        % Test, // BSD-style
+      "junit"              % "junit"               % "4.12"        % Test  // Eclipse Public License 1.0
+    )
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._, Keys._
 
 object Dependencies {
 
-  val ScalaVersions = Seq("2.11.8", "2.12.0-RC2")
+  val ScalaVersions = Seq("2.11.8", "2.12.0")
   val AkkaVersion = "2.4.12"
 
   val Common = Seq(
@@ -39,7 +39,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-persistence" % AkkaVersion,
       "com.typesafe.akka" %% "akka-persistence-query-experimental" % AkkaVersion,
-      "com.github.dnvriend" %% "akka-persistence-inmemory" % "1.3.13" % Test,
+      "com.github.dnvriend" %% "akka-persistence-inmemory" % "1.3.14" % Test,
       "commons-io" % "commons-io" % "2.5" % Test,
       "org.iq80.leveldb" % "leveldb" % "0.7" % Test,
       "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8" % Test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13


### PR DESCRIPTION
A journal-writer, a flow and sink component for Alpakka that can be handy for the following use cases:

- migrating events from one journal to another
- transforming event serialization strategy from one journal to another
- bulk loading events from a big flat file (eg. CSV or JSON) into a journal.

