### PR TITLE
use Scala 2.11 as default

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._, Keys._
 
 object Dependencies {
 
-  val ScalaVersions = Seq("2.12.0", "2.11.8")
+  val ScalaVersions = Seq("2.11.8", "2.12.0")
   val AkkaVersion = "2.4.12"
 
   val Common = Seq(


### PR DESCRIPTION
* development should be done with Scala 2.11 so that new
  features (e.g. in library) are not accidentilly used