### PR TITLE
Use common bintray package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script:
 deploy:
   provider: script
   script:
-    - sbt -J-XX:ReservedCodeCacheSize=128m +publish bintraySyncMavenCentral
+    # do the maven central sync only once, as all of the artifacts are under the same bintray package
+    - sbt -J-XX:ReservedCodeCacheSize=128m +publish amqp/bintraySyncMavenCentral
   on:
     tags: true
     repo: akka/alpakka

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -21,7 +21,8 @@ object Publish extends AutoPlugin {
   override def requires = BintrayPlugin
 
   override def projectSettings = Seq(
-    bintrayOrganization := Some("akka")
+    bintrayOrganization := Some("akka"),
+    bintrayPackage := "alpakka"
   )
 }
 


### PR DESCRIPTION
So all of the subprojects can be released at once, and new subprojects do not need maintenance when being released the first time (like requesting new bintray package to be included into JCenter).