### PR TITLE
Publish unidoc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,4 +86,4 @@ Example:
 
 1. Create a [new release](https://github.com/akka/alpakka/releases/new) with the next tag version (e.g. `v0.3`), title and release decsription including notable changes mentioning external contributors.
 2. Travis CI will start a [CI build](https://travis-ci.org/akka/alpakka/builds) for the new tag and publish artifacts to Bintray and will sync them to Maven Central.
-3. Checkout the newly created tag and run `sbt "deployRsync repo.akka.io"` to deploy API and reference documentation.
+3. Update the configuration of [Lightbend Tech Hub](https://github.com/typesafehub/tech-hub/blob/master/docsites.sbt#L70) to include the latest version.

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,7 @@
 lazy val alpakka = project
   .in(file("."))
-  .enablePlugins(NoPublish, DeployRsync)
-  .disablePlugins(BintrayPlugin)
+  .enablePlugins(PublishUnidoc)
   .aggregate(amqp, cassandra, docs, files, mqtt)
-  .settings(
-    unidocSettings,
-    deployRsyncArtifact := (sbtunidoc.Plugin.UnidocKeys.unidoc in Compile).value.head -> s"www/api/alpakka/${version.value}"
-  )
 
 lazy val amqp = project
   .in(file("amqp"))
@@ -34,7 +29,7 @@ lazy val files = project
 
 lazy val mqtt = project
   .in(file("mqtt"))
-  .enablePlugins()
+  .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "akka-stream-alpakka-mqtt",
     Dependencies.Mqtt,
@@ -46,7 +41,7 @@ lazy val mqtt = project
 
 lazy val docs = project
   .in(file("docs"))
-  .enablePlugins(ParadoxPlugin, NoPublish, DeployRsync)
+  .enablePlugins(ParadoxPlugin, NoPublish)
   .disablePlugins(BintrayPlugin)
   .settings(
     name := "Alpakka",
@@ -59,6 +54,5 @@ lazy val docs = project
       "extref.paho-api.base_url" -> "https://www.eclipse.org/paho/files/javadoc/index.html?%s.html",
       "scaladoc.akka.base_url" -> s"http://doc.akka.io/api/akka/${Dependencies.AkkaVersion}",
       "scaladoc.akka.stream.alpakka.base_url" -> s"http://doc.akka.io/api/alpakka/${version.value}"
-    ),
-    deployRsyncArtifact := (paradox in Compile).value -> s"www/docs/alpakka/${version.value}"
+    )
   )


### PR DESCRIPTION
So Lightbend Tech Hub can consume the scaladoc jar and server Alpakka Api docs.