### PR TITLE
Amazon SQS Source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_install:
   - docker run -p 9042:9042 -d cassandra:3
   - docker pull rabbitmq:3
   - docker run -p 5672:5672 -d rabbitmq:3
+  - docker pull expert360/elasticmq
+  - docker run -p 9324:9324 -d expert360/elasticmq
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_install:
   - docker run -p 9042:9042 -d cassandra:3
   - docker pull rabbitmq:3
   - docker run -p 5672:5672 -d rabbitmq:3
-  - docker pull expert360/elasticmq
-  - docker run -p 9324:9324 -d expert360/elasticmq
+  - docker pull expert360/elasticmq:0.8.12
+  - docker run -p 9324:9324 -d expert360/elasticmq:0.8.12
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val alpakka = project
   .in(file("."))
   .enablePlugins(PublishUnidoc)
-  .aggregate(amqp, cassandra, docs, files, mqtt, s3, ftp)
+  .aggregate(amqp, cassandra, docs, files, mqtt, s3, sqs, ftp)
 
 lazy val amqp = project
   .enablePlugins(AutomateHeaderPlugin)
@@ -42,6 +42,14 @@ lazy val s3 = project
     name := "akka-stream-alpakka-s3",
     Dependencies.S3
   )
+
+lazy val sqs = project
+    .in(file("sqs"))
+    .enablePlugins(AutomateHeaderPlugin)
+    .settings(
+      name := "akka-stream-alpakka-sqs",
+      Dependencies.Sqs
+    )
 
 lazy val ftp = project
   .enablePlugins(AutomateHeaderPlugin)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,7 @@ services:
     image: rabbitmq:3
     ports:
       - "5672:5672"
+  elasticmq:
+    image: expert360/elasticmq:0.8.12
+    ports:
+      - "9324:9324"

--- a/docs/src/main/paradox/connectors.md
+++ b/docs/src/main/paradox/connectors.md
@@ -7,6 +7,7 @@
 * [File Connectors](file.md)
 * [MQTT Connector](mqtt.md)
 * [FTP Connector](ftp.md)
+* [SQS Connector](sqs.md)
 * [External Connectors](external-connectors.md)
 
 @@@

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -68,7 +68,9 @@ SQS queues never finished because there is no direct way to determine the end of
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
 
 > The test code uses [ElasticMQ](https://github.com/adamw/elasticmq) as queuing service which serves an AWS SQS 
-> compatible API.
+> compatible API.  You can start one quickly using docker:
+>
+> `docker run -p 9324:9324 -d expert360/elasticmq`
 
 Scala
 :   ```

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -1,6 +1,7 @@
 # AWS SQS Connector
 
 The AWS SQS connector allows to stream SQS `Message` from a AWS SQS queue.
+For more information about AWS SQS please visit the [official docmentation](https://aws.amazon.com/documentation/sqs/).
 
 ## Artifacts
 

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -1,0 +1,83 @@
+# AWS SQS Connector
+
+The AWS SQS connector allows to stream SQS `Message` from a AWS SQS queue.
+
+## Artifacts
+
+sbt
+:   @@@vars
+    ```scala
+    libraryDependencies += "com.typesafe.akka" %% "akka-stream-alpakka-sqs" % "$version$"
+    ```
+    @@@
+
+Maven
+:   @@@vars
+    ```xml
+    <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-stream-alpakka-sqs_$scala.binaryVersion$</artifactId>
+      <version>$version$</version>
+    </dependency>
+    ```
+    @@@
+
+Gradle
+:   @@@vars
+    ```gradle
+    dependencies {
+      compile group: "com.typesafe.akka", name: "akka-stream-alpakka-sqs_$scala.binaryVersion$", version: "$version$"
+    }
+    ```
+    @@@
+
+## Usage
+
+Sources provided by this connector need a prepared `AmazonSQSAsyncClient` to load messages from a queue. 
+
+Scala
+: @@snip (../../../../sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala) { #init-client }
+
+Java
+: @@snip (../../../../sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java) { #init-client }
+
+We will also need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and an @scaladoc[ActorMaterializer](akka.stream.ActorMaterializer).
+
+Scala
+: @@snip (../../../../sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala) { #init-mat }
+
+Java
+: @@snip (../../../../sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java) { #init-mat }
+
+This is all preparation that we are going to need.
+
+Now we can stream AWS Java SDK SQS `Message` objects from any SQS queue where we have access to by providing the queue URL to the
+@scaladoc[SqsSource](akka.stream.alpakka.sqs.scaladsl.SqsSource$) factory.
+
+Scala
+: @@snip (../../../../sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala) { #run }
+
+Java
+: @@snip (../../../../sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java) { #run }
+
+As you have seen we consume the stream for 100 milliseconds. The reason for this is, that reading messages from
+SQS queues never finished because there is no direct way to determine the end of a queue.
+
+### Running the example code
+
+The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
+
+> The test code uses [ElasticMQ](https://github.com/adamw/elasticmq) as queuing service which serves an AWS SQS 
+> compatible API.
+
+Scala
+:   ```
+    sbt
+    > sqs/testOnly *.SqsSourceSpec
+    ```
+
+Java
+:   ```
+    sbt
+    > sqs/testOnly *.SqsSourceTest
+    ```

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -8,7 +8,7 @@ For more information about AWS SQS please visit the [official docmentation](http
 sbt
 :   @@@vars
     ```scala
-    libraryDependencies += "com.typesafe.akka" %% "akka-stream-alpakka-sqs" % "$version$"
+    libraryDependencies += "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % "$version$"
     ```
     @@@
 
@@ -16,7 +16,7 @@ Maven
 :   @@@vars
     ```xml
     <dependency>
-      <groupId>com.typesafe.akka</groupId>
+      <groupId>com.lightbend.akka</groupId>
       <artifactId>akka-stream-alpakka-sqs_$scala.binaryVersion$</artifactId>
       <version>$version$</version>
     </dependency>
@@ -27,7 +27,7 @@ Gradle
 :   @@@vars
     ```gradle
     dependencies {
-      compile group: "com.typesafe.akka", name: "akka-stream-alpakka-sqs_$scala.binaryVersion$", version: "$version$"
+      compile group: "com.lightbend.akka", name: "akka-stream-alpakka-sqs_$scala.binaryVersion$", version: "$version$"
     }
     ```
     @@@
@@ -61,8 +61,8 @@ Scala
 Java
 : @@snip (../../../../sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java) { #run }
 
-As you have seen we consume the stream for 100 milliseconds. The reason for this is, that reading messages from
-SQS queues never finished because there is no direct way to determine the end of a queue.
+As you have seen we take the first 100 elements from the stream. The reason for this is, that reading messages from
+SQS queues never finishes because there is no direct way to determine the end of a queue.
 
 ### Running the example code
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,9 +14,9 @@ object Dependencies {
       "junit"              % "junit"               % "4.12"        % Test  // Eclipse Public License 1.0
     )
   )
-  
+
   val AkkaHttpVersion = "10.0.0-RC2"
-  
+
   val S3 = Seq(
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-http"     % AkkaHttpVersion,
@@ -62,6 +62,14 @@ object Dependencies {
       "org.slf4j"             % "slf4j-api"            % "1.7.21"   % Test, // MIT
       "ch.qos.logback"        % "logback-classic"      % "1.1.7"    % Test, // Eclipse Public License 1.0
       "ch.qos.logback"        % "logback-core"         % "1.1.7"    % Test  // Eclipse Public License 1.0
+    )
+  )
+
+  val Sqs = Seq(
+    libraryDependencies ++= Seq(
+      "com.amazonaws"   % "aws-java-sdk-sqs"    % "1.11.51",          // ApacheV2
+      "org.elasticmq"  %% "elasticmq-rest-sqs"  % "0.10.1"    % Test  // ApacheV2
+
     )
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,9 +67,7 @@ object Dependencies {
 
   val Sqs = Seq(
     libraryDependencies ++= Seq(
-      "com.amazonaws"   % "aws-java-sdk-sqs"    % "1.11.51",          // ApacheV2
-      "org.elasticmq"  %% "elasticmq-rest-sqs"  % "0.10.1"    % Test  // ApacheV2
-
+      "com.amazonaws"   % "aws-java-sdk-sqs"    % "1.11.51" // ApacheV2
     )
   )
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceStage.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceStage.scala
@@ -9,7 +9,7 @@ import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import com.amazonaws.services.sqs.model.{ Message, ReceiveMessageRequest, ReceiveMessageResult }
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
 
@@ -50,7 +50,7 @@ class SqsSourceStage(queueUrl: String, settings: SqsSourceSettings, sqsClient: A
 
       def handleSuccess(result: ReceiveMessageResult): Unit = {
 
-        buffer.enqueue(result.getMessages.reverse: _*)
+        buffer.enqueue(result.getMessages.asScala.reverse: _*)
 
         if (result.getMessages.isEmpty || buffer.size < settings.maxBufferSize) {
           receiveMessages()

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
@@ -24,6 +24,6 @@ object SqsSource {
    * Scala API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]] with default settings.
    */
   def create(queueUrl: String, sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] = {
-    Source.fromGraph(new SqsSourceStage(queueUrl, SqsSourceSettings(20.seconds, 100), sqsClient))
+    Source.fromGraph(new SqsSourceStage(queueUrl, SqsSourceSettings.Defaults, sqsClient))
   }
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.javadsl
+
+import akka.NotUsed
+import akka.stream.alpakka.sqs.{ SqsSourceSettings, SqsSourceStage }
+import akka.stream.javadsl.Source
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient
+import com.amazonaws.services.sqs.model.Message
+
+import scala.concurrent.duration._
+
+object SqsSource {
+
+  /**
+   * Java API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]]
+   */
+  def create(queueUrl: String, settings: SqsSourceSettings, sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] = {
+    Source.fromGraph(new SqsSourceStage(queueUrl, settings, sqsClient))
+  }
+
+  /**
+   * Scala API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]] with default settings.
+   */
+  def create(queueUrl: String, sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] = {
+    Source.fromGraph(new SqsSourceStage(queueUrl, SqsSourceSettings(20.seconds, 100), sqsClient))
+  }
+}

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
@@ -16,14 +16,14 @@ object SqsSource {
   /**
    * Java API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]]
    */
-  def create(queueUrl: String, settings: SqsSourceSettings, sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] = {
+  def create(queueUrl: String,
+             settings: SqsSourceSettings,
+             sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] =
     Source.fromGraph(new SqsSourceStage(queueUrl, settings, sqsClient))
-  }
 
   /**
    * Scala API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]] with default settings.
    */
-  def create(queueUrl: String, sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] = {
+  def create(queueUrl: String, sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] =
     Source.fromGraph(new SqsSourceStage(queueUrl, SqsSourceSettings.Defaults, sqsClient))
-  }
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
@@ -15,7 +15,7 @@ object SqsSource {
   /**
    * Scala API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]]
    */
-  def apply(queueUrl: String, settings: SqsSourceSettings = SqsSourceSettings(20.seconds, 100))(implicit sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] =
+  def apply(queueUrl: String, settings: SqsSourceSettings = SqsSourceSettings.Defaults)(implicit sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] =
     Source.fromGraph(new SqsSourceStage(queueUrl, settings, sqsClient))
 
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.scaladsl
+
+import akka.NotUsed
+import akka.stream.alpakka.sqs.{ SqsSourceSettings, SqsSourceStage }
+import akka.stream.scaladsl.Source
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient
+import com.amazonaws.services.sqs.model.Message
+import scala.concurrent.duration._
+
+object SqsSource {
+
+  /**
+   * Scala API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]]
+   */
+  def apply(queueUrl: String, settings: SqsSourceSettings = SqsSourceSettings(20.seconds, 100))(implicit sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] =
+    Source.fromGraph(new SqsSourceStage(queueUrl, settings, sqsClient))
+
+}

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
@@ -15,7 +15,8 @@ object SqsSource {
   /**
    * Scala API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]]
    */
-  def apply(queueUrl: String, settings: SqsSourceSettings = SqsSourceSettings.Defaults)(implicit sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] =
+  def apply(queueUrl: String, settings: SqsSourceSettings = SqsSourceSettings.Defaults)(
+      implicit sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] =
     Source.fromGraph(new SqsSourceStage(queueUrl, settings, sqsClient))
 
 }

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
@@ -7,6 +7,8 @@ import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Sink;
 import akka.testkit.JavaTestKit;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
 import org.elasticmq.rest.sqs.SQSRestServer;
 import org.elasticmq.rest.sqs.SQSRestServerBuilder;
@@ -29,6 +31,7 @@ public class SqsSourceTest {
     static ActorSystem system;
     static ActorMaterializer materializer;
     static SQSRestServer sqsServer;
+    static AWSCredentials credentials;
     static AmazonSQSAsyncClient sqsClient;
 
 
@@ -49,6 +52,7 @@ public class SqsSourceTest {
         sqsServer.waitUntilStarted();
 
         //#init-client
+        credentials = new BasicAWSCredentials("x", "x");
         sqsClient = new AmazonSQSAsyncClient()
             .withEndpoint("http://localhost:9325");
         //#init-client

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.javadsl;
+
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Sink;
+import akka.testkit.JavaTestKit;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
+import org.elasticmq.rest.sqs.SQSRestServer;
+import org.elasticmq.rest.sqs.SQSRestServerBuilder;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scala.concurrent.duration.Duration;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+public class SqsSourceTest {
+
+    static ActorSystem system;
+    static ActorMaterializer materializer;
+    static SQSRestServer sqsServer;
+    static AmazonSQSAsyncClient sqsClient;
+
+
+    @BeforeClass
+    public static void setup() {
+
+        //#init-mat
+        system = ActorSystem.create();
+        materializer = ActorMaterializer.create(system);
+        //#init-mat
+
+        sqsServer = SQSRestServerBuilder
+            .withActorSystem(system)
+            .withInterface("localhost")
+            .withPort(9325)
+            .start();
+
+        sqsServer.waitUntilStarted();
+
+        //#init-client
+        sqsClient = new AmazonSQSAsyncClient()
+            .withEndpoint("http://localhost:9325");
+        //#init-client
+
+    }
+
+    @AfterClass
+    public static void teardown() {
+        sqsServer.stopAndWait();
+        JavaTestKit.shutdownActorSystem(system);
+    }
+
+    static String randomQueueUrl() {
+        //there is a bug in elasticmq which returns incorrect queueUrls
+        return sqsClient.createQueue(String.format("queue-%s", new Random().nextInt())).getQueueUrl().replaceFirst("9324","9325");
+    }
+
+    @Test
+    public void streamFromQueue() throws Exception {
+
+        final String queueUrl = randomQueueUrl();
+
+        final List<String> input = IntStream.range(1, 100).boxed().map(i -> String.format("alpakka-%s", i)).collect(Collectors.toList());
+        input.forEach(m -> sqsClient.sendMessage(queueUrl, m));
+
+        //#run
+        final CompletionStage<List<String>> cs = SqsSource.create(queueUrl, sqsClient)
+            .map(m -> m.getBody())
+            .takeWithin(Duration.create(1, TimeUnit.SECONDS))
+            .runWith(Sink.seq(), materializer);
+        //#run
+
+        assertEquals(input.size(), cs.toCompletableFuture().get(3, TimeUnit.SECONDS).size());
+
+    }
+}

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
@@ -42,7 +42,7 @@ public class SqsSourceTest {
 
         //#init-client
         credentials = new BasicAWSCredentials("x", "x");
-        sqsClient = new AmazonSQSAsyncClient()
+        sqsClient = new AmazonSQSAsyncClient(credentials)
             .withEndpoint("http://localhost:9324");
         //#init-client
 

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.scaladsl
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.sqs.SqsSourceSettings
+import akka.stream.scaladsl.Sink
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient
+import org.elasticmq.rest.sqs.{ SQSRestServer, SQSRestServerBuilder }
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future }
+import scala.util.{ Random, Try }
+
+class SqsSourceSpec extends WordSpec with BeforeAndAfterAll with ScalaFutures with Matchers {
+
+  //#init-mat
+  implicit val system = ActorSystem()
+  implicit val mat = ActorMaterializer()
+  //#init-mat
+
+  //#init-client
+  implicit val sqsClient: AmazonSQSAsyncClient = new AmazonSQSAsyncClient()
+    .withEndpoint("http://localhost:9324")
+  //#init-client
+
+  val server: SQSRestServer = SQSRestServerBuilder
+    .withActorSystem(system)
+    .withPort(9324)
+    .withInterface("localhost")
+    .start()
+
+  override protected def afterAll(): Unit = {
+    server.stopAndWait()
+    Await.ready(system.terminate(), 5.seconds)
+  }
+
+  def randomQueueUrl(): String = sqsClient.createQueue(s"queue-${Random.nextInt}").getQueueUrl
+
+  "SqsSource" should {
+
+    "stream a single batch from the queue" in {
+
+      val queue = randomQueueUrl()
+
+      sqsClient.sendMessage(queue, "alpakka")
+
+      val f = SqsSource(queue)
+        .takeWithin(100.millis)
+        .runWith(Sink.seq)
+
+      f.futureValue.map(_.getBody) should contain("alpakka")
+    }
+
+    "stream multiple batches from the queue" in {
+
+      val queue = randomQueueUrl()
+
+      val input = 1 to 100 map { i => s"alpakka-$i" }
+
+      input foreach { m => sqsClient.sendMessage(queue, m) }
+
+      //#run
+      val f = SqsSource(queue)
+        .takeWithin(100.millis)
+        .runWith(Sink.seq)
+      //#run
+
+      f.futureValue.map(_.getBody) should have size 100
+    }
+
+    //This test has to block for a seconds because it is not possible to go below 1 second with the wait time
+    "continue streaming if receives an empty response" in {
+
+      val queue = randomQueueUrl()
+
+      val f = SqsSource(queue, SqsSourceSettings(1.second, 100))
+        .takeWithin(1100.millis)
+        .runWith(Sink.seq)
+
+      Thread.sleep(1000)
+
+      sqsClient.sendMessage(queue, s"alpakka")
+
+      f.futureValue should have size 1
+    }
+
+    "should finish immediately if the queue does not exist" in {
+
+      val queue = "http://localhost:9324/queue/not-existing"
+
+      val f = SqsSource(queue)
+        .runWith(Sink.seq)
+
+      Await.ready(f, 1.seconds)
+    }
+  }
+}

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
@@ -71,7 +71,7 @@ class SqsSourceSpec extends AsyncWordSpec with BeforeAndAfterAll with ScalaFutur
 
       val queue = randomQueueUrl()
 
-      val f = SqsSource(queue, SqsSourceSettings(0.seconds, 100))
+      val f = SqsSource(queue, SqsSourceSettings(0.seconds, 100, 10))
         .take(1)
         .runWith(Sink.seq)
 

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
@@ -26,13 +26,12 @@ class SqsSourceSpec extends AsyncWordSpec with BeforeAndAfterAll with ScalaFutur
 
   //#init-client
   val credentials = new BasicAWSCredentials("x", "x")
-  implicit val sqsClient: AmazonSQSAsyncClient = new AmazonSQSAsyncClient(credentials)
-    .withEndpoint("http://localhost:9324")
+  implicit val sqsClient: AmazonSQSAsyncClient =
+    new AmazonSQSAsyncClient(credentials).withEndpoint("http://localhost:9324")
   //#init-client
 
-  override protected def afterAll(): Unit = {
+  override protected def afterAll(): Unit =
     Await.ready(system.terminate(), 5.seconds)
-  }
 
   def randomQueueUrl(): String = sqsClient.createQueue(s"queue-${Random.nextInt}").getQueueUrl
 
@@ -43,10 +42,7 @@ class SqsSourceSpec extends AsyncWordSpec with BeforeAndAfterAll with ScalaFutur
       val queue = randomQueueUrl()
       sqsClient.sendMessage(queue, "alpakka")
 
-      SqsSource(queue)
-        .take(1)
-        .runWith(Sink.seq)
-        .map(_.map(_.getBody) should contain("alpakka"))
+      SqsSource(queue).take(1).runWith(Sink.seq).map(_.map(_.getBody) should contain("alpakka"))
 
     }
 
@@ -54,15 +50,16 @@ class SqsSourceSpec extends AsyncWordSpec with BeforeAndAfterAll with ScalaFutur
 
       val queue = randomQueueUrl()
 
-      val input = 1 to 100 map { i => s"alpakka-$i" }
+      val input = 1 to 100 map { i =>
+        s"alpakka-$i"
+      }
 
-      input foreach { m => sqsClient.sendMessage(queue, m) }
+      input foreach { m =>
+        sqsClient.sendMessage(queue, m)
+      }
 
       //#run
-      SqsSource(queue)
-        .take(100)
-        .runWith(Sink.seq)
-        .map(_ should have size 100)
+      SqsSource(queue).take(100).runWith(Sink.seq).map(_ should have size 100)
       //#run
 
     }
@@ -71,9 +68,7 @@ class SqsSourceSpec extends AsyncWordSpec with BeforeAndAfterAll with ScalaFutur
 
       val queue = randomQueueUrl()
 
-      val f = SqsSource(queue, SqsSourceSettings(0.seconds, 100, 10))
-        .take(1)
-        .runWith(Sink.seq)
+      val f = SqsSource(queue, SqsSourceSettings(0.seconds, 100, 10)).take(1).runWith(Sink.seq)
 
       sqsClient.sendMessage(queue, s"alpakka")
 
@@ -84,8 +79,7 @@ class SqsSourceSpec extends AsyncWordSpec with BeforeAndAfterAll with ScalaFutur
 
       val queue = "http://localhost:9324/queue/not-existing"
 
-      val f = SqsSource(queue)
-        .runWith(Sink.seq)
+      val f = SqsSource(queue).runWith(Sink.seq)
 
       f.failed.map(_ shouldBe a[QueueDoesNotExistException])
     }

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
@@ -7,14 +7,15 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.sqs.SqsSourceSettings
 import akka.stream.scaladsl.Sink
+import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
-import org.elasticmq.rest.sqs.{ SQSRestServer, SQSRestServerBuilder }
+import org.elasticmq.rest.sqs.{SQSRestServer, SQSRestServerBuilder}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
-import scala.util.{ Random, Try }
+import scala.concurrent.{Await, Future}
+import scala.util.{Random, Try}
 
 class SqsSourceSpec extends WordSpec with BeforeAndAfterAll with ScalaFutures with Matchers {
 
@@ -24,7 +25,8 @@ class SqsSourceSpec extends WordSpec with BeforeAndAfterAll with ScalaFutures wi
   //#init-mat
 
   //#init-client
-  implicit val sqsClient: AmazonSQSAsyncClient = new AmazonSQSAsyncClient()
+  val credentials = new BasicAWSCredentials("x","x")
+  implicit val sqsClient: AmazonSQSAsyncClient = new AmazonSQSAsyncClient(credentials)
     .withEndpoint("http://localhost:9324")
   //#init-client
 


### PR DESCRIPTION
Hi, this is the SqsSource implementation that depends only on the aws-java-sdk-sqs and no other dependencies (issue #44). 

The source does not automatically delete messages from a queue (not even configurable) because usually you will ensure that the message was successfully processed before removing it from the queue. Either way, it would be only one line to explicitly remove a message from a SQS queue.

The SqsSourceStage gets the `AmazonSQSAsyncClient` as an explicit argument and does not create its own for exact the same reason and if it would create an own one, the user had to create a second client to remove the message.
