### PR TITLE
Tune S3 (ACL, safe keys, object content type)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._, Keys._
 object Dependencies {
 
   val ScalaVersions = Seq("2.11.8", "2.12.0")
-  val AkkaVersion = "2.4.12"
+  val AkkaVersion = "2.4.14"
 
   val Common = Seq(
     libraryDependencies ++= Seq(
@@ -15,7 +15,7 @@ object Dependencies {
     )
   )
 
-  val AkkaHttpVersion = "10.0.0-RC2"
+  val AkkaHttpVersion = "10.0.0"
 
   val S3 = Seq(
     libraryDependencies ++= Seq(

--- a/s3/src/main/scala/akka/stream/alpakka/s3/acl/CannedAcl.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/acl/CannedAcl.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.s3.acl
+
+/**
+ * Documentation: http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
+ */
+sealed abstract class CannedAcl(val value: String)
+
+object CannedAcl {
+  case object AuthenticatedRead extends CannedAcl("authenticated-read")
+  case object AwsExecRead extends CannedAcl("aws-exec-read")
+  case object BucketOwnerFullControl extends CannedAcl("bucket-owner-full-control")
+  case object BucketOwnerRead extends CannedAcl("bucket-owner-read")
+  case object Private extends CannedAcl("private")
+  case object PublicRead extends CannedAcl("public-read")
+  case object PublicReadWrite extends CannedAcl("public-read-write")
+}

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -5,7 +5,8 @@ package akka.stream.alpakka.s3.javadsl
 
 import akka.actor.ActorSystem
 import akka.http.impl.model.JavaUri
-import akka.http.javadsl.model.Uri
+import akka.http.javadsl.model.{ ContentType, Uri }
+import akka.http.scaladsl.model.{ ContentType => ScalaContentType, ContentTypes }
 import akka.stream.Materializer
 import akka.stream.alpakka.s3.impl.CompleteMultipartUploadResult
 import akka.stream.alpakka.s3.auth.AWSCredentials
@@ -31,9 +32,14 @@ final class S3Client(credentials: AWSCredentials, region: String, system: ActorS
   def download(bucket: String, key: String): Source[ByteString, NotUsed] =
     impl.download(S3Location(bucket, key)).asJava
 
-  def multipartUpload(bucket: String, key: String): Sink[ByteString, CompletionStage[MultipartUploadResult]] =
+  def multipartUpload(bucket: String,
+                      key: String,
+                      contentType: ContentType): Sink[ByteString, CompletionStage[MultipartUploadResult]] =
     impl
-      .multipartUpload(S3Location(bucket, key))
+      .multipartUpload(S3Location(bucket, key), contentType.asInstanceOf[ScalaContentType])
       .mapMaterializedValue(_.map(MultipartUploadResult.create)(system.dispatcher).toJava)
       .asJava
+
+  def multipartUpload(bucket: String, key: String): Sink[ByteString, CompletionStage[MultipartUploadResult]] =
+    multipartUpload(bucket, key, ContentTypes.`application/octet-stream`)
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
@@ -6,12 +6,12 @@ package akka.stream.alpakka.s3.scaladsl
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import akka.stream.alpakka.s3.impl.S3Location
-import akka.stream.alpakka.s3.impl.S3Stream
+import akka.stream.alpakka.s3.impl.{ S3Location, S3Stream }
+import akka.stream.alpakka.s3.acl.CannedAcl
 import akka.stream.alpakka.s3.auth.AWSCredentials
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
-import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.{ ContentType, ContentTypes, Uri }
 import akka.stream.scaladsl.Sink
 import scala.concurrent.Future
 import akka.stream.alpakka.s3.impl.CompleteMultipartUploadResult
@@ -35,9 +35,11 @@ final class S3Client(credentials: AWSCredentials, region: String)(implicit syste
 
   def multipartUpload(bucket: String,
                       key: String,
+                      contentType: ContentType = ContentTypes.`application/octet-stream`,
                       chunkSize: Int = MinChunkSize,
-                      chunkingParallelism: Int = 4): Sink[ByteString, Future[MultipartUploadResult]] =
+                      chunkingParallelism: Int = 4,
+                      cannedAcl: CannedAcl = CannedAcl.Private): Sink[ByteString, Future[MultipartUploadResult]] =
     impl
-      .multipartUpload(S3Location(bucket, key), chunkSize, chunkingParallelism)
+      .multipartUpload(S3Location(bucket, key), contentType, cannedAcl, chunkSize, chunkingParallelism)
       .mapMaterializedValue(_.map(MultipartUploadResult.apply)(system.dispatcher))
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.s3.impl
+
+import java.time.LocalDate
+
+import akka.http.scaladsl.model.{ HttpEntity, MediaTypes }
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.stream.alpakka.s3.acl.CannedAcl
+import org.scalatest.{ FlatSpec, Matchers }
+
+class HttpRequestsSpec extends FlatSpec with Matchers {
+  it should "initiate multipart upload" in {
+    val location = S3Location("bucket", "image-1024@2x")
+    val contentType = MediaTypes.`image/jpeg`
+    val acl = CannedAcl.PublicRead
+    val req = HttpRequests.initiateMultipartUploadRequest(location, contentType, acl)
+
+    req.entity shouldEqual HttpEntity.empty(contentType)
+    req.headers should contain(RawHeader("x-amz-acl", acl.value))
+  }
+}


### PR DESCRIPTION
- [x] Added [Canned ACL](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL) (https://github.com/akka/alpakka/issues/90)
- [x] Ability to pass a content type of object
- [x] Fixed signer error when an object key is not url safe (image@2x as an example)

And thanks for this awesome library!

/cc @johanandren @2m @patriknw