### PR TITLE
Implement #111 parallel Mqtt tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,11 +37,7 @@ lazy val mqtt = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "akka-stream-alpakka-mqtt",
-    Dependencies.Mqtt,
-
-    // Scala and Java tests start a separate MQTT broker.
-    // Make it not step on each other by running Scala and Java tests sequentially.
-    parallelExecution in Test := false
+    Dependencies.Mqtt
   )
 
 lazy val s3 = project

--- a/mqtt/src/test/resources/logback.xml
+++ b/mqtt/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%highlight(%date{HH:mm:ss.SSS} %-5level %-50.50([%logger{50}])) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="error">
+        <appender-ref ref="console"/>
+    </root>
+
+</configuration>

--- a/mqtt/src/test/scala/akka/stream/alpakka/mqtt/AvailablePort.scala
+++ b/mqtt/src/test/scala/akka/stream/alpakka/mqtt/AvailablePort.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.mqtt
+
+import java.net.ServerSocket
+
+trait AvailablePort {
+
+  def nextPort(): Int = this.synchronized {
+    val socket = new ServerSocket(0)
+    socket.close()
+    socket.getLocalPort
+  }
+}
+
+object AvailablePort extends AvailablePort

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,8 @@ object Dependencies {
 
   val ScalaVersions = Seq("2.11.8", "2.12.1")
   val AkkaVersion = "2.4.16"
+  val Slf4jVersion = "1.7.21"
+  val logbackVersion = "1.1.7"
 
   val Common = Seq(
     libraryDependencies ++= Seq(
@@ -58,8 +60,11 @@ object Dependencies {
 
   val Mqtt = Seq(
     libraryDependencies ++= Seq(
-      "org.eclipse.paho" % "org.eclipse.paho.client.mqttv3" % "1.1.0",       // Eclipse Public License 1.0
-      "io.moquette"      % "moquette-broker"                % "0.8.1" % Test // ApacheV2
+      "org.eclipse.paho" % "org.eclipse.paho.client.mqttv3" % "1.1.0",                // Eclipse Public License 1.0
+      "io.moquette"      % "moquette-broker"                % "0.8.1"         % Test // ApacheV2
+        exclude("org.slf4j", "slf4j-log4j12"),
+      "ch.qos.logback"   % "logback-classic"                % logbackVersion  % Test, // Eclipse Public License 1.0
+      "ch.qos.logback"   % "logback-core"                   % logbackVersion  % Test  // Eclipse Public License 1.0
     ),
     resolvers += "moquette" at "http://dl.bintray.com/andsel/maven/"
   )
@@ -72,14 +77,14 @@ object Dependencies {
 
   val Ftp = Seq(
     libraryDependencies ++= Seq(
-      "commons-net"           % "commons-net"          % "3.5",             // ApacheV2
-      "com.jcraft"            % "jsch"                 % "0.1.54",          // BSD-style
-      "org.apache.ftpserver"  % "ftpserver-core"       % "1.0.6"    % Test, // ApacheV2
-      "org.apache.sshd"       % "sshd-core"            % "1.3.0"    % Test, // ApacheV2
-      "com.google.jimfs"      % "jimfs"                % "1.1"      % Test, // ApacheV2
-      "org.slf4j"             % "slf4j-api"            % "1.7.21"   % Test, // MIT
-      "ch.qos.logback"        % "logback-classic"      % "1.1.7"    % Test, // Eclipse Public License 1.0
-      "ch.qos.logback"        % "logback-core"         % "1.1.7"    % Test  // Eclipse Public License 1.0
+      "commons-net"           % "commons-net"          % "3.5",               // ApacheV2
+      "com.jcraft"            % "jsch"                 % "0.1.54",            // BSD-style
+      "org.apache.ftpserver"  % "ftpserver-core"       % "1.0.6"        % Test, // ApacheV2
+      "org.apache.sshd"       % "sshd-core"            % "1.3.0"        % Test, // ApacheV2
+      "com.google.jimfs"      % "jimfs"                % "1.1"          % Test, // ApacheV2
+      "org.slf4j"             % "slf4j-api"            % Slf4jVersion   % Test, // MIT
+      "ch.qos.logback"        % "logback-classic"      % logbackVersion % Test, // Eclipse Public License 1.0
+      "ch.qos.logback"        % "logback-core"         % logbackVersion % Test  // Eclipse Public License 1.0
     )
   )
 


### PR DESCRIPTION
 - Add trait to discover an available TCP port
 - Change the Mqtt tests to make use of the autodiscovery TCP port trait
 - Update sbt settings to allow parallel Mqtt tests execution