### PR TITLE
Add SQS publish sink

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     image: rabbitmq:3
     ports:
       - "5672:5672"
-  elasticmq:
-    image: expert360/elasticmq:0.8.12
+  sqs:
+    image: s12v/elasticmq:0.12.0
     ports:
       - "9324:9324"
   mqtt:

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -1,6 +1,7 @@
 # AWS SQS Connector
 
-The AWS SQS connector allows to stream SQS `Message` from a AWS SQS queue.
+The AWS SQS connector provides Akka Stream sources and sinks for AWS SQS queues.
+
 For more information about AWS SQS please visit the [official docmentation](https://aws.amazon.com/documentation/sqs/).
 
 ## Artifacts
@@ -37,7 +38,7 @@ Gradle
 Sources provided by this connector need a prepared `AmazonSQSAsyncClient` to load messages from a queue. 
 
 Scala
-: @@snip (../../../../sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala) { #init-client }
+: @@snip (../../../../sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala) { #init-client }
 
 Java
 : @@snip (../../../../sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java) { #init-client }
@@ -45,12 +46,14 @@ Java
 We will also need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and an @scaladoc[ActorMaterializer](akka.stream.ActorMaterializer).
 
 Scala
-: @@snip (../../../../sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala) { #init-mat }
+: @@snip (../../../../sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala) { #init-mat }
 
 Java
 : @@snip (../../../../sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java) { #init-mat }
 
 This is all preparation that we are going to need.
+
+### Stream messages from a SQS queue
 
 Now we can stream AWS Java SDK SQS `Message` objects from any SQS queue where we have access to by providing the queue URL to the
 @scaladoc[SqsSource](akka.stream.alpakka.sqs.scaladsl.SqsSource$) factory.
@@ -64,6 +67,38 @@ Java
 As you have seen we take the first 100 elements from the stream. The reason for this is, that reading messages from
 SQS queues never finishes because there is no direct way to determine the end of a queue.
 
+#### Source configuration
+
+Scala
+: @@snip (../../../../sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceStage.scala) { #SqsSourceSettings }
+
+Options:
+
+ - `maxBatchSize` - the maximum number of messages to return (see `MaxNumberOfMessages` in AWS docs). Default: 10
+ - `maxBufferSize` - internal buffer size used by the `Source`. Default: 100 messages
+ - `waitTimeSeconds` - the duration for which the call waits for a message to arrive in the queue before
+    returning (see `WaitTimeSeconds` in AWS docs). Default: 20 seconds
+
+### Stream messages to a SQS queue
+
+Create a sink, that forwards `String` to the SQS queue.
+
+Scala
+: @@snip (../../../../sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala) { #run }
+
+Java
+: @@snip (../../../../sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSinkTest.java) { #run }
+
+
+#### Sink configuration
+
+Scala
+: @@snip (../../../../sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSinkStage.scala) { #SqsSinkSettings }
+
+Options:
+
+ - `maxInFlight` - maximum number of messages being processed by `AmazonSQSAsync` at the same time. Default: 10
+
 ### Running the example code
 
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
@@ -71,7 +106,7 @@ The code in this guide is part of runnable tests of this project. You are welcom
 > The test code uses [ElasticMQ](https://github.com/adamw/elasticmq) as queuing service which serves an AWS SQS 
 > compatible API.  You can start one quickly using docker:
 >
-> `docker run -p 9324:9324 -d expert360/elasticmq`
+> `docker run -p 9324:9324 -d s12v/elasticmq`
 
 Scala
 :   ```

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,7 +83,8 @@ object Dependencies {
 
   val Sqs = Seq(
     libraryDependencies ++= Seq(
-      "com.amazonaws"   % "aws-java-sdk-sqs"    % "1.11.51" // ApacheV2
+      "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.76",        // ApacheV2
+      "org.mockito"   % "mockito-core"     % "2.3.7"    % Test // MIT
     )
   )
 

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSinkStage.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSinkStage.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs
+
+import akka.Done
+import akka.stream._
+import akka.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, InHandler, StageLogging }
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.amazonaws.services.sqs.model.{ SendMessageRequest, SendMessageResult }
+
+import scala.concurrent.{ Future, Promise }
+
+object SqsSinkSettings {
+  val Defaults = SqsSinkSettings(maxInFlight = 10)
+}
+
+//#SqsSinkSettings
+final case class SqsSinkSettings(maxInFlight: Int) {
+  require(maxInFlight > 0)
+}
+//#SqsSinkSettings
+
+class SqsSinkStage(queueUrl: String, settings: SqsSinkSettings, sqsClient: AmazonSQSAsync)
+    extends GraphStageWithMaterializedValue[SinkShape[String], Future[Done]] {
+
+  val in: Inlet[String] = Inlet("SqsSink.in")
+
+  override val shape: SinkShape[String] = SinkShape(in)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Done]) = {
+    val promise = Promise[Done]()
+    val logic = new SqsSinkStageLogic(queueUrl, settings, sqsClient, in, shape, promise)
+
+    (logic, promise.future)
+  }
+}
+
+private[sqs] class SqsSinkStageLogic(
+    queueUrl: String,
+    settings: SqsSinkSettings,
+    sqsClient: AmazonSQSAsync,
+    in: Inlet[String],
+    shape: SinkShape[String],
+    promise: Promise[Done]
+) extends GraphStageLogic(shape)
+    with StageLogging {
+
+  private var inFlight = 0
+  private var isShutdownInProgress = false
+  private var amazonSendMessageHandler: AsyncHandler[SendMessageRequest, SendMessageResult] = _
+
+  setHandler(in,
+    new InHandler {
+    override def onPush(): Unit = {
+      inFlight += 1
+      sqsClient.sendMessageAsync(new SendMessageRequest(queueUrl, grab(in)), amazonSendMessageHandler)
+      tryPull()
+    }
+
+    override def onUpstreamFailure(exception: Throwable): Unit = {
+      log.error(exception, "Upstream failure: {}", exception.getMessage)
+      failStage(exception)
+      promise.tryFailure(exception)
+    }
+
+    override def onUpstreamFinish(): Unit = {
+      isShutdownInProgress = true
+      tryShutdown()
+    }
+  })
+
+  override def preStart(): Unit = {
+    setKeepGoing(true)
+
+    val failureCallback = getAsyncCallback[Throwable](handleFailure)
+    val sendCallback = getAsyncCallback[SendMessageResult](handleResult)
+
+    amazonSendMessageHandler = new AsyncHandler[SendMessageRequest, SendMessageResult] {
+      override def onError(exception: Exception): Unit =
+        failureCallback.invoke(exception)
+
+      override def onSuccess(request: SendMessageRequest, result: SendMessageResult): Unit =
+        sendCallback.invoke(result)
+    }
+
+    // This requests one element at the Sink startup.
+    pull(in)
+  }
+
+  private def handleResult(result: SendMessageResult): Unit = {
+    log.debug(s"Sent SQS message {}", result.getMessageId)
+    inFlight -= 1
+    tryShutdown()
+    tryPull()
+  }
+
+  private def tryPull(): Unit =
+    if (inFlight < settings.maxInFlight && !isClosed(in) && !hasBeenPulled(in)) {
+      pull(in)
+    }
+
+  private def tryShutdown(): Unit =
+    if (isShutdownInProgress && inFlight <= 0) {
+      completeStage()
+      promise.trySuccess(Done)
+    }
+
+  private def handleFailure(exception: Throwable): Unit = {
+    log.error(exception, "AmazonSQSAsync failure: {}", exception.getMessage)
+    inFlight -= 1
+    failStage(exception)
+    promise.tryFailure(exception)
+  }
+}

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSink.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSink.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.javadsl
+
+import akka.Done
+import akka.stream.alpakka.sqs.{ SqsSinkSettings, SqsSinkStage, SqsSourceStage }
+import akka.stream.javadsl.Sink
+import com.amazonaws.services.sqs.AmazonSQSAsync
+
+import scala.concurrent.Future
+
+object SqsSink {
+
+  /**
+   * Java API: creates a [[SqsSinkStage]] for a SQS queue using an [[AmazonSQSAsync]]
+   */
+  def create(queueUrl: String, settings: SqsSinkSettings, sqsClient: AmazonSQSAsync): Sink[String, Future[Done]] =
+    Sink.fromGraph(new SqsSinkStage(queueUrl, settings, sqsClient))
+
+  /**
+   * Java API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsync]] with default settings.
+   */
+  def create(queueUrl: String, sqsClient: AmazonSQSAsync): Sink[String, Future[Done]] =
+    Sink.fromGraph(new SqsSinkStage(queueUrl, SqsSinkSettings.Defaults, sqsClient))
+}

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
@@ -22,7 +22,7 @@ object SqsSource {
     Source.fromGraph(new SqsSourceStage(queueUrl, settings, sqsClient))
 
   /**
-   * Scala API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]] with default settings.
+   * Java API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]] with default settings.
    */
   def create(queueUrl: String, sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] =
     Source.fromGraph(new SqsSourceStage(queueUrl, SqsSourceSettings.Defaults, sqsClient))

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSink.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSink.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.scaladsl
+
+import akka.Done
+import akka.stream.alpakka.sqs.{ SqsSinkSettings, SqsSinkStage }
+import akka.stream.scaladsl.Sink
+import com.amazonaws.services.sqs.AmazonSQSAsync
+
+import scala.concurrent.Future
+
+object SqsSink {
+
+  /**
+   * Scala API: creates a [[SqsSinkStage]] for a SQS queue using an [[AmazonSQSAsync]]
+   */
+  def apply(queueUrl: String, settings: SqsSinkSettings = SqsSinkSettings.Defaults)(
+      implicit sqsClient: AmazonSQSAsync): Sink[String, Future[Done]] =
+    Sink.fromGraph(new SqsSinkStage(queueUrl, settings, sqsClient))
+}

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
@@ -8,7 +8,6 @@ import akka.stream.alpakka.sqs.{ SqsSourceSettings, SqsSourceStage }
 import akka.stream.scaladsl.Source
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import com.amazonaws.services.sqs.model.Message
-import scala.concurrent.duration._
 
 object SqsSource {
 

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSinkTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSinkTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.javadsl;
+
+import akka.Done;
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.testkit.JavaTestKit;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
+import com.amazonaws.services.sqs.model.Message;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class SqsSinkTest {
+
+    private static ActorSystem system;
+    private static ActorMaterializer materializer;
+    private static AmazonSQSAsyncClient sqsClient;
+
+
+    @BeforeClass
+    public static void setup() {
+
+        //#init-mat
+        system = ActorSystem.create();
+        materializer = ActorMaterializer.create(system);
+        //#init-mat
+
+        //#init-client
+        AWSCredentials credentials = new BasicAWSCredentials("x", "x");
+        sqsClient = new AmazonSQSAsyncClient(credentials).withEndpoint("http://localhost:9324");
+        //#init-client
+
+    }
+
+    @AfterClass
+    public static void teardown() {
+        JavaTestKit.shutdownActorSystem(system);
+    }
+
+    private static String randomQueueUrl() {
+        return sqsClient.createQueue(String.format("queue-%s", new Random().nextInt())).getQueueUrl();
+    }
+
+    @Test
+    public void sendToQueue() throws Exception {
+
+        final String queueUrl = randomQueueUrl();
+
+        //#run
+        Future<Done> done = Source
+                .single("alpakka")
+                .runWith(SqsSink.create(queueUrl, sqsClient), materializer);
+        Await.ready(done, new FiniteDuration(1, TimeUnit.SECONDS));
+        //#run
+        List<Message> messages = sqsClient.receiveMessage(queueUrl).getMessages();
+
+        assertEquals(1, messages.size());
+        assertEquals("alpakka", messages.get(0).getBody());
+    }
+}

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.scaladsl
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient
+import org.scalatest.{ BeforeAndAfterAll, Suite, Tag }
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.Random
+
+trait DefaultTestContext extends BeforeAndAfterAll { this: Suite =>
+
+  object Integration extends Tag("akka.stream.alpakka.sqs.scaladsl.Integration")
+
+  //#init-mat
+  implicit val system = ActorSystem()
+  implicit val mat = ActorMaterializer()
+  //#init-mat
+
+  //#init-client
+  val credentials = new BasicAWSCredentials("x", "x")
+  implicit val sqsClient: AmazonSQSAsyncClient =
+    new AmazonSQSAsyncClient(credentials).withEndpoint("http://localhost:9324")
+  //#init-client
+
+  def randomQueueUrl(): String = sqsClient.createQueue(s"queue-${Random.nextInt}").getQueueUrl
+
+  override protected def afterAll(): Unit =
+    Await.ready(system.terminate(), 5.seconds)
+}

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSinkSettingsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSinkSettingsSpec.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.scaladsl
+
+import akka.stream.alpakka.sqs.SqsSinkSettings
+import org.scalatest.{ FlatSpec, Matchers }
+
+class SqsSinkSettingsSpec extends FlatSpec with Matchers {
+
+  it should "require valid maxInFlight" in {
+    a[IllegalArgumentException] should be thrownBy {
+      SqsSinkSettings(0)
+    }
+  }
+
+  it should "accept valid parameters" in {
+    SqsSinkSettings(1)
+  }
+}

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSinkSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSinkSpec.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.scaladsl
+
+import java.util.concurrent.{ CompletableFuture, Future }
+
+import akka.Done
+import akka.stream.scaladsl.Keep
+import akka.stream.testkit.scaladsl.TestSource
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.amazonaws.services.sqs.model.{ SendMessageRequest, SendMessageResult }
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.scalatest.mockito.MockitoSugar.mock
+import org.scalatest.{ FlatSpec, Matchers }
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class SqsSinkSpec extends FlatSpec with Matchers with DefaultTestContext {
+
+  it should "send a message" in {
+    implicit val sqsClient: AmazonSQSAsync = mock[AmazonSQSAsync]
+    when(sqsClient.sendMessageAsync(any[SendMessageRequest](), any())).thenAnswer(
+      new Answer[AnyRef] {
+        override def answer(invocation: InvocationOnMock): Future[SendMessageResult] = {
+          val sendMessageRequest = invocation.getArgument[SendMessageRequest](0)
+          invocation
+            .getArgument[AsyncHandler[SendMessageRequest, SendMessageResult]](1)
+            .onSuccess(
+              sendMessageRequest,
+              new SendMessageResult().withMessageId(sendMessageRequest.getMessageBody)
+            )
+          new CompletableFuture()
+        }
+      }
+    )
+
+    val (probe, future) = TestSource.probe[String].toMat(SqsSink("notused"))(Keep.both).run()
+    probe.sendNext("notused").sendComplete()
+    Await.result(future, 1.second) shouldBe Done
+
+    verify(sqsClient, times(1)).sendMessageAsync(any[SendMessageRequest](), any())
+  }
+
+  it should "fail stage on client failure and fail the promise" in {
+    implicit val sqsClient: AmazonSQSAsync = mock[AmazonSQSAsync]
+    when(sqsClient.sendMessageAsync(any[SendMessageRequest](), any())).thenAnswer(
+      new Answer[AnyRef] {
+        override def answer(invocation: InvocationOnMock): Object = {
+          invocation
+            .getArgument[AsyncHandler[SendMessageRequest, SendMessageResult]](1)
+            .onError(new RuntimeException("Fake client error"))
+          new CompletableFuture()
+        }
+      }
+    )
+
+    val (probe, future) = TestSource.probe[String].toMat(SqsSink("notused"))(Keep.both).run()
+    probe.sendNext("notused").sendComplete()
+
+    a[RuntimeException] should be thrownBy {
+      Await.result(future, 1.second)
+    }
+
+    verify(sqsClient, times(1)).sendMessageAsync(any[SendMessageRequest](), any())
+  }
+
+  it should "failure the promise on upstream failure" in {
+    implicit val sqsClient: AmazonSQSAsync = mock[AmazonSQSAsync]
+    val (probe, future) = TestSource.probe[String].toMat(SqsSink("notused"))(Keep.both).run()
+
+    probe.sendError(new RuntimeException("Fake upstream failure"))
+
+    a[RuntimeException] should be thrownBy {
+      Await.result(future, 1.second)
+    }
+  }
+
+  it should "complete promise after all messages have been sent" in {
+    implicit val sqsClient: AmazonSQSAsync = mock[AmazonSQSAsync]
+    when(sqsClient.sendMessageAsync(any[SendMessageRequest](), any())).thenAnswer(
+      new Answer[AnyRef] {
+        override def answer(invocation: InvocationOnMock): Object = {
+          val sendMessageRequest = invocation.getArgument[SendMessageRequest](0)
+          val callback = invocation.getArgument[AsyncHandler[SendMessageRequest, SendMessageResult]](1)
+          callback.onSuccess(
+            sendMessageRequest,
+            new SendMessageResult().withMessageId(sendMessageRequest.getMessageBody)
+          )
+          new CompletableFuture()
+        }
+      }
+    )
+
+    val (probe, future) = TestSource.probe[String].toMat(SqsSink("notused"))(Keep.both).run()
+    probe
+      .sendNext("test-101")
+      .sendNext("test-102")
+      .sendNext("test-103")
+      .sendNext("test-104")
+      .sendNext("test-105")
+      .sendComplete()
+    Await.result(future, 1.second) shouldBe Done
+
+    verify(sqsClient, times(5)).sendMessageAsync(any[SendMessageRequest](), any())
+  }
+}

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSettingsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSettingsSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.scaladsl
+
+import akka.stream.alpakka.sqs.SqsSourceSettings
+import org.scalatest.{ FlatSpec, Matchers }
+
+class SqsSourceSettingsSpec extends FlatSpec with Matchers {
+
+  it should "accept valid parameters" in {
+    SqsSourceSettings(waitTimeSeconds = 1, maxBatchSize = 2, maxBufferSize = 3)
+  }
+
+  it should "require maxBatchSize <= maxBufferSize" in {
+    a[IllegalArgumentException] should be thrownBy {
+      SqsSourceSettings(waitTimeSeconds = 1, maxBatchSize = 5, maxBufferSize = 3)
+    }
+  }
+
+  it should "require waitTimeSeconds within AWS SQS limits" in {
+    a[IllegalArgumentException] should be thrownBy {
+      SqsSourceSettings(waitTimeSeconds = -1, maxBatchSize = 1, maxBufferSize = 2)
+    }
+
+    a[IllegalArgumentException] should be thrownBy {
+      SqsSourceSettings(waitTimeSeconds = 100, maxBatchSize = 1, maxBufferSize = 2)
+    }
+  }
+
+  it should "require maxBatchSize within AWS SQS limits" in {
+    a[IllegalArgumentException] should be thrownBy {
+      SqsSourceSettings(waitTimeSeconds = 5, maxBatchSize = 0, maxBufferSize = 2)
+    }
+
+    a[IllegalArgumentException] should be thrownBy {
+      SqsSourceSettings(waitTimeSeconds = 5, maxBatchSize = 11, maxBufferSize = 2)
+    }
+  }
+}

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.scaladsl
+
+import akka.Done
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.scaladsl.TestSink
+import com.amazonaws.services.sqs.model.Message
+import org.scalatest.{ FlatSpec, Matchers }
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class SqsSpec extends FlatSpec with Matchers with DefaultTestContext {
+
+  it should "publish and pull a message" taggedAs Integration in {
+    val queue = randomQueueUrl()
+
+    //#sink
+    val future = Source.single("alpakka").runWith(SqsSink(queue))
+    Await.ready(future, 1.second)
+    //#sink
+
+    val probe = SqsSource(queue).runWith(TestSink.probe[Message])
+    probe.requestNext().getBody shouldBe "alpakka"
+    probe.cancel()
+  }
+
+  it should "pull a message and publish it to another queue" taggedAs Integration in {
+    val queue1 = randomQueueUrl()
+    val queue2 = randomQueueUrl()
+
+    sqsClient.sendMessage(queue1, "alpakka")
+
+    val future = SqsSource(queue1)
+      .take(1)
+      .map { m: Message =>
+        m.getBody
+      }
+      .runWith(SqsSink(queue2))
+    Await.result(future, 1.second) shouldBe Done
+
+    val result = sqsClient.receiveMessage(queue2)
+    result.getMessages.size() shouldBe 1
+    result.getMessages.get(0).getBody shouldBe "alpakka"
+  }
+}


### PR DESCRIPTION
First PR for https://github.com/akka/alpakka/issues/118

Adds `SqsSink` for publishing messages in SQS

Also:
- use `StageLogging`
- factor out `DefaultTestContext` for source/sink tests
- add `Integration` tag for integration tests (the ones that require running fake-sqs/elasticmq)
- update ElasticMQ container
- update AWS Java SDK
- remove "docker pull" in .travis.yml
- add Mockito for testing (sqs project only)
- use `AmazonSQSAsync` interface instead of `AmazonSQSAsyncClient` class

TODO:
 - [x] javadsl
- [x] update docs