### PR TITLE
AWS DynamoDB Connector #77

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,15 @@ lazy val cassandra = project
     Dependencies.Cassandra
   )
 
+lazy val dynamodb = project
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(
+    name := "akka-stream-alpakka-dynamodb",
+    resolvers += "DynamoDBLocal" at "http://dynamodb-local.s3-website-us-west-2.amazonaws.com/release/",
+    Dependencies.DynamoDB,
+    parallelExecution in Test := false
+  )
+
 lazy val files = project // The name file is taken by `sbt.file`!
   .in(file("file"))
   .enablePlugins(AutomateHeaderPlugin)

--- a/docs/src/main/paradox/connectors.md
+++ b/docs/src/main/paradox/connectors.md
@@ -4,6 +4,7 @@
 
 * [AMQP Connector](amqp.md)
 * [Cassandra Connector](cassandra.md)
+* [DynamoDB Connector](dynamodb.md)
 * [File Connectors](file.md)
 * [HBase Connectors](hbase.md)
 * [MQTT Connector](mqtt.md)

--- a/docs/src/main/paradox/dynamodb.md
+++ b/docs/src/main/paradox/dynamodb.md
@@ -1,0 +1,61 @@
+# AWS DynamoDB Connector
+
+The AWS DynamoDB connector provides a flow for streaming DynamoDB requests. For more information about DynamoDB please visit the [official documentation](https://aws.amazon.com/dynamodb/).
+
+## Artifacts
+
+sbt
+:   @@@vars
+    ```scala
+    libraryDependencies += "com.typesafe.akka" %% "akka-stream-alpakka-dynamodb" % "$version$"
+    ```
+    @@@
+
+Maven
+:   @@@vars
+    ```xml
+    <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-stream-alpakka-dynamodb_$scala.binaryVersion$</artifactId>
+      <version>$version$</version>
+    </dependency>
+    ```
+    @@@
+
+Gradle
+:   @@@vars
+    ```gradle
+    dependencies {
+      compile group: "com.typesafe.akka", name: "akka-stream-alpakka-dynamodb_$scala.binaryVersion$", version: "$version$"
+    }
+    ```
+    @@@
+
+## Usage
+
+This connector uses the [default credential provider chain](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) provided by the [DynamoDB Java SDK](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/basics.html) to retrieve credentials.
+
+Before you can construct the client, you need an @scaladoc[ActorSystem](akka.actor.ActorSystem), @scaladoc[ActorMaterializer](akka.stream.ActorMaterializer), and @scaladoc[ExecutionContext](scala.concurrent.ExecutionContext).
+
+Scala
+: @@snip (../../../../dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ExampleSpec.scala) { #init-client }
+
+Java
+: @@snip (../../../../dynamodb/src/test/java/akka/stream/alpakka/dynamodb/ExampleJavaSpec.scala) { #init-client }
+
+You can then create the client with a settings object.
+
+Scala
+: @@snip (../../../../dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ExampleSpec.scala) { #client-construct }
+
+Java
+: @@snip (../../../../dynamodb/src/test/java/akka/stream/alpakka/dynamodb/ExampleJavaSpec.scala) { #client-construct }
+
+We can now send requests to DynamoDB across the connection.
+
+Scala
+: @@snip (../../../../dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ExampleSpec.scala) { #simple-request }
+
+Java
+: @@snip (../../../../dynamodb/src/test/java/akka/stream/alpakka/dynamodb/ExampleSpec.scala) { #simple-request }
+

--- a/dynamodb/src/main/resources/reference.conf
+++ b/dynamodb/src/main/resources/reference.conf
@@ -1,0 +1,13 @@
+akka.stream.alpakka.dynamodb {
+  # The AWS region
+  region = ""
+
+  # The AWS host
+  host = ""
+
+  # The AWS port
+  port: -1
+
+  # Max number of in flight requests from the AwsClient
+  parallelism = 10
+}

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.dynamodb.impl
+
+import java.io.{ ByteArrayInputStream, InputStream }
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http.HostConnectionPool
+import akka.http.scaladsl.model.{ ContentType, HttpEntity, _ }
+import akka.stream.alpakka.dynamodb.AwsOp
+import akka.stream.alpakka.dynamodb.impl.AwsClient.{ AwsConnect, AwsRequestMetadata }
+import akka.stream.scaladsl.Flow
+import akka.stream.{ ActorAttributes, ActorMaterializer, Supervision }
+import com.amazonaws.auth.{ AWS4Signer, DefaultAWSCredentialsProviderChain }
+import com.amazonaws.http.{ HttpMethodName, HttpResponseHandler, HttpResponse => AWSHttpResponse }
+import com.amazonaws.{ DefaultRequest, HttpMethod => _, _ }
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success, Try }
+
+private[alpakka] object AwsClient {
+
+  case class AwsRequestMetadata(id: Long, op: AwsOp)
+
+  type AwsConnect =
+    Flow[(HttpRequest, AwsRequestMetadata), (Try[HttpResponse], AwsRequestMetadata), HostConnectionPool]
+
+}
+
+private[alpakka] trait AwsClient[S <: ClientSettings] {
+
+  protected implicit def system: ActorSystem
+
+  protected implicit def materializer: ActorMaterializer
+
+  protected implicit def ec: ExecutionContext
+
+  protected val settings: S
+  protected val connection: AwsConnect
+  protected val service: String
+  protected val defaultContentType: ContentType
+  protected val errorResponseHandler: HttpResponseHandler[AmazonServiceException]
+
+  private val requestId = new AtomicInteger()
+  private val credentials = new DefaultAWSCredentialsProviderChain()
+
+  private lazy val signer = {
+    val s = new AWS4Signer()
+    s.setServiceName(service)
+    s.setRegionName(settings.region)
+    s
+  }
+
+  private implicit def method(method: HttpMethodName): HttpMethod = method match {
+    case HttpMethodName.POST => HttpMethods.POST
+    case HttpMethodName.GET => HttpMethods.GET
+    case HttpMethodName.PUT => HttpMethods.PUT
+    case HttpMethodName.DELETE => HttpMethods.DELETE
+    case HttpMethodName.HEAD => HttpMethods.HEAD
+    case HttpMethodName.OPTIONS => HttpMethods.OPTIONS
+    case HttpMethodName.PATCH => HttpMethods.PATCH
+  }
+
+  private val signableUrl = Uri("https://" + settings.host + "/")
+
+  private val decider: Supervision.Decider = { case _ => Supervision.Stop }
+
+  def flow: Flow[AwsOp, AmazonWebServiceResult[ResponseMetadata], NotUsed] =
+    Flow[AwsOp]
+      .map(toAwsRequest)
+      .via(connection)
+      .mapAsync(settings.parallelism) {
+        case (Success(response), i) => toAwsResult(response, i)
+        case (Failure(ex), i) => Future.failed(ex)
+      }
+      .withAttributes(ActorAttributes.supervisionStrategy(decider))
+
+  private def toAwsRequest(s: AwsOp): (HttpRequest, AwsRequestMetadata) = {
+    val original = s.marshaller.marshall(s.request)
+    original.setEndpoint(new java.net.URI("https://" + settings.host + "/"))
+    original.getHeaders.remove("Content-Type")
+    original.getHeaders.remove("Content-Length")
+    signer.sign(original, credentials.getCredentials)
+
+    val amzHeaders = original.getHeaders
+    val body = read(original.getContent)
+
+    val httpr = HttpRequest(uri = signableUrl, method = original.getHttpMethod,
+      headers = List(
+        headers.RawHeader("x-amz-date", amzHeaders.get("X-Amz-Date")),
+        headers.RawHeader("authorization", amzHeaders.get("Authorization")),
+        headers.RawHeader("x-amz-target", amzHeaders.get("X-Amz-Target"))
+      ),
+      entity = HttpEntity(defaultContentType, body))
+
+    httpr -> AwsRequestMetadata(requestId.getAndIncrement(), s)
+  }
+
+  private def toAwsResult(response: HttpResponse,
+                          metadata: AwsRequestMetadata): Future[AmazonWebServiceResult[ResponseMetadata]] = {
+    val req = new DefaultRequest(this.service)
+    val awsResp = new AWSHttpResponse(req, null) //
+    response.entity.dataBytes.runFold(Array.emptyByteArray)(_ ++ _).flatMap { bytes =>
+      awsResp.setContent(new ByteArrayInputStream(bytes))
+      awsResp.setStatusCode(response.status.intValue)
+      awsResp.setStatusText(response.status.defaultMessage)
+      if (200 <= awsResp.getStatusCode && awsResp.getStatusCode < 300) {
+        val handle = metadata.op.handler.handle(awsResp)
+        val resp = handle.getResult
+        Future.successful(resp)
+      } else {
+        response.headers.foreach { h =>
+          awsResp.addHeader(h.name, h.value)
+        }
+        Future.failed(errorResponseHandler.handle(awsResp))
+      }
+    }
+  }
+
+  private def read(in: InputStream) = Stream.continually(in.read).takeWhile(-1 != _).map(_.toByte).toArray
+
+}

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/ClientSettings.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/ClientSettings.scala
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.dynamodb.impl
+
+abstract class ClientSettings {
+  val region: String
+  val host: String
+  val port: Int
+  val parallelism: Int
+}

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoClientImpl.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoClientImpl.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.dynamodb.impl
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.MediaType.NotCompressible
+import akka.http.scaladsl.model.{ ContentType, MediaType }
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.dynamodb.AwsOp
+import akka.stream.alpakka.dynamodb.impl.AwsClient.{ AwsConnect, AwsRequestMetadata }
+import akka.stream.scaladsl.{ Sink, Source }
+import com.amazonaws.AmazonServiceException
+import com.amazonaws.http.HttpResponseHandler
+
+class DynamoClientImpl(val settings: DynamoSettings,
+                       val errorResponseHandler: HttpResponseHandler[AmazonServiceException])(
+    implicit protected val system: ActorSystem,
+    implicit protected val materializer: ActorMaterializer)
+    extends AwsClient[DynamoSettings] {
+
+  override protected val service = "dynamodb"
+  override protected val defaultContentType =
+    ContentType.Binary(MediaType.customBinary("application", "x-amz-json-1.0", NotCompressible))
+  override protected implicit val ec = system.dispatcher
+
+  override protected val connection: AwsConnect =
+    if (settings.port == 443)
+      Http().cachedHostConnectionPoolHttps[AwsRequestMetadata](settings.host)(materializer)
+    else
+      Http().cachedHostConnectionPool[AwsRequestMetadata](settings.host, settings.port)(materializer)
+
+  def single(op: AwsOp) = Source.single(op).via(flow).map(_.asInstanceOf[op.B]).runWith(Sink.head)
+
+}

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoProtocol.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoProtocol.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.dynamodb.impl
+
+import com.amazonaws.AmazonServiceException
+import com.amazonaws.http.HttpResponseHandler
+import com.amazonaws.protocol.json._
+import com.amazonaws.services.dynamodbv2.model._
+import com.amazonaws.services.dynamodbv2.model.transform._
+
+private[alpakka] trait DynamoProtocol {
+
+  val meta = new JsonOperationMetadata().withPayloadJson(true)
+
+  val protocol: SdkJsonProtocolFactory = new SdkJsonProtocolFactory(
+      new JsonClientMetadata()
+        .addAllErrorMetadata(
+            new JsonErrorShapeMetadata()
+              .withErrorCode("ItemCollectionSizeLimitExceededException")
+              .withModeledClass(classOf[ItemCollectionSizeLimitExceededException]),
+            new JsonErrorShapeMetadata()
+              .withErrorCode("ResourceInUseException")
+              .withModeledClass(classOf[ResourceInUseException]),
+            new JsonErrorShapeMetadata()
+              .withErrorCode("ResourceNotFoundException")
+              .withModeledClass(classOf[ResourceNotFoundException]),
+            new JsonErrorShapeMetadata()
+              .withErrorCode("ProvisionedThroughputExceededException")
+              .withModeledClass(classOf[ProvisionedThroughputExceededException]),
+            new JsonErrorShapeMetadata()
+              .withErrorCode("ConditionalCheckFailedException")
+              .withModeledClass(classOf[ConditionalCheckFailedException]),
+            new JsonErrorShapeMetadata()
+              .withErrorCode("InternalServerError")
+              .withModeledClass(classOf[InternalServerErrorException]),
+            new JsonErrorShapeMetadata()
+              .withErrorCode("LimitExceededException")
+              .withModeledClass(classOf[LimitExceededException]))
+        .withBaseServiceExceptionClass(classOf[com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException]))
+
+  val errorResponseHandler: HttpResponseHandler[AmazonServiceException] =
+    protocol.createErrorResponseHandler(new JsonErrorResponseMetadata())
+
+  protected val batchGetItemM = new BatchGetItemRequestMarshaller(protocol)
+  protected val batchWriteItemM = new BatchWriteItemRequestMarshaller(protocol)
+  protected val createTableM = new CreateTableRequestMarshaller(protocol)
+  protected val deleteItemM = new DeleteItemRequestMarshaller(protocol)
+  protected val deleteTableM = new DeleteTableRequestMarshaller(protocol)
+  protected val describeLimitsM = new DescribeLimitsRequestMarshaller(protocol)
+  protected val describeTableM = new DescribeTableRequestMarshaller(protocol)
+  protected val getItemM = new GetItemRequestMarshaller(protocol)
+  protected val listTablesM = new ListTablesRequestMarshaller(protocol)
+  protected val putItemM = new PutItemRequestMarshaller(protocol)
+  protected val queryM = new QueryRequestMarshaller(protocol)
+  protected val scanM = new ScanRequestMarshaller(protocol)
+  protected val updateItemM = new UpdateItemRequestMarshaller(protocol)
+  protected val updateTableM = new UpdateTableRequestMarshaller(protocol)
+
+  protected val batchGetItemU = protocol.createResponseHandler(meta, new BatchGetItemResultJsonUnmarshaller)
+  protected val batchWriteItemU = protocol.createResponseHandler(meta, new BatchWriteItemResultJsonUnmarshaller)
+  protected val createTableU = protocol.createResponseHandler(meta, new CreateTableResultJsonUnmarshaller)
+  protected val deleteItemU = protocol.createResponseHandler(meta, new DeleteItemResultJsonUnmarshaller)
+  protected val deleteTableU = protocol.createResponseHandler(meta, new DeleteTableResultJsonUnmarshaller)
+  protected val describeLimitsU = protocol.createResponseHandler(meta, new DescribeLimitsResultJsonUnmarshaller)
+  protected val describeTableU = protocol.createResponseHandler(meta, new DescribeTableResultJsonUnmarshaller)
+  protected val getItemU = protocol.createResponseHandler(meta, new GetItemResultJsonUnmarshaller)
+  protected val listTablesU = protocol.createResponseHandler(meta, new ListTablesResultJsonUnmarshaller)
+  protected val putItemU = protocol.createResponseHandler(meta, new PutItemResultJsonUnmarshaller)
+  protected val queryU = protocol.createResponseHandler(meta, new QueryResultJsonUnmarshaller)
+  protected val scanU = protocol.createResponseHandler(meta, new ScanResultJsonUnmarshaller)
+  protected val updateItemU = protocol.createResponseHandler(meta, new UpdateItemResultJsonUnmarshaller)
+  protected val updateTableU = protocol.createResponseHandler(meta, new UpdateTableResultJsonUnmarshaller)
+
+}

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoSettings.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoSettings.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.dynamodb.impl
+
+import akka.actor.ActorSystem
+import com.typesafe.config.Config
+
+object DynamoSettings {
+  def apply(system: ActorSystem): DynamoSettings = {
+    val config = system.settings.config.getConfig("akka.stream.alpakka.dynamodb")
+    DynamoSettings(
+      region = config getString "region",
+      host = config getString "host",
+      port = config getInt "port",
+      parallelism = config getInt "parallelism"
+    )
+  }
+}
+
+case class DynamoSettings(region: String, host: String, port: Int, parallelism: Int) extends ClientSettings {
+  require(host.nonEmpty, "A host name must be provided.")
+  require(port > -1, "A port number must be provided.")
+}

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/javadsl/DynamoClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/javadsl/DynamoClient.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.dynamodb.javadsl
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.dynamodb.AwsOp
+import akka.stream.alpakka.dynamodb.impl.{ DynamoClientImpl, DynamoSettings }
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoImplicits
+import akka.stream.scaladsl.{ Sink, Source }
+import com.amazonaws.services.dynamodbv2.model._
+
+import scala.concurrent.Future
+
+object DynamoClient {
+  def create(settings: DynamoSettings, system: ActorSystem, materializer: ActorMaterializer) =
+    new DynamoClient(settings)(system, materializer)
+}
+
+final class DynamoClient(settings: DynamoSettings)(implicit system: ActorSystem, materializer: ActorMaterializer) {
+
+  private val client = new DynamoClientImpl(settings, DynamoImplicits.errorResponseHandler)
+  private implicit val ec = system.dispatcher
+
+  import DynamoImplicits._
+
+  private val flow = client.flow.asJava
+
+  private def single(op: AwsOp): Future[op.B] =
+    Source.single(op).via(client.flow).runWith(Sink.head).map(_.asInstanceOf[op.B])
+
+  def batchGetItem(request: BatchGetItemRequest) = single(BatchGetItem(request))
+
+  def createTable(request: CreateTableRequest) = single(CreateTable(request))
+
+  def deleteItem(request: DeleteItemRequest) = single(DeleteItem(request))
+
+  def deleteTable(request: DeleteTableRequest) = single(DeleteTable(request))
+
+  def describeLimits(request: DescribeLimitsRequest) = single(DescribeLimits(request))
+
+  def describeTable(request: DescribeTableRequest) = single(DescribeTable(request))
+
+  def query(request: QueryRequest) = single(Query(request))
+
+  def scan(request: ScanRequest) = single(Scan(request))
+
+  def updateItem(request: UpdateItemRequest) = single(UpdateItem(request))
+
+  def updateTable(request: UpdateTableRequest) = single(UpdateTable(request))
+
+  def putItem(request: PutItemRequest) = single(PutItem(request))
+
+  def batchWriteItem(request: BatchWriteItemRequest) = single(BatchWriteItem(request))
+
+  def getItem(request: GetItemRequest) = single(GetItem(request))
+
+  def listTables(request: ListTablesRequest) = single(ListTables(request))
+
+}

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/package.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/package.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka
+
+import com.amazonaws._
+import com.amazonaws.http.HttpResponseHandler
+import com.amazonaws.transform.Marshaller
+
+package dynamodb {
+
+  trait AwsOp {
+    type A <: AmazonWebServiceRequest
+    type B <: AmazonWebServiceResult[ResponseMetadata]
+    val request: A
+    val handler: HttpResponseHandler[AmazonWebServiceResponse[B]]
+    val marshaller: Marshaller[Request[A], A]
+  }
+
+}

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoClient.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.dynamodb.scaladsl
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.dynamodb.AwsOp
+import akka.stream.alpakka.dynamodb.impl.{ DynamoClientImpl, DynamoSettings }
+import akka.stream.scaladsl.{ Sink, Source }
+
+object DynamoClient {
+  def apply(settings: DynamoSettings)(implicit system: ActorSystem, materializer: ActorMaterializer) =
+    new DynamoClient(settings)
+}
+
+final class DynamoClient(settings: DynamoSettings)(implicit system: ActorSystem, materializer: ActorMaterializer) {
+  private val client = new DynamoClientImpl(settings, DynamoImplicits.errorResponseHandler)
+
+  val flow = client.flow
+  def single(op: AwsOp) = Source.single(op).via(client.flow).map(_.asInstanceOf[op.B]).runWith(Sink.head)
+}

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoImplicits.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoImplicits.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.dynamodb.scaladsl
+
+import akka.stream.alpakka.dynamodb.AwsOp
+import akka.stream.alpakka.dynamodb.impl.DynamoProtocol
+import com.amazonaws.http.HttpResponseHandler
+import com.amazonaws.services.dynamodbv2.model._
+import com.amazonaws.transform.Marshaller
+import com.amazonaws.{ AmazonWebServiceResponse, Request }
+
+object DynamoImplicits extends DynamoProtocol {
+
+  implicit class BatchGetItem(val request: BatchGetItemRequest) extends AwsOp {
+    override type A = BatchGetItemRequest
+    override type B = BatchGetItemResult
+    override val handler = batchGetItemU
+    override val marshaller = batchGetItemM
+  }
+
+  implicit class CreateTable(val request: CreateTableRequest) extends AwsOp {
+    override type A = CreateTableRequest
+    override type B = CreateTableResult
+    override val handler = createTableU
+    override val marshaller = createTableM
+  }
+
+  implicit class DeleteItem(val request: DeleteItemRequest) extends AwsOp {
+    override type A = DeleteItemRequest
+    override type B = DeleteItemResult
+    override val handler = deleteItemU
+    override val marshaller = deleteItemM
+  }
+
+  implicit class DeleteTable(val request: DeleteTableRequest) extends AwsOp {
+    override type A = DeleteTableRequest
+    override type B = DeleteTableResult
+    override val handler = deleteTableU
+    override val marshaller = deleteTableM
+  }
+
+  implicit class DescribeLimits(val request: DescribeLimitsRequest) extends AwsOp {
+    override type A = DescribeLimitsRequest
+    override type B = DescribeLimitsResult
+    override val handler = describeLimitsU
+    override val marshaller = describeLimitsM
+  }
+
+  implicit class DescribeTable(val request: DescribeTableRequest) extends AwsOp {
+    override type A = DescribeTableRequest
+    override type B = DescribeTableResult
+    override val handler = describeTableU
+    override val marshaller = describeTableM
+  }
+
+  implicit class Query(val request: QueryRequest) extends AwsOp {
+    override type A = QueryRequest
+    override type B = QueryResult
+    override val handler = queryU
+    override val marshaller = queryM
+  }
+
+  implicit class Scan(val request: ScanRequest) extends AwsOp {
+    override type A = ScanRequest
+    override type B = ScanResult
+    override val handler = scanU
+    override val marshaller = scanM
+  }
+
+  implicit class UpdateItem(val request: UpdateItemRequest) extends AwsOp {
+    override type A = UpdateItemRequest
+    override type B = UpdateItemResult
+    override val handler = updateItemU
+    override val marshaller = updateItemM
+  }
+
+  implicit class UpdateTable(val request: UpdateTableRequest) extends AwsOp {
+    override type A = UpdateTableRequest
+    override type B = UpdateTableResult
+    override val handler = updateTableU
+    override val marshaller = updateTableM
+  }
+
+  implicit class PutItem(val request: PutItemRequest) extends AwsOp {
+    override type A = PutItemRequest
+    override type B = PutItemResult
+    override val handler: HttpResponseHandler[AmazonWebServiceResponse[PutItemResult]] = putItemU
+    override val marshaller: Marshaller[Request[PutItemRequest], PutItemRequest] = putItemM
+  }
+
+  implicit class BatchWriteItem(val request: BatchWriteItemRequest) extends AwsOp {
+    override type A = BatchWriteItemRequest
+    override type B = BatchWriteItemResult
+    override val handler = batchWriteItemU
+    override val marshaller = batchWriteItemM
+  }
+
+  implicit class GetItem(val request: GetItemRequest) extends AwsOp {
+    override type A = GetItemRequest
+    override type B = GetItemResult
+    override val handler = getItemU
+    override val marshaller = getItemM
+  }
+
+  implicit class ListTables(val request: ListTablesRequest) extends AwsOp {
+    override type A = ListTablesRequest
+    override type B = ListTablesResult
+    override val handler = listTablesU
+    override val marshaller = listTablesM
+  }
+
+}

--- a/dynamodb/src/test/java/akka/stream/alpakka/dynamodb/ExampleJavaSpec.java
+++ b/dynamodb/src/test/java/akka/stream/alpakka/dynamodb/ExampleJavaSpec.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.dynamodb;
+
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.alpakka.dynamodb.impl.DynamoSettings;
+import akka.stream.alpakka.dynamodb.javadsl.DynamoClient;
+import akka.testkit.JavaTestKit;
+import com.amazonaws.services.dynamodbv2.local.main.ServerRunner;
+import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer;
+import com.amazonaws.services.dynamodbv2.model.DescribeLimitsRequest;
+import com.amazonaws.services.dynamodbv2.model.DescribeLimitsResult;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Duration;
+
+public class ExampleJavaSpec {
+
+    static ActorSystem system;
+    static ActorMaterializer materializer;
+    static DynamoSettings dynamoSettings;
+    static DynamoClient dynamoClient;
+    static DynamoDBProxyServer serverRunner;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+
+        //#init-client
+        system = ActorSystem.create();
+        materializer = ActorMaterializer.create(system);
+        //#init-client
+
+        //#client-construct
+        dynamoSettings = DynamoSettings.apply(system);
+        dynamoClient = DynamoClient.create(dynamoSettings, system, materializer);
+        //#client-construct
+
+        String[] serverArgs = new String[] { "-port", Integer.toString(dynamoSettings.port()), "-inMemory" };
+        serverRunner = ServerRunner.createServerFromCommandLineArgs(serverArgs);
+        serverRunner.start();
+
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        JavaTestKit.shutdownActorSystem(system);
+        serverRunner.stop();
+    }
+
+    @Test
+    public void listTables() throws Exception {
+        //#simple-request
+        final Future<DescribeLimitsResult> describeLimitsResultFuture = dynamoClient.describeLimits(new DescribeLimitsRequest());
+        //#simple-request
+        final Duration duration = Duration.create(5, "seconds");
+        DescribeLimitsResult result = Await.result(describeLimitsResultFuture, duration);
+    }
+
+}

--- a/dynamodb/src/test/resources/application.conf
+++ b/dynamodb/src/test/resources/application.conf
@@ -1,0 +1,6 @@
+akka.stream.alpakka.dynamodb {
+  host = "localhost"
+  port: 8001
+  region = "us-east-1"
+  parallelism = 5
+}

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ExampleSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ExampleSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.dynamodb
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.dynamodb.impl.DynamoSettings
+import akka.stream.alpakka.dynamodb.scaladsl._
+import akka.testkit.{ SocketUtil, TestKit }
+import com.amazonaws.services.dynamodbv2.model._
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+
+class ExampleSpec extends TestKit(ActorSystem("ExampleSpec")) with WordSpecLike with Matchers with BeforeAndAfterAll {
+
+  val settings = DynamoSettings(system)
+  val localDynamo = new LocalDynamo(settings)
+
+  override def beforeAll(): Unit = localDynamo.start()
+
+  override def afterAll(): Unit = {
+    localDynamo.stop()
+    system.terminate()
+  }
+
+  "DynamoDB Client" should {
+
+    "provide a simple usage example" in {
+
+      //#init-client
+      implicit val system = ActorSystem()
+      implicit val materializer = ActorMaterializer()
+      implicit val ec = system.dispatcher
+      //#init-client
+
+      //#client-construct
+      val settings = DynamoSettings(system)
+      val client = DynamoClient(settings)
+      //#client-construct
+
+      //##simple-request
+      import DynamoImplicits._
+      val listTablesResult: Future[ListTablesResult] = client.single(new ListTablesRequest())
+      //##simple-request
+
+      Await.result(listTablesResult, 5.seconds)
+
+      system.terminate()
+
+    }
+
+  }
+
+}

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ItemSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ItemSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.dynamodb
+
+import akka.actor.ActorSystem
+import akka.stream._
+import akka.stream.alpakka.dynamodb.impl.DynamoSettings
+import akka.stream.alpakka.dynamodb.scaladsl._
+import akka.testkit.{ SocketUtil, TestKit }
+import org.scalatest._
+
+class ItemSpec extends TestKit(ActorSystem("ItemSpec")) with AsyncWordSpecLike with Matchers with BeforeAndAfterAll {
+
+  implicit val materializer = ActorMaterializer()
+  implicit val ec = system.dispatcher
+
+  val settings = DynamoSettings(system).copy(port = SocketUtil.temporaryServerAddress().getPort)
+  val localDynamo = new LocalDynamo(settings)
+
+  val client = DynamoClient(settings)
+
+  override def beforeAll(): Unit = localDynamo.start()
+
+  override def afterAll(): Unit = {
+    localDynamo.stop()
+    system.terminate()
+  }
+
+  "DynamoDB Client" should {
+
+    import ItemSpecOps._
+    import DynamoImplicits._
+
+    "1) list zero tables" in {
+      client.single(listTablesRequest).map(_.getTableNames.size shouldBe 0)
+    }
+
+    "2) create a table" in {
+      client.single(createTableRequest).map(_.getTableDescription.getTableStatus shouldBe "ACTIVE")
+    }
+
+    "3) find a new table" in {
+      client.single(listTablesRequest).map(_.getTableNames.size shouldBe 1)
+    }
+
+    "4) put an item and read it back" in {
+      client
+        .single(test4PutItemRequest)
+        .flatMap(_ => client.single(getItemRequest))
+        .map(_.getItem.get("data").getS shouldEqual "test4data")
+    }
+
+    "5) put an item and read it back in a batch" in {
+      client.single(batchWriteItemRequest).map(_.getUnprocessedItems.size() shouldEqual 0)
+    }
+
+    "6) delete an item" in {
+      client.single(deleteItemRequest).flatMap(_ => client.single(getItemRequest)).map(_.getItem() shouldEqual null)
+    }
+
+  }
+
+}

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/LocalDynamo.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/LocalDynamo.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.dynamodb
+
+import akka.stream.alpakka.dynamodb.impl.DynamoSettings
+import com.amazonaws.services.dynamodbv2.local.main.ServerRunner
+import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer
+
+class LocalDynamo(settings: DynamoSettings) {
+
+  private val serverArgs = Array("-port", settings.port.toString, "-inMemory")
+  private val server: DynamoDBProxyServer = ServerRunner.createServerFromCommandLineArgs(serverArgs)
+
+  def start(): Unit = server.start()
+
+  def stop(): Unit = server.stop()
+
+}

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TableSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TableSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.dynamodb
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.dynamodb.impl.{ DynamoClientImpl, DynamoSettings }
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoClient
+import akka.testkit.{ SocketUtil, TestKit }
+import org.scalatest.{ AsyncWordSpecLike, BeforeAndAfterAll, Matchers }
+
+class TableSpec extends TestKit(ActorSystem("TableSpec")) with AsyncWordSpecLike with Matchers with BeforeAndAfterAll {
+
+  implicit val materializer = ActorMaterializer()
+  implicit val ec = system.dispatcher
+
+  val settings = DynamoSettings(system).copy(port = SocketUtil.temporaryServerAddress().getPort)
+  val localDynamo = new LocalDynamo(settings)
+
+  override def beforeAll(): Unit = localDynamo.start()
+
+  override def afterAll(): Unit = {
+    localDynamo.stop()
+    system.terminate()
+  }
+
+  val client = DynamoClient(settings)
+
+  "DynamoDB Client" should {
+
+    import TableSpecOps._
+    import akka.stream.alpakka.dynamodb.scaladsl.DynamoImplicits._
+
+    "1) create table" in {
+      client.single(createTableRequest).map(_.getTableDescription.getTableName shouldEqual tableName)
+    }
+
+    "2) list tables" in {
+      client.single(listTablesRequest).map(_.getTableNames.size shouldEqual 1)
+    }
+
+    "3) describe table" in {
+      client.single(describeTableRequest).map(_.getTable.getTableName shouldEqual tableName)
+    }
+
+    "4) update table" in {
+      client
+        .single(describeTableRequest)
+        .map(_.getTable.getProvisionedThroughput.getWriteCapacityUnits shouldEqual 10L)
+        .flatMap(_ => client.single(updateTableRequest))
+        .map(_.getTableDescription.getProvisionedThroughput.getWriteCapacityUnits shouldEqual newMaxLimit)
+    }
+
+    "5) delete table" in {
+      client
+        .single(deleteTableRequest)
+        .flatMap(_ => client.single(listTablesRequest))
+        .map(_.getTableNames.size shouldEqual 0)
+    }
+
+  }
+
+}

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TestOps.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TestOps.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.dynamodb
+
+import com.amazonaws.services.dynamodbv2.model._
+
+import scala.collection.JavaConverters._
+
+trait TestOps {
+
+  val tableName = "test"
+  val keyCol = "kkey"
+  val sortCol = "sort"
+
+  def S(s: String) = new AttributeValue().withS(s)
+  def N(n: Int) = new AttributeValue().withN(n.toString)
+  def keyMap(hash: String, sort: Int): Map[String, AttributeValue] = Map(
+    keyCol -> S(hash),
+    sortCol -> N(sort)
+  )
+
+  object common {
+    val listTablesRequest = new ListTablesRequest()
+
+    val createTableRequest = new CreateTableRequest()
+      .withTableName(tableName)
+      .withKeySchema(
+        new KeySchemaElement().withAttributeName(keyCol).withKeyType(KeyType.HASH),
+        new KeySchemaElement().withAttributeName(sortCol).withKeyType(KeyType.RANGE)
+      )
+      .withAttributeDefinitions(
+        new AttributeDefinition().withAttributeName(keyCol).withAttributeType("S"),
+        new AttributeDefinition().withAttributeName(sortCol).withAttributeType("N")
+      )
+      .withProvisionedThroughput(
+        new ProvisionedThroughput().withReadCapacityUnits(10L).withWriteCapacityUnits(10L)
+      )
+
+    val describeTableRequest = new DescribeTableRequest().withTableName(tableName)
+  }
+
+}
+
+object ItemSpecOps extends TestOps {
+
+  val listTablesRequest = common.listTablesRequest
+
+  val createTableRequest = common.createTableRequest
+
+  val test4Data = "test4data"
+
+  val test4PutItemRequest =
+    new PutItemRequest().withTableName(tableName).withItem((keyMap("A", 0) + ("data" -> S(test4Data))).asJava)
+
+  val getItemRequest =
+    new GetItemRequest().withTableName(tableName).withKey(keyMap("A", 0).asJava).withAttributesToGet("data")
+
+  val test5Data = "test5Data"
+
+  val test5PutItemRequest =
+    new PutItemRequest().withTableName(tableName).withItem((keyMap("A", 1) + ("data" -> S(test5Data))).asJava)
+
+  val batchWriteItemRequest = new BatchWriteItemRequest().withRequestItems(
+      Map(
+          tableName ->
+          List(new WriteRequest(new PutRequest().withItem((keyMap("B", 0) + ("data" -> S(test5Data))).asJava)),
+            new WriteRequest(new PutRequest().withItem((keyMap("B",
+                  1) + ("data" -> S(test5Data))).asJava))).asJava).asJava)
+
+  val deleteItemRequest = new DeleteItemRequest().withTableName(tableName).withKey(keyMap("A", 0).asJava)
+
+  def test7PutItemRequest(n: Int) =
+    new PutItemRequest().withTableName(tableName).withItem((keyMap("A", n)).asJava)
+
+  val querySize =
+    new QueryRequest()
+      .withTableName(tableName)
+      .withKeyConditionExpression(s"$keyCol = :k")
+      .withExpressionAttributeValues(Map(":k" -> S("A")).asJava)
+
+}
+
+object TableSpecOps extends TestOps {
+
+  val createTableRequest = common.createTableRequest
+
+  val listTablesRequest = common.listTablesRequest
+
+  val describeTableRequest = common.describeTableRequest
+
+  val newMaxLimit = 5L
+  val describeLimitsRequest = new DescribeLimitsRequest()
+  val updateTableRequest = new UpdateTableRequest()
+    .withTableName(tableName)
+    .withProvisionedThroughput(
+        new ProvisionedThroughput().withWriteCapacityUnits(newMaxLimit).withReadCapacityUnits(newMaxLimit))
+
+  val deleteTableRequest = new DeleteTableRequest().withTableName(tableName)
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,6 +55,16 @@ object Dependencies {
     )
   }
 
+  val DynamoDB = Seq(
+    libraryDependencies ++= Seq(
+      "com.amazonaws"             % "aws-java-sdk-core"       % "1.11.73",          // ApacheV2
+      "com.amazonaws"             % "aws-java-sdk-dynamodb"   % "1.11.73",          // ApacheV2
+      "com.typesafe.akka"         %% "akka-http"              % AkkaHttpVersion,
+      "com.amazonaws"             % "DynamoDBLocal"           % "1.11.0"    % Test, // ApacheV2
+      "com.almworks.sqlite4java"  % "sqlite4java"             % "0.213"     % Test  // ApacheV2
+    )
+  )
+
   val Mqtt = Seq(
     libraryDependencies ++= Seq(
       "org.eclipse.paho" % "org.eclipse.paho.client.mqttv3" % "1.1.0",       // Eclipse Public License 1.0


### PR DESCRIPTION
Hello,

This is a connector for Amazon's DynamoDB associated with [#77](https://github.com/akka/alpakka/issues/77). The connector relies on the AWS Java SDK and Akka HTTP. It does not implement custom request signing or marshalling, and relies on the SDK for these facilities. This pull request only includes DynamoDB, and I can submit a separate pull request for Kinesis if this one is successful. 

There are two things to note:
- The tests rely on DynamoDBLocal which in turn relies on the native assembly for SQLite being available on the path. (This is mentioned in the documentation)
- My Kinesis implementation will depend on the same AwsClient, so it may need to be extracted to a shared location in the future? 