### PR TITLE
Add SqsAckSink

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "5672:5672"
   sqs:
-    image: s12v/elasticmq:0.12.0
+    image: s12v/elasticmq:0.13.2
     ports:
       - "9324:9324"
   mqtt:

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -105,7 +105,6 @@ Scala
 Java
 : @@snip (../../../../sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSinkTest.java) { #run }
 
-
 #### Sink configuration
 
 Scala
@@ -114,6 +113,40 @@ Scala
 Options:
 
  - `maxInFlight` - maximum number of messages being processed by `AmazonSQSAsync` at the same time. Default: 10
+
+
+### Message processing with acknowledgement
+
+`SqsAckSink` provides possibility to acknowledge (delete) or requeue a message.
+
+Your flow must decide which action to take and push it with message:
+
+ - `Ack` - delete message from the queue
+ - `RequeueWithDelay(delaySeconds: Int)` - schedule a retry
+ 
+Scala (ack)
+: @@snip (../../../../sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala) { #ack }
+
+Scala (requeue)
+: @@snip (../../../../sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala) { #requeue }
+
+Java (ack)
+: @@snip (../../../../sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsAckSinkTest.java) { #ack }
+
+Java (requeue)
+: @@snip (../../../../sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsAckSinkTest.java) { #requeue }
+
+#### SqsAckSink configuration
+
+Same as the normal `SqsSink`:
+
+Scala
+: @@snip (../../../../sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkStage.scala) { #SqsAckSinkSettings }
+
+Options:
+
+ - `maxInFlight` - maximum number of messages being processed by `AmazonSQSAsync` at the same time. Default: 10
+
 
 ### Running the example code
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -97,8 +97,8 @@ object Dependencies {
 
   val Sqs = Seq(
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.76",        // ApacheV2
-      "org.mockito"   % "mockito-core"     % "2.3.7"    % Test // MIT
+      "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.105",        // ApacheV2
+      "org.mockito"   % "mockito-core"     % "2.7.17"    % Test // MIT
     )
   )
 
@@ -113,8 +113,8 @@ object Dependencies {
 
   val AwsLambda = Seq(
     libraryDependencies ++= Seq(
-      "com.amazonaws"   % "aws-java-sdk-lambda"    % "1.11.51", // ApacheV2
-      "org.mockito"   % "mockito-core"     % "2.3.7"    % Test  // MIT
+      "com.amazonaws"   % "aws-java-sdk-lambda"    % "1.11.105", // ApacheV2
+      "org.mockito"   % "mockito-core"     % "2.7.17"    % Test  // MIT
     )
   )
 

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkStage.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkStage.scala
@@ -5,12 +5,12 @@ package akka.stream.alpakka.sqs
 
 import akka.Done
 import akka.stream._
-import akka.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, InHandler, StageLogging }
+import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, InHandler, StageLogging}
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model._
 
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{Future, Promise}
 
 object SqsAckSinkSettings {
   val Defaults = SqsAckSinkSettings(maxInFlight = 10)

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkStage.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkStage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
  */
 package akka.stream.alpakka.sqs
 

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkStage.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkStage.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs
+
+import akka.Done
+import akka.stream._
+import akka.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, InHandler, StageLogging }
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.amazonaws.services.sqs.model._
+
+import scala.concurrent.{ Future, Promise }
+
+object SqsAckSinkSettings {
+  val Defaults = SqsAckSinkSettings(maxInFlight = 10)
+}
+
+//#SqsAckSinkSettings
+final case class SqsAckSinkSettings(maxInFlight: Int) {
+  require(maxInFlight > 0)
+}
+//#SqsAckSinkSettings
+
+sealed trait MessageAction
+final case class Ack() extends MessageAction
+final case class RequeueWithDelay(delaySeconds: Int) extends MessageAction
+
+class SqsAckSinkStage(queueUrl: String, settings: SqsAckSinkSettings, sqsClient: AmazonSQSAsync)
+    extends GraphStageWithMaterializedValue[SinkShape[MessageActionPair], Future[Done]] {
+
+  val in: Inlet[MessageActionPair] = Inlet("SqsAckSink.in")
+
+  override val shape: SinkShape[MessageActionPair] = SinkShape(in)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Done]) = {
+    val promise = Promise[Done]()
+    val logic = new SqsAckSinkStageLogic(queueUrl, settings, sqsClient, in, shape, promise)
+
+    (logic, promise.future)
+  }
+}
+
+private[sqs] class SqsAckSinkStageLogic(
+    queueUrl: String,
+    settings: SqsAckSinkSettings,
+    sqsClient: AmazonSQSAsync,
+    in: Inlet[MessageActionPair],
+    shape: SinkShape[MessageActionPair],
+    promise: Promise[Done]
+) extends GraphStageLogic(shape)
+    with StageLogging {
+
+  private var inFlight = 0
+  private var isShutdownInProgress = false
+  private var amazonSendMessageHandler: AsyncHandler[SendMessageRequest, SendMessageResult] = _
+  private var amazonDeleteMessageHandler: AsyncHandler[DeleteMessageRequest, DeleteMessageResult] = _
+
+  setHandler(in,
+    new InHandler {
+    override def onPush(): Unit = {
+      inFlight += 1
+      val (message, action) = grab(in)
+      action match {
+        case Ack() =>
+          sqsClient.deleteMessageAsync(
+            new DeleteMessageRequest(queueUrl, message.getReceiptHandle),
+            amazonDeleteMessageHandler
+          )
+        case RequeueWithDelay(delaySeconds) =>
+          sqsClient.sendMessageAsync(
+            new SendMessageRequest(queueUrl, message.getBody).withDelaySeconds(delaySeconds),
+            amazonSendMessageHandler
+          )
+      }
+
+      tryPull()
+    }
+
+    override def onUpstreamFailure(exception: Throwable): Unit = {
+      log.error(exception, "Upstream failure: {}", exception.getMessage)
+      failStage(exception)
+      promise.tryFailure(exception)
+    }
+
+    override def onUpstreamFinish(): Unit = {
+      log.debug("Upstream finish")
+      isShutdownInProgress = true
+      tryShutdown()
+    }
+  })
+
+  override def preStart(): Unit = {
+    setKeepGoing(true)
+
+    val failureCallback = getAsyncCallback[Throwable](handleFailure)
+    val sendCallback = getAsyncCallback[SendMessageResult](handleSend)
+    val deleteCallback = getAsyncCallback[DeleteMessageRequest](handleDelete)
+
+    amazonSendMessageHandler = new AsyncHandler[SendMessageRequest, SendMessageResult] {
+      override def onError(exception: Exception): Unit =
+        failureCallback.invoke(exception)
+
+      override def onSuccess(request: SendMessageRequest, result: SendMessageResult): Unit =
+        sendCallback.invoke(result)
+    }
+
+    amazonDeleteMessageHandler = new AsyncHandler[DeleteMessageRequest, DeleteMessageResult] {
+      override def onError(exception: Exception): Unit =
+        failureCallback.invoke(exception)
+
+      override def onSuccess(request: DeleteMessageRequest, result: DeleteMessageResult): Unit =
+        deleteCallback.invoke(request)
+    }
+
+    pull(in)
+  }
+
+  private def tryPull(): Unit =
+    if (inFlight < settings.maxInFlight && !isClosed(in) && !hasBeenPulled(in)) {
+      pull(in)
+    }
+
+  private def tryShutdown(): Unit =
+    if (isShutdownInProgress && inFlight <= 0) {
+      completeStage()
+      promise.trySuccess(Done)
+    }
+
+  private def handleFailure(exception: Throwable): Unit = {
+    log.error(exception, "Client failure: {}", exception.getMessage)
+    inFlight -= 1
+    failStage(exception)
+    promise.tryFailure(exception)
+  }
+
+  private def handleSend(result: SendMessageResult): Unit = {
+    log.debug(s"Sent message {}", result.getMessageId)
+    inFlight -= 1
+    tryShutdown()
+    tryPull()
+  }
+
+  private def handleDelete(request: DeleteMessageRequest): Unit = {
+    log.debug(s"Deleted message {}", request.getReceiptHandle)
+    inFlight -= 1
+    tryShutdown()
+    tryPull()
+  }
+}

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsAckSink.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsAckSink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
  */
 package akka.stream.alpakka.sqs.javadsl
 

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsAckSink.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsAckSink.scala
@@ -4,7 +4,7 @@
 package akka.stream.alpakka.sqs.javadsl
 
 import akka.Done
-import akka.stream.alpakka.sqs.{MessageActionPair, SqsAckSinkSettings, SqsAckSinkStage, SqsSourceStage}
+import akka.stream.alpakka.sqs.{MessageActionPair, SqsAckSinkSettings, SqsAckSinkStage}
 import akka.stream.javadsl.Sink
 import com.amazonaws.services.sqs.AmazonSQSAsync
 
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 object SqsAckSink {
 
   /**
-   * Java API: creates a [[SqsAckSinkStage]] for a SQS queue using an [[AmazonSQSAsync]]
+   * Java API: creates a [[SqsAckSinkStage]] for a SQS queue using an [[com.amazonaws.services.sqs.AmazonSQSAsync]]
    */
   def create(queueUrl: String,
              settings: SqsAckSinkSettings,
@@ -21,7 +21,7 @@ object SqsAckSink {
     Sink.fromGraph(new SqsAckSinkStage(queueUrl, settings, sqsClient))
 
   /**
-   * Java API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsync]] with default settings.
+   * Java API: creates a [[SqsAckSinkStage]] for a SQS queue using an [[com.amazonaws.services.sqs.AmazonSQSAsync]] with default settings.
    */
   def create(queueUrl: String, sqsClient: AmazonSQSAsync): Sink[MessageActionPair, Future[Done]] =
     Sink.fromGraph(new SqsAckSinkStage(queueUrl, SqsAckSinkSettings.Defaults, sqsClient))

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsAckSink.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsAckSink.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.javadsl
+
+import akka.Done
+import akka.stream.alpakka.sqs.{MessageActionPair, SqsAckSinkSettings, SqsAckSinkStage, SqsSourceStage}
+import akka.stream.javadsl.Sink
+import com.amazonaws.services.sqs.AmazonSQSAsync
+
+import scala.concurrent.Future
+
+object SqsAckSink {
+
+  /**
+   * Java API: creates a [[SqsAckSinkStage]] for a SQS queue using an [[AmazonSQSAsync]]
+   */
+  def create(queueUrl: String,
+             settings: SqsAckSinkSettings,
+             sqsClient: AmazonSQSAsync): Sink[MessageActionPair, Future[Done]] =
+    Sink.fromGraph(new SqsAckSinkStage(queueUrl, settings, sqsClient))
+
+  /**
+   * Java API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsync]] with default settings.
+   */
+  def create(queueUrl: String, sqsClient: AmazonSQSAsync): Sink[MessageActionPair, Future[Done]] =
+    Sink.fromGraph(new SqsAckSinkStage(queueUrl, SqsAckSinkSettings.Defaults, sqsClient))
+}

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/package.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
  */
 package akka.stream.alpakka
 

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/package.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/package.scala
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka
+
+import com.amazonaws.services.sqs.model.Message
+
+package object sqs {
+
+  type MessageActionPair = (Message, MessageAction)
+}

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckSink.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckSink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
  */
 package akka.stream.alpakka.sqs.scaladsl
 

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckSink.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckSink.scala
@@ -4,7 +4,7 @@
 package akka.stream.alpakka.sqs.scaladsl
 
 import akka.Done
-import akka.stream.alpakka.sqs.{ MessageActionPair, SqsAckSinkSettings, SqsAckSinkStage }
+import akka.stream.alpakka.sqs.{MessageActionPair, SqsAckSinkSettings, SqsAckSinkStage}
 import akka.stream.scaladsl.Sink
 import com.amazonaws.services.sqs.AmazonSQSAsync
 

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckSink.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckSink.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 object SqsAckSink {
 
   /**
-   * Scala API: creates a [[SqsAckSinkStage]] for a SQS queue using an [[AmazonSQSAsync]]
+   * Scala API: creates a [[SqsAckSinkStage]] for a SQS queue using an [[com.amazonaws.services.sqs.AmazonSQSAsync]]
    */
   def apply(queueUrl: String, settings: SqsAckSinkSettings = SqsAckSinkSettings.Defaults)(
       implicit sqsClient: AmazonSQSAsync): Sink[MessageActionPair, Future[Done]] =

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckSink.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckSink.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.scaladsl
+
+import akka.Done
+import akka.stream.alpakka.sqs.{ MessageActionPair, SqsAckSinkSettings, SqsAckSinkStage }
+import akka.stream.scaladsl.Sink
+import com.amazonaws.services.sqs.AmazonSQSAsync
+
+import scala.concurrent.Future
+
+object SqsAckSink {
+
+  /**
+   * Scala API: creates a [[SqsAckSinkStage]] for a SQS queue using an [[AmazonSQSAsync]]
+   */
+  def apply(queueUrl: String, settings: SqsAckSinkSettings = SqsAckSinkSettings.Defaults)(
+      implicit sqsClient: AmazonSQSAsync): Sink[MessageActionPair, Future[Done]] =
+    Sink.fromGraph(new SqsAckSinkStage(queueUrl, settings, sqsClient))
+}

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsAckSinkTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsAckSinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
  */
 package akka.stream.alpakka.sqs.javadsl;
 

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsAckSinkTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsAckSinkTest.java
@@ -70,7 +70,7 @@ public class SqsAckSinkTest {
                 }
         );
 
-        //#run
+        //#ack
         Tuple2<Message, MessageAction> pair = new Tuple2<>(
                 new Message().withBody("test"),
                 new Ack()
@@ -79,7 +79,7 @@ public class SqsAckSinkTest {
                 .single(pair)
                 .runWith(SqsAckSink.create(queueUrl, awsClient), materializer);
         Await.ready(done, new FiniteDuration(1, TimeUnit.SECONDS));
-        //#run
+        //#ack
 
         verify(awsClient).deleteMessageAsync(any(DeleteMessageRequest.class), any());
     }
@@ -98,7 +98,7 @@ public class SqsAckSinkTest {
                 }
         );
 
-        //#run
+        //#requeue
         Tuple2<Message, MessageAction> pair = new Tuple2<>(
                 new Message().withBody("test"),
                 new RequeueWithDelay(12)
@@ -107,7 +107,7 @@ public class SqsAckSinkTest {
                 .single(pair)
                 .runWith(SqsAckSink.create(queueUrl, awsClient), materializer);
         Await.ready(done, new FiniteDuration(1, TimeUnit.SECONDS));
-        //#run
+        //#requeue
 
         verify(awsClient)
                 .sendMessageAsync(

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsAckSinkTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsAckSinkTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.javadsl;
+
+import akka.Done;
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.alpakka.sqs.Ack;
+import akka.stream.alpakka.sqs.MessageAction;
+import akka.stream.alpakka.sqs.RequeueWithDelay;
+import akka.stream.javadsl.Source;
+import akka.testkit.JavaTestKit;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
+import com.amazonaws.services.sqs.model.DeleteMessageRequest;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scala.Tuple2;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class SqsAckSinkTest {
+
+    private static ActorSystem system;
+    private static ActorMaterializer materializer;
+
+
+    @BeforeClass
+    public static void setup() {
+
+        //#init-mat
+        system = ActorSystem.create();
+        materializer = ActorMaterializer.create(system);
+        //#init-mat
+
+        //#init-client
+        AWSCredentials credentials = new BasicAWSCredentials("x", "x");
+        AmazonSQSAsyncClient sqsClient = new AmazonSQSAsyncClient(credentials).withEndpoint("http://localhost:9324");
+        //#init-client
+    }
+
+    @AfterClass
+    public static void teardown() {
+        JavaTestKit.shutdownActorSystem(system);
+    }
+
+    @Test
+    public void testAcknowledge() throws Exception {
+        final String queueUrl = "none";
+        AmazonSQSAsync awsClient = spy(AmazonSQSAsync.class);
+
+        //#run
+        Tuple2<Message, MessageAction> pair = new Tuple2<>(
+                new Message().withBody("test"),
+                new Ack()
+        );
+        Future<Done> done = Source
+                .single(pair)
+                .runWith(SqsAckSink.create(queueUrl, awsClient), materializer);
+        //#run
+
+        verify(awsClient).deleteMessageAsync(any(DeleteMessageRequest.class), any());
+    }
+
+    @Test
+    public void testRequeueWithDelay() throws Exception {
+        final String queueUrl = "none";
+        AmazonSQSAsync awsClient = spy(AmazonSQSAsync.class);
+
+        //#run
+        Tuple2<Message, MessageAction> pair = new Tuple2<>(
+                new Message().withBody("test"),
+                new RequeueWithDelay(12)
+        );
+        Future<Done> done = Source
+                .single(pair)
+                .runWith(SqsAckSink.create(queueUrl, awsClient), materializer);
+        //#run
+
+        verify(awsClient)
+                .sendMessageAsync(
+                        any(SendMessageRequest.class),
+                        any()
+                );
+    }
+}

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckSinkSettingsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckSinkSettingsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
  */
 package akka.stream.alpakka.sqs.scaladsl
 

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckSinkSettingsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckSinkSettingsSpec.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.scaladsl
+
+import akka.stream.alpakka.sqs.SqsAckSinkSettings
+import org.scalatest.{ FlatSpec, Matchers }
+
+class SqsAckSinkSettingsSpec extends FlatSpec with Matchers {
+
+  it should "require valid maxInFlight" in {
+    a[IllegalArgumentException] should be thrownBy {
+      SqsAckSinkSettings(0)
+    }
+  }
+
+  it should "accept valid parameters" in {
+    SqsAckSinkSettings(1)
+  }
+}

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckSinkSettingsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckSinkSettingsSpec.scala
@@ -4,7 +4,7 @@
 package akka.stream.alpakka.sqs.scaladsl
 
 import akka.stream.alpakka.sqs.SqsAckSinkSettings
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.{FlatSpec, Matchers}
 
 class SqsAckSinkSettingsSpec extends FlatSpec with Matchers {
 

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
@@ -3,15 +3,13 @@
  */
 package akka.stream.alpakka.sqs.scaladsl
 
-import akka.stream.alpakka.sqs.{ Ack, RequeueWithDelay }
 import akka.Done
-import akka.stream.alpakka.sqs.SqsSourceSettings
+import akka.stream.alpakka.sqs.{Ack, RequeueWithDelay, SqsSourceSettings}
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
 import com.amazonaws.services.sqs.model.{DeleteMessageRequest, Message, SendMessageRequest}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{ spy, verify }
-import com.amazonaws.services.sqs.model.Message
+import org.mockito.Mockito.{spy, verify}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.Await

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
@@ -58,7 +58,12 @@ class SqsSpec extends FlatSpec with Matchers with DefaultTestContext {
     sqsClient.sendMessage(queue, "alpakka-2")
 
     val awsClientSpy = spy(sqsClient)
-    val future = SqsSource(queue).take(1).map { (_, Ack()) }.runWith(SqsAckSink(queue)(awsClientSpy))
+    val future = SqsSource(queue)
+      .take(1)
+      .map { m: Message =>
+        (m, Ack())
+      }
+      .runWith(SqsAckSink(queue)(awsClientSpy))
 
     Await.result(future, 1.second) shouldBe Done
     verify(awsClientSpy).deleteMessageAsync(any[DeleteMessageRequest], any())
@@ -69,7 +74,12 @@ class SqsSpec extends FlatSpec with Matchers with DefaultTestContext {
     sqsClient.sendMessage(queue, "alpakka-3")
 
     val awsClientSpy = spy(sqsClient)
-    val future = SqsSource(queue).take(1).map { (_, RequeueWithDelay(5)) }.runWith(SqsAckSink(queue)(awsClientSpy))
+    val future = SqsSource(queue)
+      .take(1)
+      .map { m: Message =>
+        (m, RequeueWithDelay(5))
+      }
+      .runWith(SqsAckSink(queue)(awsClientSpy))
 
     Await.result(future, 1.second) shouldBe Done
     verify(awsClientSpy).sendMessageAsync(any[SendMessageRequest], any())

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
@@ -8,7 +8,7 @@ import akka.Done
 import akka.stream.alpakka.sqs.SqsSourceSettings
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
-import com.amazonaws.services.sqs.model.{ DeleteMessageRequest, Message, SendMessageRequest }
+import com.amazonaws.services.sqs.model.{DeleteMessageRequest, Message, SendMessageRequest}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{ spy, verify }
 import com.amazonaws.services.sqs.model.Message


### PR DESCRIPTION
Second PR for #118 

Example flows. We can acknowledge messages after processing:
```scala
SqsSource(queue)
  .map { m: Message => (m, Ack()) }
  .to(SqsAckSink(queue))
```

or put messages back in the queue, for later processing:
```scala
SqsSource(queue)
  .map { m: Message => (m, RequeueWithDelay(5)) }
  .to(SqsAckSink(queue))
```
