### PR TITLE
Limit parallelism for the SqsSource

### DIFF
--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceStage.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceStage.scala
@@ -17,6 +17,16 @@ import scala.collection.JavaConverters._
 
 object SqsSourceSettings {
   val Defaults = SqsSourceSettings(20, 100, 10, None)
+
+  def create(waitTimeSeconds: Int,
+             maxBufferSize: Int,
+             maxBatchSize: Int,
+             credentials: AWSCredentials): SqsSourceSettings =
+    SqsSourceSettings(waitTimeSeconds, maxBufferSize, maxBatchSize, Some(credentials))
+
+  private def create(waitTimeSeconds: Int, maxBufferSize: Int, maxBatchSize: Int): SqsSourceSettings =
+    SqsSourceSettings(waitTimeSeconds, maxBufferSize, maxBatchSize, None)
+
 }
 
 //#SqsSourceSettings

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
@@ -14,13 +14,13 @@ import scala.concurrent.duration._
 object SqsSource {
 
   /**
-   * Java API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]]
+   * Java API: creates a [[SqsSourceStage]] for a SQS queue.
    */
   def create(queueUrl: String, settings: SqsSourceSettings): Source[Message, NotUsed] =
     Source.fromGraph(new SqsSourceStage(queueUrl, settings))
 
   /**
-   * Java API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]] with default settings.
+   * Java API: creates a [[SqsSourceStage]] for a SQS queue with default settings.
    */
   def create(queueUrl: String): Source[Message, NotUsed] =
     Source.fromGraph(new SqsSourceStage(queueUrl, SqsSourceSettings.Defaults))

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
@@ -6,22 +6,20 @@ package akka.stream.alpakka.sqs.javadsl
 import akka.NotUsed
 import akka.stream.alpakka.sqs.{SqsSourceSettings, SqsSourceStage}
 import akka.stream.javadsl.Source
-import com.amazonaws.services.sqs.AmazonSQSAsyncClient
+import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model.Message
-
-import scala.concurrent.duration._
 
 object SqsSource {
 
   /**
    * Java API: creates a [[SqsSourceStage]] for a SQS queue.
    */
-  def create(queueUrl: String, settings: SqsSourceSettings): Source[Message, NotUsed] =
-    Source.fromGraph(new SqsSourceStage(queueUrl, settings))
+  def create(queueUrl: String, settings: SqsSourceSettings, sqs: AmazonSQSAsync): Source[Message, NotUsed] =
+    Source.fromGraph(new SqsSourceStage(queueUrl, settings)(sqs))
 
   /**
    * Java API: creates a [[SqsSourceStage]] for a SQS queue with default settings.
    */
-  def create(queueUrl: String): Source[Message, NotUsed] =
-    Source.fromGraph(new SqsSourceStage(queueUrl, SqsSourceSettings.Defaults))
+  def create(queueUrl: String, sqs: AmazonSQSAsync): Source[Message, NotUsed] =
+    Source.fromGraph(new SqsSourceStage(queueUrl, SqsSourceSettings.Defaults)(sqs))
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
@@ -19,11 +19,11 @@ object SqsSource {
   def create(queueUrl: String,
              settings: SqsSourceSettings,
              sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] =
-    Source.fromGraph(new SqsSourceStage(queueUrl, settings, sqsClient))
+    Source.fromGraph(new SqsSourceStage(queueUrl, settings))
 
   /**
    * Java API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]] with default settings.
    */
   def create(queueUrl: String, sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] =
-    Source.fromGraph(new SqsSourceStage(queueUrl, SqsSourceSettings.Defaults, sqsClient))
+    Source.fromGraph(new SqsSourceStage(queueUrl, SqsSourceSettings.Defaults))
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsSource.scala
@@ -16,14 +16,12 @@ object SqsSource {
   /**
    * Java API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]]
    */
-  def create(queueUrl: String,
-             settings: SqsSourceSettings,
-             sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] =
+  def create(queueUrl: String, settings: SqsSourceSettings): Source[Message, NotUsed] =
     Source.fromGraph(new SqsSourceStage(queueUrl, settings))
 
   /**
    * Java API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]] with default settings.
    */
-  def create(queueUrl: String, sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] =
+  def create(queueUrl: String): Source[Message, NotUsed] =
     Source.fromGraph(new SqsSourceStage(queueUrl, SqsSourceSettings.Defaults))
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.sqs.scaladsl
 import akka.NotUsed
 import akka.stream.alpakka.sqs.{SqsSourceSettings, SqsSourceStage}
 import akka.stream.scaladsl.Source
-import com.amazonaws.services.sqs.AmazonSQSAsyncClient
+import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model.Message
 
 object SqsSource {
@@ -14,7 +14,9 @@ object SqsSource {
   /**
    * Scala API: creates a [[SqsSourceStage]] for a SQS queue.
    */
-  def apply(queueUrl: String, settings: SqsSourceSettings = SqsSourceSettings.Defaults): Source[Message, NotUsed] =
+  def apply(queueUrl: String, settings: SqsSourceSettings = SqsSourceSettings.Defaults)(
+      implicit sqs: AmazonSQSAsync
+  ): Source[Message, NotUsed] =
     Source.fromGraph(new SqsSourceStage(queueUrl, settings))
 
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
@@ -16,6 +16,6 @@ object SqsSource {
    */
   def apply(queueUrl: String, settings: SqsSourceSettings = SqsSourceSettings.Defaults)(
       implicit sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] =
-    Source.fromGraph(new SqsSourceStage(queueUrl, settings, sqsClient))
+    Source.fromGraph(new SqsSourceStage(queueUrl, settings))
 
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
@@ -12,10 +12,9 @@ import com.amazonaws.services.sqs.model.Message
 object SqsSource {
 
   /**
-   * Scala API: creates a [[SqsSourceStage]] for a SQS queue using an [[AmazonSQSAsyncClient]]
+   * Scala API: creates a [[SqsSourceStage]] for a SQS queue.
    */
-  def apply(queueUrl: String, settings: SqsSourceSettings = SqsSourceSettings.Defaults)(
-      implicit sqsClient: AmazonSQSAsyncClient): Source[Message, NotUsed] =
+  def apply(queueUrl: String, settings: SqsSourceSettings = SqsSourceSettings.Defaults): Source[Message, NotUsed] =
     Source.fromGraph(new SqsSourceStage(queueUrl, settings))
 
 }

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
@@ -46,12 +46,13 @@ public class SqsSourceTest {
             .withEndpoint("http://localhost:9324");
         //#init-client
 
-        sqsSourceSettings = SqsSourceSettings.create(20, 100, 10, credentials);
+        sqsSourceSettings = SqsSourceSettings.create(20, 100, 10);
     }
 
     @AfterClass
     public static void teardown() {
         JavaTestKit.shutdownActorSystem(system);
+        sqsClient.shutdown();
     }
 
     static String randomQueueUrl() {
@@ -67,7 +68,7 @@ public class SqsSourceTest {
         input.forEach(m -> sqsClient.sendMessage(queueUrl, m));
 
         //#run
-        final CompletionStage<List<String>> cs = SqsSource.create(queueUrl, sqsSourceSettings)
+        final CompletionStage<List<String>> cs = SqsSource.create(queueUrl, sqsSourceSettings, sqsClient)
             .map(m -> m.getBody())
             .take(100)
             .runWith(Sink.seq(), materializer);

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
@@ -48,7 +48,7 @@ public class SqsSourceTest {
             .withEndpoint("http://localhost:9324");
         //#init-client
 
-        sqsSourceSettings = new SqsSourceSettings(20, 100, 10, new Some<>(credentials));
+        sqsSourceSettings = SqsSourceSettings.create(20, 100, 10, credentials);
     }
 
     @AfterClass

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
@@ -14,8 +14,6 @@ import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import scala.Some;
-import scala.concurrent.duration.Duration;
 
 import java.util.List;
 import java.util.Random;

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
@@ -7,6 +7,7 @@ import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.alpakka.sqs.SqsSourceSettings;
 import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
 import akka.testkit.JavaTestKit;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -21,8 +22,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 
@@ -66,8 +65,7 @@ public class SqsSourceTest {
 
         final String queueUrl = randomQueueUrl();
 
-        final List<String> input = IntStream.range(0, 100).boxed().map(i -> String.format("alpakka-%s", i)).collect(Collectors.toList());
-        input.forEach(m -> sqsClient.sendMessage(queueUrl, m));
+        Source.range(0, 100).map(i -> String.format("alpakka-%s", i)).runForeach((m) -> sqsClient.sendMessage(queueUrl, m), materializer);
 
         //#run
         final CompletionStage<List<String>> cs = SqsSource.create(queueUrl, sqsSourceSettings, sqsClient)
@@ -76,7 +74,7 @@ public class SqsSourceTest {
             .runWith(Sink.seq(), materializer);
         //#run
 
-        assertEquals(input.size(), cs.toCompletableFuture().get(3, TimeUnit.SECONDS).size());
+        assertEquals(100, cs.toCompletableFuture().get(3, TimeUnit.SECONDS).size());
 
     }
 
@@ -91,8 +89,7 @@ public class SqsSourceTest {
 
         final String queueUrl = randomQueueUrl();
 
-        final List<String> input = IntStream.range(0, 100).boxed().map(i -> String.format("alpakka-%s", i)).collect(Collectors.toList());
-        input.forEach(m -> sqsClient.sendMessage(queueUrl, m));
+        Source.range(0, 100).map(i -> String.format("alpakka-%s", i)).runForeach((m) -> sqsClient.sendMessage(queueUrl, m), materializer);
 
         //#run
         final CompletionStage<List<String>> cs = SqsSource.create(queueUrl, sqsSourceSettings, sqsClient)
@@ -101,7 +98,7 @@ public class SqsSourceTest {
             .runWith(Sink.seq(), materializer);
         //#run
 
-        assertEquals(input.size(), cs.toCompletableFuture().get(3, TimeUnit.SECONDS).size());
+        assertEquals(100, cs.toCompletableFuture().get(3, TimeUnit.SECONDS).size());
 
     }
 }

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsSourceTest.java
@@ -5,6 +5,7 @@ package akka.stream.alpakka.sqs.javadsl;
 
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
+import akka.stream.alpakka.sqs.SqsSourceSettings;
 import akka.stream.javadsl.Sink;
 import akka.testkit.JavaTestKit;
 import com.amazonaws.auth.AWSCredentials;
@@ -13,6 +14,7 @@ import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import scala.Some;
 import scala.concurrent.duration.Duration;
 
 import java.util.List;
@@ -30,7 +32,7 @@ public class SqsSourceTest {
     static ActorMaterializer materializer;
     static AWSCredentials credentials;
     static AmazonSQSAsyncClient sqsClient;
-
+    static SqsSourceSettings sqsSourceSettings;
 
     @BeforeClass
     public static void setup() {
@@ -46,6 +48,7 @@ public class SqsSourceTest {
             .withEndpoint("http://localhost:9324");
         //#init-client
 
+        sqsSourceSettings = new SqsSourceSettings(20, 100, 10, new Some<>(credentials));
     }
 
     @AfterClass
@@ -66,7 +69,7 @@ public class SqsSourceTest {
         input.forEach(m -> sqsClient.sendMessage(queueUrl, m));
 
         //#run
-        final CompletionStage<List<String>> cs = SqsSource.create(queueUrl, sqsClient)
+        final CompletionStage<List<String>> cs = SqsSource.create(queueUrl, sqsSourceSettings)
             .map(m -> m.getBody())
             .take(100)
             .runWith(Sink.seq(), materializer);

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
@@ -25,7 +25,7 @@ trait DefaultTestContext extends BeforeAndAfterAll { this: Suite =>
   //#init-client
   val credentials = new BasicAWSCredentials("x", "x")
   implicit val sqsClient: AmazonSQSAsyncClient =
-    new AmazonSQSAsyncClient(credentials).withEndpoint("http://localhost:9324")
+    new AmazonSQSAsyncClient(credentials).withEndpoint[AmazonSQSAsyncClient]("http://localhost:9324")
   //#init-client
 
   def randomQueueUrl(): String = sqsClient.createQueue(s"queue-${Random.nextInt}").getQueueUrl

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSettingsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSettingsSpec.scala
@@ -9,32 +9,32 @@ import org.scalatest.{FlatSpec, Matchers}
 class SqsSourceSettingsSpec extends FlatSpec with Matchers {
 
   it should "accept valid parameters" in {
-    SqsSourceSettings(waitTimeSeconds = 1, maxBatchSize = 2, maxBufferSize = 3, credentials = None)
+    SqsSourceSettings(waitTimeSeconds = 1, maxBatchSize = 2, maxBufferSize = 3)
   }
 
   it should "require maxBatchSize <= maxBufferSize" in {
     a[IllegalArgumentException] should be thrownBy {
-      SqsSourceSettings(waitTimeSeconds = 1, maxBatchSize = 5, maxBufferSize = 3, credentials = None)
+      SqsSourceSettings(waitTimeSeconds = 1, maxBatchSize = 5, maxBufferSize = 3)
     }
   }
 
   it should "require waitTimeSeconds within AWS SQS limits" in {
     a[IllegalArgumentException] should be thrownBy {
-      SqsSourceSettings(waitTimeSeconds = -1, maxBatchSize = 1, maxBufferSize = 2, credentials = None)
+      SqsSourceSettings(waitTimeSeconds = -1, maxBatchSize = 1, maxBufferSize = 2)
     }
 
     a[IllegalArgumentException] should be thrownBy {
-      SqsSourceSettings(waitTimeSeconds = 100, maxBatchSize = 1, maxBufferSize = 2, credentials = None)
+      SqsSourceSettings(waitTimeSeconds = 100, maxBatchSize = 1, maxBufferSize = 2)
     }
   }
 
   it should "require maxBatchSize within AWS SQS limits" in {
     a[IllegalArgumentException] should be thrownBy {
-      SqsSourceSettings(waitTimeSeconds = 5, maxBatchSize = 0, maxBufferSize = 2, credentials = None)
+      SqsSourceSettings(waitTimeSeconds = 5, maxBatchSize = 0, maxBufferSize = 2)
     }
 
     a[IllegalArgumentException] should be thrownBy {
-      SqsSourceSettings(waitTimeSeconds = 5, maxBatchSize = 11, maxBufferSize = 2, credentials = None)
+      SqsSourceSettings(waitTimeSeconds = 5, maxBatchSize = 11, maxBufferSize = 2)
     }
   }
 }

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSettingsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSettingsSpec.scala
@@ -9,32 +9,32 @@ import org.scalatest.{FlatSpec, Matchers}
 class SqsSourceSettingsSpec extends FlatSpec with Matchers {
 
   it should "accept valid parameters" in {
-    SqsSourceSettings(waitTimeSeconds = 1, maxBatchSize = 2, maxBufferSize = 3)
+    SqsSourceSettings(waitTimeSeconds = 1, maxBatchSize = 2, maxBufferSize = 3, credentials = None)
   }
 
   it should "require maxBatchSize <= maxBufferSize" in {
     a[IllegalArgumentException] should be thrownBy {
-      SqsSourceSettings(waitTimeSeconds = 1, maxBatchSize = 5, maxBufferSize = 3)
+      SqsSourceSettings(waitTimeSeconds = 1, maxBatchSize = 5, maxBufferSize = 3, credentials = None)
     }
   }
 
   it should "require waitTimeSeconds within AWS SQS limits" in {
     a[IllegalArgumentException] should be thrownBy {
-      SqsSourceSettings(waitTimeSeconds = -1, maxBatchSize = 1, maxBufferSize = 2)
+      SqsSourceSettings(waitTimeSeconds = -1, maxBatchSize = 1, maxBufferSize = 2, credentials = None)
     }
 
     a[IllegalArgumentException] should be thrownBy {
-      SqsSourceSettings(waitTimeSeconds = 100, maxBatchSize = 1, maxBufferSize = 2)
+      SqsSourceSettings(waitTimeSeconds = 100, maxBatchSize = 1, maxBufferSize = 2, credentials = None)
     }
   }
 
   it should "require maxBatchSize within AWS SQS limits" in {
     a[IllegalArgumentException] should be thrownBy {
-      SqsSourceSettings(waitTimeSeconds = 5, maxBatchSize = 0, maxBufferSize = 2)
+      SqsSourceSettings(waitTimeSeconds = 5, maxBatchSize = 0, maxBufferSize = 2, credentials = None)
     }
 
     a[IllegalArgumentException] should be thrownBy {
-      SqsSourceSettings(waitTimeSeconds = 5, maxBatchSize = 11, maxBufferSize = 2)
+      SqsSourceSettings(waitTimeSeconds = 5, maxBatchSize = 11, maxBufferSize = 2, credentials = None)
     }
   }
 }

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
@@ -57,7 +57,7 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
 
       val queue = "http://localhost:9324/queue/not-existing"
 
-      val f = SqsSource(queue).runWith(Sink.seq)
+      val f = SqsSource(queue, sqsSourceSettings).runWith(Sink.seq)
 
       f.failed.map(_ shouldBe a[QueueDoesNotExistException])
     }

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
@@ -44,7 +44,7 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
 
       val queue = randomQueueUrl()
 
-      val f = SqsSource(queue, SqsSourceSettings(0, 100, 10)).take(1).runWith(Sink.seq)
+      val f = SqsSource(queue, SqsSourceSettings(0, 100, 10, None)).take(1).runWith(Sink.seq)
 
       sqsClient.sendMessage(queue, s"alpakka")
 

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
@@ -7,7 +7,6 @@ import java.util.concurrent.{ExecutorService, Executors}
 
 import akka.stream.alpakka.sqs.SqsSourceSettings
 import akka.stream.scaladsl.Sink
-import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import com.amazonaws.services.sqs.model.QueueDoesNotExistException
 import org.scalatest.concurrent.ScalaFutures
@@ -24,7 +23,7 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
       val queue = randomQueueUrl()
       sqsClient.sendMessage(queue, "alpakka")
 
-      SqsSource(queue, sqsSourceSettings).take(1).runWith(Sink.seq).map(_.map(_.getBody) should contain("alpakka"))
+      SqsSource(queue, sqsSourceSettings).take(1).runWith(Sink.head).map(_.getBody shouldBe "alpakka")
 
     }
 
@@ -39,7 +38,7 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
       val queue = randomQueueUrl()
       sqsClient.sendMessage(queue, "alpakka")
 
-      SqsSource(queue, sqsSourceSettings).take(1).runWith(Sink.seq).map(_.map(_.getBody) should contain("alpakka"))
+      SqsSource(queue, sqsSourceSettings).take(1).runWith(Sink.head).map(_.getBody shouldBe "alpakka")
     }
 
     "stream multiple batches from the queue" taggedAs Integration in {

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.{AsyncWordSpec, Matchers}
 
 class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with DefaultTestContext {
 
-  private val sqsSourceSettings = SqsSourceSettings.Defaults.copy(credentials = Some(credentials))
+  private val sqsSourceSettings = SqsSourceSettings.Defaults
 
   "SqsSource" should {
 
@@ -46,7 +46,7 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
 
       val queue = randomQueueUrl()
 
-      val f = SqsSource(queue, SqsSourceSettings(0, 100, 10, Some(credentials))).take(1).runWith(Sink.seq)
+      val f = SqsSource(queue, SqsSourceSettings(0, 100, 10)).take(1).runWith(Sink.seq)
 
       sqsClient.sendMessage(queue, s"alpakka")
 

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
@@ -11,6 +11,8 @@ import org.scalatest.{AsyncWordSpec, Matchers}
 
 class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with DefaultTestContext {
 
+  private val sqsSourceSettings = SqsSourceSettings.Defaults.copy(credentials = Some(credentials))
+
   "SqsSource" should {
 
     "stream a single batch from the queue" taggedAs Integration in {
@@ -18,7 +20,7 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
       val queue = randomQueueUrl()
       sqsClient.sendMessage(queue, "alpakka")
 
-      SqsSource(queue).take(1).runWith(Sink.seq).map(_.map(_.getBody) should contain("alpakka"))
+      SqsSource(queue, sqsSourceSettings).take(1).runWith(Sink.seq).map(_.map(_.getBody) should contain("alpakka"))
 
     }
 
@@ -35,7 +37,7 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
       }
 
       //#run
-      SqsSource(queue).take(100).runWith(Sink.seq).map(_ should have size 100)
+      SqsSource(queue, sqsSourceSettings).take(100).runWith(Sink.seq).map(_ should have size 100)
       //#run
 
     }
@@ -44,7 +46,7 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
 
       val queue = randomQueueUrl()
 
-      val f = SqsSource(queue, SqsSourceSettings(0, 100, 10, None)).take(1).runWith(Sink.seq)
+      val f = SqsSource(queue, SqsSourceSettings(0, 100, 10, Some(credentials))).take(1).runWith(Sink.seq)
 
       sqsClient.sendMessage(queue, s"alpakka")
 

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 
 class SqsSpec extends FlatSpec with Matchers with DefaultTestContext {
 
-  private val sqsSourceSettings = SqsSourceSettings.Defaults.copy(credentials = Some(credentials))
+  private val sqsSourceSettings = SqsSourceSettings.Defaults
 
   it should "publish and pull a message" taggedAs Integration in {
     val queue = randomQueueUrl()

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
@@ -4,6 +4,7 @@
 package akka.stream.alpakka.sqs.scaladsl
 
 import akka.Done
+import akka.stream.alpakka.sqs.SqsSourceSettings
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
 import com.amazonaws.services.sqs.model.Message
@@ -14,6 +15,8 @@ import scala.concurrent.duration._
 
 class SqsSpec extends FlatSpec with Matchers with DefaultTestContext {
 
+  private val sqsSourceSettings = SqsSourceSettings.Defaults.copy(credentials = Some(credentials))
+
   it should "publish and pull a message" taggedAs Integration in {
     val queue = randomQueueUrl()
 
@@ -22,7 +25,7 @@ class SqsSpec extends FlatSpec with Matchers with DefaultTestContext {
     Await.ready(future, 1.second)
     //#run
 
-    val probe = SqsSource(queue).runWith(TestSink.probe[Message])
+    val probe = SqsSource(queue, sqsSourceSettings).runWith(TestSink.probe[Message])
     probe.requestNext().getBody shouldBe "alpakka"
     probe.cancel()
   }
@@ -33,7 +36,7 @@ class SqsSpec extends FlatSpec with Matchers with DefaultTestContext {
 
     sqsClient.sendMessage(queue1, "alpakka")
 
-    val future = SqsSource(queue1)
+    val future = SqsSource(queue1, sqsSourceSettings)
       .take(1)
       .map { m: Message =>
         m.getBody


### PR DESCRIPTION
Fixes #135 

The solution to the issue, as proposed by @aserrallerios was to create a custom `AmazonSQSAsyncClient` with a thread pool which is limited to `maxBufferSize / maxBatchSize` threads. To make sure the maxBufferSize is not exceeded, I keep track of the number of current requests and only allow new requests if `maxBatchSize` elements would fit into the buffer for another request.

To further optimize AWS resource usage, as soon as there is a request which returns 0 messages, I assume that the queue is empty and limit the number of concurrent requests to 1. This makes sure that there will be only one request long polling for new messages. 