### PR TITLE
Fix FTP#list to recurse through sparse dirs, #165

### DIFF
--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpBrowserGraphStage.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpBrowserGraphStage.scala
@@ -62,6 +62,7 @@ private[ftp] trait FtpBrowserGraphStage[FtpClient, S <: RemoteFileSettings] exte
       private[this] def initBuffer(basePath: String) =
         getFilesFromPath(basePath)
 
+      @scala.annotation.tailrec
       private[this] def fillBuffer(): Unit = buffer match {
         case head +: tail if head.isDirectory => {
           buffer = getFilesFromPath(head.path) ++ tail

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpBrowserGraphStage.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpBrowserGraphStage.scala
@@ -35,25 +35,12 @@ private[ftp] trait FtpBrowserGraphStage[FtpClient, S <: RemoteFileSettings] exte
         def onPull(): Unit = {
           fillBuffer()
           buffer match {
-            case Seq() =>
-              finalize()
-            case head +: Seq() =>
-              if (!head.isDirectory)
-                push(out, head)
-              finalize()
             case head +: tail =>
               buffer = tail
-              if (!head.isDirectory)
-                push(out, head)
-              else
-                onPull()
+              push(out, head)
+            case _ => finalize()
           }
-          def finalize() =
-            try {
-              disconnect()
-            } finally {
-              complete(out)
-            }
+          def finalize() = try { disconnect() } finally { complete(out) }
         } // end of onPull
 
         override def onDownstreamFinish(): Unit =
@@ -75,14 +62,13 @@ private[ftp] trait FtpBrowserGraphStage[FtpClient, S <: RemoteFileSettings] exte
       private[this] def initBuffer(basePath: String) =
         getFilesFromPath(basePath)
 
-      private[this] def fillBuffer() =
-        buffer match {
-          case Seq() => // Nothing to do
-          case head +: tail =>
-            if (head.isDirectory) {
-              buffer = getFilesFromPath(head.path) ++ tail
-            }
+      private[this] def fillBuffer(): Unit = buffer match {
+        case head +: tail if head.isDirectory => {
+          buffer = getFilesFromPath(head.path) ++ tail
+          fillBuffer()
         }
+        case _ => // do nothing
+      }
 
       private[this] def getFilesFromPath(basePath: String) =
         if (basePath.isEmpty)

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpSourceSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpSourceSpec.scala
@@ -40,6 +40,16 @@ trait CommonFtpSourceSpec extends BaseSpec {
       probe.request(40).expectNextN(30)
       probe.expectComplete()
     }
+
+    "list all files in sparse directory tree" in {
+      val deepDir = "/foo/bar/baz/foobar"
+      val basePath = "/"
+      generateFiles(1, -1, deepDir)
+      val probe =
+        listFiles(basePath).toMat(TestSink.probe)(Keep.right).run()
+      probe.request(2).expectNextN(1)
+      probe.expectComplete()
+    }
   }
 
   "FtpIOSource" should {

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpSourceSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpSourceSpec.scala
@@ -21,7 +21,7 @@ trait CommonFtpSourceSpec extends BaseSpec {
   implicit val system = getSystem
   implicit val mat = getMaterializer
   implicit val defaultPatience =
-    PatienceConfig(timeout = Span(3, Seconds), interval = Span(300, Millis))
+    PatienceConfig(timeout = Span(10, Seconds), interval = Span(300, Millis))
 
   "FtpBrowserSource" should {
     "list all files from root" in {


### PR DESCRIPTION
* Change `fillBuffer` to ensure that `buffer`
  head has a file (as opposed to file or dir).
* Clean up pattern matching on Vector.