### PR TITLE
FTP: Improve testing on binary bigger files (closes #154)

### DIFF
--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpBaseSupport.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpBaseSupport.java
@@ -96,13 +96,17 @@ abstract class FtpBaseSupport implements FtpSupport, AkkaSupport {
     }
 
     public void putFileOnFtp(String path, String fileName) {
+        putFileOnFtpWithContents(path, fileName, loremIpsum.getBytes());
+    }
+
+    public void putFileOnFtpWithContents(String path, String fileName, byte[] fileContents) {
         try {
             Path baseDir = getFileSystem().getPath(path);
             if (!Files.exists(baseDir)) {
                 Files.createDirectories(baseDir);
             }
             Path filePath = baseDir.resolve(fileName);
-            Files.write(filePath, loremIpsum.getBytes());
+            Files.write(filePath, fileContents);
         } catch (Throwable t) {
             throw new RuntimeException(t);
         }

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpSupport.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpSupport.java
@@ -21,5 +21,7 @@ interface FtpSupport {
 
     void putFileOnFtp(String path, String fileName);
 
+    void putFileOnFtpWithContents(String path, String fileName, byte[] fileContents);
+
     String getLoremIpsum();
 }

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
@@ -20,6 +20,7 @@ trait BaseFtpSpec extends PlainFtpSupportImpl with BaseSpec {
     InetAddress.getByName("localhost"),
     getPort,
     AnonFtpCredentials,
+    binary = true,
     passiveMode = true
   )
   //#create-settings

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
@@ -20,6 +20,7 @@ trait BaseFtpsSpec extends FtpsSupportImpl with BaseSpec {
     InetAddress.getByName("localhost"),
     getPort,
     AnonFtpCredentials,
+    binary = true,
     passiveMode = true
   )
   //#create-settings


### PR DESCRIPTION
This PR clarifies the use of the `binary` attribute, as opposed to `ascii` or `text` mode, on both `FTP` and `FTPs` configurations. Please, take into account that this doesn't apply to the `SFTP` configuration. As of @rafacm 's  contribution, the test suite has been improved to better show the use of `binary` mode.