### PR TITLE
Implement issue #192: List S3 buckets

### DIFF
--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -11,6 +11,7 @@ akka.stream.alpakka.s3 {
     # Hostname of the proxy. If undefined ("") proxy is not enabled.
     host = ""
     port = 8000
+    scheme = "http"
   }
 
   aws {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/S3Exception.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/S3Exception.scala
@@ -3,7 +3,7 @@
  */
 package akka.stream.alpakka.s3
 
-import scala.xml.{Elem, NodeSeq, XML}
+import scala.xml.{Elem, XML}
 
 class S3Exception(val code: String, val message: String, val requestID: String, val hostId: String)
     extends RuntimeException(message) {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/S3Settings.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/S3Settings.scala
@@ -7,7 +7,7 @@ import akka.actor.ActorSystem
 import akka.stream.alpakka.s3.auth.AWSCredentials
 import com.typesafe.config.Config
 
-final case class Proxy(host: String, port: Int)
+final case class Proxy(host: String, port: Int, scheme: String)
 
 final class S3Settings(val bufferType: BufferType,
                        val diskBufferPath: String,
@@ -47,7 +47,7 @@ object S3Settings {
     debugLogging = config.getBoolean("debug-logging"),
     proxy = {
       if (config.getString("proxy.host") != "")
-        Some(Proxy(config.getString("proxy.host"), config.getInt("proxy.port")))
+        Some(Proxy(config.getString("proxy.host"), config.getInt("proxy.port"), config.getString("proxy.scheme")))
       else None
     },
     awsCredentials = AWSCredentials(config.getString("aws.access-key-id"), config.getString("aws.secret-access-key")),

--- a/s3/src/main/scala/akka/stream/alpakka/s3/auth/CanonicalRequest.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/auth/CanonicalRequest.scala
@@ -3,10 +3,9 @@
  */
 package akka.stream.alpakka.s3.auth
 
-import java.net.URLEncoder
-
 import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
+import java.net.URLEncoder
 
 // Documentation: http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
 private[alpakka] case class CanonicalRequest(method: String,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/auth/Signer.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/auth/Signer.scala
@@ -3,14 +3,12 @@
  */
 package akka.stream.alpakka.s3.auth
 
-import java.security.MessageDigest
-import java.time.format.DateTimeFormatter
-import java.time.{ZoneOffset, ZonedDateTime}
-
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
 import akka.stream.Materializer
-
+import java.security.MessageDigest
+import java.time.format.DateTimeFormatter
+import java.time.{ZoneOffset, ZonedDateTime}
 import scala.concurrent.Future
 
 private[alpakka] object Signer {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/auth/package.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/auth/package.scala
@@ -3,12 +3,10 @@
  */
 package akka.stream.alpakka.s3
 
-import java.security.MessageDigest
-import javax.xml.bind.DatatypeConverter
-
 import akka.stream.scaladsl.{Flow, Keep, Sink}
 import akka.util.ByteString
-
+import java.security.MessageDigest
+import javax.xml.bind.DatatypeConverter
 import scala.concurrent.Future
 
 package object auth {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/Chunk.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/Chunk.scala
@@ -3,8 +3,8 @@
  */
 package akka.stream.alpakka.s3.impl
 
-import akka.stream.scaladsl.Source
 import akka.NotUsed
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 
 private[alpakka] final case class Chunk(data: Source[ByteString, NotUsed], size: Int)

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/DiskBuffer.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/DiskBuffer.scala
@@ -3,25 +3,16 @@
  */
 package akka.stream.alpakka.s3.impl
 
-import java.io.{File, FileOutputStream, RandomAccessFile}
-import java.nio.channels.FileChannel
-import java.nio.file.Files
-import java.util.concurrent.atomic.AtomicInteger
-
 import akka.NotUsed
 import akka.dispatch.ExecutionContexts
-import akka.stream.ActorAttributes
-import akka.stream.Attributes
-import akka.stream.FlowShape
-import akka.stream.Inlet
-import akka.stream.Outlet
+import akka.stream.{ActorAttributes, Attributes, FlowShape, Inlet, Outlet}
 import akka.stream.scaladsl.FileIO
-import akka.stream.stage.GraphStage
-import akka.stream.stage.GraphStageLogic
-import akka.stream.stage.InHandler
-import akka.stream.stage.OutHandler
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import akka.util.ByteString
-import java.nio.file.Path
+import java.io.{File, FileOutputStream, RandomAccessFile}
+import java.nio.channels.FileChannel
+import java.nio.file.{Files, Path}
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Buffers the complete incoming stream into a file, which can then be read several times afterwards.

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
@@ -6,7 +6,6 @@ package akka.stream.alpakka.s3.impl
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport
 import akka.http.scaladsl.model.{ContentTypes, HttpCharsets, MediaTypes}
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
-
 import scala.xml.NodeSeq
 
 private[alpakka] object Marshalling {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
@@ -32,4 +32,19 @@ private[alpakka] object Marshalling {
         )
     }
   }
+  val isTruncated = "IsTruncated"
+  val continuationToken = "NextContinuationToken"
+  val key = "Key"
+
+  implicit val listBucketResultUnmarshaller: FromEntityUnmarshaller[ListBucketResult] = {
+    nodeSeqUnmarshaller(MediaTypes.`application/xml` withCharset HttpCharsets.`UTF-8`).map {
+      case NodeSeq.Empty => throw Unmarshaller.NoContentException
+      case x =>
+        ListBucketResult(
+          (x \ isTruncated).text == "true",
+          if ((x \ continuationToken).isEmpty) None else Some((x \ continuationToken).text),
+          (x \\ key).toSeq.map(_.text)
+        )
+    }
+  }
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/MemoryBuffer.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/MemoryBuffer.scala
@@ -3,9 +3,9 @@
  */
 package akka.stream.alpakka.s3.impl
 
-import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
 import akka.stream.scaladsl.Source
 import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
 import akka.util.ByteString
 
 /**

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -60,6 +60,13 @@ private[alpakka] final class S3Stream(credentials: AWSCredentials, region: Strin
   val MinChunkSize = 5242880 //in bytes
   val signingKey = SigningKey(credentials, CredentialScope(LocalDate.now(), region, "s3"))
 
+  /** listBucket lists files in a bucket, filtered by an optional prefix 
+    * 
+    * @param bucket name of the bucket
+    * @param prefix optional prefix
+    * @return A akka Source with keys
+    * 
+    */
   def listBucket(bucket: String, prefix: Option[String] = None): Source[String, NotUsed] = {
     import mat.executionContext
     def listBucketCall(continuation_token: Option[String] = None) =

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -3,9 +3,6 @@
  */
 package akka.stream.alpakka.s3.impl
 
-import java.nio.file.Paths
-import java.time.LocalDate
-
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
@@ -17,7 +14,8 @@ import akka.stream.alpakka.s3.auth.{AWSCredentials, CredentialScope, Signer, Sig
 import akka.stream.alpakka.s3.{DiskBufferType, MemoryBufferType, S3Exception, S3Settings}
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.util.ByteString
-
+import java.nio.file.Paths
+import java.time.LocalDate
 import scala.collection.immutable.Seq
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -60,13 +58,13 @@ private[alpakka] final class S3Stream(credentials: AWSCredentials, region: Strin
   val MinChunkSize = 5242880 //in bytes
   val signingKey = SigningKey(credentials, CredentialScope(LocalDate.now(), region, "s3"))
 
-  /** listBucket lists files in a bucket, filtered by an optional prefix 
-    * 
-    * @param bucket name of the bucket
-    * @param prefix optional prefix
-    * @return A akka Source with keys
-    * 
-    */
+  /** listBucket lists files in a bucket, filtered by an optional prefix
+   *
+   * @param bucket name of the bucket
+   * @param prefix optional prefix
+   * @return A akka Source with keys
+   *
+   */
   def listBucket(bucket: String, prefix: Option[String] = None): Source[String, NotUsed] = {
     import mat.executionContext
     def listBucketCall(continuation_token: Option[String] = None) =

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/SplitAfterSize.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/SplitAfterSize.scala
@@ -3,19 +3,10 @@
  */
 package akka.stream.alpakka.s3.impl
 
-import akka.stream.scaladsl.SubFlow
-import akka.stream.scaladsl.Source
-import akka.stream.stage.GraphStage
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream.scaladsl.{Flow, SubFlow}
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import akka.util.ByteString
-import akka.stream.FlowShape
-import akka.stream.Inlet
-import akka.stream.Outlet
-import akka.stream.stage.GraphStageLogic
-import akka.stream.Attributes
-import akka.stream.stage.OutHandler
-import akka.stream.stage.InHandler
-import akka.stream.scaladsl.RunnableGraph
-import akka.stream.scaladsl.Flow
 
 /**
  * Splits up a byte stream source into sub-flows of a minimum size. Does not attempt to create chunks of an exact size.

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -3,20 +3,17 @@
  */
 package akka.stream.alpakka.s3.javadsl
 
-import java.util.concurrent.CompletionStage
-
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.impl.model.JavaUri
 import akka.http.javadsl.model.{ContentType, Uri}
-import akka.http.scaladsl.model.{ContentTypes, HttpHeader, ContentType => ScalaContentType}
+import akka.http.scaladsl.model.{ContentTypes, ContentType => ScalaContentType}
 import akka.stream.Materializer
 import akka.stream.alpakka.s3.auth.AWSCredentials
 import akka.stream.alpakka.s3.impl.{CompleteMultipartUploadResult, MetaHeaders, S3Location, S3Stream}
 import akka.stream.javadsl.{Sink, Source}
 import akka.util.ByteString
-
-import scala.collection.immutable
+import java.util.concurrent.CompletionStage
 import scala.compat.java8.FutureConverters._
 
 final case class MultipartUploadResult(location: Uri, bucket: String, key: String, etag: String)
@@ -31,6 +28,9 @@ final class S3Client(credentials: AWSCredentials, region: String, system: ActorS
 
   def download(bucket: String, key: String): Source[ByteString, NotUsed] =
     impl.download(S3Location(bucket, key)).asJava
+
+  def listBucket(bucket: String, prefix: Option[String]): Source[String, NotUsed] =
+    impl.listBucket(bucket, prefix).asJava
 
   def multipartUpload(bucket: String,
                       key: String,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
@@ -5,7 +5,7 @@ package akka.stream.alpakka.s3.scaladsl
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.{ContentType, ContentTypes, HttpHeader, Uri}
+import akka.http.scaladsl.model.{ContentType, ContentTypes, Uri}
 import akka.stream.Materializer
 import akka.stream.alpakka.s3.S3Settings
 import akka.stream.alpakka.s3.acl.CannedAcl
@@ -13,8 +13,6 @@ import akka.stream.alpakka.s3.auth.AWSCredentials
 import akka.stream.alpakka.s3.impl.{CompleteMultipartUploadResult, MetaHeaders, S3Location, S3Stream}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
-
-import scala.collection.immutable
 import scala.concurrent.Future
 
 final case class MultipartUploadResult(location: Uri, bucket: String, key: String, etag: String)
@@ -39,14 +37,14 @@ final class S3Client(credentials: AWSCredentials, region: String)(implicit syste
 
   private[this] val impl = S3Stream(credentials, region)
 
-  /** listBucket lists files in a bucket, filtered by an optional prefix 
-    * 
-    * @param bucket name of the bucket
-    * @param prefix optional prefix
-    * @return A akka Source with keys
-    * 
-    */
-  def listBucket(bucket: String, prefix: Option[String]) : Source[String, NotUsed] = impl.listBucket(bucket, prefix)
+  /** listBucket lists files in a bucket, filtered by an optional prefix
+   *
+   * @param bucket name of the bucket
+   * @param prefix optional prefix
+   * @return A akka Source with keys
+   *
+   */
+  def listBucket(bucket: String, prefix: Option[String]): Source[String, NotUsed] = impl.listBucket(bucket, prefix)
 
   def download(bucket: String, key: String): Source[ByteString, NotUsed] = impl.download(S3Location(bucket, key))
 

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
@@ -39,6 +39,15 @@ final class S3Client(credentials: AWSCredentials, region: String)(implicit syste
 
   private[this] val impl = S3Stream(credentials, region)
 
+  /** listBucket lists files in a bucket, filtered by an optional prefix 
+    * 
+    * @param bucket name of the bucket
+    * @param prefix optional prefix
+    * @return A akka Source with keys
+    * 
+    */
+  def listBucket(bucket: String, prefix: Option[String]) : Source[String, NotUsed] = impl.listBucket(bucket, prefix)
+
   def download(bucket: String, key: String): Source[ByteString, NotUsed] = impl.download(S3Location(bucket, key))
 
   def multipartUpload(bucket: String,

--- a/s3/src/test/scala/akka/stream/alpakka/s3/auth/SignerSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/auth/SignerSpec.scala
@@ -3,25 +3,15 @@
  */
 package akka.stream.alpakka.s3.auth
 
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.ZoneOffset
-
-import org.scalatest.FlatSpecLike
-import org.scalatest.Matchers
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.Millis
-import org.scalatest.time.Seconds
-import org.scalatest.time.Span
-
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.HttpMethods
-import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.model.headers.Host
-import akka.http.scaladsl.model.headers.RawHeader
-import akka.stream.ActorMaterializer
-import akka.stream.ActorMaterializerSettings
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest}
+import akka.http.scaladsl.model.headers.{Host, RawHeader}
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.TestKit
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
+import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
 
 class SignerSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLike with Matchers with ScalaFutures {
   def this() = this(ActorSystem("SignerSpec"))

--- a/s3/src/test/scala/akka/stream/alpakka/s3/auth/SigningKeySpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/auth/SigningKeySpec.scala
@@ -4,7 +4,6 @@
 package akka.stream.alpakka.s3.auth
 
 import java.time.LocalDate
-
 import org.scalatest.{FlatSpec, Matchers}
 
 class SigningKeySpec extends FlatSpec with Matchers {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/auth/StreamUtilsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/auth/StreamUtilsSpec.scala
@@ -3,27 +3,18 @@
  */
 package akka.stream.alpakka.s3.auth
 
-import java.nio.charset.StandardCharsets._
-import java.nio.file.{Files, Path}
-import java.security.DigestInputStream
-import java.security.MessageDigest
-
-import scala.concurrent.Future
-
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.Millis
-import org.scalatest.time.Seconds
-import org.scalatest.time.Span
-
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.ActorMaterializerSettings
-import akka.stream.scaladsl.Source
-import akka.stream.scaladsl.StreamConverters
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
+import akka.stream.scaladsl.{Source, StreamConverters}
 import akka.testkit.TestKit
 import akka.util.ByteString
 import com.google.common.jimfs.{Configuration, Jimfs}
+import java.nio.charset.StandardCharsets._
+import java.nio.file.{Files, Path}
+import java.security.{DigestInputStream, MessageDigest}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
 class StreamUtilsSpec(_system: ActorSystem)
     extends TestKit(_system)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/DiskBufferSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/DiskBufferSpec.scala
@@ -3,18 +3,16 @@
  */
 package akka.stream.alpakka.s3.impl
 
-import java.nio.BufferOverflowException
-import java.nio.file.Files
-
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.TestKit
 import akka.util.ByteString
+import java.nio.BufferOverflowException
+import java.nio.file.Files
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import scala.concurrent.duration._
 
 class DiskBufferSpec(_system: ActorSystem)
     extends TestKit(_system)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -11,8 +11,6 @@ import akka.stream.alpakka.s3.acl.CannedAcl
 import org.scalatest.Inspectors.{forAll => iforAll}
 import org.scalatest.{FlatSpec, Matchers}
 
-import scala.collection.immutable.Seq
-
 class HttpRequestsSpec extends FlatSpec with Matchers {
   it should "initiate multipart upload when the region is us-east-1" in {
     implicit val settings = S3Settings(ActorSystem())
@@ -27,7 +25,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers {
 
     req.entity shouldEqual HttpEntity.empty(contentType)
     req.headers should contain(RawHeader("x-amz-acl", acl.value))
-    req.uri.authority.host.toString shouldEqual "bucket.s3.amazonaws.com"
+    req.uri.authority.host.toString shouldEqual "s3.amazonaws.com"
 
     metaHeaders.map { m =>
       req.headers should contain(RawHeader(s"x-amz-meta-${m._1}", m._2))
@@ -47,7 +45,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers {
 
     req.entity shouldEqual HttpEntity.empty(contentType)
     req.headers should contain(RawHeader("x-amz-acl", acl.value))
-    req.uri.authority.host.toString shouldEqual "bucket.s3-us-east-2.amazonaws.com"
+    req.uri.authority.host.toString shouldEqual "s3-us-east-2.amazonaws.com"
 
     metaHeaders.map { m =>
       req.headers should contain(RawHeader(s"x-amz-meta-${m._1}", m._2))

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/MemoryBufferSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/MemoryBufferSpec.scala
@@ -4,13 +4,13 @@
 package akka.stream.alpakka.s3.impl
 
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.TestKit
 import akka.util.ByteString
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
-import org.scalatest.concurrent.ScalaFutures
 
 class MemoryBufferSpec(_system: ActorSystem)
     extends TestKit(_system)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3NoMock.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3NoMock.scala
@@ -11,6 +11,9 @@ import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
+import akka.stream.alpakka.s3.auth.AWSCredentials
+import akka.stream.alpakka.s3.S3Settings
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -44,5 +47,16 @@ class S3NoMock extends FlatSpecLike with BeforeAndAfterAll with Matchers with Sc
     val result = download.map(_.decodeString("utf8")).runWith(Sink.head)
 
     Await.ready(result, 5.seconds).futureValue shouldBe objectValue
+  }
+
+  it should "list contents of file " ignore {
+    val region = "us-west-2"
+    val client = new S3Stream(
+      AWSCredentials("", ""),
+      region = region,
+      settings = S3Settings(actorSystem)
+    )
+    val a = client.listBucket("salesreports").runWith(Sink.foreach(println))
+    Await.ready(a, 20.seconds).futureValue shouldBe (akka.Done)
   }
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3NoMock.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3NoMock.scala
@@ -5,15 +5,13 @@ package akka.stream.alpakka.s3.impl
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.stream.alpakka.s3.S3Settings
+import akka.stream.alpakka.s3.auth.AWSCredentials
 import akka.stream.alpakka.s3.scaladsl.S3Client
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
-
-import akka.stream.alpakka.s3.auth.AWSCredentials
-import akka.stream.alpakka.s3.S3Settings
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3SinkSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3SinkSpec.scala
@@ -10,7 +10,6 @@ import akka.stream.alpakka.s3.scaladsl.{MultipartUploadResult, S3Client}
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.util.ByteString
 import com.github.tomakehurst.wiremock.client.WireMock._
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -26,18 +25,18 @@ class S3SinkSpec extends WireMockBase {
     val etag = "5b27a21a97fcf8a7004dd1d906e7a5ba"
     val url = s"http://testbucket.s3.amazonaws.com/testKey"
     mock
-      .register(post(urlEqualTo(s"/$key?uploads")).willReturn(aResponse().withStatus(200).withHeader("x-amz-id-2", "Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==").withHeader("x-amz-request-id", "656c76696e6727732072657175657374").withBody(s"""<?xml version="1.0" encoding="UTF-8"?>
+      .register(post(urlEqualTo(s"/$bucket/$key?uploads")).willReturn(aResponse().withStatus(200).withHeader("x-amz-id-2", "Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==").withHeader("x-amz-request-id", "656c76696e6727732072657175657374").withBody(s"""<?xml version="1.0" encoding="UTF-8"?>
                     |<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
                     |  <Bucket>$bucket</Bucket>
                     |  <Key>$key</Key>
                     |  <UploadId>$uploadId</UploadId>
                     |</InitiateMultipartUploadResult>""".stripMargin)))
 
-    mock.register(put(urlEqualTo(s"/$key?partNumber=1&uploadId=$uploadId"))
+    mock.register(put(urlEqualTo(s"/$bucket/$key?partNumber=1&uploadId=$uploadId"))
         .withRequestBody(matching(body))
         .willReturn(aResponse().withStatus(200).withHeader("x-amz-id-2", "Zn8bf8aEFQ+kBnGPBc/JaAf9SoWM68QDPS9+SyFwkIZOHUG2BiRLZi5oXw4cOCEt").withHeader("x-amz-request-id", "5A37448A37622243").withHeader("ETag", "\"" + etag + "\"")))
 
-    mock.register(post(urlEqualTo(s"/$key?uploadId=$uploadId"))
+    mock.register(post(urlEqualTo(s"/$bucket/$key?uploadId=$uploadId"))
         .withRequestBody(containing("CompleteMultipartUpload"))
         .withRequestBody(containing(etag))
         .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/xml; charset=UTF-8").withHeader("x-amz-id-2", "Zn8bf8aEFQ+kBnGPBc/JaAf9SoWM68QDPS9+SyFwkIZOHUG2BiRLZi5oXw4cOCEt").withHeader("x-amz-request-id", "5A37448A3762224333").withBody(s"""<?xml version="1.0" encoding="UTF-8"?>

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3SourceSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3SourceSpec.scala
@@ -9,7 +9,6 @@ import akka.stream.alpakka.s3.auth.AWSCredentials
 import akka.stream.alpakka.s3.scaladsl.S3Client
 import akka.stream.scaladsl.Sink
 import com.github.tomakehurst.wiremock.client.WireMock._
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -19,7 +18,7 @@ class S3SourceSpec extends WireMockBase {
   "S3Source" should "work in a happy case" in {
     val body = "<response>Some content</response>"
     mock
-      .register(get(urlEqualTo("/testKey")).willReturn(aResponse().withStatus(200).withHeader("ETag", "fba9dede5f27731c9771645a39863328").withBody(body)))
+      .register(get(urlEqualTo("/testBucket/testKey")).willReturn(aResponse().withStatus(200).withHeader("ETag", "fba9dede5f27731c9771645a39863328").withBody(body)))
 
     val result = new S3Client(AWSCredentials("", ""),
       "us-east-1").download("testBucket", "testKey").map(_.decodeString("utf8")).runWith(Sink.head)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/SplitAfterSizeSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/SplitAfterSizeSpec.scala
@@ -3,20 +3,14 @@
  */
 package akka.stream.alpakka.s3.impl
 
-import akka.testkit.TestKit
-import akka.stream.ActorMaterializerSettings
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.concurrent.ScalaFutures
-import akka.stream.ActorMaterializer
 import akka.actor.ActorSystem
-import org.scalatest.Matchers
-import org.scalatest.FlatSpecLike
-import akka.stream.scaladsl.Source
-import akka.stream.scaladsl.Flow
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
+import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.testkit.TestKit
 import akka.util.ByteString
-import akka.stream.scaladsl.Sink
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
-import scala.concurrent.duration._
 
 class SplitAfterSizeSpec(_system: ActorSystem)
     extends TestKit(_system)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/WireMockBase.scala
@@ -13,7 +13,6 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
-
 import scala.concurrent.duration._
 
 object WireMockBase {
@@ -28,6 +27,7 @@ object WireMockBase {
     |  stream.alpakka.s3.proxy {
     |   host = localhost
     |   port = $port
+    |   scheme = https
     | }
     |}
   """.stripMargin


### PR DESCRIPTION
Code for basic implementation of listing contents of a S3 bucket with prefix and paginated results.
I have confirmed that it works by using my own credentials in S3NoMock-test, both with and without truncation (using "&max-keys=10" this is fairly easy to test even with small buckets)

I will be happy to add more tests though, given some pointers from maintainers on what to put effort testing.