### PR TITLE
Upgrade scalafmt to 6.1. This requires contributers to manually run s…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - docker-compose up -d
 
 script:
-  - sbt -J-XX:ReservedCodeCacheSize=128m ++$TRAVIS_SCALA_VERSION ";test;docs/paradox"
+  - sbt -J-XX:ReservedCodeCacheSize=128m ++$TRAVIS_SCALA_VERSION ";test;docs/paradox;scalafmtTest"
 
 before_cache:
   - find $HOME/.ivy2 -name "ivydata-*.properties" -print -delete

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ For a Pull Request to be considered at all it has to meet these requirements:
 4. The code must be well documented (see the [Documentation](#documentation) section below).
 5. The commit messages must properly describe the changes, see [further below](#creating-commits-and-writing-commit-messages).
 6. Do not use ``@author`` tags since it does not encourage [Collective Code Ownership](http://www.extremeprogramming.org/rules/collective.html). Contributors get the credit they deserve in the release notes.
+7. Format your code with `sbt scalafmt`
 
 If these requirements are not met then the code should **not** be merged into master, or even reviewed - regardless of how good or important it is. No exceptions.
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -3,8 +3,6 @@ import sbt.Keys._
 import sbt.plugins.JvmPlugin
 import de.heikoseeberger.sbtheader._
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
-import org.scalafmt.sbt.ScalaFmtPlugin
-import org.scalafmt.sbt.ScalaFmtPlugin.autoImport._
 
 object Common extends AutoPlugin {
 
@@ -18,8 +16,7 @@ object Common extends AutoPlugin {
 
   override def requires = JvmPlugin && HeaderPlugin
 
-  override lazy val projectSettings = reformatOnCompileSettings ++
-    Dependencies.Common ++ Seq(
+  override lazy val projectSettings = Dependencies.Common ++ Seq(
     organization := "com.lightbend.akka",
     organizationName := "Lightbend Inc.",
     homepage := Some(url("https://github.com/akka/alpakka")),
@@ -63,8 +60,6 @@ object Common extends AutoPlugin {
       "java" -> FileHeader
     ),
 
-    formatSbtFiles := false,
-    scalafmtConfig := Some(baseDirectory.in(ThisBuild).value / ".scalafmt.conf"),
     ivyScala := ivyScala.value.map(_.copy(overrideScalaVersion = sbtPlugin.value)) // TODO Remove once this workaround no longer needed (https://github.com/sbt/sbt/issues/2786)!
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,10 @@
-addSbtPlugin("de.heikoseeberger"                 % "sbt-header"       % "1.6.0")
-addSbtPlugin("com.geirsson"                      % "sbt-scalafmt"     % "0.4.10")
-addSbtPlugin("com.dwijnand"                      % "sbt-dynver"       % "1.1.1")
-addSbtPlugin("com.lightbend.paradox"             % "sbt-paradox"      % "0.2.9")
-addSbtPlugin("com.eed3si9n"                      % "sbt-unidoc"       % "0.3.3")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.6.0")
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.6.1")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "1.1.1")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.2.9")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "1.0.0")
-addSbtPlugin("me.lessis"                         % "bintray-sbt"      % "0.3.0-8-g6d0c3f8")
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0-8-g6d0c3f8")
 
-resolvers += Resolver.url("2m-sbt-plugin-releases", url("https://dl.bintray.com/2m/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
+resolvers += Resolver.url("2m-sbt-plugin-releases",
+  url("https://dl.bintray.com/2m/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)


### PR DESCRIPTION
…calafmt, and travis to check it.


Hi, let me start by saying I love scalafmt, and I liked how it was setup with scalafmt-on-compile. Sadly thats no longer a supported feature of scalafmt and alpakka is lagging behind. There are some formatting features I'd like to propose, but arent supported in 4.10.

Anyway how about this. Upgrade to 6.1 and ask contributors to manually run scalafmt in sbt. Travis can check it for us too.

This is almost as good as scalafmt-on-compile, which isnt perfect, It freaks out my IntelliJ. :)