### PR TITLE
Added listBuckets method. Change URI style to path-style URL from virtual-hosted–style URL

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/S3Exception.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/S3Exception.scala
@@ -3,7 +3,7 @@
  */
 package akka.stream.alpakka.s3
 
-import scala.xml.{Elem, NodeSeq, XML}
+import scala.xml.{Elem, XML}
 
 class S3Exception(val code: String, val message: String, val requestID: String, val hostId: String)
     extends RuntimeException(message) {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/S3Settings.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/S3Settings.scala
@@ -7,7 +7,7 @@ import akka.actor.ActorSystem
 import akka.stream.alpakka.s3.auth.AWSCredentials
 import com.typesafe.config.Config
 
-final case class Proxy(host: String, port: Int)
+final case class Proxy(host: String, port: Int, schema: String)
 
 final class S3Settings(val bufferType: BufferType,
                        val diskBufferPath: String,
@@ -47,7 +47,8 @@ object S3Settings {
     debugLogging = config.getBoolean("debug-logging"),
     proxy = {
       if (config.getString("proxy.host") != "")
-        Some(Proxy(config.getString("proxy.host"), config.getInt("proxy.port")))
+        Some(
+          Proxy(config.getString("proxy.host"), config.getInt("proxy.port"), config.getString("proxy.schema")))
       else None
     },
     awsCredentials = AWSCredentials(config.getString("aws.access-key-id"), config.getString("aws.secret-access-key")),

--- a/s3/src/main/scala/akka/stream/alpakka/s3/auth/CanonicalRequest.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/auth/CanonicalRequest.scala
@@ -3,10 +3,9 @@
  */
 package akka.stream.alpakka.s3.auth
 
-import java.net.URLEncoder
-
 import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
+import java.net.URLEncoder
 
 // Documentation: http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
 private[alpakka] case class CanonicalRequest(method: String,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/auth/Signer.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/auth/Signer.scala
@@ -3,14 +3,12 @@
  */
 package akka.stream.alpakka.s3.auth
 
-import java.security.MessageDigest
-import java.time.format.DateTimeFormatter
-import java.time.{ZoneOffset, ZonedDateTime}
-
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
 import akka.stream.Materializer
-
+import java.security.MessageDigest
+import java.time.format.DateTimeFormatter
+import java.time.{ZoneOffset, ZonedDateTime}
 import scala.concurrent.Future
 
 private[alpakka] object Signer {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/auth/package.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/auth/package.scala
@@ -3,12 +3,10 @@
  */
 package akka.stream.alpakka.s3
 
-import java.security.MessageDigest
-import javax.xml.bind.DatatypeConverter
-
 import akka.stream.scaladsl.{Flow, Keep, Sink}
 import akka.util.ByteString
-
+import java.security.MessageDigest
+import javax.xml.bind.DatatypeConverter
 import scala.concurrent.Future
 
 package object auth {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/Chunk.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/Chunk.scala
@@ -3,8 +3,8 @@
  */
 package akka.stream.alpakka.s3.impl
 
-import akka.stream.scaladsl.Source
 import akka.NotUsed
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 
 private[alpakka] final case class Chunk(data: Source[ByteString, NotUsed], size: Int)

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/DiskBuffer.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/DiskBuffer.scala
@@ -3,25 +3,16 @@
  */
 package akka.stream.alpakka.s3.impl
 
-import java.io.{File, FileOutputStream, RandomAccessFile}
-import java.nio.channels.FileChannel
-import java.nio.file.Files
-import java.util.concurrent.atomic.AtomicInteger
-
 import akka.NotUsed
 import akka.dispatch.ExecutionContexts
-import akka.stream.ActorAttributes
-import akka.stream.Attributes
-import akka.stream.FlowShape
-import akka.stream.Inlet
-import akka.stream.Outlet
+import akka.stream.{ActorAttributes, Attributes, FlowShape, Inlet, Outlet}
 import akka.stream.scaladsl.FileIO
-import akka.stream.stage.GraphStage
-import akka.stream.stage.GraphStageLogic
-import akka.stream.stage.InHandler
-import akka.stream.stage.OutHandler
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import akka.util.ByteString
-import java.nio.file.Path
+import java.io.{File, FileOutputStream, RandomAccessFile}
+import java.nio.channels.FileChannel
+import java.nio.file.{Files, Path}
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Buffers the complete incoming stream into a file, which can then be read several times afterwards.

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -12,7 +12,6 @@ import akka.stream.alpakka.s3.S3Settings
 import akka.stream.alpakka.s3.acl.CannedAcl
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
-
 import scala.collection.immutable
 import scala.collection.immutable.Seq
 import scala.concurrent.{ExecutionContext, Future}
@@ -23,6 +22,35 @@ private[alpakka] object HttpRequests {
 
   def getDownloadRequest(s3Location: S3Location, region: String)(implicit conf: S3Settings): HttpRequest =
     s3Request(s3Location, region: String)
+
+
+  def listBuckets(
+    s3PrefixLocation: S3PrefixLocation,
+    region: String,
+    maxKeys: Option[Int],
+    marker: Option[String]
+  )(implicit conf: S3Settings): HttpRequest = {
+    val prefixQuery: Map[String, String] = s3PrefixLocation.prefix match {
+      case Some(p) => Map("prefix" -> p)
+      case None => Map[String, String]().empty
+    }
+
+    val maxKeysQuery: Map[String, String] = maxKeys match {
+      case Some(m) => Map("max-keys" -> m.toString)
+      case _ => Map[String, String]().empty
+    }
+
+    val markerQuery: Map[String, String] = marker match {
+      case Some(m) => Map("marker" -> m)
+      case _ => Map[String, String]().empty
+    }
+
+    HttpRequest(HttpMethods.GET)
+      .withHeaders(Host(requestHost(region)))
+      .withUri(
+        requestUri(s3PrefixLocation.bucket, region).withQuery(Uri.Query(prefixQuery ++ markerQuery ++ maxKeysQuery))
+      )
+  }
 
   def initiateMultipartUploadRequest(s3Location: S3Location,
                                      contentType: ContentType,
@@ -84,26 +112,34 @@ private[alpakka] object HttpRequests {
                               method: HttpMethod = HttpMethods.GET,
                               uriFn: (Uri => Uri) = identity)(implicit conf: S3Settings): HttpRequest = {
 
-    def requestHost(s3Location: S3Location, region: String)(implicit conf: S3Settings): Uri.Host =
-      conf.proxy match {
-        case None =>
-          region match {
-            case "us-east-1" => Uri.Host(s"${s3Location.bucket}.s3.amazonaws.com")
-            case _ => Uri.Host(s"${s3Location.bucket}.s3-$region.amazonaws.com")
-          }
-        case Some(proxy) => Uri.Host(proxy.host)
-      }
+    HttpRequest(method)
+      .withHeaders(Host(requestHost(region)))
+      .withUri(uriFn(requestUriWithKey(s3Location.bucket, s3Location.key, region)))
+  }
 
-    def requestUri(s3Location: S3Location, region: String)(implicit conf: S3Settings): Uri = {
-      val uri = Uri(s"/${s3Location.key}").withHost(requestHost(s3Location, region)).withScheme("https")
-      conf.proxy match {
-        case None => uri
-        case Some(proxy) => uri.withPort(proxy.port)
-      }
+  private[this] def requestHost(region: String)(implicit conf: S3Settings): Uri.Host =
+    conf.proxy match {
+      case None =>
+        region match {
+          case "us-east-1" => Uri.Host("s3.amazonaws.com")
+          case _ => Uri.Host(s"s3-$region.amazonaws.com")
+        }
+      case Some(proxy) => Uri.Host(proxy.host)
     }
 
-    HttpRequest(method)
-      .withHeaders(Host(requestHost(s3Location, region)))
-      .withUri(uriFn(requestUri(s3Location, region)))
+  private[this] def requestUri(bucket: String, region: String)(implicit conf: S3Settings): Uri = {
+    val uri = Uri(s"/$bucket").withHost(requestHost(region))
+    conf.proxy match {
+      case None => uri.withScheme("https")
+      case Some(proxy) => uri.withPort(proxy.port).withScheme(proxy.schema)
+    }
+  }
+
+  private[this] def requestUriWithKey(bucket: String, key: String, region: String)(implicit conf: S3Settings): Uri = {
+    val uri = Uri(s"/$bucket/$key").withHost(requestHost(region))
+    conf.proxy match {
+      case None => uri.withScheme("https")
+      case Some(proxy) => uri.withPort(proxy.port).withScheme(proxy.schema)
+    }
   }
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
@@ -6,7 +6,6 @@ package akka.stream.alpakka.s3.impl
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport
 import akka.http.scaladsl.model.{ContentTypes, HttpCharsets, MediaTypes}
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
-
 import scala.xml.NodeSeq
 
 private[alpakka] object Marshalling {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/MemoryBuffer.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/MemoryBuffer.scala
@@ -3,9 +3,9 @@
  */
 package akka.stream.alpakka.s3.impl
 
-import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
 import akka.stream.scaladsl.Source
 import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
 import akka.util.ByteString
 
 /**

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/SplitAfterSize.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/SplitAfterSize.scala
@@ -3,19 +3,10 @@
  */
 package akka.stream.alpakka.s3.impl
 
-import akka.stream.scaladsl.SubFlow
-import akka.stream.scaladsl.Source
-import akka.stream.stage.GraphStage
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream.scaladsl.{Flow, SubFlow}
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import akka.util.ByteString
-import akka.stream.FlowShape
-import akka.stream.Inlet
-import akka.stream.Outlet
-import akka.stream.stage.GraphStageLogic
-import akka.stream.Attributes
-import akka.stream.stage.OutHandler
-import akka.stream.stage.InHandler
-import akka.stream.scaladsl.RunnableGraph
-import akka.stream.scaladsl.Flow
 
 /**
  * Splits up a byte stream source into sub-flows of a minimum size. Does not attempt to create chunks of an exact size.

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -3,20 +3,17 @@
  */
 package akka.stream.alpakka.s3.javadsl
 
-import java.util.concurrent.CompletionStage
-
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.impl.model.JavaUri
 import akka.http.javadsl.model.{ContentType, Uri}
-import akka.http.scaladsl.model.{ContentTypes, HttpHeader, ContentType => ScalaContentType}
+import akka.http.scaladsl.model.{ContentTypes, ContentType => ScalaContentType}
 import akka.stream.Materializer
 import akka.stream.alpakka.s3.auth.AWSCredentials
-import akka.stream.alpakka.s3.impl.{CompleteMultipartUploadResult, MetaHeaders, S3Location, S3Stream}
+import akka.stream.alpakka.s3.impl.{CompleteMultipartUploadResult, MetaHeaders, S3Location, S3PrefixLocation, S3Stream}
 import akka.stream.javadsl.{Sink, Source}
 import akka.util.ByteString
-
-import scala.collection.immutable
+import java.util.concurrent.CompletionStage
 import scala.compat.java8.FutureConverters._
 
 final case class MultipartUploadResult(location: Uri, bucket: String, key: String, etag: String)
@@ -31,6 +28,11 @@ final class S3Client(credentials: AWSCredentials, region: String, system: ActorS
 
   def download(bucket: String, key: String): Source[ByteString, NotUsed] =
     impl.download(S3Location(bucket, key)).asJava
+
+  def listBuckets(s3PrefixLocation: S3PrefixLocation,
+    maxKeys: Option[Int],
+    marker: Option[String]): Source[ByteString, NotUsed] = impl.listBuckets(s3PrefixLocation, maxKeys, marker).asJava
+
 
   def multipartUpload(bucket: String,
                       key: String,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
@@ -5,16 +5,14 @@ package akka.stream.alpakka.s3.scaladsl
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.{ContentType, ContentTypes, HttpHeader, Uri}
+import akka.http.scaladsl.model.{ContentType, ContentTypes, Uri}
 import akka.stream.Materializer
 import akka.stream.alpakka.s3.S3Settings
 import akka.stream.alpakka.s3.acl.CannedAcl
 import akka.stream.alpakka.s3.auth.AWSCredentials
-import akka.stream.alpakka.s3.impl.{CompleteMultipartUploadResult, MetaHeaders, S3Location, S3Stream}
+import akka.stream.alpakka.s3.impl.{CompleteMultipartUploadResult, MetaHeaders, S3Location, S3PrefixLocation, S3Stream}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
-
-import scala.collection.immutable
 import scala.concurrent.Future
 
 final case class MultipartUploadResult(location: Uri, bucket: String, key: String, etag: String)
@@ -40,6 +38,10 @@ final class S3Client(credentials: AWSCredentials, region: String)(implicit syste
   private[this] val impl = S3Stream(credentials, region)
 
   def download(bucket: String, key: String): Source[ByteString, NotUsed] = impl.download(S3Location(bucket, key))
+
+  def listBuckets(s3PrefixLocation: S3PrefixLocation,
+                  maxKeys: Option[Int],
+                  marker: Option[String]): Source[ByteString, NotUsed] = impl.listBuckets(s3PrefixLocation, maxKeys, marker)
 
   def multipartUpload(bucket: String,
                       key: String,

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -27,7 +27,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers {
 
     req.entity shouldEqual HttpEntity.empty(contentType)
     req.headers should contain(RawHeader("x-amz-acl", acl.value))
-    req.uri.authority.host.toString shouldEqual "bucket.s3.amazonaws.com"
+    req.uri.authority.host.toString shouldEqual "s3.amazonaws.com"
 
     metaHeaders.map { m =>
       req.headers should contain(RawHeader(s"x-amz-meta-${m._1}", m._2))
@@ -47,7 +47,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers {
 
     req.entity shouldEqual HttpEntity.empty(contentType)
     req.headers should contain(RawHeader("x-amz-acl", acl.value))
-    req.uri.authority.host.toString shouldEqual "bucket.s3-us-east-2.amazonaws.com"
+    req.uri.authority.host.toString shouldEqual "s3-us-east-2.amazonaws.com"
 
     metaHeaders.map { m =>
       req.headers should contain(RawHeader(s"x-amz-meta-${m._1}", m._2))

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3SinkSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3SinkSpec.scala
@@ -26,18 +26,18 @@ class S3SinkSpec extends WireMockBase {
     val etag = "5b27a21a97fcf8a7004dd1d906e7a5ba"
     val url = s"http://testbucket.s3.amazonaws.com/testKey"
     mock
-      .register(post(urlEqualTo(s"/$key?uploads")).willReturn(aResponse().withStatus(200).withHeader("x-amz-id-2", "Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==").withHeader("x-amz-request-id", "656c76696e6727732072657175657374").withBody(s"""<?xml version="1.0" encoding="UTF-8"?>
+      .register(post(urlEqualTo(s"/$bucket/$key?uploads")).willReturn(aResponse().withStatus(200).withHeader("x-amz-id-2", "Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==").withHeader("x-amz-request-id", "656c76696e6727732072657175657374").withBody(s"""<?xml version="1.0" encoding="UTF-8"?>
                     |<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
                     |  <Bucket>$bucket</Bucket>
                     |  <Key>$key</Key>
                     |  <UploadId>$uploadId</UploadId>
                     |</InitiateMultipartUploadResult>""".stripMargin)))
 
-    mock.register(put(urlEqualTo(s"/$key?partNumber=1&uploadId=$uploadId"))
+    mock.register(put(urlEqualTo(s"/$bucket/$key?partNumber=1&uploadId=$uploadId"))
         .withRequestBody(matching(body))
         .willReturn(aResponse().withStatus(200).withHeader("x-amz-id-2", "Zn8bf8aEFQ+kBnGPBc/JaAf9SoWM68QDPS9+SyFwkIZOHUG2BiRLZi5oXw4cOCEt").withHeader("x-amz-request-id", "5A37448A37622243").withHeader("ETag", "\"" + etag + "\"")))
 
-    mock.register(post(urlEqualTo(s"/$key?uploadId=$uploadId"))
+    mock.register(post(urlEqualTo(s"/$bucket/$key?uploadId=$uploadId"))
         .withRequestBody(containing("CompleteMultipartUpload"))
         .withRequestBody(containing(etag))
         .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/xml; charset=UTF-8").withHeader("x-amz-id-2", "Zn8bf8aEFQ+kBnGPBc/JaAf9SoWM68QDPS9+SyFwkIZOHUG2BiRLZi5oXw4cOCEt").withHeader("x-amz-request-id", "5A37448A3762224333").withBody(s"""<?xml version="1.0" encoding="UTF-8"?>

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3SourceSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3SourceSpec.scala
@@ -19,7 +19,7 @@ class S3SourceSpec extends WireMockBase {
   "S3Source" should "work in a happy case" in {
     val body = "<response>Some content</response>"
     mock
-      .register(get(urlEqualTo("/testKey")).willReturn(aResponse().withStatus(200).withHeader("ETag", "fba9dede5f27731c9771645a39863328").withBody(body)))
+      .register(get(urlEqualTo("/testBucket/testKey")).willReturn(aResponse().withStatus(200).withHeader("ETag", "fba9dede5f27731c9771645a39863328").withBody(body)))
 
     val result = new S3Client(AWSCredentials("", ""),
       "us-east-1").download("testBucket", "testKey").map(_.decodeString("utf8")).runWith(Sink.head)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/WireMockBase.scala
@@ -28,6 +28,7 @@ object WireMockBase {
     |  stream.alpakka.s3.proxy {
     |   host = localhost
     |   port = $port
+    |   schema = https
     | }
     |}
   """.stripMargin


### PR DESCRIPTION
The listBuckets method is something my team has been using for awhile to get the list of all keys under and given bucket with the ability to page. 

Our team also has had to use a fork of alpakka for a while due to alpakka using virtual-hosted–style URLs which causes issues for non DNS compliant bucket names. http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html

Path-style URLs solves this issue and should not cause issues for others.  