### PR TITLE
Make external libs more visible (reactive kafka)

### DIFF
--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -4,11 +4,12 @@ Welcome to the home of the Alpakka initiative, which harbours various Akka Strea
 and data transformations for integration use cases. Here you can find documentation of the components that are
 part of this project as well as links to components that are maintained by other projects.
 
-@@ toc { .main depth=3 }
+@@ toc { .main depth=2 }
 
 @@@ index
 
 * [Connectors](connectors.md)
+* [External connectors](external-connectors.md) (hosted separately)
 * [Integration Patterns](patterns.md)
 * [Data Transformations](data-transformations.md)
 

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -4,7 +4,7 @@ Welcome to the home of the Alpakka initiative, which harbours various Akka Strea
 and data transformations for integration use cases. Here you can find documentation of the components that are
 part of this project as well as links to components that are maintained by other projects.
 
-@@ toc { .main depth=2 }
+@@ toc { .main depth=3 }
 
 @@@ index
 


### PR DESCRIPTION
Now people don't notice Kafka is in here since it's "external", expanding the TOC one more level makes it more visible.

WDYT?