### PR TITLE
FTP - append mode for toPath sink + improved upstream failure handlin…

### DIFF
--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
@@ -25,7 +25,7 @@ protected[ftp] trait FtpLike[FtpClient, S <: RemoteFileSettings] {
 
   def retrieveFileInputStream(name: String, handler: Handler): Try[InputStream]
 
-  def storeFileStream(name: String, handler: Handler): Try[OutputStream]
+  def storeFileOutputStream(name: String, handler: Handler, append: Boolean): Try[OutputStream]
 }
 
 object FtpLike {

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
@@ -76,8 +76,8 @@ private[ftp] trait FtpOperations { _: FtpLike[FTPClient, FtpFileSettings] =>
     if (is != null) is else throw new IOException(s"$name: No such file or directory")
   }
 
-  def storeFileStream(name: String, handler: Handler): Try[OutputStream] = Try {
-    val os = handler.storeFileStream(name)
+  def storeFileOutputStream(name: String, handler: Handler, append: Boolean): Try[OutputStream] = Try {
+    val os = if (append) handler.appendFileStream(name) else handler.storeFileStream(name)
     if (os != null) os else throw new IOException(s"Could not write to $name")
   }
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
@@ -52,7 +52,8 @@ private[ftp] trait FtpSourceFactory[FtpClient] { self =>
 
   protected[this] def createIOSink(
       _path: String,
-      _connectionSettings: S
+      _connectionSettings: S,
+      _append: Boolean
   )(implicit _ftpLike: FtpLike[FtpClient, S]): FtpIOSinkStage[FtpClient, S] =
     new FtpIOSinkStage[FtpClient, S] {
       lazy val name: String = ftpIOSinkName
@@ -60,6 +61,7 @@ private[ftp] trait FtpSourceFactory[FtpClient] { self =>
       val connectionSettings: S = _connectionSettings
       val ftpClient: () => FtpClient = self.ftpClient
       val ftpLike: FtpLike[FtpClient, S] = _ftpLike
+      val append: Boolean = _append
     }
 
   protected[this] def defaultSettings(

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
@@ -14,6 +14,8 @@ import java.nio.file.Paths
 import scala.collection.JavaConversions._
 import java.nio.file.attribute.PosixFilePermissions
 
+import com.jcraft.jsch.ChannelSftp.{APPEND, OVERWRITE}
+
 private[ftp] trait SftpOperations { _: FtpLike[JSch, SftpSettings] =>
 
   type Handler = ChannelSftp
@@ -87,7 +89,7 @@ private[ftp] trait SftpOperations { _: FtpLike[JSch, SftpSettings] =>
     handler.get(name)
   }
 
-  def storeFileStream(name: String, handler: Handler): Try[OutputStream] = Try {
-    handler.put(name)
+  def storeFileOutputStream(name: String, handler: Handler, append: Boolean): Try[OutputStream] = Try {
+    handler.put(name, if (append) APPEND else OVERWRITE)
   }
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -164,6 +164,7 @@ object FtpCredentials {
 
   /**
    * Non-anonymous credentials
+   *
    * @param username the username
    * @param password the password
    */

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -116,13 +116,15 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
    *
    * @param path the file path
    * @param connectionSettings connection settings
+   * @param append append data if a file already exists, overwrite the file if not
    * @return A [[Sink]] of [[ByteString]] that materializes to a [[Future]] of [[IOResult]]
    */
   def toPath(
       path: String,
-      connectionSettings: S
+      connectionSettings: S,
+      append: Boolean = false
   ): Sink[ByteString, Future[IOResult]] =
-    Sink.fromGraph(createIOSink(path, connectionSettings))
+    Sink.fromGraph(createIOSink(path, connectionSettings, append))
 
   protected[this] implicit def ftpLike: FtpLike[FtpClient, S]
 }

--- a/ftp/src/test/java/org/apache/ftpserver/filesystem/jimfs/impl/JimfsFtpFile.java
+++ b/ftp/src/test/java/org/apache/ftpserver/filesystem/jimfs/impl/JimfsFtpFile.java
@@ -19,6 +19,9 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.*;
 
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
+
 public class JimfsFtpFile implements FtpFile {
 
     private final Logger LOG = LoggerFactory.getLogger(JimfsFtpFile.class);
@@ -306,7 +309,9 @@ public class JimfsFtpFile implements FtpFile {
             throw new IOException("No write permission : " + path.getFileName());
         }
 
-        return Files.newOutputStream(path, StandardOpenOption.CREATE);
+        final OpenOption openOption = offset > 0 ? APPEND : CREATE;
+
+        return Files.newOutputStream(path, openOption);
     }
 
     public InputStream createInputStream(long offset)

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
@@ -37,7 +37,7 @@ trait BaseFtpSpec extends PlainFtpSupportImpl with BaseSpec {
   //#retrieving
 
   //#storing
-  protected def storeToPath(path: String): Sink[ByteString, Future[IOResult]] =
-    Ftp.toPath(path, settings)
+  protected def storeToPath(path: String, append: Boolean): Sink[ByteString, Future[IOResult]] =
+    Ftp.toPath(path, settings, append)
   //#storing
 }

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
@@ -32,7 +32,7 @@ trait BaseFtpsSpec extends FtpsSupportImpl with BaseSpec {
   protected def retrieveFromPath(path: String): Source[ByteString, Future[IOResult]] =
     Ftps.fromPath(path, settings)
 
-  protected def storeToPath(path: String): Sink[ByteString, Future[IOResult]] =
-    Ftps.toPath(path, settings)
+  protected def storeToPath(path: String, append: Boolean): Sink[ByteString, Future[IOResult]] =
+    Ftps.toPath(path, settings, append)
 
 }

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
@@ -33,6 +33,6 @@ trait BaseSftpSpec extends SftpSupportImpl with BaseSpec {
   protected def retrieveFromPath(path: String): Source[ByteString, Future[IOResult]] =
     Sftp.fromPath(path, settings)
 
-  protected def storeToPath(path: String): Sink[ByteString, Future[IOResult]] =
-    Sftp.toPath(path, settings)
+  protected def storeToPath(path: String, append: Boolean): Sink[ByteString, Future[IOResult]] =
+    Sftp.toPath(path, settings, append)
 }

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
@@ -28,7 +28,7 @@ trait BaseSpec
 
   protected def retrieveFromPath(path: String): Source[ByteString, Future[IOResult]]
 
-  protected def storeToPath(path: String): Sink[ByteString, Future[IOResult]]
+  protected def storeToPath(path: String, append: Boolean): Sink[ByteString, Future[IOResult]]
 
   protected def startServer(): Unit
 


### PR DESCRIPTION
…g #207 

Main thought behind this PR is that we might not need all the writing modes originally put in issue #207 . Namely, 'safe_overwrite' and 'create_new' don't have a strictly streaming nature, and they could well be implemented outside the streaming logic. On the other hand, the 'append' mode is directly related to the byte streaming logic, and fairly cheap to obtain. 