### PR TITLE
AWS-SQS: Use ChangeMessageVisibility instead of RequeueWithDelay

### DIFF
--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -117,12 +117,14 @@ Options:
 
 ### Message processing with acknowledgement
 
-`SqsAckSink` provides possibility to acknowledge (delete) or requeue a message.
+`SqsAckSink` provides possibility to acknowledge (delete) or postpone a message.
 
 Your flow must decide which action to take and push it with message:
 
- - `Ack` - delete message from the queue
- - `RequeueWithDelay(delaySeconds: Int)` - schedule a retry
+ - `Delete` - delete message from the queue
+ - `ChangeMessageVisibility(visibility: Int)` - can be used to postpone a message, or make
+ the message immediately visible to other consumers. See [official documentation](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)
+for more details. 
  
 Scala (ack)
 : @@snip (../../../../sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala) { #ack }
@@ -173,12 +175,10 @@ The code in this guide is part of runnable tests of this project. You are welcom
 
 Scala
 :   ```
-    sbt
-    > sqs/testOnly *.SqsSourceSpec
+    sbt 'project sqs' test
     ```
 
 Java
 :   ```
-    sbt
-    > sqs/testOnly *.SqsSourceTest
+    sbt 'project sqs' test
     ```

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -117,11 +117,12 @@ Options:
 
 ### Message processing with acknowledgement
 
-`SqsAckSink` provides possibility to acknowledge (delete) or postpone a message.
+`SqsAckSink` provides possibility to acknowledge (delete), ignore, or postpone a message.
 
 Your flow must decide which action to take and push it with message:
 
  - `Delete` - delete message from the queue
+ - `Ignore` - ignore the message and let it reappear in the queue after visibility timeout
  - `ChangeMessageVisibility(visibility: Int)` - can be used to postpone a message, or make
  the message immediately visible to other consumers. See [official documentation](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)
 for more details. 

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -130,13 +130,19 @@ for more details.
 Scala (ack)
 : @@snip (../../../../sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala) { #ack }
 
-Scala (requeue)
+Scala (ignore)
+: @@snip (../../../../sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala) { #ignore }
+
+Scala (change visibility timeout)
 : @@snip (../../../../sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala) { #requeue }
 
 Java (ack)
 : @@snip (../../../../sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsAckSinkTest.java) { #ack }
 
-Java (requeue)
+Java (ignore)
+: @@snip (../../../../sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsAckSinkTest.java) { #ignore }
+
+Java (change visibility timeout)
 : @@snip (../../../../sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsAckSinkTest.java) { #requeue }
 
 #### SqsAckSink configuration

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -123,7 +123,7 @@ Your flow must decide which action to take and push it with message:
 
  - `Delete` - delete message from the queue
  - `Ignore` - ignore the message and let it reappear in the queue after visibility timeout
- - `ChangeMessageVisibility(visibility: Int)` - can be used to postpone a message, or make
+ - `ChangeMessageVisibility(visibilityTimeout: Int)` - can be used to postpone a message, or make
  the message immediately visible to other consumers. See [official documentation](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)
 for more details. 
  

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -154,7 +154,7 @@ object Dependencies {
 
   val Sqs = Seq(
     libraryDependencies ++= Seq(
-      "com.amazonaws"     %  "aws-java-sdk-sqs"    % "1.11.109",             // ApacheV2
+      "com.amazonaws"     %  "aws-java-sdk-sqs"    % "1.11.119",             // ApacheV2
       "org.elasticmq"     %% "elasticmq-rest-sqs"  % "0.13.4"        % Test excludeAll(
         // elasticmq-rest-sqs depends on Akka 2.5, exclude it, so we can choose Akka version
         ExclusionRule(organization = "com.typesafe.akka") //
@@ -163,7 +163,7 @@ object Dependencies {
       "com.typesafe.akka" %% "akka-slf4j"           % AkkaVersion    % Test, // ApacheV2
       // pull up akka-http version to the latest version for elasticmq-rest-sqs
       "com.typesafe.akka" %% "akka-http"           % AkkaHttpVersion % Test, // ApacheV2
-      "org.mockito"       %  "mockito-core"        % "2.7.17"        % Test  // MIT
+      "org.mockito"       %  "mockito-core"        % "2.7.22"        % Test  // MIT
     )
   )
 

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckFlowStage.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckFlowStage.scala
@@ -130,6 +130,7 @@ private[sqs] final class SqsAckFlowStage(queueUrl: String, sqsClient: AmazonSQSA
                       }
                     }
                   )
+              case Ignore() => // do nothing
             }
             push(out, responsePromise.future)
           }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkSettings.scala
@@ -14,5 +14,8 @@ final case class SqsAckSinkSettings(maxInFlight: Int) {
 //#SqsAckSinkSettings
 
 sealed trait MessageAction
-final case class Ack() extends MessageAction
-final case class RequeueWithDelay(delaySeconds: Int) extends MessageAction
+final case class Delete() extends MessageAction
+final case class ChangeMessageVisibility(visibility: Int) extends MessageAction {
+  // SQS requirements
+  require(0 <= visibility && visibility <= 43200)
+}

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkSettings.scala
@@ -15,6 +15,7 @@ final case class SqsAckSinkSettings(maxInFlight: Int) {
 
 sealed trait MessageAction
 final case class Delete() extends MessageAction
+final case class Ignore() extends MessageAction
 final case class ChangeMessageVisibility(visibility: Int) extends MessageAction {
   // SQS requirements
   require(0 <= visibility && visibility <= 43200)

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkSettings.scala
@@ -16,7 +16,7 @@ final case class SqsAckSinkSettings(maxInFlight: Int) {
 sealed trait MessageAction
 final case class Delete() extends MessageAction
 final case class Ignore() extends MessageAction
-final case class ChangeMessageVisibility(visibility: Int) extends MessageAction {
+final case class ChangeMessageVisibility(visibilityTimeout: Int) extends MessageAction {
   // SQS requirements
-  require(0 <= visibility && visibility <= 43200)
+  require(0 <= visibilityTimeout && visibilityTimeout <= 43200)
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckFlow.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckFlow.scala
@@ -26,6 +26,6 @@ object SqsAckFlow {
  * @param message message body.
  */
 final case class AckResult(
-    metadata: AmazonWebServiceResult[ResponseMetadata],
+    metadata: Option[AmazonWebServiceResult[ResponseMetadata]],
     message: String
 )

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/ChangeMessageVisibilitySpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/ChangeMessageVisibilitySpec.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.sqs.scaladsl
+
+import akka.stream.alpakka.sqs.ChangeMessageVisibility
+import org.scalatest.{FlatSpec, Matchers}
+
+class ChangeMessageVisibilitySpec extends FlatSpec with Matchers {
+
+  it should "require valid visibility" in {
+    a[IllegalArgumentException] should be thrownBy {
+      ChangeMessageVisibility(43201)
+    }
+    a[IllegalArgumentException] should be thrownBy {
+      ChangeMessageVisibility(-1)
+    }
+  }
+
+  it should "accept valid parameters" in {
+    ChangeMessageVisibility(300)
+  }
+
+  it should "allow terminating visibility" in {
+    ChangeMessageVisibility(0)
+  }
+}


### PR DESCRIPTION
 - Fixes https://github.com/akka/alpakka/issues/257 - change message visibility instead of requeueing
 - **BREAKING** changed `Ack` to `Delete` and `RequeueWithDelay` to `ChangeMessageVisibility` - using SQS actions names
 - Added `Ignore` to ignore messages and let them reappear in the queue after visibility timeoue
 - updated dependencies
 - updated documentation

TODO
 - [x] Rebase & resolve
