### PR TITLE
Add version info and links on index page

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,23 @@
 lazy val alpakka = project
   .in(file("."))
   .enablePlugins(PublishUnidoc)
-  .aggregate(amqp, awslambda, cassandra, csv, dynamodb, files, ftp, googleCloudPubSub, hbase, ironmq, jms, mqtt, s3, simpleCodecs, sns, sqs, sse)
+  .aggregate(amqp,
+             awslambda,
+             cassandra,
+             csv,
+             dynamodb,
+             files,
+             ftp,
+             googleCloudPubSub,
+             hbase,
+             ironmq,
+             jms,
+             mqtt,
+             s3,
+             simpleCodecs,
+             sns,
+             sqs,
+             sse)
 
 lazy val amqp = project
   .enablePlugins(AutomateHeaderPlugin)
@@ -133,8 +149,12 @@ val defaultParadoxSettings: Seq[Setting[_]] = Seq(
   paradoxTheme := Some(builtinParadoxTheme("generic")),
   paradoxProperties ++= Map(
     "version" -> version.value,
-    "scala.binaryVersion" -> scalaBinaryVersion.value,
-    "extref.akka-docs.base_url" -> s"http://doc.akka.io/docs/akka/${Dependencies.AkkaVersion}/%s.html",
+    "scalaVersion" -> scalaVersion.value,
+    "scalaBinaryVersion" -> scalaBinaryVersion.value,
+    "akkaVersion" -> Dependencies.AkkaVersion,
+    "akkaHttpVersion" -> Dependencies.AkkaHttpVersion,
+    "extref.akka-docs.base_url" -> s"http://doc.akka.io/docs/akka/${Dependencies.AkkaVersion}/%s",
+    "extref.akka-http-docs.base_url" -> s"http://doc.akka.io/docs/akka-http/${Dependencies.AkkaHttpVersion}/%s",
     "extref.java-api.base_url" -> "https://docs.oracle.com/javase/8/docs/api/index.html?%s.html",
     "extref.paho-api.base_url" -> "https://www.eclipse.org/paho/files/javadoc/index.html?%s.html",
     "scaladoc.akka.base_url" -> s"http://doc.akka.io/api/akka/${Dependencies.AkkaVersion}",
@@ -154,7 +174,8 @@ lazy val docs = project
     paradoxProperties in Local ++= Map(
       // point API doc links to locally generated API docs
       "scaladoc.akka.stream.alpakka.base_url" -> rebase(
-        (baseDirectory in alpakka).value, "../../../../../"
+        (baseDirectory in alpakka).value,
+        "../../../../../"
       )((sbtunidoc.Plugin.UnidocKeys.unidoc in alpakka in Compile).value.head).get
     )
   )

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -4,6 +4,14 @@ Welcome to the home of the Alpakka initiative, which harbours various Akka Strea
 and data transformations for integration use cases. Here you can find documentation of the components that are
 part of this project as well as links to components that are maintained by other projects.
 
+The code in this documentation is compiled against
+
+* Alpakka $version$ ([Github](https://github.com/akka/alpakka))
+* Scala $scalaBinaryVersion$
+* Akka Streams $akkaVersion$ (@extref[Docs Scala](akka-docs:scala/stream/index.html), @extref[Docs Java](akka-docs:java/stream/index.html), [Github](https://github.com/akka/akka))
+* Akka Http $akkaHttpVersion$ (@extref[Docs Scala](akka-http-docs:scala.html), @extref[Docs Java](akka-http-docs:java.html), [Github](https://github.com/akka/akka-http))
+
+
 @@ toc { .main depth=2 }
 
 @@@ index


### PR DESCRIPTION
By passing versions to Paradox properties correct versions and links can be created in md files.
(Just as I did for [Akka Stream Kafka](http://doc.akka.io/docs/akka-stream-kafka/current/home.html).)