### PR TITLE
sse: Upgrade to Akka SSE 3 and make test more robust

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,9 +2,9 @@ import sbt._, Keys._
 
 object Dependencies {
 
-  val ScalaVersions = Seq("2.11.8", "2.12.1")
+  val ScalaVersions = Seq("2.11.11", "2.12.2")
   val AkkaVersion = "2.4.17"
-  val AkkaHttpVersion = "10.0.5"
+  val AkkaHttpVersion = "10.0.6"
 
   val Common = Seq(
     libraryDependencies ++= Seq(
@@ -92,7 +92,7 @@ object Dependencies {
   val Sse = Seq(
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-http"         % AkkaHttpVersion,
-      "de.heikoseeberger" %% "akka-sse"          % "2.0.0", // ApacheV2
+      "de.heikoseeberger" %% "akka-sse"          % "3.0.0", // ApacheV2
       "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test
     )
   )

--- a/sse/src/main/scala/akka/stream/alpakka/sse/javadsl/EventSource.scala
+++ b/sse/src/main/scala/akka/stream/alpakka/sse/javadsl/EventSource.scala
@@ -9,12 +9,12 @@ import akka.http.javadsl.model.{HttpRequest, HttpResponse, Uri}
 import akka.http.scaladsl.model.{HttpResponse => SHttpResponse}
 import akka.stream.Materializer
 import akka.stream.javadsl.Source
-import de.heikoseeberger.akkasse.japi.ServerSentEvent
+import de.heikoseeberger.akkasse.javadsl.model.ServerSentEvent
 import java.util.Optional
 import java.util.concurrent.CompletionStage
+import java.util.function.{Function => JFunction}
 import scala.compat.java8.FutureConverters
 import scala.compat.java8.OptionConverters
-import java.util.function.{Function => JFunction}
 
 /**
  * This stream processing stage establishes a continuous source of server-sent events from the given URI.

--- a/sse/src/main/scala/akka/stream/alpakka/sse/scaladsl/EventSource.scala
+++ b/sse/src/main/scala/akka/stream/alpakka/sse/scaladsl/EventSource.scala
@@ -11,10 +11,10 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL, Merge, Source}
 import akka.stream.{Materializer, SourceShape}
-import de.heikoseeberger.akkasse.MediaTypes.`text/event-stream`
-import de.heikoseeberger.akkasse.headers.`Last-Event-ID`
-import de.heikoseeberger.akkasse.{EventStreamUnmarshalling, ServerSentEvent}
-import de.heikoseeberger.akkasse.ServerSentEvent.heartbeat
+import de.heikoseeberger.akkasse.scaladsl.model.MediaTypes.`text/event-stream`
+import de.heikoseeberger.akkasse.scaladsl.model.ServerSentEvent
+import de.heikoseeberger.akkasse.scaladsl.model.headers.`Last-Event-ID`
+import de.heikoseeberger.akkasse.scaladsl.unmarshalling.EventStreamUnmarshalling
 import scala.concurrent.Future
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
@@ -67,7 +67,7 @@ object EventSource {
 
   private val noEvents = Future.successful(Source.empty[ServerSentEvent])
 
-  private val singleDelimiter = Source.single(heartbeat)
+  private val singleDelimiter = Source.single(ServerSentEvent.heartbeat)
 
   /**
    * @param uri URI with absolute path, e.g. "http://myserver/events
@@ -113,7 +113,7 @@ object EventSource {
       val trigger = builder.add(Source.single(initialLastEventId))
       val merge = builder.add(Merge[Option[String]](2))
       val bcast = builder.add(Broadcast[ServerSentEvent](2))
-      val events = builder.add(Flow[ServerSentEvent].filter(_ != heartbeat))
+      val events = builder.add(Flow[ServerSentEvent].filter(_ != ServerSentEvent.heartbeat))
       val delay = builder.add(Flow[Option[String]].delay(retryDelay))
       // format: OFF
       trigger ~> merge ~>   continuousEvents   ~> bcast ~> events


### PR DESCRIPTION
This is an important fix for the SSE connector, because in Akka SSE 2 heartbeats, which are used by this connector as framing delimiter, aren't ignored during unmarshalling.