### PR TITLE
Remove duplicated region argument in client methods

### DIFF
--- a/docs/src/main/paradox/s3.md
+++ b/docs/src/main/paradox/s3.md
@@ -44,7 +44,7 @@ Configuration
 ### Create an S3 client
 
 Scala
-: @@snip (../../../../s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ClientIntegrationSpec.scala) { #client }
+: @@snip (../../../../s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala) { #client }
 
 Java
 : @@snip (../../../../s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java) { #client }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/S3Settings.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/S3Settings.scala
@@ -5,16 +5,16 @@ package akka.stream.alpakka.s3
 
 import akka.actor.ActorSystem
 import akka.stream.alpakka.s3.auth.AWSCredentials
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigFactory}
 
 final case class Proxy(host: String, port: Int, scheme: String)
 
-final class S3Settings(val bufferType: BufferType,
-                       val diskBufferPath: String,
-                       val proxy: Option[Proxy],
-                       val awsCredentials: AWSCredentials,
-                       val s3Region: String,
-                       val pathStyleAccess: Boolean) {
+case class S3Settings(bufferType: BufferType,
+                      diskBufferPath: String,
+                      proxy: Option[Proxy],
+                      awsCredentials: AWSCredentials,
+                      s3Region: String,
+                      pathStyleAccess: Boolean) {
 
   override def toString: String =
     s"S3Settings($bufferType,$diskBufferPath,$proxy,$awsCredentials,$s3Region,$pathStyleAccess)"
@@ -31,27 +31,33 @@ case object DiskBufferType extends BufferType {
 }
 
 object S3Settings {
-  def apply(system: ActorSystem): S3Settings =
-    apply(system.settings.config.getConfig("akka.stream.alpakka.s3"))
+  //def apply(system: ActorSystem): S3Settings = apply(system.settings.config.getConfig("akka.stream.alpakka.s3"))
+
+  def apply(): S3Settings = apply(ConfigFactory.load())
 
   /**
    * Create [[S3Settings]] from a Config subsection.
    */
   def apply(config: Config): S3Settings = new S3Settings(
-    bufferType = config.getString("buffer") match {
+    bufferType = config.getString("akka.stream.alpakka.s3.buffer") match {
       case "memory" => MemoryBufferType
       case "disk" => DiskBufferType
       case _ => throw new IllegalArgumentException("Buffer type must be 'memory' or 'disk'")
     },
-    diskBufferPath = config.getString("disk-buffer-path"),
+    diskBufferPath = config.getString("akka.stream.alpakka.s3.disk-buffer-path"),
     proxy = {
-      if (config.getString("proxy.host") != "") {
-        val scheme = if (config.getBoolean("proxy.secure")) "https" else "http"
-        Some(Proxy(config.getString("proxy.host"), config.getInt("proxy.port"), scheme))
+      if (config.getString("akka.stream.alpakka.s3.proxy.host") != "") {
+        val scheme = if (config.getBoolean("akka.stream.alpakka.s3.proxy.secure")) "https" else "http"
+        Some(
+          Proxy(config.getString("akka.stream.alpakka.s3.proxy.host"),
+                config.getInt("akka.stream.alpakka.s3.proxy.port"),
+                scheme)
+        )
       } else None
     },
-    awsCredentials = AWSCredentials(config.getString("aws.access-key-id"), config.getString("aws.secret-access-key")),
-    s3Region = config.getString("aws.default-region"),
-    pathStyleAccess = config.getBoolean("path-style-access")
+    awsCredentials = AWSCredentials(config.getString("akka.stream.alpakka.s3.aws.access-key-id"),
+                                    config.getString("akka.stream.alpakka.s3.aws.secret-access-key")),
+    s3Region = config.getString("akka.stream.alpakka.s3.aws.default-region"),
+    pathStyleAccess = config.getBoolean("akka.stream.alpakka.s3.path-style-access")
   )
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/S3Settings.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/S3Settings.scala
@@ -9,12 +9,12 @@ import com.typesafe.config.{Config, ConfigFactory}
 
 final case class Proxy(host: String, port: Int, scheme: String)
 
-case class S3Settings(bufferType: BufferType,
-                      diskBufferPath: String,
-                      proxy: Option[Proxy],
-                      awsCredentials: AWSCredentials,
-                      s3Region: String,
-                      pathStyleAccess: Boolean) {
+final case class S3Settings(bufferType: BufferType,
+                            diskBufferPath: String,
+                            proxy: Option[Proxy],
+                            awsCredentials: AWSCredentials,
+                            s3Region: String,
+                            pathStyleAccess: Boolean) {
 
   override def toString: String =
     s"S3Settings($bufferType,$diskBufferPath,$proxy,$awsCredentials,$s3Region,$pathStyleAccess)"
@@ -31,12 +31,14 @@ case object DiskBufferType extends BufferType {
 }
 
 object S3Settings {
-  //def apply(system: ActorSystem): S3Settings = apply(system.settings.config.getConfig("akka.stream.alpakka.s3"))
-
-  def apply(): S3Settings = apply(ConfigFactory.load())
 
   /**
-   * Create [[S3Settings]] from a Config subsection.
+   * Scala API: Creates [[S3Settings]] from the [[Config]] attached to an [[ActorSystem]].
+   */
+  def apply()(implicit system: ActorSystem): S3Settings = apply(system.settings.config)
+
+  /**
+   * Scala API: Creates [[S3Settings]] from a [[Config]] object.
    */
   def apply(config: Config): S3Settings = new S3Settings(
     bufferType = config.getString("akka.stream.alpakka.s3.buffer") match {
@@ -60,4 +62,14 @@ object S3Settings {
     s3Region = config.getString("akka.stream.alpakka.s3.aws.default-region"),
     pathStyleAccess = config.getBoolean("akka.stream.alpakka.s3.path-style-access")
   )
+
+  /**
+   * Java API: Creates [[S3Settings]] from the [[Config]] attached to an [[ActorSystem]].
+   */
+  def create(system: ActorSystem) = apply()(system)
+
+  /**
+   * Java API: Creates [[S3Settings]] from a [[Config]].
+   */
+  def create(config: Config) = apply(config)
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -45,12 +45,11 @@ final case class CompleteMultipartUploadResult(location: Uri, bucket: String, ke
 
 object S3Stream {
 
-  def apply(credentials: AWSCredentials, region: String)(implicit system: ActorSystem, mat: Materializer): S3Stream =
-    new S3Stream(credentials, region, S3Settings(system))
+  def apply(credentials: AWSCredentials)(implicit system: ActorSystem, mat: Materializer): S3Stream =
+    new S3Stream(credentials, S3Settings(system))
 }
 
 private[alpakka] final class S3Stream(credentials: AWSCredentials,
-                                      region: String,
                                       val settings: S3Settings)(implicit system: ActorSystem, mat: Materializer) {
 
   import Marshalling._
@@ -58,7 +57,7 @@ private[alpakka] final class S3Stream(credentials: AWSCredentials,
 
   implicit val conf = settings
   val MinChunkSize = 5242880 //in bytes
-  val signingKey = SigningKey(credentials, CredentialScope(LocalDate.now(), region, "s3"))
+  val signingKey = SigningKey(credentials, CredentialScope(LocalDate.now(), settings.s3Region, "s3"))
 
   def download(s3Location: S3Location, range: Option[ByteRange] = None): Source[ByteString, NotUsed] = {
     import mat.executionContext
@@ -66,7 +65,7 @@ private[alpakka] final class S3Stream(credentials: AWSCredentials,
   }
 
   def request(s3Location: S3Location, rangeOption: Option[ByteRange] = None): Future[HttpResponse] = {
-    val downloadRequest = getDownloadRequest(s3Location, region)
+    val downloadRequest = getDownloadRequest(s3Location)
     signAndGet(rangeOption match {
       case Some(range) => downloadRequest.withHeaders(headers.Range(range))
       case _ => downloadRequest
@@ -89,7 +88,7 @@ private[alpakka] final class S3Stream(credentials: AWSCredentials,
                                       s3Headers: S3Headers): Future[MultipartUpload] = {
     import mat.executionContext
 
-    val req = initiateMultipartUploadRequest(s3Location, contentType, region, s3Headers)
+    val req = initiateMultipartUploadRequest(s3Location, contentType, s3Headers)
 
     val response = for {
       signedReq <- Signer.signedRequest(req, signingKey)
@@ -109,7 +108,7 @@ private[alpakka] final class S3Stream(credentials: AWSCredentials,
                                       parts: Seq[SuccessfulUploadPart]): Future[CompleteMultipartUploadResult] = {
     import mat.executionContext
 
-    for (req <- completeMultipartUploadRequest(parts.head.multipartUpload, parts.map(p => p.index -> p.etag), region);
+    for (req <- completeMultipartUploadRequest(parts.head.multipartUpload, parts.map(p => p.index -> p.etag));
          res <- signAndGetAs[CompleteMultipartUploadResult](req)) yield res
   }
 
@@ -150,7 +149,7 @@ private[alpakka] final class S3Stream(credentials: AWSCredentials,
         case (chunkedPayload, (uploadInfo, chunkIndex)) =>
           //each of the payload requests are created
           val partRequest =
-            uploadPartRequest(uploadInfo, chunkIndex, chunkedPayload.data, chunkedPayload.size, region)
+            uploadPartRequest(uploadInfo, chunkIndex, chunkedPayload.data, chunkedPayload.size)
           (partRequest, (uploadInfo, chunkIndex))
       }
       .mapAsync(parallelism) { case (req, info) => Signer.signedRequest(req, signingKey).zip(Future.successful(info)) }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -49,7 +49,7 @@ object S3Stream {
     new S3Stream(settings)
 }
 
-private[alpakka] final class S3Stream(val settings: S3Settings)(implicit system: ActorSystem, mat: Materializer) {
+private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: ActorSystem, mat: Materializer) {
 
   import Marshalling._
   import HttpRequests._

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -28,8 +28,8 @@ object MultipartUploadResult {
     new MultipartUploadResult(JavaUri(r.location), r.bucket, r.key, r.etag)
 }
 
-final class S3Client(credentials: AWSCredentials, region: String, system: ActorSystem, mat: Materializer) {
-  private val impl = S3Stream(credentials, region)(system, mat)
+final class S3Client(credentials: AWSCredentials, system: ActorSystem, mat: Materializer) {
+  private val impl = S3Stream(credentials)(system, mat)
 
   def request(bucket: String, key: String): CompletionStage[HttpResponse] =
     impl.request(S3Location(bucket, key)).map(_.asInstanceOf[HttpResponse])(system.dispatcher).toJava

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -13,11 +13,13 @@ import akka.http.javadsl.model.{ContentType, HttpResponse, Uri}
 import akka.http.scaladsl.model.{ContentTypes, ContentType => ScalaContentType}
 import akka.http.scaladsl.model.headers.{ByteRange => ScalaByteRange}
 import akka.stream.Materializer
+import akka.stream.alpakka.s3.S3Settings
 import akka.stream.alpakka.s3.acl.CannedAcl
 import akka.stream.alpakka.s3.auth.AWSCredentials
 import akka.stream.alpakka.s3.impl._
 import akka.stream.javadsl.{Sink, Source}
 import akka.util.ByteString
+import com.typesafe.config.ConfigFactory
 
 import scala.compat.java8.FutureConverters._
 
@@ -28,8 +30,20 @@ object MultipartUploadResult {
     new MultipartUploadResult(JavaUri(r.location), r.bucket, r.key, r.etag)
 }
 
-final class S3Client(credentials: AWSCredentials, system: ActorSystem, mat: Materializer) {
-  private val impl = S3Stream(credentials)(system, mat)
+object S3Client {
+  def create(system: ActorSystem, mat: Materializer): S3Client =
+    new S3Client(S3Settings(ConfigFactory.load()), system, mat)
+
+  def create(credentials: AWSCredentials, region: String)(implicit system: ActorSystem, mat: Materializer): S3Client = {
+    val settings = S3Settings
+      .apply(ConfigFactory.load())
+      .copy(awsCredentials = credentials, s3Region = region)
+    new S3Client(settings, system, mat)
+  }
+}
+
+final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materializer) {
+  private val impl = S3Stream(s3Settings)(system, mat)
 
   def request(bucket: String, key: String): CompletionStage[HttpResponse] =
     impl.request(S3Location(bucket, key)).map(_.asInstanceOf[HttpResponse])(system.dispatcher).toJava

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
@@ -29,15 +29,15 @@ object S3Client {
 
   def apply()(implicit system: ActorSystem, mat: Materializer): S3Client = {
     val s3Settings = S3Settings(system)
-    new S3Client(s3Settings.awsCredentials, s3Settings.s3Region)
+    new S3Client(s3Settings.awsCredentials)
   }
 }
 
-final class S3Client(credentials: AWSCredentials, region: String)(implicit system: ActorSystem, mat: Materializer) {
+final class S3Client(credentials: AWSCredentials)(implicit system: ActorSystem, mat: Materializer) {
 
   import S3Client._
 
-  private[this] val impl = S3Stream(credentials, region)
+  private[this] val impl = S3Stream(credentials)
 
   def request(bucket: String, key: String): Future[HttpResponse] = impl.request(S3Location(bucket, key))
 

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
@@ -14,6 +14,7 @@ import akka.stream.alpakka.s3.auth.AWSCredentials
 import akka.stream.alpakka.s3.impl._
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
+import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.Future
 
@@ -27,17 +28,22 @@ object MultipartUploadResult {
 object S3Client {
   val MinChunkSize = 5242880
 
-  def apply()(implicit system: ActorSystem, mat: Materializer): S3Client = {
-    val s3Settings = S3Settings(system)
-    new S3Client(s3Settings.awsCredentials)
+  def apply()(implicit system: ActorSystem, mat: Materializer): S3Client =
+    new S3Client(S3Settings(ConfigFactory.load()))
+
+  def apply(credentials: AWSCredentials, region: String)(implicit system: ActorSystem, mat: Materializer): S3Client = {
+    val settings = S3Settings
+      .apply(ConfigFactory.load())
+      .copy(awsCredentials = credentials, s3Region = region)
+    new S3Client(settings)
   }
 }
 
-final class S3Client(credentials: AWSCredentials)(implicit system: ActorSystem, mat: Materializer) {
+final class S3Client(s3Settings: S3Settings)(implicit system: ActorSystem, mat: Materializer) {
 
   import S3Client._
 
-  private[this] val impl = S3Stream(credentials)
+  private[this] val impl = S3Stream(s3Settings)
 
   def request(bucket: String, key: String): Future[HttpResponse] = impl.request(S3Location(bucket, key))
 

--- a/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
+++ b/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
@@ -29,7 +29,7 @@ public class S3ClientTest extends S3WireMockBase {
 
     //#client
     final AWSCredentials credentials = new BasicCredentials("my-AWS-access-key-ID", "my-AWS-password");
-    final S3Client client = new S3Client(credentials, "us-east-1", system(), materializer);
+    final S3Client client = new S3Client(credentials, system(), materializer);
     //#client
 
     @Test

--- a/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
+++ b/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
@@ -8,6 +8,10 @@ import akka.http.javadsl.model.Uri;
 import akka.http.javadsl.model.headers.ByteRange;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
+import akka.stream.alpakka.s3.BufferType;
+import akka.stream.alpakka.s3.MemoryBufferType;
+import akka.stream.alpakka.s3.Proxy;
+import akka.stream.alpakka.s3.S3Settings;
 import akka.stream.alpakka.s3.auth.AWSCredentials;
 import akka.stream.alpakka.s3.auth.BasicCredentials;
 import akka.stream.alpakka.s3.scaladsl.S3WireMockBase;
@@ -15,6 +19,7 @@ import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import org.junit.Test;
+import scala.Some;
 
 import java.util.Arrays;
 import java.util.concurrent.CompletionStage;
@@ -29,7 +34,9 @@ public class S3ClientTest extends S3WireMockBase {
 
     //#client
     final AWSCredentials credentials = new BasicCredentials("my-AWS-access-key-ID", "my-AWS-password");
-    final S3Client client = new S3Client(credentials, system(), materializer);
+    final Proxy proxy = new Proxy("localhost",port(),"http");
+    final S3Settings settings = new S3Settings(MemoryBufferType.getInstance(),"", Some.apply(proxy),credentials,"us-east-1",false);
+    final S3Client client = new S3Client(settings, system(), materializer);
     //#client
 
     @Test

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -6,8 +6,9 @@ package akka.stream.alpakka.s3.impl
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{HttpEntity, MediaTypes}
-import akka.stream.alpakka.s3.S3Settings
+import akka.stream.alpakka.s3.{BufferType, MemoryBufferType, Proxy, S3Settings}
 import akka.stream.alpakka.s3.acl.CannedAcl
+import akka.stream.alpakka.s3.auth.AWSCredentials
 import akka.stream.scaladsl.Source
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
@@ -16,40 +17,13 @@ import org.scalatest.{FlatSpec, Matchers}
 class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
 
   // test fixtures
-  val pathStyleAcessConfig =
-    """
-     |buffer = "memory"
-     |disk-buffer-path = ""
-     |debug-logging = false
-     |proxy {
-     |  host = ""
-     |  port = 8080
-     |}
-     |aws {
-     |  access-key-id = ""
-     |  secret-access-key = ""
-     |  default-region = "us-east-1"
-     |}
-     |path-style-access = true
-   """.stripMargin
-
-  val proxyConfig =
-    """
-      |buffer = "memory"
-      |disk-buffer-path = ""
-      |debug-logging = false
-      |proxy {
-      |  host = "localhost"
-      |  port = 8080
-      |  secure = false
-      |}
-      |aws {
-      |  access-key-id = ""
-      |  secret-access-key = ""
-      |  default-region = "us-east-1"
-      |}
-      |path-style-access = false
-    """.stripMargin
+  def getSettings(bufferType: BufferType = MemoryBufferType,
+                  diskBufferPath: String = "",
+                  proxy: Option[Proxy] = None,
+                  awsCredentials: AWSCredentials = AWSCredentials("", ""),
+                  s3Region: String = "us-east-1",
+                  pathStyleAccess: Boolean = false) =
+    new S3Settings(bufferType, diskBufferPath, proxy, awsCredentials, s3Region, pathStyleAccess)
 
   val location = S3Location("bucket", "image-1024@2x")
   val contentType = MediaTypes.`image/jpeg`
@@ -58,13 +32,10 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   val multipartUpload = MultipartUpload(S3Location("testBucket", "testKey"), "uploadId")
 
   it should "initiate multipart upload when the region is us-east-1" in {
-    implicit val settings = S3Settings(ActorSystem())
+    implicit val settings = getSettings()
 
     val req =
-      HttpRequests.initiateMultipartUploadRequest(location,
-                                                  contentType,
-                                                  "us-east-1",
-                                                  S3Headers(acl, MetaHeaders(metaHeaders)))
+      HttpRequests.initiateMultipartUploadRequest(location, contentType, S3Headers(acl, MetaHeaders(metaHeaders)))
 
     req.entity shouldEqual HttpEntity.empty(contentType)
     req.headers should contain(RawHeader("x-amz-acl", acl.value))
@@ -77,13 +48,10 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "initiate multipart upload with other regions" in {
-    implicit val settings = S3Settings(ActorSystem())
+    implicit val settings = getSettings(s3Region = "us-east-2")
 
     val req =
-      HttpRequests.initiateMultipartUploadRequest(location,
-                                                  contentType,
-                                                  "us-east-2",
-                                                  S3Headers(acl, MetaHeaders(metaHeaders)))
+      HttpRequests.initiateMultipartUploadRequest(location, contentType, S3Headers(acl, MetaHeaders(metaHeaders)))
 
     req.entity shouldEqual HttpEntity.empty(contentType)
     req.headers should contain(RawHeader("x-amz-acl", acl.value))
@@ -96,35 +64,29 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "initiate multipart upload with path-style access in region us-east-1" in {
-    implicit val settings = S3Settings(ConfigFactory.parseString(pathStyleAcessConfig))
+    implicit val settings = getSettings(s3Region = "us-east-1", pathStyleAccess = true)
 
     val req =
-      HttpRequests.initiateMultipartUploadRequest(location,
-                                                  contentType,
-                                                  "us-east-1",
-                                                  S3Headers(acl, MetaHeaders(metaHeaders)))
+      HttpRequests.initiateMultipartUploadRequest(location, contentType, S3Headers(acl, MetaHeaders(metaHeaders)))
 
     req.uri.authority.host.toString shouldEqual "s3.amazonaws.com"
     req.uri.path.toString shouldEqual "/bucket/image-1024@2x"
   }
 
   it should "support download requests with path-style access in region us-east-1" in {
-    implicit val settings = S3Settings(ConfigFactory.parseString(pathStyleAcessConfig))
+    implicit val settings = getSettings(s3Region = "us-east-1", pathStyleAccess = true)
 
-    val req = HttpRequests.getDownloadRequest(location, "us-east-1")
+    val req = HttpRequests.getDownloadRequest(location)
 
     req.uri.authority.host.toString shouldEqual "s3.amazonaws.com"
     req.uri.path.toString shouldEqual "/bucket/image-1024@2x"
   }
 
   it should "initiate multipart upload with path-style access in other regions" in {
-    implicit val settings = S3Settings(ConfigFactory.parseString(pathStyleAcessConfig))
+    implicit val settings = getSettings(s3Region = "us-west-2", pathStyleAccess = true)
 
     val req =
-      HttpRequests.initiateMultipartUploadRequest(location,
-                                                  contentType,
-                                                  "us-west-2",
-                                                  S3Headers(acl, MetaHeaders(metaHeaders)))
+      HttpRequests.initiateMultipartUploadRequest(location, contentType, S3Headers(acl, MetaHeaders(metaHeaders)))
 
     req.uri.authority.host.toString shouldEqual "s3-us-west-2.amazonaws.com"
     req.uri.path.toString shouldEqual "/bucket/image-1024@2x"
@@ -132,83 +94,80 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "support download requests with path-style access in other regions" in {
-    implicit val settings = S3Settings(ConfigFactory.parseString(pathStyleAcessConfig))
+    implicit val settings = getSettings(s3Region = "eu-west-1", pathStyleAccess = true)
 
-    val req = HttpRequests.getDownloadRequest(location, "eu-west-1")
+    val req = HttpRequests.getDownloadRequest(location)
 
     req.uri.authority.host.toString shouldEqual "s3-eu-west-1.amazonaws.com"
     req.uri.path.toString shouldEqual "/bucket/image-1024@2x"
   }
 
   it should "support download requests via HTTP when such scheme configured for `proxy`" in {
-    implicit val settings = S3Settings(ConfigFactory.parseString(proxyConfig))
+    implicit val settings = getSettings(s3Region = "region", proxy = Option(Proxy("localhost", 8080, "http")))
 
-    val req = HttpRequests.getDownloadRequest(location, "region")
+    val req = HttpRequests.getDownloadRequest(location)
 
     req.uri.scheme shouldEqual "http"
   }
 
   it should "support multipart init upload requests via HTTP when such scheme configured for `proxy`" in {
-    implicit val settings = S3Settings(ConfigFactory.parseString(proxyConfig))
+    implicit val settings = getSettings(s3Region = "region", proxy = Option(Proxy("localhost", 8080, "http")))
 
     val req =
-      HttpRequests.initiateMultipartUploadRequest(location,
-                                                  contentType,
-                                                  "region",
-                                                  S3Headers(acl, MetaHeaders(metaHeaders)))
+      HttpRequests.initiateMultipartUploadRequest(location, contentType, S3Headers(acl, MetaHeaders(metaHeaders)))
 
     req.uri.scheme shouldEqual "http"
   }
 
   it should "support multipart upload part requests via HTTP when such scheme configured for `proxy`" in {
-    implicit val settings = S3Settings(ConfigFactory.parseString(proxyConfig))
+    implicit val settings = getSettings(s3Region = "region", proxy = Option(Proxy("localhost", 8080, "http")))
 
     val req =
-      HttpRequests.uploadPartRequest(multipartUpload, 1, Source.empty, 1, "region")
+      HttpRequests.uploadPartRequest(multipartUpload, 1, Source.empty, 1)
 
     req.uri.scheme shouldEqual "http"
   }
 
   it should "support multipart upload complete requests via HTTP when such scheme configured for `proxy`" in {
-    implicit val settings = S3Settings(ConfigFactory.parseString(proxyConfig))
+    implicit val settings = getSettings(s3Region = "region", proxy = Option(Proxy("localhost", 8080, "http")))
     implicit val executionContext = scala.concurrent.ExecutionContext.global
 
     val reqFuture =
-      HttpRequests.completeMultipartUploadRequest(multipartUpload, (1, "part") :: Nil, "region")
+      HttpRequests.completeMultipartUploadRequest(multipartUpload, (1, "part") :: Nil)
 
     reqFuture.futureValue.uri.scheme shouldEqual "http"
   }
 
   it should "initiate multipart upload with AES-256 server side encryption" in {
-    implicit val settings = S3Settings(ActorSystem())
+    implicit val settings = getSettings(s3Region = "us-east-2", proxy = Option(Proxy("localhost", 8080, "http")))
     val s3Headers = S3Headers(ServerSideEncryption.AES256)
-    val req = HttpRequests.initiateMultipartUploadRequest(location, contentType, "us-east-2", s3Headers)
+    val req = HttpRequests.initiateMultipartUploadRequest(location, contentType, s3Headers)
 
     req.headers should contain(RawHeader("x-amz-server-side-encryption", "AES256"))
   }
 
   it should "initiate multipart upload with aws:kms server side encryption" in {
-    implicit val settings = S3Settings(ActorSystem())
+    implicit val settings = getSettings(s3Region = "us-east-2")
     val testArn = "arn:aws:kms:my-region:my-account-id:key/my-key-id"
     val s3Headers = S3Headers(ServerSideEncryption.KMS(testArn))
-    val req = HttpRequests.initiateMultipartUploadRequest(location, contentType, "us-east-2", s3Headers)
+    val req = HttpRequests.initiateMultipartUploadRequest(location, contentType, s3Headers)
 
     req.headers should contain(RawHeader("x-amz-server-side-encryption", "aws:kms"))
     req.headers should contain(RawHeader("x-amz-server-side-encryption-aws-kms-key-id", testArn))
   }
 
   it should "initiate multipart upload with custom s3 storage class" in {
-    implicit val settings = S3Settings(ActorSystem())
+    implicit val settings = getSettings(s3Region = "us-east-2")
     val s3Headers = S3Headers(StorageClass.ReducedRedundancy)
-    val req = HttpRequests.initiateMultipartUploadRequest(location, contentType, "us-east-2", s3Headers)
+    val req = HttpRequests.initiateMultipartUploadRequest(location, contentType, s3Headers)
 
     req.headers should contain(RawHeader("x-amz-storage-class", "REDUCED_REDUNDANCY"))
   }
 
   it should "initiate multipart upload with custom s3 headers" in {
-    implicit val settings = S3Settings(ActorSystem())
+    implicit val settings = getSettings(s3Region = "us-east-2")
     val s3Headers = S3Headers(Map("Cache-Control" -> "no-cache"))
-    val req = HttpRequests.initiateMultipartUploadRequest(location, contentType, "us-east-2", s3Headers)
+    val req = HttpRequests.initiateMultipartUploadRequest(location, contentType, s3Headers)
 
     req.headers should contain(RawHeader("Cache-Control", "no-cache"))
   }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ClientIntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ClientIntegrationSpec.scala
@@ -5,7 +5,6 @@ package akka.stream.alpakka.s3.scaladsl
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import akka.stream.alpakka.s3.auth.AWSCredentials
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
@@ -18,10 +17,4 @@ trait S3ClientIntegrationSpec
 
   implicit val system: ActorSystem
   implicit val materializer = ActorMaterializer()
-
-  //#client
-  val awsCredentials = AWSCredentials(accessKeyId = "my-AWS-access-key-ID", secretAccessKey = "my-AWS-password")
-  val s3Client = new S3Client(credentials = awsCredentials)(system, materializer)
-  //#client
-
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ClientIntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ClientIntegrationSpec.scala
@@ -21,7 +21,7 @@ trait S3ClientIntegrationSpec
 
   //#client
   val awsCredentials = AWSCredentials(accessKeyId = "my-AWS-access-key-ID", secretAccessKey = "my-AWS-password")
-  val s3Client = new S3Client(credentials = awsCredentials, region = "us-east-1")(system, materializer)
+  val s3Client = new S3Client(credentials = awsCredentials)(system, materializer)
   //#client
 
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
@@ -3,6 +3,8 @@
  */
 package akka.stream.alpakka.s3.scaladsl
 
+import akka.stream.alpakka.s3.auth.AWSCredentials
+import akka.stream.alpakka.s3.{MemoryBufferType, Proxy, S3Settings}
 import akka.stream.alpakka.s3.impl.{S3Headers, ServerSideEncryption}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
@@ -10,6 +12,11 @@ import akka.util.ByteString
 import scala.concurrent.Future
 
 class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
+
+  val awsCredentials = AWSCredentials(accessKeyId = "my-AWS-access-key-ID", secretAccessKey = "my-AWS-password")
+  val proxy = Option(Proxy("localhost", port, "http"))
+  val settings = new S3Settings(MemoryBufferType, "", proxy, awsCredentials, "us-east-1", false)
+  val s3Client = new S3Client(settings)(system, materializer)
 
   "S3Sink" should "upload a stream of bytes to S3" in {
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
@@ -5,13 +5,21 @@ package akka.stream.alpakka.s3.scaladsl
 
 import akka.NotUsed
 import akka.http.scaladsl.model.headers.ByteRange
-import akka.stream.alpakka.s3.S3Exception
+import akka.stream.alpakka.s3.auth.AWSCredentials
+import akka.stream.alpakka.s3.{MemoryBufferType, Proxy, S3Exception, S3Settings}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 
 import scala.concurrent.Future
 
 class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
+
+  //#client
+  val awsCredentials = AWSCredentials(accessKeyId = "my-AWS-access-key-ID", secretAccessKey = "my-AWS-password")
+  val proxy = Option(Proxy("localhost", port, "http"))
+  val settings = new S3Settings(MemoryBufferType, "", proxy, awsCredentials, "us-east-1", false)
+  val s3Client = new S3Client(settings)(system, materializer)
+  //#client
 
   "S3Source" should "download a stream of bytes from S3" in {
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -15,10 +15,11 @@ import com.github.tomakehurst.wiremock.matching.EqualToPattern
 
 abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockServer) extends TestKit(_system) {
 
-  def this(mock: WireMockServer) = this(ActorSystem(getCallerName(getClass), config(mock.httpsPort())), mock)
+  def this(mock: WireMockServer) = this(ActorSystem(getCallerName(getClass)), mock)
   def this() = this(initServer())
 
   val mock = new WireMock("localhost", _wireMockServer.port())
+  val port = _wireMockServer.port()
 
   def mock404s(): Unit =
     mock.register(
@@ -116,21 +117,6 @@ abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockSer
 }
 
 private object S3WireMockBase {
-  def config(port: Int) = ConfigFactory.parseString(
-    s"""
-    |akka {
-    |  loggers = ["akka.testkit.TestEventListener"]
-    |
-    |  ssl-config.trustManager.stores = [
-    |        {type = "PEM", path = "./s3/src/test/resources/rootCA.crt"}
-    |      ]
-    |  stream.alpakka.s3.proxy {
-    |   host = localhost
-    |   port = $port
-    | }
-    |}
-  """.stripMargin
-  )
 
   def getCallerName(clazz: Class[_]): String = {
     val s = (Thread.currentThread.getStackTrace map (_.getClassName) drop 1)


### PR DESCRIPTION
In my opinion an S3 client should be configured for a region via the config file.