### PR TITLE
PubSub: Add support for emulator host variables

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,9 @@ lazy val googleCloudPubSub = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "akka-stream-alpakka-google-cloud-pub-sub",
-    Dependencies.GooglePubSub
+    Dependencies.GooglePubSub,
+    fork in Test := true,
+    envVars in Test := Map("PUBSUB_EMULATOR_HOST" -> "localhost:8538")
   )
 
 lazy val hbase = project

--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/HttpApi.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/HttpApi.scala
@@ -27,8 +27,17 @@ import scala.collection.immutable
  */
 @akka.annotation.InternalApi
 private object HttpApi extends HttpApi {
-  val PubSubGoogleApisHost = "https://pubsub.googleapis.com"
-  val GoogleApisHost = "https://www.googleapis.com"
+  val DefaultPubSubGoogleApisHost = "https://pubsub.googleapis.com"
+  val DefaultGoogleApisHost = "https://www.googleapis.com"
+  val PubSubEmulatorHostVarName = "PUBSUB_EMULATOR_HOST"
+
+  val PubSubGoogleApisHost: String = PubSubEmulatorHost.getOrElse(DefaultPubSubGoogleApisHost)
+  val GoogleApisHost: String = PubSubEmulatorHost.getOrElse(DefaultGoogleApisHost)
+
+  private[pubsub] lazy val PubSubEmulatorHost: Option[String] = sys.props
+    .get(PubSubEmulatorHostVarName)
+    .orElse(sys.env.get(PubSubEmulatorHostVarName))
+    .map(host => s"http://$host")
 
   private case class PullRequest(returnImmediately: Boolean, maxMessages: Int)
 }

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/HttpApiSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/HttpApiSpec.scala
@@ -173,6 +173,18 @@ class HttpApiSpec extends FlatSpec with BeforeAndAfterAll with ScalaFutures with
     result.futureValue shouldBe (())
   }
 
+  private val httpApi = HttpApi
+  if (httpApi.PubSubEmulatorHost.isDefined) it should "honor emulator host variables" in {
+    val emulatorVar = sys.props
+      .get(httpApi.PubSubEmulatorHostVarName)
+      .orElse(sys.env.get(httpApi.PubSubEmulatorHostVarName))
+
+    emulatorVar.foreach { emulatorHost =>
+      httpApi.PubSubGoogleApisHost shouldEqual s"http://$emulatorHost"
+      httpApi.GoogleApisHost shouldEqual s"http://$emulatorHost"
+    }
+  }
+
   override def afterAll(): Unit = {
     wiremockServer.stop()
     Await.result(system.terminate(), 5.seconds)


### PR DESCRIPTION
Works whether the `PUBSUB_EMULATOR_HOST` variable is defined as a property or as environment variable.

Refs: #286 