### PR TITLE
#310 exclude newer Akka dependency

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -115,7 +115,12 @@ object Dependencies {
   val Sqs = Seq(
     libraryDependencies ++= Seq(
       "com.amazonaws"     %  "aws-java-sdk-sqs"    % "1.11.109",             // ApacheV2
-      "org.elasticmq"     %% "elasticmq-rest-sqs"  % "0.13.4"        % Test, // ApacheV2
+      "org.elasticmq"     %% "elasticmq-rest-sqs"  % "0.13.4"        % Test excludeAll(
+        // elasticmq-rest-sqs depends on Akka 2.5, exclude it, so we can choose Akka version
+        ExclusionRule(organization = "com.typesafe.akka") //
+      ), // ApacheV2
+      // elasticmq-rest-sqs depends on akka-slf4j which was excluded
+      "com.typesafe.akka" %% "akka-slf4j"           % AkkaVersion    % Test, // ApacheV2
       // pull up akka-http version to the latest version for elasticmq-rest-sqs
       "com.typesafe.akka" %% "akka-http"           % AkkaHttpVersion % Test, // ApacheV2
       "org.mockito"       %  "mockito-core"        % "2.7.17"        % Test  // MIT


### PR DESCRIPTION
So older version is not evicted.

Fixes #310