### PR TITLE
CSV: Emit all lines on completion

### DIFF
--- a/csv/src/main/scala/akka/stream/alpakka/csv/CsvParsingStage.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/CsvParsingStage.scala
@@ -4,11 +4,11 @@
 package akka.stream.alpakka.csv
 
 import akka.event.Logging
-import akka.stream.alpakka.csv.scaladsl.CsvParsing
 import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
 import akka.util.ByteString
 
+import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 /**
@@ -37,18 +37,30 @@ private[csv] class CsvParsingStage(delimiter: Byte, quoteChar: Byte, escapeChar:
       override def onPull(): Unit =
         tryPollBuffer()
 
-      override def onUpstreamFinish(): Unit =
-        buffer.poll(requireLineEnd = false) match {
-          case Some(csvLine) ⇒ emit(out, csvLine)
-          case _ ⇒ completeStage()
-        }
+      override def onUpstreamFinish(): Unit = {
+        emitRemaining()
+        completeStage()
+      }
 
       private def tryPollBuffer() =
         try buffer.poll(requireLineEnd = true) match {
           case Some(csvLine) ⇒ push(out, csvLine)
-          case _ ⇒ if (isClosed(in)) completeStage() else pull(in)
+          case _ ⇒
+            if (isClosed(in)) {
+              emitRemaining()
+              completeStage()
+            } else pull(in)
         } catch {
           case NonFatal(ex) ⇒ failStage(ex)
         }
+
+      @tailrec private def emitRemaining(): Unit =
+        buffer.poll(requireLineEnd = false) match {
+          case Some(csvLine) ⇒
+            emit(out, csvLine)
+            emitRemaining()
+          case _ ⇒
+        }
+
     }
 }


### PR DESCRIPTION
As @kciesielski described in #315 he encountered a bug which sometimes swallowed CSV
lines.
The issue occurs on stream completion when more than on CSV line is not parsed yet and the
last line has no line ending.
I haven't been able to re-create the issue in a proper test case as it is connected to
stream execution timings.