### PR TITLE
WIP Reactive marshalling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -126,6 +126,14 @@ lazy val hbase = project
     fork in Test := true
   )
 
+lazy val marshal = project
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(
+    name := "akka-stream-alpakka-marshal",
+    Dependencies.Marshal,
+    fork in Test := true
+  )
+
 lazy val ironmq = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/Protocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/Protocol.java
@@ -1,0 +1,88 @@
+package akka.stream.alpakka.marshal;
+
+import javaslang.Function1;
+import javaslang.control.Try;
+
+public interface Protocol<E,T> extends ReadProtocol<E,T>, WriteProtocol<E,T> {
+    /**
+     * Returns a protocol that considers all events emitted results, and vice-versa.
+     */
+    public static <T> Protocol<T,T> identity(Class<T> type) {
+        return new Protocol<T,T>() {
+            @Override
+            public Reader<T, T> reader() {
+                return Reader.identity();
+            }
+
+            @Override
+            public Class<? extends T> getEventType() {
+                return type;
+            }
+
+            @Override
+            public Writer<T, T> writer() {
+                return Writer.identity();
+            }
+        };
+    }
+    
+    /**
+     * Combines a read-only and a write-only protocol into a read/write protocol
+     */
+    public static <E,T> Protocol<E,T> of(ReadProtocol<E,T> read, WriteProtocol<E,T> write) {
+        return new Protocol<E,T>() {
+            @Override
+            public Writer<E,T> writer() {
+                return write.writer();
+            }
+
+            @Override
+            public Class<? extends E> getEventType() {
+                return write.getEventType();
+            }
+
+            @Override
+            public Reader<E,T> reader() {
+                return read.reader();
+            }
+            
+            @Override
+            public Try<T> empty() {
+                return read.empty();
+            }
+            
+            @Override
+            public String toString() {
+                return read.toString();
+            }
+        };
+    }
+    
+    /**
+     * Maps the protocol into a different type, invoking [onRead] after reading and [beforeWrite] before writing.
+     */
+    public default <U> Protocol<E,U> map(Function1<T,U> onRead, Function1<U,T> beforeWrite) {
+        Protocol<E,T> parent = this;
+        return new Protocol<E,U>() {
+            @Override
+            public Reader<E,U> reader() {
+                return parent.reader().map(onRead);
+            }
+
+            @Override
+            public Writer<E,U> writer() {
+                return parent.writer().compose(beforeWrite);
+            }
+            
+            @Override
+            public Try<U> empty() {
+                return parent.empty().map(onRead);
+            }
+            
+            @Override
+            public Class<? extends E> getEventType() {
+                return parent.getEventType();
+            }
+        };
+    };
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/ProtocolFilter.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/ProtocolFilter.java
@@ -1,0 +1,132 @@
+package akka.stream.alpakka.marshal;
+
+import static javaslang.control.Option.none;
+import static javaslang.control.Option.some;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.NotUsed;
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Graph;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Source;
+import akka.stream.stage.AbstractInHandler;
+import akka.stream.stage.AbstractOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+import javaslang.collection.Vector;
+import javaslang.control.Option;
+import javaslang.control.Try;
+
+/**
+ * Selectively routes events that are matched by a {@link ReadProtocol} into a separate flow, allowing
+ * unmatched events to pass unchanged.
+ */
+public class ProtocolFilter {
+    private static final Logger log = LoggerFactory.getLogger(ProtocolFilter.class);
+    
+    private static class Marker {}
+    private static final Marker SELECTED = new Marker();
+    private static final Marker NOT_SELECTED = new Marker();
+    
+    /**
+     * Creates a flow that feeds each event into [selector], and:
+     * - If the selector emits a result, that result, and further results that also match, are fed through [target], and then merged into the stream.
+     * - If the selector emits {@link ReadProtocol#none()}, the event is passed downstream unchanged
+     * - If the selector emits a failure, the stream is failed.
+     */
+    public static <E> Flow<E, E, NotUsed> filter(ReadProtocol<E,E> selector, Graph<FlowShape<E,E>, ?> target) {
+        return Flow
+            .<E>create()
+            .via(insertMarkers(selector))
+            .splitWhen(Marker.class::isInstance)
+            .prefixAndTail(1)
+            .flatMapConcat(t -> {
+                // This is safe because all of the "tail" in "prefixAndTail" above comes from the original stream of E.
+                Source<E, NotUsed> source = uncheckedCast(t.second());
+                return isSelected(t.first().get(0)) ? source.via(target) : source;
+            })
+            .concatSubstreams();
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static <E> Source<E, NotUsed> uncheckedCast(Source<Object, NotUsed> second) {
+        return (Source) second;
+    }
+
+    private static boolean isSelected(Object marker) {
+        return (Marker.class.cast(marker) == SELECTED);
+    }
+
+    /**
+     * Inserts marker objects into the stream whenever [selector] starts or stops selecting.
+     *  - inserts SELECTED before events where [selector] started selecting
+     *  - inserts NOT_SELECTED before events where [selector] stopped selecting
+     * The output stream will always start with a marker object.
+     */
+    private static <E> GraphStage<FlowShape<E,Object>> insertMarkers(ReadProtocol<E,E> selector) {
+        return new GraphStage<FlowShape<E,Object>>() {
+            private final Inlet<E> in = Inlet.create("in");
+            private final Outlet<Object> out = Outlet.create("out");
+            private final FlowShape<E, Object> shape = FlowShape.of(in, out);
+
+            @Override
+            public FlowShape<E, Object> shape() {
+                return shape;
+            }
+
+            @Override
+            public GraphStageLogic createLogic(Attributes attr) {
+                return new GraphStageLogic(shape) {
+                    private final Reader<E,E> reader = selector.reader();
+                    private Option<Boolean> prevSelected = none();
+                    {
+                        setHandler(in, new AbstractInHandler(){
+                            @Override
+                            public void onPush() {
+                                final E event = grab(in);
+                                final Try<E> result = reader.apply(event);
+                                final boolean selected = !ReadProtocol.isNone(result);
+                                log.debug("in {}, reader {}", event, result);
+                                
+                                if (selected && result.isFailure()) {
+                                    failStage(result.failed().get());
+                                } else {
+                                    if (prevSelected.filter(p -> p == selected).isDefined()) {
+                                        // no new marker needed
+                                        if (selected) {
+                                            push(out, result.get());
+                                        } else {
+                                            push(out, event);
+                                        }
+                                    } else {
+                                        log.debug("New marker! selected={}", selected);
+                                        // insert a marker since the selector has changed outputting
+                                        if (selected) {
+                                            emitMultiple(out, Vector.of(SELECTED, result.get()).iterator());
+                                        } else {
+                                            emitMultiple(out, Vector.of(NOT_SELECTED, event).iterator());
+                                        }
+                                    }
+                                    prevSelected = some(selected);
+                                }
+                            }
+                        });
+                        
+                        setHandler(out, new AbstractOutHandler() {
+                            @Override
+                            public void onPull() {
+                                pull(in);
+                            }
+                        });
+                    }
+                };
+            }
+        };
+    }
+    
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/ProtocolReader.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/ProtocolReader.java
@@ -1,0 +1,76 @@
+package akka.stream.alpakka.marshal;
+
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInHandler;
+import akka.stream.stage.AbstractOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+import javaslang.control.Try;
+
+/**
+ * Transforms a stream of events E into a stream T, by applying a {@link ReadProtocol} to each event E.
+ */
+public class ProtocolReader<E,T> extends GraphStage<FlowShape<E, T>> {
+    public static <E,T> ProtocolReader<E,T> of(ReadProtocol<E,T> protocol) {
+        return new ProtocolReader<>(protocol);
+    }
+    
+    private final Inlet<E> in = Inlet.create("in");
+    private final Outlet<T> out = Outlet.create("out");
+    private final FlowShape<E, T> shape = FlowShape.of(in, out);
+    
+    private final ReadProtocol<E,T> protocol;
+    
+    private ProtocolReader(ReadProtocol<E, T> protocol) {
+        this.protocol = protocol;
+    }
+
+    @Override
+    public FlowShape<E, T> shape() {
+        return shape;
+    }
+    
+    @Override
+    public GraphStageLogic createLogic(Attributes attr) throws Exception {
+        Reader<E, T> reader = protocol.reader();
+        return new GraphStageLogic(shape) {{
+            setHandler(out, new AbstractOutHandler() {
+                @Override
+                public void onPull() throws Exception {
+                    pull(in);
+                }
+            });
+            
+            setHandler(in, new AbstractInHandler() {
+                @Override
+                public void onPush() throws Exception {
+                    E event = grab(in);
+                    Try<T> result = reader.apply(event);
+                    if (result.isSuccess()) {
+                        push(out, result.get());
+                    } else if (result.isFailure() && !ReadProtocol.isNone(result)) {
+                        failStage(result.failed().get());
+                    } else {
+                        pull(in);
+                    }
+                }
+                
+                @Override
+                public void onUpstreamFinish() throws Exception {
+                    Try<T> result = reader.reset();
+                    if (result.isSuccess()) {
+                        push(out, result.get());
+                        complete(out);
+                    } else if (result.isFailure() && !ReadProtocol.isNone(result)) {
+                        failStage(result.failed().get());
+                    } else {
+                        complete(out);
+                    }
+                }
+            });
+        }};
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/ProtocolWriter.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/ProtocolWriter.java
@@ -1,0 +1,83 @@
+package akka.stream.alpakka.marshal;
+
+import static javaslang.control.Option.none;
+import static javaslang.control.Option.some;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInHandler;
+import akka.stream.stage.AbstractOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+import javaslang.control.Option;
+
+public class ProtocolWriter {
+    /**
+     * Transforms a stream of T into a stream of events E, by applying a {@link WriteProtocol} to each element T.
+     */
+    public static <T,E> GraphStage<FlowShape<T, E>> of(WriteProtocol<E,T> protocol) {
+        return ProtocolWriter.using(() -> {
+            Writer<E, T> writer = protocol.writer();
+            return t -> writer;
+        });
+    }
+
+    /**
+     * Returns a graph stage which writes each element T using (potentially) its own writer that is created using
+     * the given factory.
+     * 
+     * @param factory Supplier returning a function that returns the writer for an element. The supplier is invoked
+     * each time the graph stage is materialized; the function is then invoked on each element.
+     */
+    public static <T,E> GraphStage<FlowShape<T, E>> using(Supplier<Function<T,Writer<E,T>>> factory) {
+        return new GraphStage<FlowShape<T, E>>() {
+            private final Inlet<T> in = Inlet.create("in");
+            private final Outlet<E> out = Outlet.create("out");
+            private final FlowShape<T, E> shape = FlowShape.of(in, out);
+            
+            @Override
+            public FlowShape<T, E> shape() {
+                return shape;
+            }
+
+            @Override
+            public GraphStageLogic createLogic(Attributes attr) throws Exception {
+                Function<T, Writer<E, T>> writerFn = factory.get();
+                return new GraphStageLogic(shape) {
+                    private Option<Writer<E,T>> writer = none();
+                {
+                    setHandler(out, new AbstractOutHandler() {
+                        @Override
+                        public void onPull() throws Exception {
+                            pull(in);
+                        }
+                    });
+                    
+                    setHandler(in, new AbstractInHandler() {
+                        @Override
+                        public void onPush() throws Exception {
+                            T t = grab(in);
+                            writer = some(writerFn.apply(t));
+                            Seq<E> events = writer.get().apply(t);
+                            emitMultiple(out, events.iterator());
+                        }
+                        
+                        @Override
+                        public void onUpstreamFinish() throws Exception {
+                            Seq<E> events = writer.map(w -> w.reset()).getOrElse(Vector.empty());
+                            emitMultiple(out, events.iterator(), () -> complete(out));
+                        }
+                    });
+                }};
+            }
+        };
+    }
+    
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/ReadProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/ReadProtocol.java
@@ -1,0 +1,69 @@
+package akka.stream.alpakka.marshal;
+
+import java.util.NoSuchElementException;
+
+import javaslang.Function1;
+import javaslang.control.Option;
+import javaslang.control.Try;
+
+/**
+ * Protocol for reading a stream of events E into possibly multiple instances of T
+ */
+public interface ReadProtocol<E,T> {
+    public static class Constants {
+        private static final Try<?> NONE = Option.none().toTry();
+    }
+    
+    /**
+     * Widens a Reader for T to return a superclass S of T instead.
+     * This is OK, since a ReadProtocol that produces T always produces a subclass of S.
+     */
+    @SuppressWarnings("unchecked")
+    public static <E, S, T extends S> ReadProtocol<E,S> widen(ReadProtocol<E,T> p){
+        return (ReadProtocol<E,S>) p;
+    }
+    
+
+    /**
+     * Returns a failed Try that indicates no value was found.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Try<T> none() {
+        return (Try<T>) Constants.NONE;
+    }
+
+    /**
+     * Checks whether the given Try indicates that no value was found (by being a failure of NoSuchElementException).
+     */
+    public static boolean isNone(Try<?> t) {
+        return t.isFailure() && t.failed().get() instanceof NoSuchElementException;
+    }
+    
+    public abstract Reader<E,T> reader();
+    
+    /**
+     * Returns an appropriate representation of "empty" for this read protocol. By default, returns NONE, which is a failure.
+     */
+    public default Try<T> empty() {
+        return none();
+    }
+    
+    /**
+     * Maps the protocol into a different type, invoking [onRead] after reading.
+     */
+    public default <U> ReadProtocol<E,U> map(Function1<T,U> onRead) {
+        final ReadProtocol<E,T> parent = this;
+        
+        return new ReadProtocol<E,U>() {
+            @Override
+            public Reader<E, U> reader() {
+                return parent.reader().map(onRead);
+            }
+            
+            @Override
+            public Try<U> empty() {
+                return parent.empty().map(onRead);
+            }
+        };
+    };
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/Reader.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/Reader.java
@@ -1,0 +1,65 @@
+package akka.stream.alpakka.marshal;
+
+import javaslang.Function1;
+import javaslang.control.Try;
+
+public interface Reader<E,T> {
+    /**
+     * A Reader that produces U always produces a subclass of T.
+     */
+    @SuppressWarnings("unchecked")
+    public static <E, T, U extends T> Reader<E,T> narrow(Reader<E,U> p){
+        return (Reader<E,T>) p;
+    }
+    
+    /**
+     * Returns a reader that emits a result on every event, the result being the event itself.
+     */
+    public static <T, E extends T> Reader<E,T> identity() {
+        return new Reader<E, T>() {
+            @Override
+            public Try<T> reset() {
+                return ReadProtocol.none();
+            }
+
+            @Override
+            public Try<T> apply(E event) {
+                return Try.success(event);
+            }
+        };
+    }
+    
+    Try<T> reset();
+    Try<T> apply(E event);
+    
+    public default <U> Reader<E,U> map(Function1<T,U> f) {
+        Reader<E,T> parent = this;
+        return new Reader<E,U>() {
+            @Override
+            public Try<U> reset() {
+                return parent.reset().mapTry(f::apply);
+            }
+
+            @Override
+            public Try<U> apply(E evt) {
+                return parent.apply(evt).mapTry(f::apply);
+            }
+        };
+    }
+    
+    public default <U> Reader<E,U> flatMap(Function1<T,Try<U>> f) {
+        Reader<E,T> parent = this;
+        return new Reader<E,U>() {
+            @Override
+            public Try<U> reset() {
+                return parent.reset().flatMap(f);
+            }
+
+            @Override
+            public Try<U> apply(E evt) {
+                return parent.apply(evt).flatMap(f);
+            }
+        };
+    }
+    
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/WriteProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/WriteProtocol.java
@@ -1,0 +1,46 @@
+package akka.stream.alpakka.marshal;
+
+import javaslang.Function1;
+
+/**
+ * Protocol for writing possibly multiple instances of T into events E.
+ */
+public interface WriteProtocol<E,T> {
+    /**
+     * Narrows a protocol for writing T to become a writer for a subclass of T.
+     * This is OK, since a writer that accepts a T for writing will also accept a U.
+     */
+    @SuppressWarnings("unchecked")
+    public static <E, T, U extends T> WriteProtocol<E,U> narrow(WriteProtocol<E,T> w) {
+        return (WriteProtocol<E,U>) w;
+    }
+    
+    /**
+     * Returns the specific subtype of events that this protocol will emit (if known, otherwise E)
+     */
+    public Class<? extends E> getEventType();
+    
+    /**
+     * Creates and returns a new writer can write instances of T by emitting events of type E.
+     */
+    public abstract Writer<E,T> writer();
+
+    /**
+     * Maps the protocol into a different type, invoking [beforeWrite] before writing.
+     */
+    public default <U> WriteProtocol<E,U> compose(Function1<U,T> beforeWrite) {
+        WriteProtocol<E,T> parent = this;
+        return new WriteProtocol<E,U>() {
+            @Override
+            public Writer<E,U> writer() {
+                return parent.writer().compose(beforeWrite);
+            }
+            
+            @Override
+            public Class<? extends E> getEventType() {
+                return parent.getEventType();
+            }
+        };
+    };
+    
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/Writer.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/Writer.java
@@ -1,0 +1,130 @@
+package akka.stream.alpakka.marshal;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import javaslang.Function1;
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+
+/**
+ * Writes out instances of T into sequences of events E. Implementations of this interface
+ * are not safe to be called from multiple threads simultaneously.
+ */
+public interface Writer<E,T> {
+    /**
+     * Widens a writer of U to become a writer of a superclass of U. This is OK, since a writer that
+     * produces U is in fact producing a T.
+     */
+    @SuppressWarnings("unchecked")
+    public static <E, T, U extends T> Writer<E,T> widen(Writer<E,U> w) {
+        return (Writer<E,T>) w;
+    }
+    
+    /**
+     * Returns a Writer that calls the given function for apply(), and nothing for reset().
+     */
+    public static <E,T> Writer<E,T> of (Function<T,Seq<E>> f) {
+        return new Writer<E, T>() {
+            @Override
+            public Seq<E> apply(T value) {
+                return f.apply(value);
+            }
+
+            @Override
+            public Seq<E> reset() {
+                return Vector.empty();
+            }
+        };
+    }
+    
+    /**
+     * Returns a writer that emits an event for every element, the event being the element itself.
+     */
+    public static <E, T extends E> Writer<E,T> identity() {
+        return new Writer<E,T>() {
+            @Override
+            public Seq<E> apply(T value) {
+                return Vector.of(value);
+            }
+            
+            @Override
+            public Seq<E> reset() {
+                return Vector.empty();
+            }
+        };
+    }
+    
+    /**
+     * Writes out the given value, and resets the writer.
+     */
+    public default Seq<E> applyAndReset(T value) {
+        return apply(value).appendAll(reset());
+    }
+    
+    /**
+     * Writes out a value, and returns the events to be emitted for that value. Can be called repeatedly.
+     */
+    Seq<E> apply(T value);
+    
+    /**
+     * Signals completion of the write process, returning any final events to emit.
+     * The writer is reset to an initial state after this.
+     */
+    Seq<E> reset();
+
+    /**
+     * Invokes the given function before calling this writer.
+     */
+    public default <U> Writer<E,U> compose(Function1<U,T> f) {
+        Writer<E,T> parent = this;
+        return new Writer<E,U>() {
+            @Override
+            public Seq<E> apply(U value) {
+                return parent.apply(f.apply(value));
+            }
+            
+            @Override
+            public Seq<E> reset() {
+                return parent.reset();
+            }
+        };
+    }
+    
+    /**
+     * Applies the given transformation to the returned events of {@link #apply} and {@link #reset}
+     */
+    public default Writer<E,T> map(Function<Seq<E>, Seq<E>> f) {
+        Writer<E,T> parent = this;
+        return new Writer<E,T>() {
+            @Override
+            public Seq<E> apply(T value) {
+                return f.apply(parent.apply(value));
+            }
+
+            @Override
+            public Seq<E> reset() {
+                return f.apply(parent.reset());
+            }
+        };
+    }
+    
+    /**
+     * Applies the given transformation to the returned events of {@link #apply} (but not to {@link #reset}), also passing in the original input
+     */
+    public default Writer<E,T> mapWithInput(BiFunction<T, Seq<E>, Seq<E>> f) {
+        Writer<E,T> parent = this;
+        return new Writer<E,T>() {
+            @Override
+            public Seq<E> apply(T value) {
+                return f.apply(value, parent.apply(value));
+            }
+
+            @Override
+            public Seq<E> reset() {
+                return parent.reset();
+            }
+        };
+    }
+    
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/csv/CharsetDecoderFlow.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/csv/CharsetDecoderFlow.java
@@ -1,0 +1,92 @@
+package akka.stream.alpakka.marshal.csv;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CoderResult;
+
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+import akka.util.ByteString;
+
+/**
+ * Decodes a stream of bytes into a stream of characters, using a supplied {@link Charset}.
+ */
+public class CharsetDecoderFlow extends GraphStage<FlowShape<ByteString, String>> {
+
+    private final Inlet<ByteString> in = Inlet.create("in");
+    private final Outlet<String> out = Outlet.create("out");
+    private final FlowShape<ByteString, String> shape = FlowShape.of(in, out);
+    
+    private final Charset encoding;
+    
+    public CharsetDecoderFlow(Charset encoding) {
+        this.encoding = encoding;
+    }
+
+    @Override
+    public FlowShape<ByteString, String> shape() {
+        return shape;
+    }
+
+    @Override
+    public GraphStageLogic createLogic(Attributes arg0) throws Exception {
+        return new GraphStageLogic(shape) {
+            final CharsetDecoder decoder = encoding.newDecoder();
+            ByteString buf = ByteString.empty();
+            {
+                setHandlers(in, out, new AbstractInOutHandler() {
+                    @Override
+                    public void onPull() {
+                        pull(in);
+                    }
+                    
+                    @Override
+                    public void onPush() throws CharacterCodingException {
+                        deliver(buf.concat(grab(in)).asByteBuffer());
+                    }
+
+                    @Override
+                    public void onUpstreamFinish() throws CharacterCodingException {
+                        deliver(buf.asByteBuffer());
+                        if (!buf.isEmpty()) {
+                            throw new IllegalArgumentException("Stray bytes at end of input that could not be decoded: " + buf);
+                        }
+                        completeStage();
+                    }
+                    
+                    private void deliver(ByteBuffer bytes) throws CharacterCodingException {
+                        CharBuffer chars = CharBuffer.allocate(bytes.limit());
+                        CoderResult result = decoder.decode(bytes, chars, false);
+                        if (result.isOverflow()) {
+                            failStage(new IllegalArgumentException("Incoming bytes decoded into more characters. Huh?"));
+                            return;
+                        }
+                        if (result.isError()) {
+                            result.throwException();
+                        }
+                        
+                        int count = chars.position();
+                        chars.rewind();
+                        if (count > 0) {
+                            push(out, new String(chars.array(), chars.position(), count));
+                        } else if (!isClosed(in)) {
+                            pull(in);
+                        }
+                        
+                        // save the remaining bytes for later
+                        buf = ByteString.fromByteBuffer(bytes);
+                    }
+                });
+            }
+        };
+    }
+
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/csv/CharsetEncoderFlow.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/csv/CharsetEncoderFlow.java
@@ -1,0 +1,95 @@
+package akka.stream.alpakka.marshal.csv;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+import akka.util.ByteString;
+
+/**
+ * Encodes a stream of strings into a stream of bytes, using a supplied {@link Charset}.
+ */
+public class CharsetEncoderFlow extends GraphStage<FlowShape<String, ByteString>> {
+    private final Inlet<String> in = Inlet.create("in");
+    private final Outlet<ByteString> out = Outlet.create("out");
+    private final FlowShape<String, ByteString> shape = FlowShape.of(in, out);
+    private final Charset encoding;
+    
+    public CharsetEncoderFlow(Charset encoding) {
+        this.encoding = encoding;
+    }
+
+    @Override
+    public FlowShape<String, ByteString> shape() {
+        return shape;
+    }
+
+    @Override
+    public GraphStageLogic createLogic(Attributes arg0) throws Exception {
+        return new GraphStageLogic(shape) {
+            final CharsetEncoder encoder = encoding.newEncoder();
+            String buf = "";
+            {
+                setHandlers(in, out, new AbstractInOutHandler() {
+                    @Override
+                    public void onPull() {
+                        pull(in);
+                    }
+                    
+                    @Override
+                    public void onPush() throws CharacterCodingException {
+                        String input = grab(in);
+                        CharBuffer chars = CharBuffer.allocate(input.length() + buf.length());
+                        chars.append(buf);
+                        chars.append(input);
+                        chars.rewind();
+                        deliver(chars);
+                    }
+
+                    @Override
+                    public void onUpstreamFinish() throws CharacterCodingException {
+                        deliver(CharBuffer.wrap(buf));
+                        if (!buf.isEmpty()) {
+                            throw new IllegalArgumentException("Stray bytes at end of input that could not be decoded: " + buf);
+                        }
+                        completeStage();
+                    }
+                                        
+                    private void deliver(CharBuffer chars) throws CharacterCodingException {
+                        ByteBuffer bytes = ByteBuffer.allocate(chars.limit() * 4);
+                        CoderResult result = encoder.encode(chars, bytes, false);
+                        if (result.isOverflow()) {
+                            failStage(new IllegalArgumentException("Incoming chars decoded into more than size*4 characters. Huh?"));
+                            return;
+                        }
+                        if (result.isError()) {
+                            result.throwException();
+                        }
+                        
+                        int count = bytes.position();
+                        bytes.rewind();
+                        bytes.limit(count);
+                        if (count > 0) {
+                            push(out, ByteString.fromByteBuffer(bytes));
+                        } else if (!isClosed(in)) {
+                            pull(in);
+                        }
+                        
+                        // save the remaining chars for later
+                        buf = chars.toString();
+                    }
+                });
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/csv/CsvEvent.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/csv/CsvEvent.java
@@ -1,0 +1,106 @@
+package akka.stream.alpakka.marshal.csv;
+
+/**
+ * Represents a single eveny in a CSV stream.
+ */
+public abstract class CsvEvent {
+    public static class Text extends CsvEvent {
+        private final String text;
+
+        private Text(String text) {
+            this.text = text;
+        }
+        
+        public String getText() {
+            return text;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((text == null) ? 0 : text.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            Text other = (Text) obj;
+            if (text == null) {
+                if (other.text != null)
+                    return false;
+            } else if (!text.equals(other.text))
+                return false;
+            return true;
+        }
+        
+        @Override
+        public String toString() {
+            return "\"" + text + "\"";
+        }
+    }
+
+    /**
+     * @author jan
+     *
+     */
+    public static class EndRecord extends CsvEvent {
+        private EndRecord() {}
+        
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+        
+        @Override
+        public boolean equals(Object obj) {
+            return (obj instanceof EndRecord);
+        }
+        
+        @Override
+        public String toString() {
+            return "endRecord()";
+        }
+    }
+    
+    private static final EndRecord END_RECORD = new EndRecord();
+    
+    public static EndRecord endRecord() {
+        return END_RECORD;
+    }
+    
+    public static class EndValue extends CsvEvent {
+        private EndValue() {}
+        
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+        
+        @Override
+        public boolean equals(Object obj) {
+            return (obj instanceof EndValue);
+        }
+        
+        @Override
+        public String toString() {
+            return "endValue()";
+        }
+    }
+    
+    private static final EndValue END_VALUE = new EndValue();
+    
+    public static EndValue endValue() {
+        return END_VALUE;
+    }
+    
+    public static Text text(String text) {
+        return new Text(text);
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/csv/CsvParser.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/csv/CsvParser.java
@@ -1,0 +1,165 @@
+package akka.stream.alpakka.marshal.csv;
+
+import java.nio.charset.CharacterCodingException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+
+/**
+ * Parses an incoming stream of strings making up a CSV document into individual CSV events.
+ */
+public class CsvParser extends GraphStage<FlowShape<String, CsvEvent>> {
+    private static final Logger log = LoggerFactory.getLogger(CsvParser.class);
+    private static enum State { FIELD_START, QUOTED_FIELD, UNQUOTED_FIELD, AFTER_QUOTED_FIELD } ;
+    private static final char BOM = '\uFEFF';
+    
+    private final Inlet<String> in = Inlet.create("in");
+    private final Outlet<CsvEvent> out = Outlet.create("out");
+    private final FlowShape<String, CsvEvent> shape = FlowShape.of(in, out);
+    
+    private final CsvSettings settings;
+    
+    public CsvParser(CsvSettings settings) {
+        this.settings = settings;
+    }
+
+    @Override
+    public FlowShape<String, CsvEvent> shape() {
+        return shape;
+    }
+
+    @Override
+    public GraphStageLogic createLogic(Attributes arg0) {
+        return new GraphStageLogic(shape) {
+            State state = State.FIELD_START;
+            String buf = "";
+            
+            {
+                setHandlers(in, out, new AbstractInOutHandler() {
+                    @Override
+                    public void onPull() {
+                        pull(in);
+                    }
+                    
+                    @Override
+                    public void onPush() throws CharacterCodingException {
+                        String s = buf + grab(in);
+                        log.debug("<< {}", s);
+                        buf = parseAndEmit(s);
+                        if (isAvailable(out)) {
+                            // apparently, we haven't emitted anything while parsing
+                            pull(in);
+                        }
+                    }
+                    
+                    public void onUpstreamFinish() {
+                        if (!buf.isEmpty()) {
+                            // emit the remaining buffer, unless we were in a quoted field and it's just the remaining quote
+                            if (state != State.QUOTED_FIELD || !buf.equals(String.valueOf(settings.getQuote()))) {
+                                emit(out, CsvEvent.text(settings.unescape(buf)));
+                            }
+                        }
+                        emit(out, CsvEvent.endValue());
+                        emit(out, CsvEvent.endRecord());
+                        completeStage();
+                    };
+                });
+            }
+            
+            private String parseAndEmit(String s) {
+                int p = (s.charAt(0) == BOM ? 1 : 0);
+                while (p < s.length()) {
+                    log.debug("[{}] {}", p, state);
+                    switch(state) {
+                        case FIELD_START:
+                            if (s.charAt(p) == settings.getQuote()) {
+                                p++;
+                                state = State.QUOTED_FIELD;
+                                if (p > s.length()) {
+                                    return "";
+                                }
+                            } else if (s.charAt(p) == settings.getSeparator()) {
+                                // empty field
+                                emit(out, CsvEvent.endValue());
+                                p++;
+                            } else if (s.charAt(p) == '\n') {
+                                // end of record
+                                emit(out, CsvEvent.endValue());
+                                emit(out, CsvEvent.endRecord());
+                                p++;
+                            } else {
+                                state = State.UNQUOTED_FIELD;
+                            }
+                            break;
+                        case UNQUOTED_FIELD:
+                            int sepPos = s.indexOf(settings.getSeparator(), p);
+                            int lfPos = s.indexOf('\n', p);
+                            if (sepPos == -1 && lfPos == -1) {
+                                if (p != s.length()) {
+                                    emit(out, CsvEvent.text(s.substring(p)));
+                                }
+                                return "";
+                            } else {
+                                int q = (sepPos == -1) ? lfPos : (lfPos == -1) ? sepPos : Math.min(sepPos, lfPos);
+                                if (p != q) {
+                                    emit(out, CsvEvent.text(s.substring(p, q)));
+                                }
+                                p = q;
+                                state = State.FIELD_START;
+                            }
+                            break;
+                        case QUOTED_FIELD:
+                                int q = p;
+                                while (q < s.length()) {
+                                    log.debug("p = {}, q = {}", p, q);
+                                    if (s.length() - q < settings.getEscapedQuote().length() &&
+                                        s.regionMatches(q, settings.getEscapedQuote(), 0, s.length() - q)) {
+                                        if (p != q) {
+                                            emit(out, CsvEvent.text(settings.unescape(s.substring(p, q))));
+                                        }
+                                        // partial match of escaped quote at [q], towards end of buffer
+                                        return s.substring(q);
+                                    } else if (s.regionMatches(q, settings.getEscapedQuote(), 0, settings.getEscapedQuote().length())) {
+                                        // complete escaped quote at [q]
+                                        q += settings.getEscapedQuote().length();
+                                    } else if (s.charAt(q) == settings.getQuote()) {
+                                        if (p != q) {
+                                            emit(out, CsvEvent.text(settings.unescape(s.substring(p, q))));
+                                        }
+                                        p = q + 1;
+                                        state = State.AFTER_QUOTED_FIELD;
+                                        break;
+                                    } else {
+                                        q++;
+                                    }
+                                }
+                                if (q >= s.length()) {
+                                    // reached end of buffer with no end quote -> emit what we have, and pull in next buffer
+                                    if (p < s.length()) {
+                                        emit(out, CsvEvent.text(settings.unescape(s.substring(p))));
+                                    }
+                                    return "";
+                                }
+                            break;
+                        case AFTER_QUOTED_FIELD:
+                            // expect either CR/LF or a separator
+                            if (s.charAt(p) != settings.getSeparator() && s.charAt(p) != '\n') {
+                                throw new IllegalArgumentException("expecting SEPARATOR or NEWLINE after closing quote of field, but got '" + s.charAt(p) + "'");
+                            }
+                            state = State.FIELD_START;
+                            break;
+                    }
+                }
+                return "";
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/csv/CsvSettings.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/csv/CsvSettings.java
@@ -1,0 +1,70 @@
+package akka.stream.alpakka.marshal.csv;
+
+/**
+ * Encapsulates the settings that make up a particular CSV variant.
+ */
+public class CsvSettings {
+    /**
+     * Describes the "official" CSV format, according to https://tools.ietf.org/html/rfc4180 , which uses
+     * a double quote (") to quote fields, two double quotes ("") to represent a double qoute within a field,
+     * and a semicolon (;) to separate fields.
+     */
+    public static final CsvSettings RFC4180 = new CsvSettings('"', "\"\"", ';');
+    
+    private final char quote;
+    private final String escapedQuote;
+    private final char separator;
+
+    /**
+     * Creates a new CsvSettings with the given values.
+     */
+    public CsvSettings(char quote, String escapedQuote, char separator) {
+        this.quote = quote;
+        this.escapedQuote = escapedQuote;
+        this.separator = separator;
+    }
+
+    /**
+     * Returns the character used to (optionally) quote fields, by starting and finishing the field value with this character.
+     */
+    public char getQuote() {
+        return quote;
+    }
+    
+    /**
+     * Returns the string which is used when an actual quote (the return value of {{@link #getQuote()}) occurs in a quoted field's value.
+     */
+    public String getEscapedQuote() {
+        return escapedQuote;
+    }
+    
+    /**
+     * Returns the separator character that goes between fields.
+     */
+    public char getSeparator() {
+        return separator;
+    }
+
+    /**
+     * Returns [s] with any escaped quotes replaced by quotes.
+     */
+    public String unescape(String s) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            if (s.regionMatches(i, getEscapedQuote(), 0, getEscapedQuote().length())) {
+                result.append(getQuote());
+                i += getEscapedQuote().length() - 1; // skip over remaining chars
+            } else {
+                result.append(s.charAt(i));
+            }
+        }
+        return result.toString();
+    }
+
+    /**
+     * Returns [s] with any quote characters replaced by escaped quotes.
+     */
+    public String escape(String s) {
+        return s.replace(String.valueOf(quote), escapedQuote);
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/csv/CsvTextAggregator.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/csv/CsvTextAggregator.java
@@ -1,0 +1,97 @@
+package akka.stream.alpakka.marshal.csv;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import akka.stream.alpakka.marshal.csv.CsvEvent.Text;
+
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+
+/**
+ * Aggregates subsequent CsvEvent.text() events for the same column value into single text event, up to a given limit
+ */
+public class CsvTextAggregator extends GraphStage<FlowShape<CsvEvent, CsvEvent>> {
+    public static CsvTextAggregator create() {
+        return new CsvTextAggregator(65535);
+    }
+
+    public static CsvTextAggregator create(int maxCharsPerEvent) {
+        return new CsvTextAggregator(maxCharsPerEvent);
+    }
+
+    private final Inlet<CsvEvent> in = Inlet.create("in");
+    private final Outlet<CsvEvent> out = Outlet.create("out");
+    private final FlowShape<CsvEvent, CsvEvent> shape = FlowShape.of(in, out);
+
+    private final int maxCharsPerEvent;
+
+    private CsvTextAggregator(int maxCharsPerEvent) {
+        this.maxCharsPerEvent = maxCharsPerEvent;
+    }
+
+    @Override
+    public FlowShape<CsvEvent, CsvEvent> shape() {
+        return shape;
+    }
+
+    @Override
+    public GraphStageLogic createLogic(Attributes arg0) throws Exception {
+        return new GraphStageLogic(shape) {
+            List<CsvEvent.Text> buf = new ArrayList<>();
+
+            {
+                setHandlers(in, out, new AbstractInOutHandler() {
+                    @Override
+                    public void onPull() {
+                        pull(in);
+                    }
+
+                    @Override
+                    public void onPush() {
+                        CsvEvent event = grab(in);
+                        if (event instanceof CsvEvent.Text) {
+                            Text text = CsvEvent.Text.class.cast(event);
+                            if (!text.getText().isEmpty()) {
+                                buf.add(text);
+                            }
+                            pull(in);
+                        } else {
+                            emitBuf();
+                            emit(out, event);
+                        }
+                    }
+
+                    public void onUpstreamFinish() throws Exception {
+                        emitBuf();
+                        completeStage();
+                    }
+
+                    private void emitBuf() {
+                        if (!buf.isEmpty()) {
+                            if (buf.size() == 1) {
+                                emit(out, buf.get(0));
+                            } else {
+                                StringBuilder text = new StringBuilder();
+                                for (CsvEvent.Text event: buf) {
+                                    text.append(event.getText());
+                                    if (text.length() > maxCharsPerEvent) {
+                                        throw new IllegalArgumentException("Column value exceeds maximum of " + maxCharsPerEvent + " characters.");
+                                    }
+                                }
+                                emit(out, CsvEvent.text(text.toString()));
+                            }
+                            buf.clear();
+                        }
+                    }
+                });
+            }
+        };
+    }
+
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/csv/CsvWriter.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/csv/CsvWriter.java
@@ -1,0 +1,92 @@
+package akka.stream.alpakka.marshal.csv;
+
+import java.nio.charset.CharacterCodingException;
+
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+
+/**
+ * Renders an incoming stream of CSV events into string content, according to the given settings.
+ */
+public class CsvWriter extends GraphStage<FlowShape<CsvEvent, String>> {
+    private final Inlet<CsvEvent> in = Inlet.create("in");
+    private final Outlet<String> out = Outlet.create("out");
+    private final FlowShape<CsvEvent, String> shape = FlowShape.of(in, out);
+
+    private final CsvSettings settings;
+    private final String quote;
+    private final String separator;
+    
+    public CsvWriter(CsvSettings settings) {
+        this.settings = settings;
+        this.quote = String.valueOf(settings.getQuote());
+        this.separator = String.valueOf(settings.getSeparator());
+    }
+
+    @Override
+    public FlowShape<CsvEvent, String> shape() {
+        return shape;
+    }
+
+    @Override
+    public GraphStageLogic createLogic(Attributes arg0) {
+        return new GraphStageLogic(shape) {
+            boolean startedValue = false;
+            boolean needSeparator = false;
+            
+            {
+                setHandlers(in, out, new AbstractInOutHandler() {
+                    @Override
+                    public void onPull() {
+                        pull(in);
+                    }
+                    
+                    @Override
+                    public void onPush() throws CharacterCodingException {
+                        CsvEvent e = grab(in);
+                        if (e instanceof CsvEvent.EndRecord) {
+                            if (startedValue) {
+                                emit(out, quote);
+                            }
+                            emit(out, "\n");
+                            startedValue = false;
+                            needSeparator = false;
+                        } else if (e instanceof CsvEvent.EndValue) {
+                            if (startedValue) {
+                                emit(out, quote);
+                            } else {
+                                // empty field
+                                if (needSeparator) {
+                                    emit(out, separator);
+                                } else {
+                                    pull(in);
+                                }
+                            }
+                            startedValue = false;
+                            needSeparator = true;
+                        } else {
+                            String s = CsvEvent.Text.class.cast(e).getText();
+                            if (s.length() > 0) {
+                                if (!startedValue) {
+                                    if (needSeparator) {
+                                        emit(out, separator);
+                                    }
+                                    emit(out, quote);
+                                }
+                                emit(out, settings.escape(s));
+                                startedValue = true;
+                            } else {
+                                pull(in);
+                            }
+                        }
+                    }
+                });
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/csv/MultiReadProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/csv/MultiReadProtocol.java
@@ -1,0 +1,106 @@
+package akka.stream.alpakka.marshal.csv;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.isNone;
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+
+import javaslang.Function1;
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+import javaslang.control.Try;
+
+/**
+ * Combines several nested protocols that each return separate values into a single value,
+ * that is emitted at the end of every record.
+ */
+public class MultiReadProtocol<T> implements ReadProtocol<CsvEvent, T> {
+    private static final Logger log = LoggerFactory.getLogger(MultiReadProtocol.class);
+    
+    private final Seq<ReadProtocol<CsvEvent,?>> protocols;
+    private final Function1<List<?>, T> produce;
+
+    /**
+     * Creates a MultiReadProtocol
+     * @param protocols The nested protocols to forward all events to
+     * @param produce Function that is invoked with a list of what the nested protocols have emitted, at the
+     * end of every record.
+     */
+    public MultiReadProtocol(Iterable<ReadProtocol<CsvEvent,?>> protocols, Function1<List<?>, T> produce) {
+        this.protocols = Vector.ofAll(protocols);
+        this.produce = produce;
+    }
+    
+    @Override
+    public Reader<CsvEvent, T> reader() {
+        @SuppressWarnings("unchecked")
+        Seq<Reader<CsvEvent, Object>> readers = protocols.map(c -> (Reader<CsvEvent,Object>) c.reader());
+        @SuppressWarnings("unchecked")
+        Try<Object>[] values = new Try[protocols.size()];
+        
+        return new Reader<CsvEvent, T>() {
+            {
+                reset();
+            }
+            
+            @SuppressWarnings("unchecked")
+            @Override
+            public Try<T> reset() {
+                readers.forEach(r -> r.reset());
+                Arrays.fill(values, none());
+                for (int i = 0; i < protocols.size(); i++) {
+                    values[i] = (Try<Object>) protocols.get(i).empty();
+                }
+                return none();
+            }
+
+            @Override
+            public Try<T> apply(CsvEvent event) {
+                for (int i = 0; i < protocols.size(); i++) {
+                    Try<Object> result = readers.apply(i).apply(event);
+                    if (!isNone(result)) {
+                        values[i] = result;
+                    }
+                }
+                
+                if (event instanceof CsvEvent.EndRecord) {
+                    // end of line -> time to emit a value
+                    AtomicReference<Throwable> failure = new AtomicReference<>();
+                    for (int i = 0; i < readers.size(); i++) {
+                        Try<Object> r = readers.get(i).reset();
+                        log.debug("{} reset: {}", protocols.get(i), r);
+                        if (!isNone(r) && values[i].eq(protocols.get(i).empty())) {
+                            values[i] = r;
+                        }
+                    }
+                    Object[] args = new Object[protocols.size()];
+                    for (int i = 0; i < values.length; i++) {
+                        Try<Object> t = values[i];
+                        t.failed().forEach(failure::set);
+                        args[i] = t.getOrElse((Object)null);
+                    }
+                    Try<T> result = (failure.get() != null) ? Try.failure(failure.get()) : Try.success(produce.apply(Arrays.asList(args)));
+                    reset();
+                    log.debug("{} emitting {}", MultiReadProtocol.this, result);
+                    return result;
+                } else {
+                    return none();
+                }
+            }
+            
+        };
+    }
+    
+    @Override
+    public String toString() {
+        return "(" + protocols.mkString("; ") + ")";
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/csv/MultiWriteProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/csv/MultiWriteProtocol.java
@@ -1,0 +1,101 @@
+package akka.stream.alpakka.marshal.csv;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.stream.alpakka.marshal.WriteProtocol;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.Function1;
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+
+/**
+ * Groups nested {@see WriteProtocol} protocols to write a combined file.
+ * 
+ * When writing a T, it will allow each nested protocol to contribute column(s) to a line, until it emits endRecord().
+ * The endRecord() of each contributing protocol is not forwarded though; rather, the next contributing protocol is then
+ * allowed to append to the line. Only after all protocols have emitted for one T, is an endRecord() emitted.
+ * 
+ * The inner records must also properly emit endValue() before endRecord().
+ */
+public class MultiWriteProtocol<T> implements WriteProtocol<CsvEvent, T> {
+    private static final Logger log = LoggerFactory.getLogger(MultiWriteProtocol.class);
+    
+    private final Seq<WriteProtocol<CsvEvent,?>> protocols;
+    private final Seq<Function1<T,?>> getters;
+
+    public MultiWriteProtocol(Iterable<WriteProtocol<CsvEvent,?>> protocols, Iterable<Function1<T,?>> getters) {
+        this.protocols = Vector.ofAll(protocols);
+        this.getters = Vector.ofAll(getters);
+    }
+
+    @Override
+    public Class<? extends CsvEvent> getEventType() {
+        return CsvEvent.class;
+    }
+
+    @Override
+    public Writer<CsvEvent, T> writer() {
+        @SuppressWarnings("unchecked")
+        Seq<Writer<CsvEvent, Object>> writers = protocols.map(c -> (Writer<CsvEvent,Object>) c.writer());
+        
+        return new Writer<CsvEvent,T>() {
+            @Override
+            public Seq<CsvEvent> apply(T value) {
+                return emit(i -> writers.apply(i).apply(getters.apply(i).apply(value)));
+            }
+
+            @Override
+            public Seq<CsvEvent> reset() {
+                return emit(i -> writers.apply(i).reset());
+            }
+            
+            private Seq<CsvEvent> emit(Function1<Integer, Seq<CsvEvent>> getEvents) {
+                List<Seq<CsvEvent>> resultRows = new ArrayList<>();
+                for (int writerIdx = 0; writerIdx < writers.size(); writerIdx++) {
+                    Seq<CsvEvent> events = getEvents.apply(writerIdx);
+                    int row = 0;
+                    if (events.isEmpty()) {
+                        log.warn("{} did not emit any events. Emitting empty column instead.", protocols.apply(writerIdx));
+                        events = Vector.of(CsvEvent.endRecord());
+                    } else {
+                        if (!events.endsWith(Vector.of(CsvEvent.endValue(), CsvEvent.endRecord()))) {
+                            throw new IllegalArgumentException("Expecting nested writer to end its write with endValue, endRecord but did not: " + events);
+                        }
+                        events = events.dropRight(1);
+                        while (!events.isEmpty()) {
+                            Seq<CsvEvent> rowEvents = events.takeWhile(e -> !(e instanceof CsvEvent.EndRecord));
+                            log.debug("Row {}, writer {}: {}", row, writerIdx, rowEvents);
+                            events = events.drop(rowEvents.size());
+                            if (!events.isEmpty()) {
+                                // drop the endRecord() separator between two rows of a single inner write
+                                events = events.drop(1);
+                            }
+                            while (row >= resultRows.size()) {
+                                if (row == resultRows.size()) {
+                                    // empty columns until current writer
+                                    resultRows.add(Vector.fill(writerIdx, () -> CsvEvent.endValue()));
+                                } else {
+                                    // completely empty row
+                                    resultRows.add(Vector.fill(writers.size(), () -> CsvEvent.endValue()));
+                                }
+                            }
+                            resultRows.set(row, resultRows.get(row).appendAll(rowEvents));
+                            row++;
+                        }
+                    }
+                    // fill the rows that weren't emitted from this writer (but were from others) with empty columns
+                    while (row < resultRows.size()) {
+                        resultRows.set(row, resultRows.get(row).append(CsvEvent.endValue()));
+                        row++;
+                    }
+                }
+                return Vector.ofAll(resultRows).map(row -> row.append(CsvEvent.endRecord())).fold(Vector.empty(), (a,b) -> a.appendAll(b));
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/csv/NamedColumnReadProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/csv/NamedColumnReadProtocol.java
@@ -1,0 +1,87 @@
+package akka.stream.alpakka.marshal.csv;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+
+import javaslang.control.Try;
+
+/**
+ * Reads and writes a named column (the name being set by the first line in the file), delegating to
+ * an inner protocol for all the text that is in that column.
+ * 
+ * If several columns are declared to have the same name, the first one is used.
+ */
+public class NamedColumnReadProtocol<T> implements ReadProtocol<CsvEvent,T> {
+    private static final Logger log = LoggerFactory.getLogger(NamedColumnReadProtocol.class);
+    
+    private final String name;
+    private final ReadProtocol<CsvEvent, T> inner;
+
+    public NamedColumnReadProtocol(String name, ReadProtocol<CsvEvent,T> inner) {
+        this.name = name;
+        this.inner = inner;
+    }
+
+    @Override
+    public Reader<CsvEvent, T> reader() {
+        Reader<CsvEvent, T> innerReader = inner.reader();
+        return new Reader<CsvEvent, T>() {
+            boolean firstLine = true;
+            int columnIdx = 0;
+            int targetColumnIdx = -1;
+            String firstLineCurrentColumn = "";
+            
+            @Override
+            public Try<T> reset() {
+                log.debug("{} resetting", NamedColumnReadProtocol.this);
+                columnIdx = 0;
+                return innerReader.reset();
+            }
+
+            @Override
+            public Try<T> apply(CsvEvent event) {
+                if (firstLine) {
+                    if (event instanceof CsvEvent.Text) {
+                        if (firstLineCurrentColumn.length() <= name.length()) {
+                            // don't keep buffering bytes if this can never be the name we're looking for
+                            firstLineCurrentColumn += CsvEvent.Text.class.cast(event).getText();
+                        }
+                    } else if (event instanceof CsvEvent.EndValue) {
+                        if (targetColumnIdx == -1 && firstLineCurrentColumn.equals(name)) {
+                            log.debug("{} found our column at {}", NamedColumnReadProtocol.this, columnIdx);
+                            targetColumnIdx = columnIdx;
+                        }
+                        columnIdx++;
+                        firstLineCurrentColumn = "";
+                        return innerReader.reset();
+                    } else if (event instanceof CsvEvent.EndRecord) {
+                        firstLine = false;
+                        columnIdx = 0;
+                    }
+                } else {
+                    if (event instanceof CsvEvent.Text) {
+                        if (columnIdx == targetColumnIdx) {
+                            log.debug("{} forwarding {}", NamedColumnReadProtocol.this, event);
+                            return innerReader.apply(event);
+                        }
+                    } else if (event instanceof CsvEvent.EndValue) {
+                        columnIdx++;
+                    } else if (event instanceof CsvEvent.EndRecord) {
+                        columnIdx = 0;
+                    }
+                }
+                return none();
+            }
+        };
+    }
+    
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/csv/NamedColumnWriteProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/csv/NamedColumnWriteProtocol.java
@@ -1,0 +1,56 @@
+package akka.stream.alpakka.marshal.csv;
+
+import akka.stream.alpakka.marshal.WriteProtocol;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+
+/**
+ * Writes the column name + endValue() + endRecord() on the first line,
+ * and routes to to the inner protocol for all values found within subsequent lines.
+ * 
+ * The inner protocol is expected to only emit {@link CsvEvent.Text} events.
+ */
+public class NamedColumnWriteProtocol<T> implements WriteProtocol<CsvEvent, T> {
+    private final String name;
+    private final WriteProtocol<CsvEvent, T> inner;
+    
+    public NamedColumnWriteProtocol(String name, WriteProtocol<CsvEvent, T> inner) {
+        this.name = name;
+        this.inner = inner;
+    }
+
+    @Override
+    public Class<? extends CsvEvent> getEventType() {
+        return inner.getEventType();
+    }
+
+    @Override
+    public Writer<CsvEvent, T> writer() {
+        Writer<CsvEvent, T> innerWriter = inner.writer();
+        
+        return new Writer<CsvEvent, T>() {
+            boolean first = true;
+            
+            @Override
+            public Seq<CsvEvent> apply(T value) {
+                Seq<CsvEvent> events =
+                    (first) ? Vector.of(CsvEvent.text(name), CsvEvent.endValue(), CsvEvent.endRecord()) : Vector.empty();
+                first = false;
+                return events.appendAll(innerWriter.apply(value)).append(CsvEvent.endValue()).append(CsvEvent.endRecord());
+            }
+
+            @Override
+            public Seq<CsvEvent> reset() {
+                if (first) {
+                    first = false;
+                    return Vector.of(CsvEvent.text(name), CsvEvent.endValue(), CsvEvent.endRecord());
+                } else {
+                    return Vector.empty();
+                }
+            }
+        };
+    }
+    
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/csv/StringValueProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/csv/StringValueProtocol.java
@@ -1,0 +1,17 @@
+package akka.stream.alpakka.marshal.csv;
+
+import akka.stream.alpakka.marshal.generic.Locator;
+import akka.stream.alpakka.marshal.generic.StringProtocol;
+
+/**
+ * Decorates {@link ValueProtocol} with additional String conversion functions.
+ */
+public class StringValueProtocol extends StringProtocol<CsvEvent> {
+    private static final Locator<CsvEvent> locator = event -> "???";
+    
+    public static final StringValueProtocol instance = new StringValueProtocol();
+
+    private StringValueProtocol() {
+        super(ValueProtocol.instance, locator);
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/csv/ValueProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/csv/ValueProtocol.java
@@ -1,0 +1,64 @@
+package akka.stream.alpakka.marshal.csv;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+import javaslang.control.Try;
+
+/**
+ * Aggregates CSV text events into a String when reading, and outputs a single String as a single CSV text event when writing.
+ */
+public class ValueProtocol implements Protocol<CsvEvent,String> {
+    public static final ValueProtocol instance = new ValueProtocol();
+    
+    @Override
+    public Reader<CsvEvent, String> reader() {
+        return new Reader<CsvEvent, String>() {
+            private StringBuilder buffer = new StringBuilder();
+            
+            @Override
+            public Try<String> reset() {
+                Try<String> result = (buffer.length() > 0) ? Try.success(buffer.toString()) : none();
+                buffer = new StringBuilder();
+                return result;
+            }
+
+            @Override
+            public Try<String> apply(CsvEvent event) {
+                if (event instanceof CsvEvent.Text) {
+                    buffer.append(CsvEvent.Text.class.cast(event).getText());
+                }
+                return none();
+            }
+        };
+    }
+
+    @Override
+    public Class<? extends CsvEvent> getEventType() {
+        return CsvEvent.Text.class;
+    }
+
+    @Override
+    public Writer<CsvEvent, String> writer() {
+        return new Writer<CsvEvent, String>() {
+            @Override
+            public Seq<CsvEvent> apply(String value) {
+                if (value.isEmpty()) {
+                    return Vector.empty();
+                } else {
+                    return Vector.of(CsvEvent.text(value));
+                }
+            }
+
+            @Override
+            public Seq<CsvEvent> reset() {
+                return Vector.empty();
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/AnyOfProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/AnyOfProtocol.java
@@ -1,0 +1,86 @@
+package akka.stream.alpakka.marshal.generic;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.isNone;
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.Writer;
+import javaslang.collection.Seq;
+import javaslang.control.Try;
+
+/**
+ * Forwards read events to multiple alternative protocols, emitting whenever any of the alternatives emit. If multiple
+ * alternatives emit for the same event, the first one wins.
+ */
+public class AnyOfProtocol<E,T> implements ReadProtocol<E,T> {
+    private static final Logger log = LoggerFactory.getLogger(AnyOfProtocol.class);
+    
+    private final Seq<ReadProtocol<E,T>> alternatives;
+
+    public AnyOfProtocol(Seq<ReadProtocol<E,T>> alternatives) {
+        this.alternatives = alternatives;
+    }
+
+    @Override
+    public Reader<E,T> reader() {
+        Seq<Reader<E,T>> readers = alternatives.map(p -> p.reader());
+        return new Reader<E,T>() {
+            @Override
+            public Try<T> reset() {
+                return perform(r -> r.reset());
+            }
+
+            @Override
+            public Try<T> apply(E evt) {
+                return perform(r -> r.apply(evt));
+            }
+            
+            private Try<T> perform(Function<Reader<E,T>, Try<T>> f) {
+                Try<T> result = none();
+                for (Reader<E,T> reader: readers) {
+                    Try<T> readerResult = f.apply(reader);
+                    log.debug("reader {} said {}", reader, readerResult);
+                    if (!isNone(readerResult)) {
+                        if (isNone(result) || (result.isFailure() && readerResult.isSuccess())) {
+                            result = readerResult;
+                        } else if (readerResult.isFailure() && result.isFailure()) {
+                            result = Try.failure(new IllegalArgumentException(result.failed().get().getMessage() + ", alternatively " + readerResult.failed().get().getMessage()));
+                        }
+                    }
+                }
+                return result;
+            }
+        };
+    }
+    
+    /**
+     * Returns a Protocol that uses an AlternativesProtocol for reading, and always picks the first alternative when writing.
+     */
+    public static <E,T> Protocol<E,T> readWrite(Seq<Protocol<E,T>> alternatives) {
+        Protocol<E,T> write = alternatives.head();
+        AnyOfProtocol<E,T> read = new AnyOfProtocol<>(Seq.narrow(alternatives));
+        return new Protocol<E,T>() {
+            @Override
+            public Writer<E,T> writer() {
+                return write.writer();
+            }
+
+            @Override
+            public Class<? extends E> getEventType() {
+                return write.getEventType();
+            }
+
+            @Override
+            public Reader<E,T> reader() {
+                return read.reader();
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/Base64Decoder.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/Base64Decoder.java
@@ -1,0 +1,110 @@
+package akka.stream.alpakka.marshal.generic;
+
+import java.nio.charset.StandardCharsets;
+
+import akka.NotUsed;
+import akka.parboiled2.util.Base64;
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.javadsl.Flow;
+import akka.stream.stage.AbstractInHandler;
+import akka.stream.stage.AbstractOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+import akka.util.ByteString;
+import akka.util.ByteStringBuilder;
+import scala.Tuple2;
+
+public abstract class Base64Decoder {
+    /**
+     * A graph stage that decodes input bytes, which are assumed to be ASCII base64-encoded, into their binary representation.
+     * 
+     * The implementation is according to RFC4648.
+     */
+    public static final Flow<ByteString,ByteString,NotUsed> decodeBase64Bytes = Flow.fromGraph(new GraphStage<FlowShape<ByteString,ByteString>>() {
+        private final Inlet<ByteString> in = Inlet.create("in");
+        private final Outlet<ByteString> out = Outlet.create("out");
+        private final FlowShape<ByteString, ByteString> shape = FlowShape.of(in, out);
+
+        @Override
+        public FlowShape<ByteString, ByteString> shape() {
+            return shape;
+        }
+
+        @Override
+        public GraphStageLogic createLogic(Attributes attr) throws Exception {
+            return new GraphStageLogic(shape) {
+                private ByteString buf = ByteString.empty();
+                {
+                    setHandler(in, new AbstractInHandler() {
+                        @Override
+                        public void onPush() {
+                            buf = buf.concat(grab(in));
+                            // only decode in 4-character groups
+                            Tuple2<ByteString, ByteString> split = buf.splitAt(buf.size() - (buf.size() % 4));
+                            if (split._1.isEmpty()) {
+                                pull(in);
+                            } else {
+                                try {
+                                    push(out, decode(split._1));
+                                } catch (IllegalArgumentException x) {
+                                    failStage(x);
+                                }
+                            }
+                            buf = split._2;
+                        }
+
+                        private ByteString decode(ByteString encoded) {
+                            byte[] a = Base64.rfc2045().decode(encoded.toArray());
+                            if (a == null) {
+                                throw new IllegalArgumentException("Base64 input is not a valid multiple of 4-char sequences.");
+                            }
+                            return unsafeWrapByteArray(a);
+                        }
+                        
+                        public void onUpstreamFinish() {
+                            if (buf.isEmpty()) {
+                                complete(out);
+                            } else {
+                                try {
+                                    emit(out, decode(buf), () -> complete(out));
+                                } catch (IllegalArgumentException x) {
+                                    failStage(x);
+                                }
+                            }
+                        };
+                    });
+                    
+                    setHandler(out, new AbstractOutHandler() {
+                        @Override
+                        public void onPull() {
+                            pull(in);
+                        }
+                    });
+                }
+            };
+        }
+    });
+    
+    /**
+     * A graph stage that decodes input strings, which are assumed to be ASCII base64-encoded, into their binary representation.
+     */
+    public static final Flow<String,ByteString,NotUsed> decodeBase64Strings =
+        Flow.of(String.class)
+            .map(s -> s.getBytes(StandardCharsets.ISO_8859_1))
+            .map(Base64Decoder::unsafeWrapByteArray)
+            .via(decodeBase64Bytes);
+        
+    /**
+     * Wraps a byte array that is known to no longer be externally modified by any thread, ever, in an immutable ByteString.
+     * 
+     * This uses internal akka API, which is unsupported (but saves an array copy operation).
+     */
+    private static ByteString unsafeWrapByteArray(byte[] bytes) {
+        return new ByteStringBuilder()
+            .putByteArrayUnsafe(bytes)
+            .result();
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/ByteStringOutputStream.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/ByteStringOutputStream.java
@@ -1,0 +1,64 @@
+package akka.stream.alpakka.marshal.generic;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import akka.util.ByteString;
+import akka.util.ByteStringBuilder;
+
+/**
+ * Captures bytes written to an output stream as ByteString instances, which can be picked off
+ * repeatedly by invoking {@link #getBytesAndReset()}.
+ * 
+ * Instances of this class are not safe to be invoked concurrently from multiple threads.
+ */
+public class ByteStringOutputStream extends OutputStream {
+    private ByteStringBuilder buffer = new ByteStringBuilder();
+    private OutputStream delegate = buffer.asOutputStream();
+
+    @Override
+    public void write(int b) throws IOException {
+        delegate.write(b);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        delegate.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        delegate.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        delegate.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+
+    /**
+     * Returns a ByteString containing the bytes that have been written so far, and then
+     * empties the internal buffer.
+     */
+    public ByteString getBytesAndReset() {
+        try {
+            delegate.close();
+        } catch (IOException e) { // can't occur, we're not doing I/O
+            throw new RuntimeException(e);
+        }
+        ByteString result = buffer.result();
+        buffer = new ByteStringBuilder();
+        delegate = buffer.asOutputStream();
+        return result;
+    }
+
+    public boolean hasBytes() {
+        return buffer.length() > 0;
+    }
+    
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/CombinedProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/CombinedProtocol.java
@@ -1,0 +1,59 @@
+package akka.stream.alpakka.marshal.generic;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.isNone;
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import java.util.function.Function;
+
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+import javaslang.control.Try;
+
+/**
+ * Forwards read events to multiple alternative protocols, emitting whenever any of the alternatives emit.
+ * If multiple alternatives emit for the same event, all results are emitted.
+ * If at least one alternative emits for an event, any errors on other alternatives are ignored.
+ * If all alternatives yield errors for an event, the errors are concatenated and escalated.
+ */
+public class CombinedProtocol<E,T> implements ReadProtocol<E,Seq<T>> {
+    private final Seq<ReadProtocol<E,T>> alternatives;
+
+    public CombinedProtocol(Seq<ReadProtocol<E,T>> alternatives) {
+        this.alternatives = alternatives;
+    }
+
+    @Override
+    public Reader<E,Seq<T>> reader() {
+        Seq<Reader<E,T>> readers = alternatives.map(p -> p.reader());
+        return new Reader<E,Seq<T>>() {
+            @Override
+            public Try<Seq<T>> reset() {
+                return perform(r -> r.reset());
+            }
+
+            @Override
+            public Try<Seq<T>> apply(E evt) {
+                return perform(r -> r.apply(evt));
+            }
+
+            private Try<Seq<T>> perform(Function<Reader<E,T>, Try<T>> f) {
+                Try<Seq<T>> result = none();
+                for (Reader<E,T> reader: readers) {
+                    Try<T> readerResult = f.apply(reader);
+                    if (!isNone(readerResult)) {
+                        if (isNone(result) || (result.isFailure() && readerResult.isSuccess())) {
+                            result = readerResult.map(Vector::of);
+                        } else if (!result.isFailure() && readerResult.isSuccess()) {
+                            result = result.map(seq -> seq.append(readerResult.get()));
+                        } else if (readerResult.isFailure() && result.isFailure()) {
+                            result = Try.failure(new IllegalArgumentException(result.failed().get().getMessage() + ", alternatively " + readerResult.failed().get().getMessage()));
+                        }
+                    }
+                }
+                return result;
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/ConstantProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/ConstantProtocol.java
@@ -1,0 +1,80 @@
+package akka.stream.alpakka.marshal.generic;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.WriteProtocol;
+import akka.stream.alpakka.marshal.Writer;
+import javaslang.control.Try;
+
+/**
+ * Protocol that always writes the same value, and on reading emits "Present" when the expected value was indeed read.
+ */
+public class ConstantProtocol {
+    /**
+     * Marker type to indicate that the constant was indeed found in the incoming event stream (during reading).
+     * During writing, the constant is always output whenever the writer is invoked.
+     */
+    public static class Present {
+        private Present() {}
+        
+        @Override
+        public String toString() {
+            return "present";
+        }
+    }
+    public static final Present PRESENT = new Present();
+    
+    public static <E,T> ReadProtocol<E,Present> read(ReadProtocol<E,T> inner, T value) {
+        return new ReadProtocol<E,Present>() {
+            @Override
+            public Reader<E,Present> reader() {
+                final Reader<E,T> innerReader = inner.reader();
+                
+                return new Reader<E,Present>() {
+                    @Override
+                    public Try<Present> reset() {
+                        return emit(innerReader.reset());
+                    }
+
+                    @Override
+                    public Try<Present> apply(E evt) {
+                        return emit(innerReader.apply(evt));
+                    }
+                    
+                    private Try<Present> emit(Try<T> t) {
+                        return t.filter(value::equals).map(v -> PRESENT);
+                    }
+                };
+            }
+            
+            @Override
+            public String toString() {
+                return inner.toString() + "=" + value;
+            }
+        };
+    }
+
+    public static <E,T> WriteProtocol<E,Present> write(WriteProtocol<E,T> inner, T value) {
+        return new WriteProtocol<E,Present>() {
+            @Override
+            public Writer<E,Present> writer() {
+                return inner.writer().compose(present -> value);
+            }
+
+            @Override
+            public Class<? extends E> getEventType() {
+                return inner.getEventType();
+            }
+            
+            @Override
+            public String toString() {
+                return inner.toString() + "=" + value;
+            }
+        };
+    }
+
+    public static <E,T> Protocol<E,Present> readWrite(Protocol<E,T> inner, T value) {
+        return Protocol.of(read(inner, value), write(inner, value));
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/FoldProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/FoldProtocol.java
@@ -1,0 +1,87 @@
+package akka.stream.alpakka.marshal.generic;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.isNone;
+
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+import javaslang.Function2;
+import javaslang.control.Option;
+import javaslang.control.Try;
+
+/**
+ * Folds over a repeated nested protocol, merging the results into a single element. Only for read protocols.
+ */
+public class FoldProtocol {
+    private static final Logger log = LoggerFactory.getLogger(FoldProtocol.class);
+
+    /**
+     * Returns a protocol that accumulates multiple read emissions from an inner protocol into a single value.
+     * @param name Name for the operation (appears in toString)
+     * @param inner Inner protocol that emits the elements
+     * @param initial Initial value to start accumulating on
+     * @param combine Function that combines the previous result (or initial) with a parsed element
+     */
+    public static <E,T,U> ReadProtocol<E,U> read(String name, ReadProtocol<E,T> inner, Supplier<U> initial, Function2<U,T,U> combine) {
+        Try<U> EMPTY = Try.success(initial.get());
+        
+        return new ReadProtocol<E,U>() {
+            ReadProtocol<E,U> parent = this;
+            @Override
+            public Reader<E,U> reader() {
+                Reader<E,T> parentReader = inner.reader();
+                return new Reader<E,U>() {
+                    Option<U> value = Option.none();
+                    
+                    @Override
+                    public Try<U> apply(E evt) {
+                        Try<T> result = parentReader.apply(evt);
+                        if (result.isSuccess()) {
+                            value = Option.some(combine.apply(value.getOrElse(initial), result.get()));
+                            log.debug("Success, now {}", value);
+                            return ReadProtocol.none();
+                        } else if (isNone(result)) {
+                            // skip over
+                            return ReadProtocol.none();
+                        } else {
+                            // failure: emit immediately, throw away rest
+                            log.debug("Failure: {}", result);
+                            value = Option.none();
+                            return result.map(t->null);
+                        }
+                    }
+
+                    @Override
+                    public Try<U> reset() {
+                        Try<T> result = parentReader.reset();
+                        Try<U> r;
+                        if (result.isSuccess()) {
+                            r = Try.success(combine.apply(value.getOrElse(initial), result.get()));
+                        } else if (isNone(result)) {
+                            r = (value.isDefined()) ? value.toTry() : EMPTY;
+                        } else {
+                            r = Try.failure(result.failed().get());
+                        }
+                        value = Option.none();
+                        log.debug("{} reset as {}", parent, r);
+                        return r;
+                    }
+                };
+            }
+            
+            @Override
+            public Try<U> empty() {
+                return EMPTY;
+            }
+            
+            @Override
+            public String toString() {
+                return name + "(" + inner.toString() + ")";
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/IterableProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/IterableProtocol.java
@@ -1,0 +1,56 @@
+package akka.stream.alpakka.marshal.generic;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.WriteProtocol;
+import akka.stream.alpakka.marshal.Writer;
+import javaslang.collection.Vector;
+
+/**
+ * Write support for generic Iterable, and read support for mutable collection classes.
+ */
+public class IterableProtocol {
+    /**
+     * @param factory Function that creates a new mutable collection with a single value
+     * @param add Consumer that adds an element to the collection
+     * @param empty Empty collection instance (global, it won't be modified)
+     */
+    public static <E,T,C extends Iterable<T>> ReadProtocol<E,C> read(ReadProtocol<E,T> inner, Supplier<C> factory, BiConsumer<C,T> add) {
+        return FoldProtocol.read("*", inner, factory, (c,t) -> {
+            add.accept(c, t);
+            return c;
+        });
+    }
+    
+    public static <E,T> WriteProtocol<E,Iterable<T>> write(WriteProtocol<E,T> inner) {
+        return new WriteProtocol<E,Iterable<T>>() {
+            @Override
+            public Writer<E,Iterable<T>> writer() {
+                Writer<E,T> parentWriter = inner.writer();
+                
+                return Writer.of(iterable -> {
+                    Vector<T> items = Vector.ofAll(iterable);
+                    if (items.isEmpty()) {
+                        return parentWriter.reset();
+                    } else {
+                        return items.map(parentWriter::applyAndReset)
+                            .flatMap(Function.identity());
+                    }
+                });
+            }
+            
+            @Override
+            public Class<? extends E> getEventType() {
+                return inner.getEventType();
+            }
+            
+            @Override
+            public String toString() {
+                return "*(" + inner + ")";
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/Locator.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/Locator.java
@@ -1,0 +1,9 @@
+package akka.stream.alpakka.marshal.generic;
+
+/**
+ * Returns a human-readable parsing location for inclusion with errors reported when
+ * handling a particular event of type E.
+ */
+public interface Locator<E> {
+    public String getLocation(E e);
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/MapProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/MapProtocol.java
@@ -1,0 +1,30 @@
+package akka.stream.alpakka.marshal.generic;
+
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.WriteProtocol;
+import javaslang.Function1;
+import javaslang.Tuple2;
+import javaslang.collection.Map;
+
+/**
+ * Reads and writes an inner read/write protocol of tuples, which may match multiple times, 
+ * by mapping it to an immutable {@link javaslang.collection.Map}.
+ */
+public class MapProtocol {
+    /**
+     * Reads a series of tuples into a map.
+     * @param factory Function that creates a singleton collection around a value
+     * @param empty Empty collection
+     */
+    @SuppressWarnings("unchecked")
+    public static <E,K,V,M extends Map<K,V>> ReadProtocol<E,M> read(ReadProtocol<E,Tuple2<K,V>> inner, Function1<Tuple2<K,V>,M> factory, M empty) {
+        return FoldProtocol.read("map", inner, () -> empty, (map, t) -> (M) map.put(t));
+    }
+
+    /**
+     * Writes a map by considering it a series of tuples.
+     */
+    public static <E,K,V> WriteProtocol<E,Map<K,V>> write(WriteProtocol<E,Tuple2<K,V>> inner) {
+        return WriteProtocol.narrow(IterableProtocol.write(inner));
+    }    
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/OptionProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/OptionProtocol.java
@@ -1,0 +1,16 @@
+package akka.stream.alpakka.marshal.generic;
+
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.WriteProtocol;
+import javaslang.control.Option;
+
+public class OptionProtocol {
+    
+    public static <E,T> ReadProtocol<E,Option<T>> read(ReadProtocol<E,T> inner) {
+        return FoldProtocol.read("option", inner, () -> Option.<T>none(), (opt, t) -> Option.some(t));
+    }
+
+    public static <E,T> WriteProtocol<E,Option<T>> write(WriteProtocol<E,T> inner) {
+        return WriteProtocol.narrow(IterableProtocol.write(inner));
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/PushPullOutputStreamAdapter.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/PushPullOutputStreamAdapter.java
@@ -1,0 +1,89 @@
+package akka.stream.alpakka.marshal.generic;
+
+import java.io.OutputStream;
+
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInHandler;
+import akka.stream.stage.AbstractOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+import akka.util.ByteString;
+
+/**
+ * Adapts a writer W that can write to an OutputStream to serve in an akka stream in a non-blocking fashion.
+ * The writer W is expected to write to an OutputStream as a result of receiving elements of type T. For example,
+ * W could be an XML writer emitting bytes for every XML event.
+ * 
+ * W does not have to be multi-thread safe; it can be assumed to only be operated upon by one thread at a time.
+ * 
+ * @param <T> The input element type that is given to W
+ * @param <W> The writer object that transforms T into calls on an output stream
+ */
+public class PushPullOutputStreamAdapter<T,W> extends GraphStage<FlowShape<T, ByteString>> {
+    private final Outlet<ByteString> out = Outlet.create("out");
+    private final Inlet<T> in = Inlet.create("in");
+    private final FlowShape<T, ByteString> shape = FlowShape.of(in, out);
+    
+    private final CheckedBiFunction<Attributes,OutputStream,W> factory;
+    private final CheckedBiConsumer<W,T> write;
+
+    /**
+     * Creates a new PushPullOutputStreamAdapter
+     * @param factory Lambda that will create a new writer W based on stream attributes and a target output stream.
+     * @param write Lamda that will tell a writer to to write an element T to its output stream.
+     */
+    public PushPullOutputStreamAdapter(CheckedBiFunction<Attributes, OutputStream, W> factory, CheckedBiConsumer<W, T> write) {
+        this.factory = factory;
+        this.write = write;
+    }
+
+    @Override
+    public FlowShape<T, ByteString> shape() {
+        return shape;
+    }
+
+    @Override
+    public GraphStageLogic createLogic(Attributes attr) throws Exception {
+        ByteStringOutputStream stream = new ByteStringOutputStream();
+        W writer = factory.apply(attr, stream);
+        return new GraphStageLogic(shape) {{
+            setHandler(out, new AbstractOutHandler() {
+                @Override
+                public void onPull() throws Exception {
+                    if (stream.hasBytes()) {
+                        push(out, stream.getBytesAndReset());
+                    } else {
+                        pull(in);
+                    }
+                }
+            });
+            
+            setHandler(in, new AbstractInHandler() {
+                @Override
+                public void onPush() throws Exception {
+                    T t = grab(in);
+                    write.accept(writer, t);
+                    if (stream.hasBytes()) {
+                        push(out, stream.getBytesAndReset());
+                    } else {
+                        pull(in);
+                    }
+                }
+            });
+        }};
+    }
+    
+    @FunctionalInterface
+    public interface CheckedBiConsumer<T, U> {
+        void accept(T t, U u) throws Exception;
+    }
+    
+    @FunctionalInterface
+    public interface CheckedBiFunction<T, U, R> {
+        R apply(T t, U u) throws Exception;
+    }
+    
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/Regex.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/Regex.java
@@ -1,0 +1,146 @@
+package akka.stream.alpakka.marshal.generic;
+
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.control.Option;
+
+/**
+ * A regular expression with compile-time known capture groups, which extract to a known type when matched.
+ */
+public abstract class Regex<T> {
+    /**
+     * A Regex that matches a UUID
+     */
+    public static final Regex<UUID> aUUID = Regex
+        .compile1("([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})", Pattern.CASE_INSENSITIVE)
+        .map(UUID::fromString);
+    
+    private final Pattern regex;
+    
+    @Override
+    public int hashCode() {
+        return regex.hashCode();
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        return (obj instanceof Regex) && Regex.class.cast(obj).regex.equals(regex);
+    }
+    
+    @Override
+    public String toString() {
+        return regex.toString();
+    }
+    
+    /**
+     * Returns a Regex for a regular expression with 1 capture group.
+     */
+    public static Regex<String> compile1(String regex) {
+        return compile1(regex, 0);
+    }
+    
+    /**
+     * Returns a Regex for a regular expression with 1 capture group.
+     */
+    public static Regex<String> compile1(String regex, int flags) {
+        return new Regex<String>(regex, flags) {
+            @Override
+            protected String extract(Matcher m) {
+                return m.group(1);
+            }
+        };
+    }
+    
+    /**
+     * Returns a Regex for a regular expression with 2 capture groups.
+     */
+    public static Regex<Tuple2<String,String>> compile2(String regex) {
+        return compile2(regex, 0);
+    }
+    
+    /**
+     * Returns a Regex for a regular expression with 2 capture groups.
+     */
+    public static Regex<Tuple2<String,String>> compile2(String regex, int flags) {
+        return new Regex<Tuple2<String,String>>(regex, flags) {
+            @Override
+            protected Tuple2<String, String> extract(Matcher m) {
+                return Tuple.of(m.group(1), m.group(2));
+            }
+        };
+    }
+    
+    private Regex(String regex, int flags) {
+        this.regex = Pattern.compile(regex, flags);
+    }
+    
+    protected Regex() { // constructor for subclasses overriding match()
+        this.regex = null;
+    }
+
+    /**
+     * Returns an Option containing the value of the capture groups, or Option.none() if the 
+     * regular expression did not match.
+     */
+    public Option<T> match(String source) {
+        Matcher m = regex.matcher(source);
+        if (m.matches()) {
+            return Option.of(extract(m));
+        } else {
+            return Option.none();
+        }        
+    }
+    
+    /**
+     * Returns a regex that transforms the returned type from T into U, using the supplied function.
+     */
+    public <U> Regex<U> map(Function<T,U> f) {
+        final Regex<T> parent = this;
+        return new Regex<U>() {
+            @Override
+            public Option<U> match(String source) {
+                return parent.match(source).map(f);
+            }
+
+            @Override
+            protected U extract(Matcher m) {
+                return null;
+            }
+            
+            @Override
+            public String toString() {
+                return parent.toString();
+            }
+        };
+    }
+    
+    /**
+     * Returns a regex that transforms the returned type from T into {@code Option<U>} , using the supplied function.
+     */
+    public <U> Regex<U> flatMap(Function<T,Option<U>> f) {
+        final Regex<T> parent = this;
+        return new Regex<U>() {
+            @Override
+            public Option<U> match(String source) {
+                return parent.match(source).flatMap(f);
+            }
+
+            @Override
+            protected U extract(Matcher m) {
+                return null;
+            }
+            
+            @Override
+            public String toString() {
+                return parent.toString();
+            }
+        };
+    }
+    
+    protected abstract T extract(Matcher m);
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/SeqProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/SeqProtocol.java
@@ -1,0 +1,18 @@
+package akka.stream.alpakka.marshal.generic;
+
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.WriteProtocol;
+import javaslang.collection.Seq; 
+
+public class SeqProtocol {
+    
+    @SuppressWarnings("unchecked")
+    public static <E,T,S extends Seq<T>> ReadProtocol<E, S> read(ReadProtocol<E, T> inner, S empty) {
+        return FoldProtocol.read("*", inner, () -> empty, (seq, t) -> (S) seq.append(t));
+    }
+
+    public static <E,T> WriteProtocol<E,Seq<T>> write(WriteProtocol<E,T> inner) {
+        return WriteProtocol.narrow(IterableProtocol.write(inner));
+    }
+    
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/StringMarshallable.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/StringMarshallable.java
@@ -1,0 +1,155 @@
+package akka.stream.alpakka.marshal.generic;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.function.Function;
+
+import javaslang.control.Try;
+
+/**
+ * Converts arbitrary types to and from String
+ */
+public abstract class StringMarshallable<T> {
+    public abstract Try<T> tryRead(String value);
+    
+    public abstract String write(T value);
+
+    public static final StringMarshallable<String> STRING = new StringMarshallable<String>() {
+        @Override
+        public Try<String> tryRead(String value) {
+            return Try.success(value);
+        }
+
+        @Override
+        public String write(String value) {
+            return value;
+        }
+        
+        @Override
+        public String toString() {
+            return "string";
+        }
+    };
+
+    /** Java Long converter. For JSON, please prefer to use {@link JSONProtocol.longValue} since it maps to JSON number instead of string. */
+    public static final StringMarshallable<Long> LONG = new StringMarshallable<Long>() {
+        @Override
+        public Try<Long> tryRead(String value) {
+            return Try.of(() -> Long.parseLong(value)).recover(prefixMessage("Expecting a signed 64-bit decimal integer "));
+        }
+
+        @Override
+        public String write(Long value) {
+            return String.valueOf(value);
+        }
+        
+        @Override
+        public String toString() {
+            return "long";
+        }
+    };
+    
+    /** Java Integer converter. For JSON, please prefer to use {@link JSONProtocol.integerValue} since it maps to JSON number instead of string. */
+    public static final StringMarshallable<Integer> INTEGER = new StringMarshallable<Integer>() {
+        @Override
+        public Try<Integer> tryRead(String value) {
+            return Try.of(() -> Integer.parseInt(value)).recover(prefixMessage("Expecting a signed 32-bit decimal integer "));
+        }
+
+        @Override
+        public String write(Integer value) {
+            return String.valueOf(value);
+        }
+        
+        @Override
+        public String toString() {
+            return "integer";
+        }
+    };
+    
+    /** Java BigDecimal converter. For JSON, please prefer to use {@link JSONProtocol.longValue} since it maps to JSON number instead of string. */
+    public static final StringMarshallable<BigDecimal> BIG_DECIMAL = new StringMarshallable<BigDecimal>() {
+        @Override
+        public Try<BigDecimal> tryRead(String value) {
+            return Try.of(() -> new BigDecimal(value)).recover(prefixMessage("Expecting an arbitrary precision decimal number "));
+        }
+
+        @Override
+        public String write(BigDecimal value) {
+            return value.toString();
+        }
+        
+        @Override
+        public String toString() {
+            return "big decimal";
+        }
+    };
+    
+    /** Java BigInteger converter. For JSON, please prefer to use {@link JSONProtocol.longValue} since it maps to JSON number instead of string. */
+    public static final StringMarshallable<BigInteger> BIG_INTEGER = new StringMarshallable<BigInteger>() {
+        @Override
+        public Try<BigInteger> tryRead(String value) {
+            return Try.of(() -> new BigInteger(value)).recover(prefixMessage("Expecting an arbitrary precision decimal integer "));
+        }
+
+        @Override
+        public String write(BigInteger value) {
+            return value.toString();
+        }
+        
+        @Override
+        public String toString() {
+            return "big integer";
+        }
+    };
+    
+    /** Java UUID converter */
+    public static final StringMarshallable<UUID> UUID_T = new StringMarshallable<UUID>() {
+        @Override
+        public Try<UUID> tryRead(String value) {
+            return Try.of(() -> UUID.fromString(value)).recover(prefixMessage("Expecting a UUID "));
+        }
+
+        @Override
+        public String write(UUID value) {
+            return value.toString();
+        }
+        
+        @Override
+        public String toString() {
+            return "uuid";
+        }
+    };
+    
+    /**
+     * (un)marshals an Instant using ISO 8601 ( "2014-10-23T00:35:14.800Z" )
+     */
+    public static final StringMarshallable<Instant> INSTANT = new StringMarshallable<Instant>() {
+        @Override
+        public Try<Instant> tryRead(String value) {
+            return Try.of(() -> Instant.parse(value)).recover(prefixMessage("Expecting an ISO 8601 date"));
+        }
+
+        @Override
+        public String write(Instant value) {
+            return value.toString(); // formats as ISO 8601
+        }
+        
+        @Override
+        public String toString() {
+            return "ISO 8601 date";
+        }
+    };
+    
+    private static <T> Function<Throwable,T> prefixMessage(String msg) {
+        return t -> {
+            if (t instanceof IllegalArgumentException) {
+                throw new IllegalArgumentException(msg + t.getMessage(), t);
+            } else {
+                throw (RuntimeException)t;
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/StringMarshallableProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/StringMarshallableProtocol.java
@@ -1,0 +1,63 @@
+package akka.stream.alpakka.marshal.generic;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.Writer;
+import javaslang.control.Try;
+
+/**
+ * A protocol for a String that has been marshalled to and from T using a {@link StringMarshallable}.
+ */
+public class StringMarshallableProtocol<E,T> implements Protocol<E,T> {
+    private final Locator<E> locator;
+    private final StringMarshallable<T> type;
+    private final Protocol<E,String> delegate;
+    
+    public StringMarshallableProtocol(StringMarshallable<T> type, Protocol<E,String> delegate, Locator<E> locator) {
+        this.type = type;
+        this.delegate = delegate;
+        this.locator = locator;
+    }
+
+    @Override
+    public Writer<E,T> writer() {
+        return delegate.writer().compose(type::write);
+    }
+
+    @Override
+    public Reader<E,T> reader() {
+        return addLocationOnError(delegate.reader().flatMap(s -> type.tryRead(s)), locator);
+    }
+
+    @Override
+    public Class<? extends E> getEventType() {
+        return delegate.getEventType();
+    }
+    
+    @Override
+    public String toString() {
+        return delegate.toString() + " as " + type.toString();
+    }
+
+    static <E,T> Reader<E,T> addLocationOnError(Reader<E,T> inner, Locator<E> locator) {
+        return new Reader<E,T>() {
+            @Override
+            public Try<T> reset() {
+                return inner.reset();
+            }
+
+            @Override
+            public Try<T> apply(E event) {
+                return addLocation(inner.apply(event), locator.getLocation(event));
+            }
+            
+            private Try<T> addLocation(Try<T> t, String location) {
+                if (t.isFailure() && t.failed().get() instanceof IllegalArgumentException) {
+                    return Try.failure(new IllegalArgumentException(t.failed().get().getMessage() + " at " + location, t.failed().get()));
+                } else {
+                    return t;
+                }
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/StringProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/StringProtocol.java
@@ -1,0 +1,94 @@
+package akka.stream.alpakka.marshal.generic;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.Writer;
+import javaslang.Function1;
+import javaslang.control.Try;
+
+/**
+ * Protocol for String, which can be converted to other types using .as(), or made to conform
+ * to a regular expression using .matching().
+ */
+public class StringProtocol<E> implements Protocol<E,String> {
+    private final Locator<E> locator;
+    private final Protocol<E,String> delegate;
+    
+    public StringProtocol(Protocol<E, String> delegate, Locator<E> locator) {
+        this.delegate = delegate;
+        this.locator = locator;
+    }
+    
+    @Override
+    public Writer<E,String> writer() {
+        return delegate.writer();
+    }
+
+    @Override
+    public Reader<E,String> reader() {
+        return delegate.reader();
+    }
+
+    @Override
+    public Class<? extends E> getEventType() {
+        return delegate.getEventType();
+    }
+    
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+    
+    /**
+     * Converts the body to a different type.
+     */
+    public <T> Protocol<E,T> as(StringMarshallable<T> type) {
+        return new StringMarshallableProtocol<>(type, this, locator);
+    }
+    
+    /**
+     * Returns an XMLProtocol that only reads strings that match the given regular expression. The resulting
+     * protocol can not be used for writing.
+     */
+    public <T> ReadProtocol<E,T> matching(Regex<T> regex) {
+        StringProtocol<E> parent = this;
+        return new ReadProtocol<E,T>() {
+            @Override
+            public Reader<E,T> reader() {
+                return parent.reader().flatMap(s -> regex.match(s).toTry());
+            }
+        };
+    }
+
+    /**
+     * Returns an XMLProtocol that only reads strings that match the given regular expression.
+     * During writing, the given function is called. It's the callers responsibility to ensure that
+     * the result of the function matches the regex.
+     */
+    public <T> Protocol<E,T> matching(Regex<T> regex, Function1<T,String> onWrite) {
+        StringProtocol<E> parent = this;
+        return new Protocol<E,T>() {
+            @Override
+            public Reader<E,T> reader() {
+                return parent.reader().flatMap(s -> regex.match(s).toTry().orElse(() -> Try.failure(new ValidationException(parent.toString() + " should match " + regex))));
+            }
+
+            @Override
+            public Writer<E,T> writer() {
+                return parent.writer().compose(onWrite);
+            }
+            
+            @Override
+            public Class<? extends E> getEventType() {
+                return parent.getEventType();
+            }
+            
+            @Override
+            public String toString() {
+                return parent.toString() + " matching " + regex;
+            }
+        };
+    }
+
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/TStringProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/TStringProtocol.java
@@ -1,0 +1,84 @@
+package akka.stream.alpakka.marshal.generic;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.Writer;
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.control.Try;
+
+/**
+ * Protocol for a tuple of T and String, where the String can be transformed to other types
+ * by invoking .as(TYPE).
+ */
+public class TStringProtocol<E,T1> implements Protocol<E,Tuple2<T1, String>> {
+    private final Protocol<E,Tuple2<T1, String>> delegate;
+    private final Locator<E> locator;
+    
+    public TStringProtocol(Protocol<E,Tuple2<T1, String>> delegate, Locator<E> locator) {
+        this.delegate = delegate;
+        this.locator = locator;
+    }
+    
+    @Override
+    public  Class<? extends E> getEventType() {
+        return delegate.getEventType();
+    }
+
+    @Override
+    public Reader<E, Tuple2<T1, String>> reader() {
+        return delegate.reader();
+    }
+
+    @Override
+    public Try<Tuple2<T1, String>> empty() {
+        return delegate.empty();
+    }
+
+    @Override
+    public Writer<E, Tuple2<T1, String>> writer() {
+        return delegate.writer();
+    }
+    
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    /**
+     * Converts _2 of the tuple to a different type.
+     */
+    public <T2> Protocol<E,Tuple2<T1,T2>> as(StringMarshallable<T2> type) {
+        return new Protocol<E,Tuple2<T1,T2>>() {
+            @Override
+            public Writer<E,Tuple2<T1, T2>> writer() {
+                return TStringProtocol.this.writer().compose(t -> t.map2(type::write));
+            }
+
+            @Override
+            public Try<Tuple2<T1, T2>> empty() {
+                return TStringProtocol.this.empty().flatMap(tuple -> 
+                    type.tryRead(tuple._2()).map(t2 -> Tuple.of(tuple._1, t2)));
+            }
+            
+            @Override
+            public Reader<E,Tuple2<T1, T2>> reader() {
+                return StringMarshallableProtocol.addLocationOnError(
+                    TStringProtocol.this.reader().flatMap(tuple -> 
+                        type.tryRead(tuple._2()).map(t2 -> Tuple.of(tuple._1(), t2)))
+                    , locator);
+            }
+            
+            @Override
+            public Class<? extends E> getEventType() {
+                return delegate.getEventType();
+            }
+            
+            @Override
+            public String toString() {
+                return delegate.toString() + " as " + type.toString();
+            }            
+        };
+    }    
+    
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/generic/ValidationException.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/generic/ValidationException.java
@@ -1,0 +1,24 @@
+package akka.stream.alpakka.marshal.generic;
+
+/**
+ * Thrown by readers when the encountered structure does not match the expected structure, e.g. missing fields, wrong format, etc.
+ */
+@SuppressWarnings("serial")
+public class ValidationException extends IllegalArgumentException {
+
+    public ValidationException() {
+        super();
+    }
+
+    public ValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ValidationException(String message) {
+        super(message);
+    }
+
+    public ValidationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/http/HttpFlow.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/http/HttpFlow.java
@@ -1,0 +1,122 @@
+package akka.stream.alpakka.marshal.http;
+
+import static javaslang.control.Option.none;
+import static javaslang.control.Option.some;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Predicate;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.NotUsed;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.model.ContentType;
+import akka.http.javadsl.model.HttpEntities;
+import akka.http.javadsl.model.HttpHeader;
+import akka.http.javadsl.model.HttpMethod;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.RequestEntity;
+import akka.http.javadsl.model.Uri;
+import akka.stream.Materializer;
+import akka.stream.javadsl.AsPublisher;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Keep;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+import javaslang.control.Option;
+
+public class HttpFlow {
+    private static final Logger log = LoggerFactory.getLogger(HttpFlow.class);
+    private static final Predicate<HttpResponse> defaultIsSuccess = r -> r.status().isSuccess();
+    
+    private final Http http;
+    private final Materializer materializer;
+    
+    public HttpFlow(Http http, Materializer materializer) {
+        this.http = http;
+        this.materializer = materializer;
+    }
+    
+    
+    /**
+     * Returns a flow that, when materialized, makes an HTTP request with the given [method] to [uri], with an entity
+     * of [contentType] and optional extra [headers], using flow input as request body.
+     * 
+     * The flow output will be the body of the HTTP response.
+     * 
+     * The materialized value of the flow is the HTTP response itself, which can be used to check headers and status code. It is NOT
+     * legal to access the entity data from the materialized value, since its contents is already consumed as the flow output.
+     * 
+     * @param isSuccess predicate that decides whether a response is acceptable. If not, the stream will be failed with
+     *        an IllegalStateException.
+     */
+    public Flow<ByteString, ByteString, CompletionStage<HttpResponse>> flow(HttpMethod method, Uri uri, ContentType contentType, Predicate<HttpResponse> isSuccess, HttpHeader... headers) {
+        return createFlow(method, uri, some(contentType), isSuccess, headers);
+    }
+    
+    public Flow<ByteString, ByteString, CompletionStage<HttpResponse>> flow(HttpMethod method, Uri uri, ContentType contentType, HttpHeader... headers) {
+        return flow(method, uri, contentType, defaultIsSuccess, headers);
+    }
+    
+    /**
+     * Returns a source that, when materialized, makes an HTTP request with the given [method] to [uri], with no request entity, and optional extra [headers].
+     * 
+     * The source output will be the body of the HTTP response.
+     * 
+     * The materialized value of the flow is the HTTP response itself, which can be used to check headers and status code. It is NOT
+     * legal to access the entity data from the materialized value, since its contents is already consumed as the flow output.
+     * 
+     * @param isSuccess predicate that decides whether a response is acceptable. If not, the stream will be failed with
+     *        an IllegalStateException.
+     */
+    public Source<ByteString,CompletionStage<HttpResponse>> source(HttpMethod method, Uri uri, Predicate<HttpResponse> isSuccess, HttpHeader... headers) {
+        return Source.<ByteString>empty().viaMat(createFlow(method, uri, none(), isSuccess, headers), (m1,m2) -> m2);
+    }
+    
+    public Source<ByteString,CompletionStage<HttpResponse>> source(HttpMethod method, Uri uri, HttpHeader... headers) {
+        return source(method, uri, defaultIsSuccess, headers);
+    }
+
+    private Flow<ByteString, ByteString, CompletionStage<HttpResponse>> createFlow(HttpMethod method, Uri uri, Option<ContentType> contentType, Predicate<HttpResponse> isSuccess, HttpHeader... headers) {
+        Sink<ByteString, Publisher<ByteString>> in = Sink.asPublisher(AsPublisher.WITH_FANOUT); // akka internally recreates this twice, on some errors...
+        Source<ByteString, Subscriber<ByteString>> out = Source.asSubscriber();
+        
+        return Flow.fromSinkAndSourceMat(in, out, Keep.both()).mapMaterializedValue(pair -> {
+            RequestEntity entity;
+            if (contentType.isDefined()) {
+                Source<ByteString, NotUsed> inReader = Source.fromPublisher(pair.first());
+                entity = HttpEntities.createChunked(contentType.get(), inReader);
+            } else {
+                entity = HttpEntities.EMPTY;
+            }
+            HttpRequest rq = HttpRequest.create().withMethod(method).withUri(uri).addHeaders(Arrays.asList(headers)).withEntity(entity);
+            
+            return http.singleRequest(rq, materializer).thenApply(resp -> {
+                if (isSuccess.test(resp)) {
+                    resp.entity().getDataBytes()
+                        .runWith(Sink.fromSubscriber(pair.second()), materializer);
+                } else {
+                    log.info("Http responded error: {} for request {}", resp, rq);
+                    resp.discardEntityBytes(materializer);
+                    pair.second().onError(new IllegalStateException("Unsuccessful HTTP response: " + resp + " for " + rq));
+                }
+                return resp;
+            }).exceptionally(x -> {
+                Throwable cause = (x instanceof CompletionException) ? x.getCause() : x;
+                if (!(cause instanceof IllegalStateException)) {
+                    log.info("Could not make http request " + rq, cause);
+                }
+                pair.second().onError(cause);
+                throw (cause instanceof RuntimeException) ? (RuntimeException) x : new RuntimeException(cause);
+            });
+        });
+    }
+
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/http/HttpStreamingMarshallers.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/http/HttpStreamingMarshallers.java
@@ -1,0 +1,20 @@
+package akka.stream.alpakka.marshal.http;
+
+import akka.http.javadsl.marshalling.Marshaller;
+import akka.http.javadsl.model.ContentType;
+import akka.http.javadsl.model.HttpEntities;
+import akka.http.javadsl.model.RequestEntity;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+
+public class HttpStreamingMarshallers {
+    /**
+     * Returns a marshaller that renders a source of bytes into a response entity with the given [contentType].
+     * FIXME check if this is still necessary, or create an akka-http PR instead.
+     */
+    public static final Marshaller<Source<ByteString,?>, RequestEntity> sourceToEntity(ContentType contentType) {
+        return Marshaller.opaque((Source<ByteString,?> data) -> {
+            return HttpEntities.createChunked(contentType, data);
+        });
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/http/JSONMarshallers.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/http/JSONMarshallers.java
@@ -1,0 +1,118 @@
+package akka.stream.alpakka.marshal.http;
+
+import static com.tradeshift.reaktive.akka.AsyncUnmarshallers.entityToStream;
+
+import java.util.Arrays;
+
+import com.tradeshift.reaktive.akka.AsyncUnmarshallers;
+import akka.stream.alpakka.marshal.json.JSONEvent;
+import akka.stream.alpakka.marshal.json.JacksonWriter;
+import akka.stream.alpakka.marshal.json.ActsonReader;
+import akka.stream.alpakka.marshal.ProtocolReader;
+import akka.stream.alpakka.marshal.ProtocolWriter;
+import akka.stream.alpakka.marshal.ReadProtocol;
+
+import akka.NotUsed;
+import akka.http.javadsl.marshalling.Marshaller;
+import akka.http.javadsl.model.ContentType;
+import akka.http.javadsl.model.ContentType.WithFixedCharset;
+import akka.http.javadsl.model.HttpEntity;
+import akka.http.javadsl.model.MediaTypes;
+import akka.http.javadsl.model.RequestEntity;
+import akka.http.javadsl.unmarshalling.Unmarshaller;
+import akka.http.javadsl.model.MediaType;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.stream.alpakka.marshal.WriteProtocol;
+
+public class JSONMarshallers {
+
+    /**
+     * Returns a marshaller that will render a stream of T into a JSON response using [protocol],
+     * with the given content type.
+     */
+    public static <T> Marshaller<Source<T,?>, RequestEntity> sourceToJSON(WriteProtocol<JSONEvent, T> protocol, ContentType contentType) {
+        return HttpStreamingMarshallers
+            .sourceToEntity(contentType)
+            .compose((Source<T,?> source) -> source
+                .via(ProtocolWriter.of(protocol))
+                .via(JacksonWriter.flow()));
+    }
+    
+    /**
+     * Returns a marshaller that will render a stream of T into a JSON response using [protocol],
+     * as application/json.
+     */
+    public static <T> Marshaller<Source<T,?>, RequestEntity> sourceToJSON(WriteProtocol<JSONEvent, T> protocol) {
+        return sourceToJSON(protocol, APPLICATION_JSON);
+    }
+    
+ 
+    /**
+     * Returns a marshaller that will render a T into a JSON response using [protocol],
+     * with the given content type
+     */
+    public static <T> Marshaller<T, RequestEntity> toJSON(WriteProtocol<JSONEvent, T> protocol, ContentType contentType) {
+        return sourceToJSON(protocol, contentType).compose((T t) -> Source.single(t));
+    }
+    
+    /**
+     * Returns a marshaller that will render a T into a JSON response using [protocol],
+     * as application/json
+     */
+    public static <T> Marshaller<T, RequestEntity> toJSON(WriteProtocol<JSONEvent, T> protocol) {
+        return toJSON(protocol, APPLICATION_JSON);
+    }
+    
+    /**
+     * Returns an unmarshaller that will read a JSON request into a stream of T using [protocol],
+     * if it has any of the given media types.
+     */
+    public static <T> Unmarshaller<HttpEntity, Source<T,NotUsed>> sourceFromJSON(ReadProtocol<JSONEvent, T> protocol, MediaType... mediaTypes) {
+        return Unmarshaller.forMediaTypes(Arrays.asList(mediaTypes), entityToStream().thenApply(source -> source
+            .via(ActsonReader.instance)
+            .via(ProtocolReader.of(protocol))));
+    }
+    
+    /**
+     * Returns an unmarshaller that will read a JSON request into a stream of T using [protocol], accepting the following media types:
+     *   MediaTypes.APPLICATION_JSON,
+     *   MediaTypes.APPLICATION_JSON_PATCH_JSON,
+     *   MediaTypes.APPLICATION_VND_API_JSON
+     */
+    public static <T> Unmarshaller<HttpEntity, Source<T,NotUsed>> sourceFromJSON(ReadProtocol<JSONEvent, T> protocol) {
+        return sourceFromJSON(protocol, ACCEPTED_JSON);
+    }
+    
+    /**
+     * Returns an unmarshaller that will read a JSON request into a T using [protocol],
+     * if it has any of the given media types.
+     */
+    public static <T> Unmarshaller<HttpEntity, T> fromJSON(ReadProtocol<JSONEvent, T> protocol, MediaType... mediaTypes) {
+        Unmarshaller<HttpEntity, Source<T, NotUsed>> streamUnmarshaller = sourceFromJSON(protocol, mediaTypes);
+        
+        return AsyncUnmarshallers.<HttpEntity, T>withMaterializer((ctx, mat, entity) -> {
+            return streamUnmarshaller.unmarshal(entity, ctx, mat).thenCompose(src -> src.runWith(Sink.head(), mat));
+        });
+    }
+    
+    /**
+     * Returns an unmarshaller that will read a JSON request into a T using [protocol], accepting the following media types:
+     *   MediaTypes.APPLICATION_JSON,
+     *   MediaTypes.APPLICATION_JSON_PATCH_JSON,
+     *   MediaTypes.APPLICATION_VND_API_JSON
+     */
+    public static <T> Unmarshaller<HttpEntity, T> fromJSON(ReadProtocol<JSONEvent, T> protocol) {
+        return fromJSON(protocol, ACCEPTED_JSON);
+    }
+    
+    private static final WithFixedCharset APPLICATION_JSON = MediaTypes.APPLICATION_JSON.toContentType();
+
+    /** The known JSON media types that are accepted by default*/
+    private static final MediaType[] ACCEPTED_JSON = Arrays.asList(
+        MediaTypes.APPLICATION_JSON,
+        MediaTypes.APPLICATION_JSON_PATCH_JSON,
+        MediaTypes.APPLICATION_VND_API_JSON
+    ).toArray(new MediaType[0]);
+    
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/http/XMLMarshallers.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/http/XMLMarshallers.java
@@ -1,0 +1,116 @@
+package akka.stream.alpakka.marshal.http;
+
+import java.util.Arrays;
+
+import javax.xml.stream.events.XMLEvent;
+
+import com.tradeshift.reaktive.akka.AsyncMarshallers;
+import com.tradeshift.reaktive.akka.AsyncUnmarshallers;
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.WriteProtocol;
+import akka.stream.alpakka.marshal.xml.AaltoReader;
+import akka.stream.alpakka.marshal.ProtocolReader;
+import akka.stream.alpakka.marshal.ProtocolWriter;
+import akka.stream.alpakka.marshal.xml.StaxWriter;
+
+import akka.NotUsed;
+import akka.http.javadsl.marshalling.Marshaller;
+import akka.http.javadsl.model.ContentType;
+import akka.http.javadsl.model.ContentTypes;
+import akka.http.javadsl.model.HttpCharsets;
+import akka.http.javadsl.model.HttpEntity;
+import akka.http.javadsl.model.MediaType;
+import akka.http.javadsl.model.MediaTypes;
+import akka.http.javadsl.model.RequestEntity;
+import akka.http.javadsl.unmarshalling.Unmarshaller;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+
+public class XMLMarshallers {
+    /**
+     * Returns a marshaller that will render a stream of T into an XML response using [protocol], with the given [contentType]
+     */
+    public static <T> Marshaller<Source<T,?>, RequestEntity> sourceToXML(WriteProtocol<XMLEvent, T> protocol, ContentType contentType) {
+        return HttpStreamingMarshallers
+            .sourceToEntity(contentType)
+            .compose((Source<T,?> source) -> source
+                .via(ProtocolWriter.of(protocol))
+                .via(StaxWriter.flow()));
+    }
+    
+    /**
+     * Returns a marshaller that will render a stream of T into an XML response using [protocol], using either text/xml or application/xml.
+     */
+    public static <T> Marshaller<Source<T,?>, RequestEntity> sourceToXML(WriteProtocol<XMLEvent, T> protocol) {
+        return AsyncMarshallers.oneOf(
+            sourceToXML(protocol, ContentTypes.TEXT_XML_UTF8),
+            sourceToXML(protocol, MediaTypes.APPLICATION_XML.toContentType(HttpCharsets.UTF_8)));
+    }
+    
+ 
+    /**
+     * Returns a marshaller that will render a T into an XML response using [protocol], with the given [contentType].
+     */
+    public static <T> Marshaller<T, RequestEntity> toXML(WriteProtocol<XMLEvent, T> protocol, ContentType contentType) {
+        return sourceToXML(protocol, contentType).compose(Source::single);
+    }
+    
+    /**
+     * Returns a marshaller that will render a T into an XML response using [protocol], using either text/xml or application/xml.
+     */
+    public static <T> Marshaller<T, RequestEntity> toXML(WriteProtocol<XMLEvent, T> protocol) {
+        return sourceToXML(protocol).compose(Source::single);
+    }
+    
+    /**
+     * Returns an unmarshaller that will read an XML request into a stream of T using [protocol], accepting given media types.
+     */
+    public static <T> Unmarshaller<HttpEntity, Source<T,NotUsed>> sourceFromXML(ReadProtocol<XMLEvent, T> protocol, MediaType... mediaTypes) {
+        return Unmarshaller.forMediaTypes(Arrays.asList(mediaTypes), AsyncUnmarshallers.entityToStream().thenApply(source -> source
+            .via(AaltoReader.instance)
+            .via(ProtocolReader.of(protocol))));
+    }
+
+    /**
+     * Returns an unmarshaller that will read an XML request into a stream of T using [protocol], accepting the following media types:
+     *      MediaTypes.APPLICATION_ATOM_XML,
+     *      MediaTypes.APPLICATION_RSS_XML,
+     *      MediaTypes.APPLICATION_SOAP_XML,
+     *      MediaTypes.APPLICATION_XML,
+     *      MediaTypes.TEXT_XML
+     */
+    public static <T> Unmarshaller<HttpEntity, Source<T,NotUsed>> sourceFromXML(ReadProtocol<XMLEvent, T> protocol) {
+        return sourceFromXML(protocol,
+            MediaTypes.APPLICATION_ATOM_XML,
+            MediaTypes.APPLICATION_RSS_XML,
+            MediaTypes.APPLICATION_SOAP_XML,
+            MediaTypes.APPLICATION_XML,
+            MediaTypes.TEXT_XML
+        );
+    }
+    
+    /**
+     * Returns an unmarshaller that will read an XML request into a T using [protocol], accepting the given media types.
+     */
+    public static <T> Unmarshaller<HttpEntity, T> fromXML(ReadProtocol<XMLEvent, T> protocol, MediaType... mediaTypes) {
+        return head(sourceFromXML(protocol, mediaTypes));
+    }
+
+    /**
+     * Returns an unmarshaller that will read an XML request into a T using [protocol], accepting the following media types:
+     *      MediaTypes.APPLICATION_ATOM_XML,
+     *      MediaTypes.APPLICATION_RSS_XML,
+     *      MediaTypes.APPLICATION_SOAP_XML,
+     *      MediaTypes.APPLICATION_XML,
+     *      MediaTypes.TEXT_XML
+     */
+    public static <T> Unmarshaller<HttpEntity, T> fromXML(ReadProtocol<XMLEvent, T> protocol) {
+        return head(sourceFromXML(protocol));
+    }
+    
+    private static <T> Unmarshaller<HttpEntity, T> head(Unmarshaller<HttpEntity, Source<T, NotUsed>> streamUnmarshaller) {
+        return AsyncUnmarshallers.<HttpEntity, T>withMaterializer((ctx, mat, entity) -> {
+            return streamUnmarshaller.unmarshal(entity, ctx, mat).thenCompose(src -> src.runWith(Sink.head(), mat));
+        });
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/javadsl/CsvProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/javadsl/CsvProtocol.java
@@ -1,0 +1,124 @@
+package akka.stream.alpakka.marshal.javadsl;
+
+import java.util.List;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.WriteProtocol;
+import akka.stream.alpakka.marshal.csv.CsvEvent;
+import akka.stream.alpakka.marshal.csv.MultiReadProtocol;
+import akka.stream.alpakka.marshal.csv.MultiWriteProtocol;
+import akka.stream.alpakka.marshal.csv.NamedColumnReadProtocol;
+import akka.stream.alpakka.marshal.csv.NamedColumnWriteProtocol;
+import akka.stream.alpakka.marshal.csv.ValueProtocol;
+import akka.stream.alpakka.marshal.generic.Locator;
+import akka.stream.alpakka.marshal.generic.StringProtocol;
+import javaslang.Function1;
+import javaslang.Function2;
+import javaslang.Function3;
+import javaslang.collection.Vector;
+
+/**
+ * Contains static methods for the Java CSV marshalling DSL.
+ */
+@SuppressWarnings("unchecked")
+public class CsvProtocol {
+    private static final Locator<CsvEvent> locator = event -> "(unknown)"; // FIXME add location information to the CSV parser
+    
+    /**
+     * Returns a read/write protocol for a CSV format in which only a single column is read or written.
+     */
+    public static StringProtocol<CsvEvent> column(String name) {
+        return new StringProtocol<>(column(name, ValueProtocol.instance), locator);
+    }
+    
+    //// ---- 2-ary methods -------------------------
+    
+    /**
+     * Returns a read/write protocol for a CSV format consisting of several nested protocols (probably created
+     * using {@link #column(String)} ), invoking the [produce] function on reading, and using the
+     * specified getters for writing.
+     */
+    public static <T,F1,F2> Protocol<CsvEvent, T> csv(
+        Protocol<CsvEvent,F1> p1, Protocol<CsvEvent,F2> p2,
+        Function2<F1,F2,T> produce,
+        Function1<T,F1> g1, Function1<T,F2> g2) {
+        return multi(Vector.of(p1, p2), args -> produce.apply((F1) args.get(0), (F2) args.get(1)), Vector.of(g1, g2));
+    }
+
+    /**
+     * Returns a read-only protocol for a CSV format consisting of several nested protocols (probably created
+     * using {@link #column(String)} ), invoking the [produce] function on reading.
+     */
+    public static <T,F1,F2> ReadProtocol<CsvEvent, T> csv(
+        ReadProtocol<CsvEvent,F1> p1,
+        ReadProtocol<CsvEvent,F2> p2,
+        Function2<F1,F2,T> produce) {
+        return multi(Vector.of(p1, p2), args -> produce.apply((F1) args.get(0), (F2) args.get(1)));
+    }
+
+    /**
+     * Returns a read/write protocol for a CSV format consisting of several nested protocols (probably created
+     * using {@link #column(String)} ), using the
+     * specified getters for writing.
+     */
+    public static <T,F1,F2> WriteProtocol<CsvEvent, T> csv(
+        Function1<T,F1> g1, Protocol<CsvEvent,F1> p1,
+        Function1<T,F2> g2, Protocol<CsvEvent,F2> p2) {
+        return multi(Vector.of(p1, p2), Vector.of(g1, g2));
+    }
+
+    //// ---- 3-ary methods -------------------------
+    
+    /**
+     * Returns a read/write protocol for a CSV format consisting of several nested protocols (probably created
+     * using {@link #column(String)} ), invoking the [produce] function on reading, and using the
+     * specified getters for writing.
+     */
+    public static <T,F1,F2,F3> Protocol<CsvEvent, T> csv(
+        Protocol<CsvEvent,F1> p1, Protocol<CsvEvent,F2> p2, Protocol<CsvEvent,F3> p3,
+        Function3<F1,F2,F3,T> produce,
+        Function1<T,F1> g1, Function1<T,F2> g2, Function1<T,F3> g3) {
+        return multi(Vector.of(p1, p2, p3), args -> produce.apply((F1) args.get(0), (F2) args.get(1), (F3) args.get(2)), Vector.of(g1, g2, g3));
+    }
+
+    /**
+     * Returns a read-only protocol for a CSV format consisting of several nested protocols (probably created
+     * using {@link #column(String)} ), invoking the [produce] function on reading.
+     */
+    public static <T,F1,F2,F3> ReadProtocol<CsvEvent, T> csv(
+        ReadProtocol<CsvEvent,F1> p1,
+        ReadProtocol<CsvEvent,F2> p2,
+        ReadProtocol<CsvEvent,F3> p3,
+        Function3<F1,F2,F3,T> produce) {
+        return multi(Vector.of(p1, p2, p3), args -> produce.apply((F1) args.get(0), (F2) args.get(1), (F3) args.get(2)));
+    }
+
+    /**
+     * Returns a read/write protocol for a CSV format consisting of several nested protocols (probably created
+     * using {@link #column(String)} ), using the
+     * specified getters for writing.
+     */
+    public static <T,F1,F2,F3> WriteProtocol<CsvEvent, T> csv(
+        Function1<T,F1> g1, Protocol<CsvEvent,F1> p1,
+        Function1<T,F2> g2, Protocol<CsvEvent,F2> p2,
+        Function1<T,F3> g3, Protocol<CsvEvent,F3> p3) {
+        return multi(Vector.of(p1, p2, p3), Vector.of(g1, g2, g3));
+    }
+
+    private static <T> Protocol<CsvEvent, T> multi(Vector<Protocol<CsvEvent, ?>> protocols, Function1<List<?>,T> produce, Vector<Function1<T, ?>> getters) {
+        return Protocol.of(new MultiReadProtocol<>(Vector.narrow(protocols), produce), new MultiWriteProtocol<>(Vector.narrow(protocols), getters));
+    }
+    
+    private static <T> ReadProtocol<CsvEvent, T> multi(Vector<ReadProtocol<CsvEvent, ?>> protocols, Function1<List<?>,T> produce) {
+        return new MultiReadProtocol<>(Vector.narrow(protocols), produce);
+    }
+    
+    private static <T> WriteProtocol<CsvEvent, T> multi(Vector<Protocol<CsvEvent, ?>> protocols, Vector<Function1<T, ?>> getters) {
+        return new MultiWriteProtocol<>(Vector.narrow(protocols), getters);
+    }
+    
+    private static <T> Protocol<CsvEvent, T> column(String name, Protocol<CsvEvent,T> inner) {
+        return Protocol.of(new NamedColumnReadProtocol<>(name, inner), new NamedColumnWriteProtocol<>(name, inner));
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/javadsl/JSONProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/javadsl/JSONProtocol.java
@@ -1,0 +1,210 @@
+package akka.stream.alpakka.marshal.javadsl;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.WriteProtocol;
+import akka.stream.alpakka.marshal.generic.StringProtocol;
+import akka.stream.alpakka.marshal.json.AnyFieldProtocol;
+import akka.stream.alpakka.marshal.json.ArrayProtocol;
+import akka.stream.alpakka.marshal.json.FieldProtocol;
+import akka.stream.alpakka.marshal.json.JSONEvent;
+import akka.stream.alpakka.marshal.json.ObjectProtocol;
+import akka.stream.alpakka.marshal.json.ObjectReadProtocol;
+import akka.stream.alpakka.marshal.json.ObjectWriteProtocol;
+import akka.stream.alpakka.marshal.json.StringValueProtocol;
+import akka.stream.alpakka.marshal.json.ValueProtocol;
+import javaslang.Function1;
+import javaslang.Function2;
+import javaslang.Function3;
+import javaslang.Function4;
+import javaslang.Function5;
+import javaslang.Tuple2;
+
+@SuppressWarnings("unchecked")
+public class JSONProtocol<T> {
+    public static final StringProtocol<JSONEvent> stringValue = StringValueProtocol.INSTANCE;
+    
+    public static final Protocol<JSONEvent,Long> longValue = ValueProtocol.LONG;
+    public static final Protocol<JSONEvent,Integer> integerValue = ValueProtocol.INTEGER;
+    public static final Protocol<JSONEvent,BigInteger> bigIntegerValue = ValueProtocol.BIGINTEGER;
+    public static final Protocol<JSONEvent,BigDecimal> bigDecimalValue = ValueProtocol.BIGDECIMAL;
+    public static final Protocol<JSONEvent,Boolean> booleanValue = ValueProtocol.BOOLEAN;
+
+    public static <E> Protocol<JSONEvent, E> array(Protocol<JSONEvent, E> inner) {
+        return Protocol.of(ArrayProtocol.read(inner), ArrayProtocol.write(inner));
+    }
+    
+    public static <E> ReadProtocol<JSONEvent, E> array(ReadProtocol<JSONEvent, E> inner) {
+        return ArrayProtocol.read(inner);
+    }
+    
+    public static <E> WriteProtocol<JSONEvent, E> array(WriteProtocol<JSONEvent, E> inner) {
+        return ArrayProtocol.write(inner);
+    }
+    
+    public static <T> Protocol<JSONEvent, T> field(String name, Protocol<JSONEvent, T> inner) {
+        return Protocol.of(FieldProtocol.read(name, inner), FieldProtocol.write(name, inner));
+    }
+    
+    public static <T> ReadProtocol<JSONEvent, T> field(String name, ReadProtocol<JSONEvent, T> inner) {
+        return FieldProtocol.read(name, inner);
+    }
+    
+    public static <T> WriteProtocol<JSONEvent, T> field(String name, WriteProtocol<JSONEvent, T> inner) {
+        return FieldProtocol.write(name, inner);
+    }
+    
+    public static <T> Protocol<JSONEvent, Tuple2<String,T>> anyField(Protocol<JSONEvent, T> inner) {
+        return Protocol.of(AnyFieldProtocol.read(inner), AnyFieldProtocol.write(inner));
+    }
+    
+    public static <T> ReadProtocol<JSONEvent, Tuple2<String,T>> anyField(ReadProtocol<JSONEvent, T> inner) {
+        return AnyFieldProtocol.read(inner);
+    }
+    
+    public static <T> WriteProtocol<JSONEvent, Tuple2<String,T>> anyField(WriteProtocol<JSONEvent, T> inner) {
+        return AnyFieldProtocol.write(inner);
+    }
+            
+    // ---------------------- object(), 1 type argument ----------------------------------------------
+    
+    /**
+     * Returns a JSON protocol for an object having a single field, typed to the field's type.
+     */
+    public static <T> ObjectProtocol<T> object(Protocol<JSONEvent, T> field) {
+        return new ObjectProtocol<>(field);
+    }
+    
+    /**
+     * Returns a JSON protocol for reading an object having a single field, typed to the field's type.
+     */
+    public static <T> ObjectReadProtocol<T> object(ReadProtocol<JSONEvent, T> field) {
+        return new ObjectReadProtocol<>(field);
+    }
+    
+    /**
+     * Returns a JSON protocol for writing an object having a single field, typed to the field's type.
+     */
+    public static <T> ObjectWriteProtocol<T> object(WriteProtocol<JSONEvent, T> field) {
+        return new ObjectWriteProtocol<>(field);
+    }
+    
+    /**
+     * Returns a protocol for a JSON object with a single field [p1], using [f] to turn it into a Java object, and [g1] to get the field when writing.
+     */
+    public static <F1,T> ObjectProtocol<T> object(Protocol<JSONEvent, F1> p1, Function1<F1, T> f, Function1<T, F1> g1) {
+        return new ObjectProtocol<>(Arrays.asList(p1), args -> f.apply((F1) args.get(0)), Arrays.asList(g1));
+    }
+    
+    /**
+     * Returns a read-only protocol for a JSON object with a single field [p1], using [f] to turn it into a Java object.
+     */
+    public static <F1,T> ObjectReadProtocol<T> object(ReadProtocol<JSONEvent, F1> p1, Function1<F1, T> f) {
+        return new ObjectReadProtocol<>(Arrays.asList(p1), args -> f.apply((F1) args.get(0)));
+    }
+    
+    /**
+     * Returns a write-only protocol for a JSON object with a single field [p1], using [g1] to get the field when writing.
+     */
+    public static <F1,T> ObjectWriteProtocol<T> object(Function1<T, F1> g1, WriteProtocol<JSONEvent, F1> p1) {
+        return new ObjectWriteProtocol<>(Arrays.asList(p1), Arrays.asList(g1));
+    }
+
+    // ---------------------- object(), 2 type arguments ----------------------------------------------
+    
+    /**
+     * Returns a protocol for a JSON object with a fields [p*], using [f] to turn it into a Java object, and [g*] to get the fields when writing.
+     */
+    public static <F1,F2,T> ObjectProtocol<T> object(Protocol<JSONEvent, F1> p1, Protocol<JSONEvent, F2> p2, Function2<F1, F2, T> f, Function1<T, F1> g1, Function1<T, F2> g2) {
+        return new ObjectProtocol<>(Arrays.asList(p1, p2), args -> f.apply((F1) args.get(0), (F2) args.get(1)), Arrays.asList(g1, g2));
+    }
+    
+    /**
+     * Returns a read-only protocol for a JSON object with fields [p*], using [f] to turn it into a Java object.
+     */
+    public static <F1,F2,T> ObjectReadProtocol<T> object(ReadProtocol<JSONEvent, F1> p1, ReadProtocol<JSONEvent, F2> p2, Function2<F1, F2, T> f) {
+        return new ObjectReadProtocol<>(Arrays.asList(p1, p2), args -> f.apply((F1) args.get(0), (F2) args.get(1)));
+    }
+    
+    /**
+     * Returns a write-only protocol for a JSON object with fields [p*], using [g*] to get the fields when writing.
+     */
+    public static <F1,F2,T> ObjectWriteProtocol<T> object(Function1<T, F1> g1, WriteProtocol<JSONEvent, F1> p1, Function1<T, F2> g2, WriteProtocol<JSONEvent, F2> p2) {
+        return new ObjectWriteProtocol<>(Arrays.asList(p1, p2), Arrays.asList(g1, g2));
+    }
+    
+    // ---------------------- object(), 3 type arguments ----------------------------------------------
+    
+    /**
+     * Returns a protocol for a JSON object with a fields [p*], using [f] to turn it into a Java object, and [g*] to get the fields when writing.
+     */
+    public static <F1,F2,F3,T> ObjectProtocol<T> object(Protocol<JSONEvent, F1> p1, Protocol<JSONEvent, F2> p2, Protocol<JSONEvent, F3> p3, Function3<F1, F2, F3, T> f, Function1<T, F1> g1,  Function1<T, F2> g2, Function1<T, F3> g3) {
+        return new ObjectProtocol<>(Arrays.asList(p1, p2, p3), args -> f.apply((F1) args.get(0), (F2) args.get(1), (F3) args.get(2)), Arrays.asList(g1, g2, g3));
+    }
+    
+    /**
+     * Returns a read-only protocol for a JSON object with fields [p*], using [f] to turn it into a Java object.
+     */
+    public static <F1,F2,F3,T> ObjectReadProtocol<T> object(ReadProtocol<JSONEvent, F1> p1, ReadProtocol<JSONEvent, F2> p2, ReadProtocol<JSONEvent, F3> p3, Function3<F1, F2, F3, T> f) {
+        return new ObjectReadProtocol<>(Arrays.asList(p1, p2, p3), args -> f.apply((F1) args.get(0), (F2) args.get(1), (F3) args.get(2)));
+    }
+    
+    /**
+     * Returns a write-only protocol for a JSON object with fields [p*], using [g*] to get the fields when writing.
+     */
+    public static <F1,F2,F3,T> ObjectWriteProtocol<T> object(Function1<T, F1> g1, WriteProtocol<JSONEvent, F1> p1, Function1<T, F2> g2, WriteProtocol<JSONEvent, F2> p2, Function1<T, F3> g3, WriteProtocol<JSONEvent, F3> p3) {
+        return new ObjectWriteProtocol<>(Arrays.asList(p1, p2, p3), Arrays.asList(g1, g2, g3));
+    }
+
+    // ---------------------- object(), 4 type arguments ----------------------------------------------
+
+    /**
+     * Returns a protocol for a JSON object with a fields [p*], using [f] to turn it into a Java object, and [g*] to get the fields when writing.
+     */
+    public static <F1, F2, F3, F4, T> ObjectProtocol<T> object(Protocol<JSONEvent, F1> p1, Protocol<JSONEvent, F2> p2, Protocol<JSONEvent, F3> p3, Protocol<JSONEvent, F4> p4, Function4<F1, F2, F3, F4, T> f, Function1<T, F1> g1, Function1<T, F2> g2, Function1<T, F3> g3, Function1<T, F4> g4) {
+        return new ObjectProtocol<>(Arrays.asList(p1, p2, p3, p4), args -> f.apply((F1) args.get(0), (F2) args.get(1), (F3) args.get(2), (F4) args.get(3)), Arrays.asList(g1, g2, g3, g4));
+    }
+
+    /**
+     * Returns a read-only protocol for a JSON object with fields [p*], using [f] to turn it into a Java object.
+     */
+    public static <F1, F2, F3, F4, T> ObjectReadProtocol<T> object(ReadProtocol<JSONEvent, F1> p1, ReadProtocol<JSONEvent, F2> p2, ReadProtocol<JSONEvent, F3> p3, ReadProtocol<JSONEvent, F4> p4, Function4<F1, F2, F3, F4, T> f) {
+        return new ObjectReadProtocol<>(Arrays.asList(p1, p2, p3, p4), args -> f.apply((F1) args.get(0), (F2) args.get(1), (F3) args.get(2), (F4) args.get(3)));
+    }
+
+    /**
+     * Returns a write-only protocol for a JSON object with fields [p*], using [g*] to get the fields when writing.
+     */
+    public static <F1, F2, F3, F4, T> ObjectWriteProtocol<T> object(Function1<T, F1> g1, WriteProtocol<JSONEvent, F1> p1, Function1<T, F2> g2, WriteProtocol<JSONEvent, F2> p2, Function1<T, F3> g3, WriteProtocol<JSONEvent, F3> p3, Function1<T, F4> g4, WriteProtocol<JSONEvent, F4> p4) {
+        return new ObjectWriteProtocol<>(Arrays.asList(p1, p2, p3, p4), Arrays.asList(g1, g2, g3, g4));
+    }
+
+    // ---------------------- object(), 5 type arguments ----------------------------------------------
+
+    /**
+     * Returns a protocol for a JSON object with a fields [p*], using [f] to turn it into a Java object, and [g*] to get the fields when writing.
+     */
+    public static <F1, F2, F3, F4, F5, T> ObjectProtocol<T> object(Protocol<JSONEvent, F1> p1, Protocol<JSONEvent, F2> p2, Protocol<JSONEvent, F3> p3, Protocol<JSONEvent, F4> p4, Protocol<JSONEvent, F5> p5, Function5<F1, F2, F3, F4, F5, T> f, Function1<T, F1> g1, Function1<T, F2> g2, Function1<T, F3> g3, Function1<T, F4> g4, Function1<T, F5> g5) {
+        return new ObjectProtocol<>(Arrays.asList(p1, p2, p3, p4, p5), args -> f.apply((F1) args.get(0), (F2) args.get(1), (F3) args.get(2), (F4) args.get(3), (F5) args.get(4)), Arrays.asList(g1, g2, g3, g4, g5));
+    }
+
+    /**
+     * Returns a read-only protocol for a JSON object with fields [p*], using [f] to turn it into a Java object.
+     */
+    public static <F1, F2, F3, F4, F5, T> ObjectReadProtocol<T> object(ReadProtocol<JSONEvent, F1> p1, ReadProtocol<JSONEvent, F2> p2, ReadProtocol<JSONEvent, F3> p3, ReadProtocol<JSONEvent, F4> p4, ReadProtocol<JSONEvent, F5> p5, Function5<F1, F2, F3, F4, F5, T> f) {
+        return new ObjectReadProtocol<>(Arrays.asList(p1, p2, p3, p4, p5), args -> f.apply((F1) args.get(0), (F2) args.get(1), (F3) args.get(2), (F4) args.get(3), (F5) args.get(4)));
+    }
+
+    /**
+     * Returns a write-only protocol for a JSON object with fields [p*], using [g*] to get the fields when writing.
+     */
+    public static <F1, F2, F3, F4, F5, T> ObjectWriteProtocol<T> object(Function1<T, F1> g1, WriteProtocol<JSONEvent, F1> p1, Function1<T, F2> g2, WriteProtocol<JSONEvent, F2> p2, Function1<T, F3> g3, WriteProtocol<JSONEvent, F3> p3, Function1<T, F4> g4, WriteProtocol<JSONEvent, F4> p4, Function1<T, F5> g5, WriteProtocol<JSONEvent, F5> p5) {
+        return new ObjectWriteProtocol<>(Arrays.asList(p1, p2, p3, p4, p5), Arrays.asList(g1, g2, g3, g4, g5));
+    }
+    
+    // --------------------------------------------------------------------
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/javadsl/JavaProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/javadsl/JavaProtocol.java
@@ -1,0 +1,168 @@
+package akka.stream.alpakka.marshal.javadsl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.WriteProtocol;
+import akka.stream.alpakka.marshal.generic.AnyOfProtocol;
+import akka.stream.alpakka.marshal.generic.CombinedProtocol;
+import akka.stream.alpakka.marshal.generic.FoldProtocol;
+import akka.stream.alpakka.marshal.generic.IterableProtocol;
+import akka.stream.alpakka.marshal.generic.MapProtocol;
+import akka.stream.alpakka.marshal.generic.OptionProtocol;
+import akka.stream.alpakka.marshal.generic.SeqProtocol;
+import javaslang.Function2;
+import javaslang.Tuple2;
+import javaslang.collection.HashMap;
+import javaslang.collection.Map;
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+import javaslang.control.Option;
+
+/**
+ * Contains Java DSL protocol factory methods
+ */
+public class JavaProtocol {
+    // ----------------------- Alternatives -----------------------------
+    
+    /**
+     * Forwards read events to multiple alternative protocols, emitting whenever any of the alternatives emit. If multiple
+     * alternatives emit for the same event, the first one wins.
+     */
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public static <E,T> ReadProtocol<E,T> anyOf(ReadProtocol<E,T> first, ReadProtocol<E,T> second, ReadProtocol<E,T>... others) {
+        return new AnyOfProtocol<>(Vector.of(first, second).appendAll(Arrays.asList(others)));
+    }
+
+    /**
+     * Forwards read events to multiple alternative protocols, emitting whenever any of the alternatives emit. If multiple
+     * alternatives emit for the same event, the first one wins.
+     * 
+     * Always picks the first alternative during writing.
+     */
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public static <E,T> Protocol<E,T> anyOf(Protocol<E,T> first, Protocol<E,T> second, Protocol<E,T>... others) {
+        return AnyOfProtocol.readWrite(Vector.of(first, second).appendAll(Arrays.asList(others)));
+    }
+
+    /**
+     * Forwards read events to multiple alternative protocols, emitting whenever any of the alternatives emit.
+     * If multiple alternatives emit for the same event, all results are emitted.
+     * If at least one alternative emits for an event, any errors on other alternatives are ignored.
+     * If all alternatives yield errors for an event, the errors are concatenated and escalated.
+     */
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public static <E,T> ReadProtocol<E,Seq<T>> combine(ReadProtocol<E,T> first, ReadProtocol<E,T> second, ReadProtocol<E,T>... others) {
+        return new CombinedProtocol<>(Vector.of(first, second).appendAll(Arrays.asList(others)));
+    }
+    
+    // ----------------------- Collections -----------------------------
+    
+    /**
+     * Reads an inner protocol multiple times. On reading, creates a {@link javaslang.collection.Vector} to represent it.
+     */
+    public static <E,T> ReadProtocol<E,Vector<T>> vector(ReadProtocol<E,T> inner) {
+        return SeqProtocol.read(inner, Vector.empty());
+    }
+    
+    /**
+     * Reads and writes an inner protocol multiple times. On reading, creates a {@link javaslang.collection.Vector} to hold the values.
+     * On writing, any {@link javaslang.collection.Seq} will do.
+     */
+    public static <E,T> Protocol<E,Seq<T>> vector(Protocol<E,T> inner) {
+        return Protocol.of(SeqProtocol.read(inner, Vector.empty()), SeqProtocol.write(inner));
+    }
+
+    /**
+     * Writes an inner protocol multiple times, represented by a {@link javaslang.collection.Seq}.
+     */
+    public static <E,T> WriteProtocol<E,Seq<T>> seq(WriteProtocol<E,T> inner) {
+        return SeqProtocol.write(inner);
+    }
+
+    /**
+     * Folds over a repeated nested protocol, merging the results into a single element.
+     */
+    public static <E,T,U> ReadProtocol<E,U> foldLeft(ReadProtocol<E,T> inner, Supplier<U> initial, Function2<U,T,U> combine) {
+        return FoldProtocol.read("*", inner, initial, combine);
+    }
+    
+    /**
+     * Invokes the given function for every item the inner protocol emits, while emitting a single null as outer value.
+     */
+    public static <E,T> ReadProtocol<E,Void> forEach(ReadProtocol<E,T> inner, Consumer<T> consumer) {
+        return FoldProtocol.read("*", inner, () -> null, (v1,v2) -> { consumer.accept(v2); return null; });
+    }
+    
+    /**
+     * Writes an inner protocol multiple times, represented by a {@link java.util.Iterable}.
+     */
+    public static <E,T> WriteProtocol<E,Iterable<T>> iterable(WriteProtocol<E,T> inner) {
+        return IterableProtocol.write(inner);
+    }
+
+    /**
+     * Reads an inner protocol multiple times. On reading, creates a {@link java.util.ArrayList} to represent it.
+     */
+    public static <E,T> ReadProtocol<E,ArrayList<T>> arrayList(ReadProtocol<E,T> inner) {
+        return IterableProtocol.read(inner, () -> new ArrayList<>(), java.util.List::add);
+    }
+    
+    /**
+     * Reads and writes an inner protocol multiple times. On reading, creates a {@link java.util.ArrayList} to hold the values.
+     * On writing, any {@link java.util.List} will do.
+     */
+    public static <E,T> Protocol<E,java.util.List<T>> arrayList(Protocol<E,T> inner) {
+        return Protocol.of(ReadProtocol.widen(arrayList((ReadProtocol<E,T>)inner)), WriteProtocol.narrow(iterable(inner)));
+    }
+    
+    /**
+     * Reads and writes an inner protocol of tuples multiple times. On reading, creates a {@link javaslang.collection.HashMap} to hold the result.
+     * On writing, any {@link javaslang.collection.Map} will do.
+     */
+    public static <E,K,V> Protocol<E,Map<K,V>> hashMap(Protocol<E,Tuple2<K,V>> inner) {
+        return Protocol.of(ReadProtocol.widen(hashMap((ReadProtocol<E,Tuple2<K,V>>) inner)), map(inner));
+    }
+    
+    /**
+     * Reads an inner protocol of tuples multiple times. On reading, creates a {@link javaslang.collection.HashMap} to hold the result.
+     */
+    public static <E,K,V> ReadProtocol<E,HashMap<K,V>> hashMap(ReadProtocol<E,Tuple2<K,V>> inner) {
+        return MapProtocol.read(inner, HashMap::of, HashMap.empty());
+    }
+    
+    /**
+     * Writes a map using an inner protocol, by turning it into writing multiple tuples.
+     */
+    public static <E,K,V> WriteProtocol<E,Map<K,V>> map(Protocol<E,Tuple2<K,V>> inner) {
+        return MapProtocol.write(inner);
+    }
+    
+    /**
+     * Reads and writes a nested protocol optionally, representing it by a {@link javaslang.control.Option}.
+     */
+    public static <E,T> Protocol<E,Option<T>> option(Protocol<E,T> inner) {
+        return Protocol.of(OptionProtocol.read(inner), OptionProtocol.write(inner));
+    }
+    
+    /**
+     * Reads a nested protocol optionally, representing it by a {@link javaslang.control.Option}.
+     */
+    public static <E,T> ReadProtocol<E,Option<T>> option(ReadProtocol<E,T> inner) {
+        return OptionProtocol.read(inner);
+    }
+
+    /**
+     * Writes a nested protocol optionally, representing it by a {@link javaslang.control.Option}.
+     */
+    public static <E,T> WriteProtocol<E,Option<T>> option(WriteProtocol<E,T> inner) {
+        return OptionProtocol.write(inner);
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/javadsl/XMLProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/javadsl/XMLProtocol.java
@@ -1,0 +1,353 @@
+package akka.stream.alpakka.marshal.javadsl;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.events.Characters;
+import javax.xml.stream.events.Namespace;
+import javax.xml.stream.events.XMLEvent;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.WriteProtocol;
+import akka.stream.alpakka.marshal.xml.AnyAttributeProtocol;
+import akka.stream.alpakka.marshal.xml.AttributeProtocol;
+import akka.stream.alpakka.marshal.xml.BodyEventsProtocol;
+import akka.stream.alpakka.marshal.xml.BodyProtocol;
+import akka.stream.alpakka.marshal.xml.JAXBProtocol;
+import akka.stream.alpakka.marshal.xml.QNameStringProtocol;
+import akka.stream.alpakka.marshal.xml.SelectedTagProtocol;
+import akka.stream.alpakka.marshal.xml.TagProtocol;
+import akka.stream.alpakka.marshal.xml.TagReadProtocol;
+import akka.stream.alpakka.marshal.xml.TagWriteProtocol;
+import javaslang.Function1;
+import javaslang.Function2;
+import javaslang.Function3;
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.collection.Vector;
+import javaslang.control.Option;
+
+@SuppressWarnings("unchecked")
+public class XMLProtocol {
+    private static final XMLEventFactory factory = XMLEventFactory.newFactory();
+
+    //---------------------- 0-arity tag methods -----------------------------------
+    
+    /**
+     * Matches an exact XML tag, and emits the start and end tags themselves, including any sub-events that make up its body.
+     */
+    public static Protocol<XMLEvent, XMLEvent> tag(QName name) {
+        return new SelectedTagProtocol(name);
+    }
+    
+    /**
+     * Accepts any single tag when reading, routing its body through to the given inner protocol.
+     */
+    public static <T> ReadProtocol<XMLEvent, T> anyTag(ReadProtocol<XMLEvent, T> inner) {
+        return new TagReadProtocol<>(Option.none(), inner);
+    }
+    
+    //---------------------- 1-arity tag methods -----------------------------------
+    
+    /**
+     * Reads and writes a tag and one child element (tag or attribute), where the result of this tag is the result of the single child.
+     */
+    public static <T> TagProtocol<T> tag(QName name, Protocol<XMLEvent,T> p1) {
+        return new TagProtocol<>(Option.of(name), p1);
+    }
+    
+    /**
+     * Reads a tag and one child element (tag or attribute), where the result of this tag is the result of the single child.
+     */
+    public static <T> TagReadProtocol<T> tag(QName name, ReadProtocol<XMLEvent,T> p1) {
+        return new TagReadProtocol<>(Option.of(name), p1);
+    }
+    
+    /**
+     * Writes a tag and one child element (tag or attribute), where the result of this tag is the result of the single child.
+     */
+    public static <T> TagWriteProtocol<T> tag(QName name, WriteProtocol<XMLEvent,T> p1) {
+        return new TagWriteProtocol<>(Option.of(name), Vector.of(p1), Vector.of(Function1.identity()));
+    }
+    
+    /**
+     * Reads and writes a tag and one child element (tag or attribute) using [p1], using [f] to create the result on reading, getting values using [g1] for writing.
+     */
+    public static <F1,T> TagProtocol<T> tag(QName qname, Protocol<XMLEvent,F1> p1, Function1<F1,T> f, Function1<T,F1> g1) {
+        return new TagProtocol<>(Option.of(qname), Vector.of(p1), args -> f.apply((F1) args.get(0)), Vector.of(g1));
+    }
+    
+    /**
+     * Reads a tag and one child element (tag or attribute) using [p1], creating its result using [f].
+     */
+    public static <F1,T> TagReadProtocol<T> tag(QName name, ReadProtocol<XMLEvent,F1> p1, Function1<F1,T> f) {
+        return new TagReadProtocol<>(Option.of(name), Vector.of(p1), args -> f.apply((F1) args.get(0)));
+    }
+    
+    /**
+     * Writes a tag and one child element (tag or attribute) using [p1], getting values using [g1] for writing.
+     */
+    public static <F1,T> TagWriteProtocol<T> tag(QName qname, Function1<T,F1> g1, WriteProtocol<XMLEvent,F1> p1) {
+        return new TagWriteProtocol<>(Option.of(qname), Vector.of(p1), Vector.of(g1));
+    }
+    
+    //---------------------- 2-arity tag methods -----------------------------------
+    
+    /**
+     * Reads and writes a tag and child elements (tag or attribute) using [p*], using [f] to create the result on reading, getting values using [g*] for writing.
+     */
+    public static <F1,F2,T> TagProtocol<T> tag(QName qname, Protocol<XMLEvent,F1> p1, Protocol<XMLEvent,F2> p2, Function2<F1,F2,T> f, Function1<T,F1> g1, Function1<T,F2> g2) {
+        return new TagProtocol<>(Option.of(qname), Vector.of(p1, p2), args -> f.apply((F1) args.get(0), (F2) args.get(1)), Vector.of(g1, g2));
+    }
+    
+    /**
+     * Reads a tag and child elements (tag or attribute) using [p*], using [f] to create the result on reading.
+     */
+    public static <F1,F2,T> TagReadProtocol<T> tag(QName qname, ReadProtocol<XMLEvent,F1> p1, ReadProtocol<XMLEvent,F2> p2, Function2<F1,F2,T> f) {
+        return new TagReadProtocol<>(Option.of(qname), Vector.of(p1, p2), args -> f.apply((F1) args.get(0), (F2) args.get(1)));
+    }
+    
+    /**
+     * Writes a tag and child elements (tag or attribute) using [p*], getting values using [g*] for writing.
+     */
+    public static <F1,F2,T> TagWriteProtocol<T> tag(QName qname, Function1<T,F1> g1, WriteProtocol<XMLEvent,F1> p1, Function1<T,F2> g2, WriteProtocol<XMLEvent,F2> p2) {
+        return new TagWriteProtocol<>(Option.of(qname), Vector.of(p1, p2), Vector.of(g1, g2));
+    }
+    
+    /**
+     * Reads and writes a tag and child elements (tag or attribute) using [p*], represented by a Tuple2.
+     */
+    public static <F1,F2> TagProtocol<Tuple2<F1,F2>> tag(QName qname, Protocol<XMLEvent,F1> p1, Protocol<XMLEvent,F2> p2) {
+        return tag(qname, p1, p2, Tuple::of, Tuple2::_1, Tuple2::_2);
+    }
+    
+    /**
+     * Reads a tag and child elements (tag or attribute) using [p*], represented by a Tuple2.
+     */
+    public static <F1,F2> TagReadProtocol<Tuple2<F1,F2>> tag(QName qname, ReadProtocol<XMLEvent,F1> p1, ReadProtocol<XMLEvent,F2> p2) {
+        return tag(qname, p1, p2, Tuple::of);
+    }
+    
+    /**
+     * Writes a tag and child elements (tag or attribute) using [p*], represented by a Tuple2.
+     */
+    public static <F1,F2> TagWriteProtocol<Tuple2<F1,F2>> tag(QName qname, WriteProtocol<XMLEvent,F1> p1, WriteProtocol<XMLEvent,F2> p2) {
+        return tag(qname, Tuple2::_1, p1, Tuple2::_2, p2);
+    }
+    
+    //---------------------- 3-arity tag methods -----------------------------------
+    
+    /**
+     * Reads and writes a tag and child elements (tag or attribute) using [p*], using [f] to create the result on reading, getting values using [g*] for writing.
+     */
+    public static <F1,F2,F3,T> TagProtocol<T> tag(QName qname, Protocol<XMLEvent,F1> p1, Protocol<XMLEvent,F2> p2, Protocol<XMLEvent,F3> p3, Function3<F1,F2,F3,T> f, Function1<T,F1> g1, Function1<T,F2> g2, Function1<T,F3> g3) {
+        return new TagProtocol<>(Option.of(qname), Vector.of(p1, p2, p3), args -> f.apply((F1) args.get(0), (F2) args.get(1), (F3) args.get(2)), Vector.of(g1, g2, g3));
+    }
+    /**
+     * Reads a tag and child elements (tag or attribute) using [p*], using [f] to create the result on reading.
+     */
+    public static <F1,F2,F3,T> TagReadProtocol<T> tag(QName qname, ReadProtocol<XMLEvent,F1> p1, ReadProtocol<XMLEvent,F2> p2, ReadProtocol<XMLEvent,F3> p3, Function3<F1,F2,F3,T> f) {
+        return new TagReadProtocol<>(Option.of(qname), Vector.of(p1, p2, p3), args -> f.apply((F1) args.get(0), (F2) args.get(1), (F3) args.get(2)));
+    }
+    /**
+     * Writes a tag and child elements (tag or attribute) using [p*], getting values using [g*] for writing.
+     */
+    public static <F1,F2,F3,T> TagWriteProtocol<T> tag(QName qname, Function1<T,F1> g1, WriteProtocol<XMLEvent,F1> p1, Function1<T,F2> g2, WriteProtocol<XMLEvent,F2> p2, Function1<T,F3> g3, WriteProtocol<XMLEvent,F3> p3) {
+        return new TagWriteProtocol<>(Option.of(qname), Vector.of(p1, p2, p3), Vector.of(g1, g2, g3));
+    }
+    
+    //---------------------- 1-arity tagName methods -----------------------------------
+    
+    /**
+     * Reads and writes a tag with any name
+     */
+    public static final Protocol<XMLEvent,QName> tagName = tagName(Function1.identity(), Function1.identity());
+    
+    /**
+     * Reads and writes a tag with any name, using [f] to create the result on reading, getting values using [g1] for writing.
+     */
+    public static <T> TagProtocol<T> tagName(Function1<QName,T> f, Function1<T,QName> g1) {
+        return new TagProtocol<>(Option.none(), Vector.empty(), args -> f.apply((QName) args.get(0)), Vector.of(g1));
+    }
+    
+    /**
+     * Reads a tag with any name, creating its result using [f].
+     */
+    public static <T> TagReadProtocol<T> readTagName(Function1<QName,T> f) {
+        return new TagReadProtocol<>(Option.none(), Vector.empty(), args -> f.apply((QName) args.get(0)));
+    }
+    
+    /**
+     * Writes a tag and with any name, getting values using [g1] for writing.
+     */
+    public static <T> TagWriteProtocol<T> writeTagName(Function1<T,QName> g1) {
+        return new TagWriteProtocol<>(Option.none(), Vector.empty(), Vector.of(g1));
+    }
+    
+    //---------------------- 2-arity tagName methods -----------------------------------
+    
+    /**
+     * Reads and writes a tag with any name and inner protocols using [p*], using [f] to create the result on reading, getting values using [g*] for writing.
+     */
+    public static <F2,T> TagProtocol<T> tagName(Protocol<XMLEvent,F2> p2, Function2<QName,F2,T> f, Function1<T,QName> g1, Function1<T,F2> g2) {
+        return new TagProtocol<>(Option.none(), Vector.of(p2), args -> f.apply((QName) args.get(0), (F2) args.get(1)), Vector.of(g1, g2));
+    }
+    
+    /**
+     * Reads a tag with any name and inner protocols using [p*], using [f] to create the result on reading.
+     */
+    public static <F2,T> TagReadProtocol<T> tagName(ReadProtocol<XMLEvent,F2> p2, Function2<QName,F2,T> f) {
+        return new TagReadProtocol<>(Option.none(), Vector.of(p2), args -> f.apply((QName) args.get(0), (F2) args.get(1)));
+    }
+    
+    /**
+     * Writes a tag with any name and inner protocols using [p*], getting values using [g*] for writing.
+     */
+    public static <F2,T> TagWriteProtocol<T> tagName(Function1<T,QName> g1, Function1<T,F2> g2, WriteProtocol<XMLEvent,F2> p2) {
+        return new TagWriteProtocol<>(Option.none(), Vector.of(p2), Vector.of(g1, g2));
+    }
+    
+    /**
+     * Reads and writes a tag with any name and inner protocols using [p*], represented by a Tuple2.
+     */
+    public static <F2> TagProtocol<Tuple2<QName,F2>> tagNameAnd(Protocol<XMLEvent,F2> p2) {
+        return tagName(p2, Tuple::of, Tuple2::_1, Tuple2::_2);
+    }
+    
+    /**
+     * Reads a tag with any name and inner protocols using [p*], represented by a Tuple2.
+     */
+    public static <F2> TagReadProtocol<Tuple2<QName,F2>> tagNameAnd(ReadProtocol<XMLEvent,F2> p2) {
+        return tagName(p2, Tuple::of);
+    }
+    
+    /**
+     * Writes a tag with any name and inner protocols using [p*], represented by a Tuple2.
+     */
+    public static <F2> TagWriteProtocol<Tuple2<QName,F2>> tagNameAnd(WriteProtocol<XMLEvent,F2> p2) {
+        return tagName(Tuple2::_1, Tuple2::_2, p2);
+    }
+    
+    //---------------------- 3-arity tagName methods -----------------------------------
+    
+    /**
+     * Reads and writes a tag with any name and inner protocols using [p*], using [f] to create the result on reading, getting values using [g*] for writing.
+     */
+    public static <F2,F3,T> TagProtocol<T> tagName(Protocol<XMLEvent,F2> p2, Protocol<XMLEvent,F3> p3, Function3<QName,F2,F3,T> f, Function1<T,QName> g1, Function1<T,F2> g2, Function1<T,F3> g3) {
+        return new TagProtocol<>(Option.none(), Vector.of(p2, p3), args -> f.apply((QName) args.get(0), (F2) args.get(1), (F3) args.get(2)), Vector.of(g1, g2, g3));
+    }
+    /**
+     * Reads a tag with any name and inner protocols using [p*], using [f] to create the result on reading.
+     */
+    public static <F2,F3,T> TagReadProtocol<T> tagName(ReadProtocol<XMLEvent,F2> p2, ReadProtocol<XMLEvent,F3> p3, Function3<QName,F2,F3,T> f) {
+        return new TagReadProtocol<>(Option.none(), Vector.of(p2, p3), args -> f.apply((QName) args.get(0), (F2) args.get(1), (F3) args.get(2)));
+    }
+    /**
+     * Writes a tag with any name and inner protocols using [p*], getting values using [g*] for writing.
+     */
+    public static <F2,F3,T> TagWriteProtocol<T> tagName(Function1<T,QName> g1, Function1<T,F2> g2, WriteProtocol<XMLEvent,F2> p2, Function1<T,F3> g3, WriteProtocol<XMLEvent,F3> p3) {
+        return new TagWriteProtocol<>(Option.none(), Vector.of(p2, p3), Vector.of(g1, g2, g3));
+    }
+    
+    // --------------------------------------------------------------------------------
+    
+    /**
+     * Reads and writes a namespaced string attribute
+     */
+    public static AttributeProtocol attribute(Namespace ns, String name) {
+        return attribute(qname(ns, name));
+    }
+    
+    /**
+     * Reads a string attribute in the default namespace
+     */
+    public static AttributeProtocol attribute(String name) {
+        return attribute(qname(name));
+    }
+    
+    /**
+     * Reads and writes a namespaced string attribute
+     */
+    public static AttributeProtocol attribute(QName name) {
+        return new AttributeProtocol(name);
+    }
+    
+    /**
+     * Reads and writes the body of the current XML tag
+     */
+    public static final BodyProtocol body = BodyProtocol.INSTANCE;
+    
+    /**
+     * Reads and writes the body of the current XML tag as actual XML {@link Characters} events.
+     */
+    public static final Protocol<XMLEvent, Characters> bodyEvents = BodyEventsProtocol.INSTANCE;
+    
+    /**
+     * Returns a QName for a tag in the default namespace.
+     */
+    public static QName qname(String name) {
+        return new QName(name);
+    }
+    
+    /**
+     * Combines a Namespace and local name into a QName.
+     */
+    public static QName qname(Namespace ns, String name) {
+        return new QName(ns.getNamespaceURI(), name, ns.getPrefix());
+    }
+
+    /**
+     * Creates a Namespace that can be used both for reading and writing XMl.
+     */
+    public static final Namespace ns(String prefix, String namespace) {
+        return factory.createNamespace(prefix, namespace);
+    }
+    
+    /**
+     * Creates a Namespace that can only be used for reading XML.
+     */
+    public static final Namespace ns(String namespace) {
+        return factory.createNamespace(namespace);
+    }
+    
+    /**
+     * Reads and writes every top-level tag's QName and its body as a Tuple2.
+     */
+    public static final QNameStringProtocol anyTagWithBody = new QNameStringProtocol(tagNameAnd(body));
+    
+    /**
+     * Reads and writes every top-level tag's QName and the (required) attribute [name] as a Tuple2.
+     */
+    public static QNameStringProtocol anyTagWithAttribute(String name) {
+        return new QNameStringProtocol(tagNameAnd(attribute(name)));
+    }
+    
+    /**
+     * Reads and writes every top-level attribute's QName and its value as a Tuple2.
+     */
+    public static final QNameStringProtocol anyAttribute = new QNameStringProtocol(AnyAttributeProtocol.INSTANCE);
+    
+    /**
+     * Reads and writes a JAXB-annotated class of a known type, by creating a default JAXBContext containing just that type.
+     */
+    public static <T> Protocol<XMLEvent,T> jaxbType(Class<T> targetType) {
+        return JAXBProtocol.jaxbType(targetType);
+    }
+    
+    /**
+     * Reads and writes a JAXB-annotated class of a known type, by using the given JAXB context.
+     */
+    public static <T> Protocol<XMLEvent,T> jaxbType(Class<T> targetType, JAXBContext context) {
+        return JAXBProtocol.jaxbType(targetType, context);
+    }
+    
+    /**
+     * Reads and writes a JAXB-annotated class of an arbitrary type, by using the given JAXB context.
+     * Since this method is not type-safe, it's up to the user to ensure that the given JAXB context
+     * can handle instances and XML given to the protocol.
+     */
+    public static Protocol<XMLEvent,Object> jaxbType(JAXBContext context) {
+        return JAXBProtocol.jaxbType(context);
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/json/ActsonReader.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/json/ActsonReader.java
@@ -1,0 +1,122 @@
+package akka.stream.alpakka.marshal.json;
+
+import static javaslang.control.Option.none;
+import static javaslang.control.Option.some;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.alpakka.marshal.generic.Locator;
+import akka.stream.stage.AbstractInHandler;
+import akka.stream.stage.AbstractOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+import akka.util.ByteString;
+import de.undercouch.actson.JsonEvent;
+import de.undercouch.actson.JsonParser;
+import javaslang.control.Option;
+
+/**
+ * Wraps the Actson JSON parser as an akka flow of ByteString to JSONEvent
+ * 
+ * @see https://www.michel-kraemer.com/actson-reactive-json-parser/
+ */
+public class ActsonReader extends GraphStage<FlowShape<ByteString,JSONEvent>> {
+    public static final Locator<JSONEvent> locator = evt -> ""; // TODO location reporting for JSON events
+    
+    private final Inlet<ByteString> in = Inlet.create("in");
+    private final Outlet<JSONEvent> out = Outlet.create("out");
+    private final FlowShape<ByteString, JSONEvent> shape = FlowShape.of(in, out);
+
+    public static final ActsonReader instance = new ActsonReader();
+    
+    @Override
+    public FlowShape<ByteString, JSONEvent> shape() {
+        return shape;
+    }
+
+    @Override
+    public GraphStageLogic createLogic(Attributes attr) throws Exception {
+        JsonParser parser = new JsonParser();
+        return new GraphStageLogic(shape) {
+            {
+                setHandler(out, new AbstractOutHandler() {
+                    @Override
+                    public void onPull() throws Exception {
+                        List<JSONEvent> events = new ArrayList<>();
+                        parseInto(events);
+                        if (events.isEmpty()) {
+                            pull(in);
+                        } else {
+                            emitMultiple(out, events.iterator());
+                        }
+                    }
+                });
+                
+                setHandler(in, new AbstractInHandler() {
+                    @Override
+                    public void onPush() throws Exception {
+                        List<JSONEvent> events = new ArrayList<>();
+                        ByteString bytes = grab(in);
+                        // TODO either PR ByteBuffer support into actson, or sneaky-access the underlying byte array fields here
+                        for (ByteBuffer b: bytes.getByteBuffers()) {
+                            byte[] buf= new byte[b.remaining()];
+                            b.get(buf, 0, b.remaining());
+                            int i = 0;
+                            while (i < buf.length) {
+                              i += parser.getFeeder().feed(buf, i, buf.length - i);
+                              parseInto(events);
+                            }
+                        }
+                        if (events.isEmpty()) {
+                            pull(in);
+                        } else {
+                            emitMultiple(out, events.iterator());
+                        }
+                    }
+                    
+                    public void onUpstreamFinish() throws Exception {
+                        parser.getFeeder().done();
+                        List<JSONEvent> events = new ArrayList<>();
+                        parseInto(events);
+                        emitMultiple(out, events.iterator());
+                        complete(out);
+                    }
+                });
+            }
+            
+            private void parseInto(List<JSONEvent> events) {
+                Option<JSONEvent> evt = next();
+                while (evt.isDefined()) {
+                    events.add(evt.get());
+                    evt = next();
+                }
+            };
+            
+            private Option<JSONEvent> next() {
+                switch(parser.nextEvent()) {
+                case JsonEvent.END_ARRAY: return some(JSONEvent.END_ARRAY);
+                case JsonEvent.END_OBJECT: return some(JSONEvent.END_OBJECT);
+                case JsonEvent.ERROR: throw new IllegalArgumentException("There was a parse error at around character " + parser.getParsedCharacterCount());
+                case JsonEvent.EOF: return none();
+                case JsonEvent.FIELD_NAME: return some(new JSONEvent.FieldName(parser.getCurrentString()));
+                case JsonEvent.NEED_MORE_INPUT: return none();
+                case JsonEvent.START_ARRAY: return some(JSONEvent.START_ARRAY);
+                case JsonEvent.START_OBJECT: return some(JSONEvent.START_OBJECT);
+                case JsonEvent.VALUE_DOUBLE: return some(new JSONEvent.NumericValue(String.valueOf(parser.getCurrentDouble())));
+                case JsonEvent.VALUE_FALSE: return some(JSONEvent.FALSE);
+                case JsonEvent.VALUE_INT: return some(new JSONEvent.NumericValue(String.valueOf(parser.getCurrentInt())));
+                case JsonEvent.VALUE_NULL: return some(JSONEvent.NULL);
+                case JsonEvent.VALUE_STRING: return some(new JSONEvent.StringValue(parser.getCurrentString()));
+                case JsonEvent.VALUE_TRUE: return some(JSONEvent.TRUE);
+                default: throw new UnsupportedOperationException("Unexpected event in JSON parser");
+                }
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/json/AnyFieldProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/json/AnyFieldProtocol.java
@@ -1,0 +1,110 @@
+package akka.stream.alpakka.marshal.json;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.WriteProtocol;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.collection.Vector;
+import javaslang.control.Option;
+import javaslang.control.Try;
+
+/**
+ * Protocol for reading and writing individual JSON fields and their value (through an inner protocol), mapping each field's name
+ * as a String, and delegating to an inner protocol for the value.
+ */
+public class AnyFieldProtocol {
+    private static final Logger log = LoggerFactory.getLogger(AnyFieldProtocol.class);
+    
+    public static <T> ReadProtocol<JSONEvent,Tuple2<String,T>> read(ReadProtocol<JSONEvent,T> innerProtocol) {
+        
+        return new ReadProtocol<JSONEvent,Tuple2<String,T>>() {
+            @Override
+            public Reader<JSONEvent, Tuple2<String, T>> reader() {
+                return new Reader<JSONEvent, Tuple2<String,T>>() {
+                    private final Reader<JSONEvent, T> inner = innerProtocol.reader();
+                    private boolean matched;
+                    private int nestedObjects = 0;
+                    private Option<String> lastField = Option.none();
+                    
+                    @Override
+                    public Try<Tuple2<String,T>> reset() {
+                        matched = false;
+                        nestedObjects = 0;
+                        Try<T> i = inner.reset();
+                        Try<Tuple2<String,T>> result = tuple(i);
+                        lastField = Option.none();
+                        return result;
+                    }
+
+                    private Try<Tuple2<String, T>> tuple(Try<T> i) {
+                        return lastField.isDefined() ? i.map(t -> Tuple.of(lastField.get(), t)) : none();
+                    }
+                    
+                    @Override
+                    public Try<Tuple2<String,T>> apply(JSONEvent evt) {
+                        if (!matched && nestedObjects == 0 && evt instanceof JSONEvent.FieldName) {
+                            matched = true;
+                            lastField = Option.some(JSONEvent.FieldName.class.cast(evt).getName());
+                            log.debug("AnyField started: {}", lastField);
+                            return none();
+                        } else if (matched && nestedObjects == 0 && (evt == JSONEvent.START_OBJECT || evt == JSONEvent.START_ARRAY)) {
+                            nestedObjects++;
+                            return tuple(inner.apply(evt));
+                        } else if (matched && nestedObjects == 1 && (evt == JSONEvent.END_OBJECT || evt == JSONEvent.END_ARRAY)) {
+                            log.debug("AnyField ending nested.");
+                            nestedObjects--;
+                            matched = false;
+                            return tuple(inner.apply(evt));
+                        } else if (matched && nestedObjects == 0 && (evt instanceof JSONEvent.Value)) {
+                            log.debug("AnyField ending value.");
+                            matched = false;
+                            return tuple(inner.apply(evt));
+                        } else {
+                            Try<T> result = (matched) ? inner.apply(evt) : none();
+                            if (evt == JSONEvent.START_OBJECT || evt == JSONEvent.START_ARRAY) {
+                                nestedObjects++;
+                            } else if (evt == JSONEvent.END_OBJECT || evt == JSONEvent.END_ARRAY) {
+                                nestedObjects--;
+                            }
+                            return tuple(result);
+                        }
+                    }
+                };
+            }
+            
+            @Override
+            public String toString() {
+                return "(any): " + innerProtocol;
+            }
+        };
+    }
+    
+    public static <T> WriteProtocol<JSONEvent, Tuple2<String,T>> write(WriteProtocol<JSONEvent, T> innerProtocol) {
+        return new WriteProtocol<JSONEvent, Tuple2<String,T>>() {
+            @Override
+            public Class<? extends JSONEvent> getEventType() {
+                return JSONEvent.class;
+            }
+            
+            @Override
+            public Writer<JSONEvent, Tuple2<String,T>> writer() {
+                return innerProtocol.writer()
+                    .compose((Tuple2<String, T> t) -> t._2)
+                    .mapWithInput((t, events) -> Vector.<JSONEvent>of(new JSONEvent.FieldName(t._1)).appendAll(events));
+            }
+            
+            @Override
+            public String toString() {
+                return "(any): " + innerProtocol;
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/json/ArrayProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/json/ArrayProtocol.java
@@ -1,0 +1,137 @@
+package akka.stream.alpakka.marshal.json;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.isNone;
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.WriteProtocol;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+import javaslang.control.Try;
+
+public class ArrayProtocol<E> {
+    private static final Logger log = LoggerFactory.getLogger(ArrayProtocol.class);
+    
+    public static <E> ReadProtocol<JSONEvent, E> read(ReadProtocol<JSONEvent, E> innerProtocol) {
+        return new ReadProtocol<JSONEvent, E>() {
+            private final ReadProtocol<JSONEvent, E> owner = this;
+            
+            @Override
+            public Reader<JSONEvent, E> reader() {
+                return new Reader<JSONEvent, E>() {
+                    private final Reader<JSONEvent, E> inner = innerProtocol.reader();
+                    private int nestedObjects = 0;
+                    private boolean matched = false;
+                    private boolean wasEmpty = true;
+
+                    @Override
+                    public Try<E> reset() {
+                        nestedObjects = 0;
+                        matched = false;
+                        wasEmpty = true;
+                        return none();
+                    }
+
+                    @Override
+                    public Try<E> apply(JSONEvent evt) {
+                        if (nestedObjects == 0) {
+                            if (evt == JSONEvent.START_OBJECT) {
+                                nestedObjects++;
+                                return none();
+                            } else if (evt == JSONEvent.START_ARRAY) {
+                                log.debug("Array has started: {}", owner);
+                                matched = true;
+                                nestedObjects++;
+                                return none();
+                            } else { // literal, just skip
+                                return none();
+                            }
+                        } else if (matched && evt == JSONEvent.END_ARRAY && nestedObjects == 1) {
+                            log.debug("Array has ended: {}", owner);
+                            reset();
+                            Try<E> result = inner.reset();
+                            return (wasEmpty && isNone(result)) ? innerProtocol.empty() : result;
+                        } else {
+                            Try<E> result = none();
+                            
+                            if (matched) {
+                                log.debug("Array forwarding {} at level {}", evt, nestedObjects);
+                                wasEmpty = false;
+                                result = inner.apply(evt);
+                            }
+                            
+                            if (evt == JSONEvent.END_ARRAY || evt == JSONEvent.END_OBJECT) {
+                                log.debug("    (nested--) {} on {}", nestedObjects, owner);
+                                nestedObjects--;
+                            } else if (evt == JSONEvent.START_ARRAY || evt == JSONEvent.START_OBJECT) {
+                                log.debug("    (nested++) {} on {}", nestedObjects, owner);
+                                nestedObjects++;
+                            }
+                            
+                            return result;
+                        }
+                    }
+                };
+            }
+            
+            @Override
+            public Try<E> empty() {
+                return innerProtocol.empty();
+            }
+            
+            @Override
+            public String toString() {
+                return "[ " + innerProtocol + "]";
+            }
+        };
+    }
+
+    public static <E> WriteProtocol<JSONEvent, E> write(WriteProtocol<JSONEvent, E> innerProtocol) {
+        return new WriteProtocol<JSONEvent, E>() {
+            WriteProtocol<JSONEvent, E> parent = this;
+            
+            @Override
+            public Class<? extends JSONEvent> getEventType() {
+                return JSONEvent.class;
+            }
+            
+            @Override
+            public Writer<JSONEvent, E> writer() {
+                Writer<JSONEvent, E> inner = innerProtocol.writer();
+                
+                return new Writer<JSONEvent,E>() {
+                    boolean started = false;
+
+                    @Override
+                    public Seq<JSONEvent> apply(E value) {
+                        log.debug("{}: Writing {}, started {}", parent, value, started);
+                        Seq<JSONEvent> prefix = (started) ? Vector.empty() : Vector.of(JSONEvent.START_ARRAY);
+                        started = true;
+                        
+                        return prefix.appendAll(inner.applyAndReset(value));
+                    }
+                        
+                    @Override
+                    public Seq<JSONEvent> reset() {
+                        log.debug("{}: Resetting ", parent);
+                        Seq<JSONEvent> prefix = (started) ? Vector.empty() : Vector.of(JSONEvent.START_ARRAY);
+                        started = false;
+                        
+                        return prefix.append(JSONEvent.END_ARRAY);
+                    }
+                };
+            }
+            
+            @Override
+            public String toString() {
+                return "[ " + innerProtocol + "]";
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/json/FieldProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/json/FieldProtocol.java
@@ -1,0 +1,149 @@
+package akka.stream.alpakka.marshal.json;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.WriteProtocol;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+import javaslang.control.Try;
+
+/**
+ * Protocol for reading and writing a single JSON field and its value (through an inner protocol)
+ */
+public class FieldProtocol {
+    private static final Logger log = LoggerFactory.getLogger(FieldProtocol.class);
+    
+    public static <T> ReadProtocol<JSONEvent, T> read(String fieldName, ReadProtocol<JSONEvent, T> innerProtocol) {
+        JSONEvent field = new JSONEvent.FieldName(fieldName);
+        return new ReadProtocol<JSONEvent, T>() {
+            @Override
+            public Try<T> empty() {
+                return innerProtocol.empty();
+            }
+            
+            @Override
+            public Reader<JSONEvent, T> reader() {
+                return new Reader<JSONEvent, T>() {
+                    private final Reader<JSONEvent, T> inner = innerProtocol.reader();
+                    private boolean matched;
+                    private boolean wasMatched = false;
+                    private int nestedObjects = 0;
+                    
+                    @Override
+                    public Try<T> reset() {
+                        matched = false;
+                        nestedObjects = 0;
+                        Try<T> r = inner.reset();
+                        if (wasMatched) {
+                            wasMatched = false;
+                            return r;
+                        } else {
+                            return none();
+                        }
+                    }
+                    
+                    @Override
+                    public Try<T> apply(JSONEvent evt) {
+                        if (!matched && nestedObjects == 0 && evt.equals(field)) {
+                            matched = true;
+                            wasMatched = true;
+                            return none();
+                        } else if (matched && nestedObjects == 0 && (evt == JSONEvent.START_OBJECT || evt == JSONEvent.START_ARRAY)) {
+                            nestedObjects++;
+                            return inner.apply(evt);
+                        } else if (matched && nestedObjects == 1 && (evt == JSONEvent.END_OBJECT || evt == JSONEvent.END_ARRAY)) {
+                            log.debug("Field ending.");
+                            nestedObjects--;
+                            matched = false;
+                            return inner.apply(evt);
+                        } else if (matched && nestedObjects == 0 && (evt instanceof JSONEvent.Value)) {
+                            matched = false;
+                            return inner.apply(evt);
+                        } else {
+                            Try<T> result = (matched) ? inner.apply(evt) : none();
+                            if (evt == JSONEvent.START_OBJECT || evt == JSONEvent.START_ARRAY) {
+                                nestedObjects++;
+                            } else if (evt == JSONEvent.END_OBJECT || evt == JSONEvent.END_ARRAY) {
+                                nestedObjects--;
+                            }
+                            return result;
+                        }
+                    }
+                };
+            }
+            
+            @Override
+            public String toString() {
+                return "" + field + "(" + innerProtocol + ")";
+            }
+        };
+    }
+    
+    public static <T> WriteProtocol<JSONEvent, T> write(String fieldName, WriteProtocol<JSONEvent, T> innerProtocol) {
+        JSONEvent field = new JSONEvent.FieldName(fieldName);
+        
+        return new WriteProtocol<JSONEvent, T>() {
+            @Override
+            public Class<? extends JSONEvent> getEventType() {
+                return JSONEvent.class;
+            }
+            
+            @Override
+            public Writer<JSONEvent, T> writer() {
+                Writer<JSONEvent, T> inner = innerProtocol.writer();
+                return new Writer<JSONEvent, T>() {
+                    Seq<JSONEvent> buffer = Vector.empty();
+                    boolean fieldStarted = false;
+
+                    @Override
+                    public Seq<JSONEvent> apply(T value) {
+                        if (fieldStarted) {
+                            return inner.apply(value);
+                        } else {
+                            buffer = buffer.appendAll(inner.apply(value));
+                            if (buffer.isEmpty() || buffer.eq(Vector.of(JSONEvent.START_ARRAY, JSONEvent.END_ARRAY))) {
+                                return Vector.empty();
+                            } else {
+                                Vector<JSONEvent> result = Vector.of(field).appendAll(buffer);
+                                buffer = Vector.empty();
+                                fieldStarted = true;
+                                return result;
+                            }
+                        }
+                    }
+                    
+                    @Override
+                    public Seq<JSONEvent> reset() {
+                        Seq<JSONEvent> result;
+                        if (fieldStarted) {
+                            result = inner.reset();
+                        } else {
+                            buffer = buffer.appendAll(inner.reset());
+                            if (buffer.isEmpty() || buffer.eq(Vector.of(JSONEvent.START_ARRAY, JSONEvent.END_ARRAY))) {
+                                result = Vector.empty();
+                            } else {
+                                result = Vector.of(field).appendAll(buffer);
+                            }
+                        }
+                        buffer = Vector.empty();
+                        fieldStarted = false;
+                        return result;
+                    }
+
+                };
+            }
+            
+            @Override
+            public String toString() {
+                return "" + field + "(" + innerProtocol + ")";
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/json/JSONEvent.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/json/JSONEvent.java
@@ -1,0 +1,203 @@
+package akka.stream.alpakka.marshal.json;
+
+public abstract class JSONEvent {
+    public static final class StartObject extends JSONEvent { 
+        private StartObject() {}
+        @Override
+        public String toString() {
+            return "{";
+        }
+    }
+    public static final StartObject START_OBJECT = new StartObject();
+    
+    public static final class EndObject extends JSONEvent { 
+        private EndObject() {}
+        @Override
+        public String toString() {
+            return "}";
+        }
+    }
+    public static final EndObject END_OBJECT = new EndObject();
+    
+    public static final class StartArray extends JSONEvent { 
+        private StartArray() {}
+        @Override
+        public String toString() {
+            return "[";
+        }
+    }
+    public static final StartArray START_ARRAY = new StartArray();
+    
+    public static final class EndArray extends JSONEvent { 
+        private EndArray() {} 
+        @Override
+        public String toString() {
+            return "]";
+        }
+    }
+    public static final EndArray END_ARRAY = new EndArray();
+    
+    public static final class FieldName extends JSONEvent {
+        private final String name;
+
+        public FieldName(String name) {
+            this.name = name;
+        }
+        
+        public String getName() {
+            return name;
+        }
+
+        public static boolean is(JSONEvent evt, String fieldName) {
+            return evt instanceof FieldName && ((FieldName)evt).name.equals(fieldName);
+        }
+        
+        @Override
+        public String toString() {
+            return name + ": ";
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((name == null) ? 0 : name.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            FieldName other = (FieldName) obj;
+            if (name == null) {
+                if (other.name != null)
+                    return false;
+            } else if (!name.equals(other.name))
+                return false;
+            return true;
+        }
+    }
+    
+    public static abstract class Value extends JSONEvent {
+        public abstract String getValueAsString();
+        
+        @Override
+        public String toString() {
+            return getValueAsString();
+        }
+    }
+    
+    public static final class True extends Value { 
+        private True() {}
+        @Override
+        public String getValueAsString() {
+            return "true";
+        }
+    }
+    public static final True TRUE = new True();
+    
+    public static final class False extends Value { 
+        private False() {}
+        @Override
+        public String getValueAsString() {
+            return "false";
+        }
+    }
+    public static final False FALSE = new False();
+    
+    public static final class Null extends Value { 
+        private Null() {}
+        @Override
+        public String getValueAsString() {
+            return "null";
+        }
+    }
+    public static final Null NULL = new Null();
+    
+    public static final class StringValue extends Value {
+        private final String value;
+
+        public StringValue(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValueAsString() {
+            return value;
+        }
+        
+        @Override
+        public String toString() {
+            return "\"" + value + "\"";
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((value == null) ? 0 : value.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            StringValue other = (StringValue) obj;
+            if (value == null) {
+                if (other.value != null)
+                    return false;
+            } else if (!value.equals(other.value))
+                return false;
+            return true;
+        }
+    }
+    
+    public static final class NumericValue extends Value {
+        private final String value;
+
+        public NumericValue(String value) {
+            // TODO validate this when writing own parser, and validate when generating
+            this.value = value;
+        }
+
+        @Override
+        public String getValueAsString() {
+            return value;
+        }
+        
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((value == null) ? 0 : value.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            NumericValue other = (NumericValue) obj;
+            if (value == null) {
+                if (other.value != null)
+                    return false;
+            } else if (!value.equals(other.value))
+                return false;
+            return true;
+        }
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/json/JacksonWriter.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/json/JacksonWriter.java
@@ -1,0 +1,77 @@
+package akka.stream.alpakka.marshal.json;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+
+import akka.NotUsed;
+import akka.stream.alpakka.marshal.generic.PushPullOutputStreamAdapter;
+import akka.stream.javadsl.Flow;
+import akka.util.ByteString;
+
+/**
+ * Serializes JSONEvents out as JSON by invoking Jackson, but in a non-blocking push/pull fashion,
+ * only writing when there is demand from downstream.
+ */
+public class JacksonWriter extends PushPullOutputStreamAdapter<List<JSONEvent>, JsonGenerator> {
+    private static final JsonFactory factory = new JsonFactory();
+    
+    /**
+     * Returns a flow that buffers up to 100 JSON events and writing them together.
+     */
+    public static Flow<JSONEvent,ByteString,NotUsed> flow() {
+        return flow(100);
+    }
+    
+    /**
+     * Returns a flow that buffers up to [maximumBatchSize] JSON events and writing them together.
+     * 
+     * Buffering is only done if upstream is faster than downstream. If there is demand from downstream,
+     * also slower batches will be written.
+     */
+    public static Flow<JSONEvent,ByteString,NotUsed> flow(int maximumBatchSize) {
+        return Flow.of(JSONEvent.class)
+            .batch(maximumBatchSize, event -> {
+                List<JSONEvent> l = new ArrayList<>();
+                l.add(event);
+                return l;
+            }, (list, event) -> {
+                list.add(event);
+                return list;
+            }).via(new JacksonWriter());
+    }
+    
+    private JacksonWriter() {
+        super(
+            (attr, out) -> factory.createGenerator(out),
+            (gen, events) -> {
+                for (JSONEvent evt: events) {
+                    if (evt == JSONEvent.START_OBJECT) {
+                        gen.writeStartObject();
+                    } else if (evt == JSONEvent.END_OBJECT) {
+                        gen.writeEndObject();
+                    } else if (evt == JSONEvent.START_ARRAY) {
+                        gen.writeStartArray();
+                    } else if (evt == JSONEvent.END_ARRAY) {
+                        gen.writeEndArray();
+                    } else if (evt == JSONEvent.TRUE) {
+                        gen.writeBoolean(true);
+                    } else if (evt == JSONEvent.FALSE) {
+                        gen.writeBoolean(false);
+                    } else if (evt == JSONEvent.NULL) {
+                        gen.writeNull();
+                    } else if (evt instanceof JSONEvent.FieldName) {
+                        gen.writeFieldName(JSONEvent.FieldName.class.cast(evt).getName());
+                    } else if (evt instanceof JSONEvent.StringValue) {
+                        gen.writeString(JSONEvent.StringValue.class.cast(evt).getValueAsString());
+                    } else if (evt instanceof JSONEvent.NumericValue) {
+                        gen.writeNumber(JSONEvent.NumericValue.class.cast(evt).getValueAsString());
+                    }
+                }
+                gen.flush();
+            }
+        );
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/json/ObjectProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/json/ObjectProtocol.java
@@ -1,0 +1,67 @@
+package akka.stream.alpakka.marshal.json;
+
+import java.util.List;
+import java.util.function.Function;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.Function1;
+import javaslang.collection.Vector;
+
+/**
+ * Generic class to combine several nested FieldProtocols into reading/writing a Java object instance.
+ */
+public class ObjectProtocol<T> implements Protocol<JSONEvent, T> {
+    private final ObjectReadProtocol<T> read;
+    private final ObjectWriteProtocol<T> write;
+
+    public ObjectProtocol(Protocol<JSONEvent, T> inner) {
+        this.read = new ObjectReadProtocol<>(inner);
+        this.write = new ObjectWriteProtocol<>(inner);
+    }
+    
+    public ObjectProtocol(
+        List<Protocol<JSONEvent, ?>> protocols,
+        Function<List<?>, T> produce,
+        List<Function1<T, ?>> getters
+    ) {
+        this.read = new ObjectReadProtocol<>(Vector.ofAll(protocols), produce, Vector.empty());
+        this.write = new ObjectWriteProtocol<>(Vector.ofAll(protocols), getters, Vector.empty());
+    }
+    
+    private ObjectProtocol(ObjectReadProtocol<T> read, ObjectWriteProtocol<T> write) {
+        this.read = read;
+        this.write = write;
+    }
+
+    @Override
+    public Reader<JSONEvent, T> reader() {
+        return read.reader();
+    }
+
+    @Override
+    public Writer<JSONEvent, T> writer() {
+        return write.writer();
+    }
+    
+    @Override
+    public String toString() {
+        return read.toString();
+    }
+    
+    @Override
+    public Class<? extends JSONEvent> getEventType() {
+        return write.getEventType();
+    }
+    
+    /**
+     * Returns a new protocol that, in addition, also requires the given nested protocol to be present with the given constant value,
+     * writing out the value when serializing as well.
+     */
+    public <U> ObjectProtocol<T> having(Protocol<JSONEvent, U> nestedProtocol, U value) {
+        return new ObjectProtocol<>(read.having(nestedProtocol, value), write.having(nestedProtocol, value));
+    }
+    
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/json/ObjectReadProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/json/ObjectReadProtocol.java
@@ -1,0 +1,185 @@
+package akka.stream.alpakka.marshal.json;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.isNone;
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.generic.ConstantProtocol;
+import akka.stream.alpakka.marshal.generic.ValidationException;
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+import javaslang.control.Try;
+
+/**
+ * Generic class to combine several nested FieldProtocols into reading/writing a Java object instance.
+ */
+@SuppressWarnings("unchecked")
+public class ObjectReadProtocol<T> implements ReadProtocol<JSONEvent, T> {
+    private static final Function<List<?>, Object> IDENTITY = list -> list.get(0);
+    private static final Logger log = LoggerFactory.getLogger(ObjectReadProtocol.class);
+    
+    private static <T> Function<List<?>, T> identity() {
+        return (Function<List<?>, T>) IDENTITY;
+    }
+    
+    private final Seq<ReadProtocol<JSONEvent, ?>> protocols;
+    private final Function<List<?>, T> produce;
+    private final Seq<ReadProtocol<JSONEvent, ConstantProtocol.Present>> conditions;
+
+    public ObjectReadProtocol(ReadProtocol<JSONEvent, T> inner) {
+        this(Vector.of(inner), identity(), Vector.empty());
+    }
+    
+    public ObjectReadProtocol(
+        List<ReadProtocol<JSONEvent, ?>> protocols,
+        Function<List<?>, T> produce
+    ) {
+        this(Vector.ofAll(protocols), produce, Vector.empty());
+    }
+    
+    ObjectReadProtocol(
+        Seq<ReadProtocol<JSONEvent, ?>> protocols,
+        Function<List<?>, T> produce,
+        Seq<ReadProtocol<JSONEvent, ConstantProtocol.Present>> conditions
+    ) {
+        this.protocols = protocols;
+        this.produce = produce;
+        this.conditions = conditions;
+    }
+
+    @Override
+    public Reader<JSONEvent, T> reader() {
+        return new Reader<JSONEvent, T>() {
+            private final Seq<ReadProtocol<JSONEvent, Object>> all = protocols.appendAll(conditions).map(p -> (ReadProtocol<JSONEvent, Object>)p);
+            private final List<Reader<JSONEvent, Object>> readers = all.map(p -> p.reader()).toJavaList();
+            private final Try<Object>[] values = (Try<Object>[]) new Try<?>[readers.size()];
+            private int nestedObjects = 0;
+            private boolean matched = false;
+            
+            {
+                reset();
+            }
+            
+            @Override
+            public Try<T> reset() {
+                log.debug("{} resetting", this);
+                Arrays.fill(values, none());
+                for (int i = 0; i < protocols.size(); i++) {
+                    values[i] = (Try<Object>) protocols.get(i).empty();
+                }
+                nestedObjects = 0;
+                matched = false;
+                return none();
+            }
+            
+            @Override
+            public Try<T> apply(JSONEvent evt) {
+                if (nestedObjects == 0) {
+                    if (evt == JSONEvent.START_OBJECT) {
+                        log.debug("{} found a match", this);
+                        matched = true;
+                        nestedObjects++;
+                        return none();
+                    } else if (evt == JSONEvent.START_ARRAY) {
+                        nestedObjects++;
+                        return none();
+                    } else { // literal, just skip
+                        return none();
+                    }
+                } else if (matched && evt == JSONEvent.END_OBJECT && nestedObjects == 1) {
+                    AtomicReference<Throwable> failure = new AtomicReference<>();
+
+                    for (int i = protocols.size(); i < values.length; i++) {
+                        if (isNone(values[i])) {
+                            failure.set(new ValidationException("must have field " + conditions.get(i - protocols.size())));
+                        }
+                    }
+                    
+                    for (int i = 0; i < readers.size(); i++) {
+                        Try<Object> r = readers.get(i).reset();
+                        
+                        if (!isNone(r) && values[i].eq(protocols.get(i).empty())) {
+                            values[i] = r;
+                        }
+                    }
+                    
+                    Object[] args = new Object[protocols.size()];
+                    for (int i = 0; i < args.length; i++) {
+                        ReadProtocol<JSONEvent, Object> p = (ReadProtocol<JSONEvent, Object>) protocols.get(i);
+                        Try<Object> t = values[i];
+                        log.debug("{} said {}", p, t);
+                        t.failed().forEach(failure::set);
+                        args[i] = t.getOrElse((Object)null);
+                    }
+                    log.debug("Object has {}, failure is ", values, failure.get());
+                    Try<T> result = (failure.get() != null)
+                        ? Try.failure(failure.get())
+                        : Try.success(produce.apply(Arrays.asList(args)));
+                    reset();
+                    return result;
+                } else {
+                    Try<T> result = none();
+                    
+                    if (matched) {
+                        if (isIdentity()) {
+                            result = (Try<T>) readers.get(0).apply(evt);
+                        } else {
+                            forward(evt);
+                        }
+                    }
+                    
+                    if (evt == JSONEvent.END_ARRAY || evt == JSONEvent.END_OBJECT) {
+                        nestedObjects--;
+                    } else if (evt == JSONEvent.START_ARRAY || evt == JSONEvent.START_OBJECT) {
+                        nestedObjects++;
+                    }
+                    
+                    return result;
+                }
+            }
+
+            private void forward(JSONEvent evt) {
+                for (int i = 0; i < readers.size(); i++) {
+                    int idx = i;
+                    Reader<JSONEvent, Object> r = readers.get(i);
+                    Try<Object> t = r.apply(evt);
+                    if (!ReadProtocol.isNone(t)) {
+                        values[idx] = t;
+                        log.debug("   -> {}", values[idx]);
+                    }
+                }
+            }
+            
+            @Override
+            public String toString() {
+                return ObjectReadProtocol.this.toString() + ",m=" + matched + ",n=" + nestedObjects + " ";
+            }
+        };
+    }
+
+    private boolean isIdentity() {
+        return conditions.isEmpty() && produce == IDENTITY;
+    }
+    
+    /**
+     * Returns a new protocol that, in addition, also requires the given nested protocol to be present with the given constant value
+     */
+    public <U> ObjectReadProtocol<T> having(ReadProtocol<JSONEvent, U> nestedProtocol, U value) {
+        return new ObjectReadProtocol<>(protocols, produce, conditions.append(ConstantProtocol.read(nestedProtocol, value)));
+    }
+    
+    @Override
+    public String toString() {
+        String c = conditions.isEmpty() ? "" : ", " + conditions.mkString(", ");
+        return "{ " + protocols.mkString(", ") + c + " }";
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/json/ObjectWriteProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/json/ObjectWriteProtocol.java
@@ -1,0 +1,113 @@
+package akka.stream.alpakka.marshal.json;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.stream.alpakka.marshal.generic.ConstantProtocol;
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.WriteProtocol;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.Function1;
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+
+/**
+ * Generic class to combine several nested FieldProtocols into reading/writing a Java object instance.
+ */
+@SuppressWarnings("unchecked")
+public class ObjectWriteProtocol<T> implements WriteProtocol<JSONEvent, T> {
+    private static final Logger log = LoggerFactory.getLogger(ObjectWriteProtocol.class);
+    
+    private final Seq<WriteProtocol<JSONEvent, ?>> protocols;
+    private final Seq<WriteProtocol<JSONEvent, ConstantProtocol.Present>> conditions;
+    private final List<Function1<T, ?>> getters;
+
+    public ObjectWriteProtocol(
+        List<WriteProtocol<JSONEvent, ?>> protocols,
+        List<Function1<T, ?>> getters
+    ) {
+        this(Vector.ofAll(protocols), getters, Vector.empty());
+    }
+    
+    public ObjectWriteProtocol(WriteProtocol<JSONEvent, T> inner) {
+        this(Vector.of((Protocol<JSONEvent, ?>)inner), Arrays.asList(Function1.identity()), Vector.empty());
+    }
+    
+    ObjectWriteProtocol(
+        Seq<WriteProtocol<JSONEvent, ?>> protocols,
+        List<Function1<T, ?>> getters,
+        Seq<WriteProtocol<JSONEvent, ConstantProtocol.Present>> conditions
+    ) {
+        this.protocols = protocols;
+        this.getters = getters;
+        this.conditions = conditions;
+        if (protocols.size() != getters.size()) {
+            throw new IllegalArgumentException("protocols must match getters");
+        }
+    }
+    
+    @Override
+    public Class<? extends JSONEvent> getEventType() {
+        return JSONEvent.class;
+    }
+
+    @Override
+    public Writer<JSONEvent, T> writer() {
+        Vector<Writer<JSONEvent, Object>> writers = Vector.range(0, protocols.size()).map(i ->
+            (Writer<JSONEvent, Object>) protocols.get(i).writer());
+        
+        return new Writer<JSONEvent, T>() {
+            boolean started = false;
+
+            @Override
+            public Seq<JSONEvent> apply(T value) {
+                log.debug("{}: Writing {}", ObjectWriteProtocol.this, value);
+                
+                Seq<JSONEvent> events = startObject();
+                for (int i = 0; i < protocols.size(); i++) {
+                    events = events.appendAll(writers.get(i).apply(getters.get(i).apply(value)));
+                }
+                
+                started = true;
+                return events;
+            }
+            
+            @Override
+            public Seq<JSONEvent> reset() {
+                log.debug("{}: Resetting ", ObjectWriteProtocol.this);
+                
+                Seq<JSONEvent> events = startObject();
+                for (int i = 0; i < protocols.size(); i++) {
+                    events = events.appendAll(writers.get(i).reset());
+                }
+                
+                events = events.appendAll(conditions.map(c -> c.writer().applyAndReset(ConstantProtocol.PRESENT)).flatMap(Function.identity()));
+                
+                started = false;
+                return events.append(JSONEvent.END_OBJECT);
+            }
+            
+            private Seq<JSONEvent> startObject() {
+                return (started) ? Vector.empty() : Vector.of(JSONEvent.START_OBJECT);
+            }
+        };
+    }
+    
+    /**
+     * Returns a new protocol that, in addition, writes out the given value when serializing.
+     */
+    public <U> ObjectWriteProtocol<T> having(WriteProtocol<JSONEvent, U> nestedProtocol, U value) {
+        return new ObjectWriteProtocol<>(protocols, getters, conditions.append(ConstantProtocol.write(nestedProtocol, value)));
+    }
+    
+    @Override
+    public String toString() {
+        String c = conditions.isEmpty() ? "" : ", " + conditions.mkString(", ");
+        return "{ " + protocols.mkString(", ") + c + " }";
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/json/StringValueProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/json/StringValueProtocol.java
@@ -1,0 +1,10 @@
+package akka.stream.alpakka.marshal.json;
+
+import akka.stream.alpakka.marshal.generic.StringProtocol;
+
+public class StringValueProtocol {
+    /**
+     * A JSON protocol that reads and writes strings.
+     */
+    public static StringProtocol<JSONEvent> INSTANCE = new StringProtocol<>(ValueProtocol.STRING, ActsonReader.locator);
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/json/ValueProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/json/ValueProtocol.java
@@ -1,0 +1,123 @@
+package akka.stream.alpakka.marshal.json;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.stream.alpakka.marshal.json.JSONEvent.Value;
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.Function1;
+import javaslang.collection.Vector;
+import javaslang.control.Try;
+
+public class ValueProtocol<T> implements Protocol<JSONEvent, T> {
+    // Only numeric and boolean types are defined here, since they have to marshal to numbers and booleans in JSON.
+    // For everything that marshals to strings, use stringValue.as(...)
+    
+    /** A Java integer represented as a JSON number (on reading, JSON string is also allowed) */
+    public static final ValueProtocol<Integer> INTEGER = of("signed 32-bit integer",
+        evt -> Integer.parseInt(evt.getValueAsString()),
+        i -> new JSONEvent.NumericValue(String.valueOf(i)));
+    
+    /** A Java long represented as a JSON number (on reading, JSON string is also allowed) */
+    public static final ValueProtocol<Long> LONG = of("signed 64-bit integer",
+        evt -> Long.parseLong(evt.getValueAsString()),
+        l -> new JSONEvent.NumericValue(String.valueOf(l)));
+
+    /** A Java big decimal represented as a JSON number (on reading, JSON string is also allowed) */
+    public static final ValueProtocol<BigDecimal> BIGDECIMAL = of("arbitrary precision decimal",
+        evt -> new BigDecimal(evt.getValueAsString()),
+        d -> new JSONEvent.NumericValue(String.valueOf(d)));
+    
+    /** A Java big integer represented as a JSON number (on reading, JSON string is also allowed) */
+    public static final ValueProtocol<BigInteger> BIGINTEGER = of("arbitrary precision integer",
+        evt -> new BigInteger(evt.getValueAsString()),
+        d -> new JSONEvent.NumericValue(String.valueOf(d)));
+    
+    /** A Java boolean represented a JSON boolean (on reading, a JSON string of "true" or "false" is also allowed) */
+    public static final ValueProtocol<Boolean> BOOLEAN = of("boolean",
+        v -> v.getValueAsString().equals("true"),
+        b -> b ? JSONEvent.TRUE : JSONEvent.FALSE);
+    
+    /** A Java String. Internal implementation, @see {@link StringValueProtocol} */
+    static final ValueProtocol<String> STRING = of("string",
+        evt -> evt.getValueAsString(),
+        s -> new JSONEvent.StringValue(s));
+    
+    private static final Logger log = LoggerFactory.getLogger(ValueProtocol.class);
+    
+    private final Function1<Value, T> tryRead;
+    private final Function1<T,Value> write;
+    private final String description;
+    
+    public static <T> ValueProtocol<T> of(String description, Function1<Value, T> tryRead, Function1<T, Value> write) {
+        return new ValueProtocol<>(description, tryRead, write);
+    }
+    
+    protected ValueProtocol(String description, Function1<Value, T> tryRead, Function1<T, Value> write) {
+        this.description = description;
+        this.tryRead = tryRead;
+        this.write = write;
+    }
+
+    @Override
+    public Reader<JSONEvent, T> reader() {
+        return new Reader<JSONEvent, T>() {
+            private int level = 0;
+            
+            @Override
+            public Try<T> reset() {
+                level = 0;
+                return none();
+            }
+
+            @Override
+            public Try<T> apply(JSONEvent evt) {
+                if (evt == JSONEvent.START_OBJECT || evt == JSONEvent.START_ARRAY) {
+                    level++;
+                } else if (evt == JSONEvent.END_OBJECT || evt == JSONEvent.END_ARRAY) {
+                    level--;
+                }
+                
+                if (level == 0 && evt instanceof JSONEvent.Value) {
+                    Try<T> result = Try.of(() -> {
+                        try {
+                            return tryRead.apply(JSONEvent.Value.class.cast(evt));
+                        } catch (IllegalArgumentException x) {
+                            String msg = (x.getMessage() == null) ? "" : ": " + x.getMessage();
+                            throw new IllegalArgumentException ("Expecting " + description + msg);
+                        }
+                    });
+                    
+                    log.info("Read {}", result);
+                    return result;
+                } else {
+                    return none();
+                }
+            }
+
+        };
+    }
+    
+    @Override
+    public Class<? extends JSONEvent> getEventType() {
+        return JSONEvent.class;
+    }
+
+    @Override
+    public Writer<JSONEvent, T> writer() {
+        return Writer.of(value -> Vector.of(write.apply(value)));
+    }
+
+    @Override
+    public String toString() {
+        return description;
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/json/jackson/Jackson.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/json/jackson/Jackson.java
@@ -1,0 +1,169 @@
+package akka.stream.alpakka.marshal.json.jackson;
+
+import static javaslang.control.Option.none;
+import static javaslang.control.Option.some;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import akka.stream.alpakka.marshal.json.JSONEvent;
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.control.Option;
+import javaslang.control.Try;
+
+public class Jackson {
+    private static final JsonFactory factory = new JsonFactory();
+    
+    public <T> String write(T obj, Writer<JSONEvent, T> writer) {
+        return write(writer.applyAndReset(obj));
+    }
+    
+    public <T> String writeAll(Stream<T> items, Writer<JSONEvent, T> writer) {
+        try {
+            StringWriter out = new StringWriter();
+            JsonGenerator gen = factory.createGenerator(out);
+            items.forEach(t -> {
+                writeTo(gen, writer.apply(t));
+            });
+            writeTo(gen, writer.reset());
+            gen.close();
+            return out.toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String write(Iterable<JSONEvent> events) {
+        try {
+            StringWriter out = new StringWriter();
+            JsonGenerator gen = factory.createGenerator(out);
+            writeTo(gen, events);
+            gen.close();
+            return out.toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    public static void writeTo(JsonGenerator gen, Iterable<JSONEvent> events) {
+        events.forEach(evt -> {
+            try {
+                writeTo(gen, evt);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+    
+    public static void writeTo(JsonGenerator gen, JSONEvent evt) throws IOException {
+        if (evt == JSONEvent.START_OBJECT) {
+            gen.writeStartObject();
+        } else if (evt == JSONEvent.END_OBJECT) {
+            gen.writeEndObject();
+        } else if (evt == JSONEvent.START_ARRAY) {
+            gen.writeStartArray();
+        } else if (evt == JSONEvent.END_ARRAY) {
+            gen.writeEndArray();
+        } else if (evt == JSONEvent.TRUE) {
+            gen.writeBoolean(true);
+        } else if (evt == JSONEvent.FALSE) {
+            gen.writeBoolean(false);
+        } else if (evt == JSONEvent.NULL) {
+            gen.writeNull();
+        } else if (evt instanceof JSONEvent.FieldName) {
+            gen.writeFieldName(JSONEvent.FieldName.class.cast(evt).getName());
+        } else if (evt instanceof JSONEvent.StringValue) {
+            gen.writeString(JSONEvent.StringValue.class.cast(evt).getValueAsString());
+        } else if (evt instanceof JSONEvent.NumericValue) {
+            gen.writeNumber(JSONEvent.NumericValue.class.cast(evt).getValueAsString());
+        }
+    }
+    
+    public <T> Stream<T> parse(String s, Reader<JSONEvent, T> reader) {
+        try {
+            return parse(factory.createParser(s), reader);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    public <T> Stream<T> parse(JsonParser input, Reader<JSONEvent, T> reader) {
+        reader.reset();
+        
+        Iterator<T> iterator = new Iterator<T>() {
+            private Option<T> next = parse();
+            
+            private Option<T> parse() {
+                for (Option<JSONEvent> evt = nextEvent(); evt.isDefined(); evt = nextEvent()) {
+                    Try<T> read = reader.apply(evt.get());
+                    if (read.isSuccess()) {
+                        return read.toOption();
+                    } else if (read.isFailure() && !ReadProtocol.isNone(read)) {
+                        throw (RuntimeException) read.failed().get();
+                    }
+                }
+                return Option.none();
+            }
+            
+            private Option<JSONEvent> nextEvent() {
+                try {
+                    if (input.nextToken() != null) {
+                        return some(getEvent(input));
+                    } else {
+                        return none(); // end of stream
+                    }
+                } catch (IOException e) {
+                    throw new IllegalArgumentException(e);
+                }
+            }
+            
+            @Override
+            public boolean hasNext() {
+                return next.isDefined();
+            }
+
+            @Override
+            public T next() {
+                T elmt = next.get();
+                next = parse();
+                return elmt;
+            }
+        };
+        
+        return StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED),
+            false);
+    }
+    
+    /**
+     * Returns the current token that [input] is pointing to as a JSONEvent.
+     */
+    public static JSONEvent getEvent(JsonParser input) throws IOException {
+        switch (input.getCurrentToken()) {
+        case START_OBJECT: return JSONEvent.START_OBJECT;
+        case END_OBJECT: return JSONEvent.END_OBJECT;
+        case START_ARRAY: return JSONEvent.START_ARRAY;
+        case END_ARRAY: return JSONEvent.END_ARRAY;
+        case VALUE_FALSE: return JSONEvent.FALSE;
+        case VALUE_TRUE: return JSONEvent.TRUE;
+        case VALUE_NULL: return JSONEvent.NULL;
+        case FIELD_NAME: return new JSONEvent.FieldName(input.getCurrentName());
+        case VALUE_NUMBER_FLOAT: return new JSONEvent.NumericValue(input.getValueAsString());
+        case VALUE_NUMBER_INT: return new JSONEvent.NumericValue(input.getValueAsString());
+        case VALUE_STRING: return new JSONEvent.StringValue(input.getValueAsString());
+        default: throw new IllegalArgumentException("Unexpected token " + input.getCurrentToken() + " at " + input.getCurrentLocation());
+        }
+    }
+    
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/AaltoReader.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/AaltoReader.java
@@ -1,0 +1,167 @@
+package akka.stream.alpakka.marshal.xml;
+
+import static com.fasterxml.aalto.AsyncXMLStreamReader.EVENT_INCOMPLETE;
+import static javaslang.control.Option.none;
+import static javaslang.control.Option.some;
+import static javax.xml.stream.XMLStreamConstants.CDATA;
+import static javax.xml.stream.XMLStreamConstants.CHARACTERS;
+import static javax.xml.stream.XMLStreamConstants.COMMENT;
+import static javax.xml.stream.XMLStreamConstants.END_DOCUMENT;
+import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
+import static javax.xml.stream.XMLStreamConstants.PROCESSING_INSTRUCTION;
+import static javax.xml.stream.XMLStreamConstants.START_DOCUMENT;
+import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
+
+
+import akka.stream.alpakka.marshal.generic.Locator;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.Namespace;
+import javax.xml.stream.events.XMLEvent;
+
+import org.codehaus.stax2.LocationInfo;
+
+import com.fasterxml.aalto.AsyncByteBufferFeeder;
+import com.fasterxml.aalto.AsyncXMLInputFactory;
+import com.fasterxml.aalto.AsyncXMLStreamReader;
+import com.fasterxml.aalto.stax.InputFactoryImpl;
+
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInHandler;
+import akka.stream.stage.AbstractOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+import akka.util.ByteString;
+import javaslang.control.Option;
+
+/**
+ * Wraps the Aalto XML parser as an akka flow of ByteString to XMLEvent.
+ * 
+ * @see https://github.com/FasterXML/aalto-xml
+ */
+public class AaltoReader extends GraphStage<FlowShape<ByteString,XMLEvent>> {
+    static final Locator<XMLEvent> locator = evt -> evt.getLocation().getLineNumber() + ":" + evt.getLocation().getColumnNumber();
+    
+    private static final AsyncXMLInputFactory factory = new InputFactoryImpl();
+    
+    public static final AaltoReader instance = new AaltoReader();
+
+    private final Inlet<ByteString> in = Inlet.create("in");
+    private final Outlet<XMLEvent> out = Outlet.create("out");
+    private final FlowShape<ByteString, XMLEvent> shape = FlowShape.of(in, out);
+
+    @Override
+    public FlowShape<ByteString, XMLEvent> shape() {
+        return shape;
+    }
+
+    @Override
+    public GraphStageLogic createLogic(Attributes attr) throws Exception {
+        XMLEventFactory efactory = XMLEventFactory.newFactory();
+        AsyncXMLStreamReader<AsyncByteBufferFeeder> parser = factory.createAsyncForByteBuffer();
+        return new GraphStageLogic(shape) {
+            {
+                setHandler(out, new AbstractOutHandler() {
+                    @Override
+                    public void onPull() {
+                        try {
+                            emitNext();
+                        } catch (XMLStreamException x) {
+                            failStage(x);
+                        }
+                    }
+                });
+                
+                setHandler(in, new AbstractInHandler() {
+                    @Override
+                    public void onPush() {
+                        try {
+                            ByteString bytes = grab(in);
+                            for (ByteBuffer b: bytes.getByteBuffers()) {
+                                parser.getInputFeeder().feedInput(b);
+                            }
+                            emitNext();
+                        } catch (XMLStreamException x) {
+                            failStage(x);
+                        }
+                    }
+                    
+                    public void onUpstreamFinish() {
+                        parser.getInputFeeder().endOfInput();
+                        List<XMLEvent> events = new ArrayList<>();
+                        try {
+                            while (parser.hasNext()) {
+                                Option<XMLEvent> n = next();
+                                if (n.isDefined()) {
+                                    events.add(n.get());
+                                } else {
+                                    emitMultiple(out, events.iterator());
+                                    failStage(new XMLStreamException("Unexpected end of XML stream"));
+                                    return;
+                                }
+                            }
+                            emitMultiple(out, events.iterator());
+                            completeStage();
+                        } catch (XMLStreamException x) {
+                            failStage(x);
+                        }
+                    };
+                });
+            }
+            
+            private void emitNext() throws XMLStreamException {
+                if (parser.hasNext()) {
+                    Option<XMLEvent> next = next();
+                    // calling into Stax2 directly gives more accurate location information within a byte chunk
+                    efactory.setLocation(((LocationInfo) parser).getCurrentLocation());
+                    if (next.isDefined()) {
+                        push(out, next.get());
+                    } else {
+                        pull(in);
+                    }
+                } else {
+                    completeStage();
+                }
+            }
+            
+            private Option<XMLEvent> next() throws XMLStreamException {
+                switch(parser.next()) {
+                case EVENT_INCOMPLETE: return none();
+                case START_DOCUMENT: return some(efactory.createStartDocument());
+                case END_DOCUMENT: return some(efactory.createEndDocument());
+                case START_ELEMENT: {
+                    List<Attribute> attributes = new ArrayList<>();
+                    for (int i = 0; i < parser.getAttributeCount(); i++) {
+                        attributes.add(efactory.createAttribute(parser.getAttributeName(i), parser.getAttributeValue(i)));
+                    }
+                    List<Namespace> namespaces = new ArrayList<>();
+                    for (int i = 0; i < parser.getNamespaceCount(); i++) {
+                        namespaces.add(efactory.createNamespace(parser.getNamespacePrefix(i), parser.getNamespaceURI(i)));
+                    }
+                    return some(efactory.createStartElement(parser.getName(), attributes.iterator(), namespaces.iterator()));
+                }
+                case END_ELEMENT: {
+                    List<Namespace> namespaces = new ArrayList<>();
+                    for (int i = 0; i < parser.getNamespaceCount(); i++) {
+                        namespaces.add(efactory.createNamespace(parser.getNamespacePrefix(i), parser.getNamespaceURI(i)));
+                    }
+                    return some(efactory.createEndElement(parser.getName(), namespaces.iterator()));
+                }
+                case CHARACTERS: return some(efactory.createCharacters(parser.getText()));
+                case PROCESSING_INSTRUCTION: return some(efactory.createProcessingInstruction(parser.getPITarget(), parser.getPIData()));
+                case COMMENT: return some(efactory.createComment(parser.getText()));
+                case CDATA: return some(efactory.createCData(parser.getText()));
+                default: throw new IllegalStateException("Unhandled event");
+                }
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/AnyAttributeProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/AnyAttributeProtocol.java
@@ -1,0 +1,71 @@
+package akka.stream.alpakka.marshal.xml;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.XMLEvent;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.collection.Vector;
+import javaslang.control.Try;
+
+/**
+ * Handles reading and writing a single attribute of a tag, matching any name
+ */
+public class AnyAttributeProtocol implements Protocol<XMLEvent,Tuple2<QName,String>> {
+    public static final AnyAttributeProtocol INSTANCE = new AnyAttributeProtocol();
+    
+    private static final XMLEventFactory factory = XMLEventFactory.newFactory();
+    
+    private final Writer<XMLEvent,Tuple2<QName,String>> writer;
+
+    private AnyAttributeProtocol() {
+        this.writer = Writer.of(t -> Vector.of(factory.createAttribute(t._1(), t._2())));
+    }
+    
+    @Override
+    public Class<? extends XMLEvent> getEventType() {
+        return Attribute.class;
+    }
+    
+    @Override
+    public Reader<XMLEvent,Tuple2<QName,String>> reader() {
+        return new Reader<XMLEvent,Tuple2<QName,String>>() {
+            private int level = 0;
+
+            @Override
+            public Try<Tuple2<QName,String>> reset() {
+                level = 0;
+                return none();
+            }
+
+            @Override
+            public Try<Tuple2<QName,String>> apply(XMLEvent evt) {
+                if (level == 0 && evt.isAttribute()) {
+                    Attribute attr = Attribute.class.cast(evt);
+                    return Try.success(Tuple.of(attr.getName(), attr.getValue()));
+                } else if (evt.isStartElement()) {
+                    level++;
+                    return none();
+                } else if (evt.isEndElement()) {
+                    level--;
+                    return none();
+                } else {
+                    return none();
+                }
+            }
+        };
+    }
+    
+    @Override
+    public Writer<XMLEvent,Tuple2<QName,String>> writer() {
+        return writer;
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/AttributeDelegate.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/AttributeDelegate.java
@@ -1,0 +1,90 @@
+package akka.stream.alpakka.marshal.xml;
+
+import java.io.Writer;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.Location;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.Characters;
+import javax.xml.stream.events.EndElement;
+import javax.xml.stream.events.StartElement;
+
+/**
+ * Groups an Attribute with a Location since the StaX XMLEventFactory (and the default JDK implementation) seem
+ * to think that attributes never have a location. With this class, we can at least point at the location of
+ * the tag owning the attribute.
+ */
+public class AttributeDelegate implements Attribute {
+    private final Attribute delegate;
+    private final Location location;
+    
+    public AttributeDelegate(Attribute delegate, Location location) {
+        this.delegate = delegate;
+        this.location = location;
+    }
+    
+    public QName getName() {
+        return delegate.getName();
+    }
+    public String getValue() {
+        return delegate.getValue();
+    }
+    public String getDTDType() {
+        return delegate.getDTDType();
+    }
+    public int getEventType() {
+        return delegate.getEventType();
+    }
+    public boolean isSpecified() {
+        return delegate.isSpecified();
+    }
+    public Location getLocation() {
+        return location;
+    }
+    public boolean isStartElement() {
+        return delegate.isStartElement();
+    }
+    public boolean isAttribute() {
+        return delegate.isAttribute();
+    }
+    public boolean isNamespace() {
+        return delegate.isNamespace();
+    }
+    public boolean isEndElement() {
+        return delegate.isEndElement();
+    }
+    public boolean isEntityReference() {
+        return delegate.isEntityReference();
+    }
+    public boolean isProcessingInstruction() {
+        return delegate.isProcessingInstruction();
+    }
+    public boolean isCharacters() {
+        return delegate.isCharacters();
+    }
+    public boolean isStartDocument() {
+        return delegate.isStartDocument();
+    }
+    public boolean isEndDocument() {
+        return delegate.isEndDocument();
+    }
+    public StartElement asStartElement() {
+        return delegate.asStartElement();
+    }
+    public EndElement asEndElement() {
+        return delegate.asEndElement();
+    }
+    public Characters asCharacters() {
+        return delegate.asCharacters();
+    }
+    public QName getSchemaType() {
+        return delegate.getSchemaType();
+    }
+    public void writeAsEncodedUnicode(Writer writer) throws XMLStreamException {
+        delegate.writeAsEncodedUnicode(writer);
+    }
+    public String toString() {
+        return delegate.toString();
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/AttributeProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/AttributeProtocol.java
@@ -1,0 +1,76 @@
+package akka.stream.alpakka.marshal.xml;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.XMLEvent;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.generic.StringProtocol;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.collection.Vector;
+import javaslang.control.Try;
+
+/**
+ * Handles reading and writing a single attribute of a tag.
+ */
+public class AttributeProtocol extends StringProtocol<XMLEvent> {
+    private static final XMLEventFactory factory = XMLEventFactory.newFactory();
+    
+    public AttributeProtocol(QName name) {
+        super(new Protocol<XMLEvent,String>() {
+            Writer<XMLEvent,String> writer = Writer.of(s -> Vector.of(factory.createAttribute(name, s)));
+            @Override
+            public Class<? extends XMLEvent> getEventType() {
+                return Attribute.class;
+            }
+            
+            @Override
+            public String toString() {
+                return "@" + name;
+            }
+
+            @Override
+            public Reader<XMLEvent,String> reader() {
+                return new Reader<XMLEvent,String>() {
+                    private int level = 0;
+
+                    @Override
+                    public Try<String> reset() {
+                        level = 0;
+                        return none();
+                    }
+
+                    @Override
+                    public Try<String> apply(XMLEvent evt) {
+                        if (level == 0 && evt.isAttribute() && matches(Attribute.class.cast(evt))) {
+                            return Try.success(Attribute.class.cast(evt).getValue());
+                        } else if (evt.isStartElement()) {
+                            level++;
+                            return none();
+                        } else if (evt.isEndElement()) {
+                            level--;
+                            return none();
+                        } else {
+                            return none();
+                        }
+                    }
+
+                    private boolean matches(Attribute attr) {
+                        return name.equals(attr.getName());
+                    }
+                    
+                };
+            }
+            
+            @Override
+            public Writer<XMLEvent,String> writer() {
+                return writer;
+            }
+        }, AaltoReader.locator);
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/BodyEventsProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/BodyEventsProtocol.java
@@ -1,0 +1,60 @@
+package akka.stream.alpakka.marshal.xml;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import javax.xml.stream.events.Characters;
+import javax.xml.stream.events.XMLEvent;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.control.Try;
+
+/**
+ * Protocol that emits the body of a tag as actual {@link Characters} events. This has the advantage that the body
+ * can be streamed, but the disadvantage that you can't directly map it to other types.
+ */
+public class BodyEventsProtocol implements Protocol<XMLEvent, Characters> {
+    public static final BodyEventsProtocol INSTANCE = new BodyEventsProtocol();
+
+    @Override
+    public Reader<XMLEvent, Characters> reader() {
+        return new Reader<XMLEvent,Characters>() {
+            private int level = 0;
+            
+            @Override
+            public Try<Characters> reset() {
+                level = 0;
+                return none();
+            }
+
+            @Override
+            public Try<Characters> apply(XMLEvent evt) {
+                if (level == 0 && evt.isCharacters()) {
+                    return Try.success(evt.asCharacters());
+                } else if (evt.isStartElement()) {
+                    level++;
+                    return none();
+                } else if (evt.isEndElement()) {
+                    level--;
+                    return none();
+                } else {
+                    return none();
+                }
+            }
+            
+        };
+    }
+
+    @Override
+    public Class<? extends XMLEvent> getEventType() {
+        return Characters.class;
+    }
+
+    @Override
+    public Writer<XMLEvent, Characters> writer() {
+        return Writer.identity();
+    }
+
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/BodyProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/BodyProtocol.java
@@ -1,0 +1,82 @@
+package akka.stream.alpakka.marshal.xml;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.events.XMLEvent;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.generic.StringProtocol;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.collection.Vector;
+import javaslang.control.Try;
+
+/**
+ * Represents the character data body at root level as a String. If during reading, an empty tag or no body is encountered,
+ * no value is emitted. In other words, no empty strings will be emitted during reading.
+ */
+public class BodyProtocol extends StringProtocol<XMLEvent> {
+    public static final BodyProtocol INSTANCE = new BodyProtocol();
+    
+    private static final XMLEventFactory factory = XMLEventFactory.newFactory();
+    
+    private BodyProtocol() {
+        super(new Protocol<XMLEvent,String>(){
+            Writer<XMLEvent,String> writer = Writer.of(value -> Vector.of(factory.createCharacters(value)));
+            
+            @Override
+            public Writer<XMLEvent,String> writer() {
+                return writer;
+            }
+            
+            @Override
+            public Class<? extends XMLEvent> getEventType() {
+                return XMLEvent.class;
+            }
+
+            @Override
+            public Reader<XMLEvent,String> reader() {
+                return new Reader<XMLEvent,String>() {
+                    private int level = 0;
+                    private final List<String> buffer = new ArrayList<>();
+                    
+                    @Override
+                    public Try<String> reset() {
+                        level = 0;
+                        Try<String> result = Try.success(buffer.stream().collect(Collectors.joining()));
+                        buffer.clear();
+                        return result.get().isEmpty() ? none() : result;
+                    }
+
+                    @Override
+                    public Try<String> apply(XMLEvent evt) {
+                        if (level == 0 && evt.isCharacters()) {
+                            buffer.add(evt.asCharacters().getData());
+                            return none();
+                        } else if (evt.isStartElement()) {
+                            level++;
+                            return none();
+                        } else if (evt.isEndElement()) {
+                            level--;
+                            return none();
+                        } else {
+                            return none();
+                        }
+                    }
+                    
+                };
+            }
+            
+            @Override
+            public String toString() {
+                return "body";
+            }
+        }, AaltoReader.locator);
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/JAXBProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/JAXBProtocol.java
@@ -1,0 +1,201 @@
+package akka.stream.alpakka.marshal.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.UnmarshallerHandler;
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLEventWriter;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.XMLEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.Writer;
+import akka.stream.alpakka.marshal.xml.impl.StaxEventHandler;
+
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+import javaslang.control.Option;
+import javaslang.control.Try;
+
+/**
+ * Reads and writes instances of T by delegating onto JAXB, so existing JAXB classes and/or annotations
+ * can be mixed in with streams.
+ */
+public class JAXBProtocol<T> implements Protocol<XMLEvent,T> {
+    private static final Logger log = LoggerFactory.getLogger(JAXBProtocol.class);
+    
+    public static <T> JAXBProtocol<T> jaxbType(Class<T> targetType) {
+        try {
+            return new JAXBProtocol<>(JAXBContext.newInstance(targetType), targetType.getSimpleName());
+        } catch (JAXBException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static JAXBProtocol<Object> jaxbType(JAXBContext context) {
+        return new JAXBProtocol<>(context, "jaxb");
+    }
+    
+    public static <T> JAXBProtocol<T> jaxbType(Class<T> targetType, JAXBContext context) {
+        return new JAXBProtocol<>(context, targetType.getSimpleName());
+    }
+    
+    private final JAXBContext context;
+    private final String name;
+
+    private JAXBProtocol(JAXBContext context, String name) {
+        this.context = context;
+        this.name = name;
+    }
+
+    @Override
+    public Reader<XMLEvent, T> reader() {
+        try {
+            UnmarshallerHandler handler = context.createUnmarshaller().getUnmarshallerHandler();
+            return new Reader<XMLEvent, T>() {
+                private Option<Boolean> fragment = Option.none();
+                private int level = 0;
+
+                @SuppressWarnings("unchecked")
+                @Override
+                public Try<T> reset() {
+                    Try<T> result;
+                    if (fragment.eq(Option.some(false))) {
+                        result = (Try<T>) Try.of(() -> handler.getResult());
+                    } else {
+                        result = ReadProtocol.none();
+                    }
+                    fragment = Option.none();
+                    level = 0;
+                    log.debug("reset: {}", result);
+                    return result;
+                }
+
+                @SuppressWarnings("unchecked")
+                @Override
+                public Try<T> apply(XMLEvent event) {
+                    log.debug("Seen {}", event);
+                    try {
+                        // Inject a startDocument if we're reading a fragment, i.e. not seeing startDocument of the whole stream
+                        if (fragment.isEmpty()) {
+                            fragment = Option.some(!event.isStartDocument());
+                            log.debug("Starting unmarshalling. Fragment={}", fragment.get());
+                            if (fragment.get()) {
+                                handler.startDocument();
+                            }
+                        }
+                        if (event.isStartElement()) {
+                            level++;
+                        } else if (event.isEndElement()) {
+                            level--;
+                        }
+                        Stax.apply(event, handler);
+                        if (fragment.get() && event.isEndElement() && level == 0) {
+                            try {
+                                handler.endDocument();
+                            } catch (SAXException e) {
+                                throw new IllegalStateException(e);
+                            }
+                            return (Try<T>) Try.of(() -> handler.getResult());
+                        }
+                    } catch (SAXException e) {
+                        throw new IllegalStateException(e);
+                    }
+                    return ReadProtocol.none();
+                }
+            };
+        } catch (JAXBException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public Class<? extends XMLEvent> getEventType() {
+        return XMLEvent.class;
+    }
+
+    @Override
+    public Writer<XMLEvent, T> writer() {
+        try {
+            Marshaller marshaller = context.createMarshaller();
+            marshaller.setProperty(Marshaller.JAXB_FRAGMENT, true);
+            return new Writer<XMLEvent, T>() {
+                @Override
+                public Seq<XMLEvent> apply(T value) {
+                    List<XMLEvent> events = new ArrayList<>();
+                    try {
+                        marshaller.marshal(value, new StaxEventHandler(new XMLEventWriter() {
+                            @Override
+                            public void setPrefix(String prefix, String uri) throws XMLStreamException {
+                            }
+                            
+                            @Override
+                            public void setNamespaceContext(NamespaceContext context) throws XMLStreamException {
+                            }
+                            
+                            @Override
+                            public void setDefaultNamespace(String uri) throws XMLStreamException {
+                            }
+                            
+                            @Override
+                            public String getPrefix(String uri) throws XMLStreamException {
+                                throw new UnsupportedOperationException();
+                            }
+                            
+                            @Override
+                            public NamespaceContext getNamespaceContext() {
+                                throw new UnsupportedOperationException();
+                            }
+                            
+                            @Override
+                            public void flush() throws XMLStreamException {
+                            }
+                            
+                            @Override
+                            public void close() throws XMLStreamException {
+                            }
+                            
+                            @Override
+                            public void add(XMLEventReader reader) throws XMLStreamException {
+                                while (reader.hasNext()) {
+                                    add(reader.nextEvent());
+                                }
+                            }
+                            
+                            @Override
+                            public void add(XMLEvent event) throws XMLStreamException {
+                                events.add(event);
+                            }
+                        }));
+                    } catch (JAXBException e) {
+                        throw new RuntimeException(e);
+                    }
+                    return Vector.ofAll(events);
+                }
+
+                @Override
+                public Seq<XMLEvent> reset() {
+                    return Vector.empty();
+                }
+            };
+        } catch (JAXBException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/QNameStringProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/QNameStringProtocol.java
@@ -1,0 +1,23 @@
+package akka.stream.alpakka.marshal.xml;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.events.XMLEvent;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.generic.TStringProtocol;
+
+import javaslang.Tuple2;
+
+public class QNameStringProtocol extends TStringProtocol<XMLEvent,QName> {
+
+    public QNameStringProtocol(Protocol<XMLEvent,Tuple2<QName, String>> delegate) {
+        super(delegate, AaltoReader.locator);
+    }
+    
+    /**
+     * Returns the protocol only reading and writing local names for _1, without namespace.
+     */
+    public TStringProtocol<XMLEvent,String> asLocalName() {
+        return new TStringProtocol<>(this.map(t -> t.map1(QName::getLocalPart), t -> t.map1(QName::new)), AaltoReader.locator);
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/SchemaValidatorFlow.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/SchemaValidatorFlow.java
@@ -1,0 +1,103 @@
+package akka.stream.alpakka.marshal.xml;
+
+import javax.xml.stream.events.XMLEvent;
+import javax.xml.validation.Schema;
+import javax.xml.validation.ValidatorHandler;
+
+import org.xml.sax.Locator;
+import org.xml.sax.SAXParseException;
+
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInHandler;
+import akka.stream.stage.AbstractOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+
+/**
+ * A graph stage that runs incoming XML events past an XSD schema, failing the flow
+ * if an error is found.
+ * 
+ * TODO (1): The implementation does currently NOT augment the XML events according to the schema.
+ *           For example, default values present in the schema are not applied to the events.
+ *           All events are passed through unchanged.
+ * 
+ * TODO (2): The implementation fails the stream on the first error. It might be desirable to accumulate
+ *           several/all/until timeout/... errors instead.
+ */
+public class SchemaValidatorFlow extends GraphStage<FlowShape<XMLEvent, XMLEvent>> {
+    public static GraphStage<FlowShape<XMLEvent, XMLEvent>> of(Schema schema) {
+        return new SchemaValidatorFlow(schema);
+    }
+    
+    private final Outlet<XMLEvent> out = Outlet.create("out");
+    private final Inlet<XMLEvent> in = Inlet.create("in");
+    private final FlowShape<XMLEvent, XMLEvent> shape = FlowShape.of(in, out);
+    private final Schema schema;
+
+    private SchemaValidatorFlow(Schema schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public FlowShape<XMLEvent, XMLEvent> shape() {
+        return shape;
+    }
+    
+    @Override
+    public GraphStageLogic createLogic(Attributes attr) throws Exception {
+        ValidatorHandler handler = schema.newValidatorHandler();
+        return new GraphStageLogic(shape) {
+            int lineNumber = -1;
+            int columnNumber = -1;
+        {
+            handler.setDocumentLocator(new Locator() {
+                @Override
+                public String getPublicId() {
+                    return null;
+                }
+
+                @Override
+                public String getSystemId() {
+                    return null;
+                }
+
+                @Override
+                public int getLineNumber() {
+                    return lineNumber;
+                }
+
+                @Override
+                public int getColumnNumber() {
+                    return columnNumber;
+                }
+            });
+            
+            setHandler(out, new AbstractOutHandler() {
+                @Override
+                public void onPull() {
+                    pull(in);
+                }
+            });
+            
+            setHandler(in, new AbstractInHandler() {
+                @Override
+                public void onPush() throws Exception {
+                    XMLEvent event = grab(in);
+                    if (event.getLocation() != null) {
+                        lineNumber = event.getLocation().getLineNumber();
+                        columnNumber = event.getLocation().getColumnNumber();
+                    }
+                    try {
+                        Stax.apply(event, handler);
+                    } catch (SAXParseException x) {
+                        throw x;
+                    }
+                    push(out, event);
+                }
+            });
+        }};
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/SelectedTagProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/SelectedTagProtocol.java
@@ -1,0 +1,85 @@
+package akka.stream.alpakka.marshal.xml;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.events.XMLEvent;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.control.Try;
+
+/**
+ * Matches an exact XML tag, and emits the tag itself and any sub-events that make up its body.
+ */
+public class SelectedTagProtocol implements Protocol<XMLEvent, XMLEvent> {
+    public static SelectedTagProtocol tag(QName name) {
+        return new SelectedTagProtocol(name);
+    }
+    
+    private final QName name;
+
+    public SelectedTagProtocol(QName name) {
+        this.name = name;
+    }
+
+    @Override
+    public Reader<XMLEvent, XMLEvent> reader() {
+        return new Reader<XMLEvent, XMLEvent>() {
+            private boolean matched = false;
+            private int level = 0;
+
+            @Override
+            public Try<XMLEvent> reset() {
+                matched = false;
+                level = 0;
+                return ReadProtocol.none();
+            }
+
+            @Override
+            public Try<XMLEvent> apply(XMLEvent event) {
+                if (level == 0) {
+                    if (event.isStartElement() && event.asStartElement().getName().equals(name)) {
+                        level++;
+                        matched = true;
+                        return Try.success(event);
+                    } else if (event.isStartElement()) {
+                        level++;
+                        return ReadProtocol.none();
+                    } else {
+                        return ReadProtocol.none();
+                    }
+                } else if (matched && level == 1 && event.isEndElement()) {
+                    level--;
+                    matched = false;
+                    return Try.success(event);
+                } else {
+                    if (event.isStartElement()) {
+                        level++;
+                    } else if (event.isEndElement()) {
+                        level--;
+                    }
+                    
+                    return (matched) ? Try.success(event) : ReadProtocol.none();
+                }
+            }
+        };
+    }
+
+    @Override
+    public Class<? extends XMLEvent> getEventType() {
+        return XMLEvent.class;
+    }
+
+    @Override
+    public Writer<XMLEvent, XMLEvent> writer() {
+        // Since the start/end tag events themselves are part of the protocol, we can simply echo all events back.
+        return Writer.identity();
+    }
+    
+    @Override
+    public String toString() {
+        return "<" + name + ">";
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/Stax.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/Stax.java
@@ -1,0 +1,207 @@
+package akka.stream.alpakka.marshal.xml;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.FactoryConfigurationError;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLEventWriter;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.Characters;
+import javax.xml.stream.events.EndElement;
+import javax.xml.stream.events.Namespace;
+import javax.xml.stream.events.ProcessingInstruction;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.control.Option;
+import javaslang.control.Try;
+
+/**
+ * Interface to and from stax to the XML marshalling framework.
+ */
+public class Stax {
+    public static final Logger log = LoggerFactory.getLogger(Stax.class);
+    
+    private static final XMLInputFactory inFactory = XMLInputFactory.newFactory();
+    private static final XMLOutputFactory outFactory = XMLOutputFactory.newFactory();
+
+    public <T> String writeAllAsString(Stream<T> stream, Writer<XMLEvent, T> writer) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writeAll(stream, writer, out);
+        return new String(out.toByteArray());
+    }
+    
+    public <T> String writeAsString(T obj, Writer<XMLEvent,T> writer) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        write(obj, writer, out);
+        return new String(out.toByteArray());
+    }
+    
+    public <T> void write(T obj, Writer<XMLEvent,T> writer, OutputStream out) {
+        try {
+            XMLEventWriter xmlW = outFactory.createXMLEventWriter(out);
+            writer.applyAndReset(obj).forEach(addTo(xmlW));
+        } catch (XMLStreamException | FactoryConfigurationError e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+    
+    public <T> void writeAll(Stream<T> objs, Writer<XMLEvent,T> writer, OutputStream out) {
+        try {
+            XMLEventWriter xmlW = outFactory.createXMLEventWriter(out);
+            objs.flatMap(obj -> writer.apply(obj).toJavaStream()).forEach(addTo(xmlW));
+            writer.reset().forEach(addTo(xmlW));
+        } catch (XMLStreamException | FactoryConfigurationError e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+    
+    public <T> Stream<T> parse(File f, Reader<XMLEvent,T> reader) {
+        try {
+            return parse(inFactory.createXMLEventReader(new BufferedInputStream(new FileInputStream(f))), reader);
+        } catch (XMLStreamException | FileNotFoundException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+    
+    public <T> Stream<T> parse(InputStream in, Reader<XMLEvent,T> reader) {
+        try {
+            return parse(inFactory.createXMLEventReader(in), reader);
+        } catch (XMLStreamException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+    
+    public <T> Stream<T> parse(String s, Reader<XMLEvent,T> reader) {
+        try {
+            return parse(inFactory.createXMLEventReader(new StringReader(s)), reader);
+        } catch (XMLStreamException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+    
+    private <T> Stream<T> parse(XMLEventReader in, Reader<XMLEvent,T> reader) {
+        reader.reset();
+        
+        Iterator<T> iterator = new Iterator<T>() {
+            private Option<T> next = parse();
+
+            private Option<T> parse() {
+                try {
+                    while (in.peek() != null) {
+                        Try<T> read = reader.apply(in.nextEvent());
+                        if (read.isSuccess()) {
+                            return read.toOption();
+                        } else if (read.isFailure() && !ReadProtocol.isNone(read)) {
+                            throw (RuntimeException) read.failed().get();
+                        }
+                    }
+                    Try<T> read = reader.reset();
+                    if (read.isSuccess()) {
+                        return read.toOption();
+                    } else if (read.isFailure() && !ReadProtocol.isNone(read)) {
+                        throw (RuntimeException) read.failed().get();
+                    }
+                    return Option.none();
+                } catch (XMLStreamException e) {
+                    throw new IllegalArgumentException(e);
+                }
+            }
+            
+            @Override
+            public boolean hasNext() {
+                return next.isDefined();
+            }
+
+            @Override
+            public T next() {
+                T elmt = next.get();
+                next = parse();
+                return elmt;
+            }
+        };
+        
+        return StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED),
+            false);
+    }
+
+    public static void apply(XMLEvent event, ContentHandler handler) throws SAXException {
+        if (event.isEndDocument()) {
+            handler.endDocument();
+        } else if (event.isEndElement()) {
+            EndElement e = event.asEndElement();
+            handler.endElement(e.getName().getNamespaceURI(), e.getName().getLocalPart(), qname(e.getName()));
+        } else if (event.isStartElement()) {
+            StartElement e = event.asStartElement();
+            AttributesImpl attr = new AttributesImpl();
+            @SuppressWarnings("rawtypes") Iterator i = e.getAttributes();
+            while (i.hasNext()) {
+                Attribute a = (Attribute) i.next();
+                attr.addAttribute(a.getName().getNamespaceURI(), a.getName().getLocalPart(), qname(a.getName()), "CDATA", a.getValue());
+            }
+            handler.startElement(e.getName().getNamespaceURI(), e.getName().getLocalPart(), qname(e.getName()), attr);
+        } else if (event.isAttribute()) {
+            // ignore, should be embedded into StartElement
+        } else if (event.isCharacters()) {
+            Characters e = event.asCharacters();
+            String s = e.asCharacters().getData();
+            handler.characters(s.toCharArray(), 0, s.length());
+        } else if (event.isNamespace()) {
+            Namespace n = (Namespace) event;
+            handler.startPrefixMapping(n.getPrefix(), n.getNamespaceURI());
+        } else if (event.isEntityReference()) {
+            // ignore
+        } else if (event.isProcessingInstruction()) {
+            ProcessingInstruction e = (ProcessingInstruction) event;
+            handler.processingInstruction(e.getTarget(), e.getData());
+        } else if (event.isStartDocument()) {
+            handler.startDocument();
+        }
+    }
+
+    private static String qname(QName name) {
+        if (name.getPrefix() != null && !name.getPrefix().isEmpty()) {
+            return name.getPrefix() + ":" + name.getLocalPart();
+        } else {
+            return name.getLocalPart();
+        }
+    }
+    
+    private static Consumer<XMLEvent> addTo(XMLEventWriter writer) {
+        return evt -> {
+            try {
+                writer.add(evt);
+            } catch (XMLStreamException e) {
+                throw new IllegalArgumentException(e);
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/StaxWriter.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/StaxWriter.java
@@ -1,0 +1,91 @@
+package akka.stream.alpakka.marshal.xml;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.XMLEventWriter;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.Namespace;
+import javax.xml.stream.events.XMLEvent;
+
+import akka.NotUsed;
+import akka.stream.alpakka.marshal.generic.PushPullOutputStreamAdapter;
+import akka.stream.javadsl.Flow;
+import akka.util.ByteString;
+
+/**
+ * Serializes XMLEvents out as XML by invoking Stax, but in a non-blocking push/pull fashion,
+ * only writing when there is demand from downstream.
+ */
+public class StaxWriter extends PushPullOutputStreamAdapter<List<XMLEvent>, XMLEventWriter> {
+    private static final XMLOutputFactory factory = XMLOutputFactory.newInstance();
+    private static final XMLEventFactory evtFactory = XMLEventFactory.newFactory();
+    
+    /**
+     * Returns a flow that buffers up to 100 XML events and writing them together.
+     */
+    public static Flow<XMLEvent,ByteString,NotUsed> flow() {
+        return flow(100);
+    }
+    
+    /**
+     * Returns a flow that buffers up to [maximumBatchSize] XML events and writing them together.
+     * 
+     * Buffering is only done if upstream is faster than downstream. If there is demand from downstream,
+     * also slower batches will be written.
+     */
+    public static Flow<XMLEvent,ByteString,NotUsed> flow(int maximumBatchSize) {
+        return Flow.of(XMLEvent.class)
+            .batch(maximumBatchSize, event -> {
+                List<XMLEvent> l = new ArrayList<>();
+                l.add(event);
+                return l;
+            }, (list, event) -> {
+                list.add(event);
+                return list;
+            }).via(new StaxWriter());
+    }
+    
+    private StaxWriter() {
+        super(
+            (attr, out) -> factory.createXMLEventWriter(out, "UTF-8"),
+            (writer, events) -> {
+                for (XMLEvent event: events) {
+                    if (event.isStartElement() && !event.asStartElement().getNamespaces().hasNext()) {
+                        List<Namespace> namespaces = new ArrayList<>();
+                        register(writer, namespaces, event.asStartElement().getName());
+                        
+                        Iterator<?> attributes = event.asStartElement().getAttributes();
+                        while (attributes.hasNext()) {
+                            Attribute attr = (Attribute) attributes.next();
+                            register(writer, namespaces, attr.getName());
+                        }
+                        
+                        if (!namespaces.isEmpty()) {
+                            event = evtFactory.createStartElement(event.asStartElement().getName(), event.asStartElement().getAttributes(), namespaces.iterator());
+                        }
+                    }
+                    writer.add(event);
+                }
+                writer.flush();
+            }
+        );
+    }
+    
+    /**
+     * Adds a namespace mapping for [name] to [namespaces], if it doesn't already exist on [writer].
+     */
+    private static void register(XMLEventWriter writer, List<Namespace> namespaces, QName name) {
+        String nsUri = name.getNamespaceURI();
+        if (nsUri != null && !nsUri.isEmpty()) {
+            String existing = writer.getNamespaceContext().getNamespaceURI(name.getPrefix());
+            if (existing == null || !existing.equals(nsUri)) {
+                namespaces.add(evtFactory.createNamespace(name.getPrefix(), nsUri));
+            }
+        }
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/TagProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/TagProtocol.java
@@ -1,0 +1,58 @@
+package akka.stream.alpakka.marshal.xml;
+
+import java.util.List;
+import java.util.function.Function;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.events.XMLEvent;
+
+import akka.stream.alpakka.marshal.Protocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.Function1;
+import javaslang.collection.Vector;
+import javaslang.control.Option;
+
+public class TagProtocol<T> implements Protocol<XMLEvent,T> {
+    private final TagReadProtocol<T> read;
+    private final TagWriteProtocol<T> write;
+
+    public TagProtocol(Option<QName> name, Protocol<XMLEvent,T> protocol) {
+        this(new TagReadProtocol<>(name, protocol), new TagWriteProtocol<>(name, Vector.of(protocol), Vector.of(Function1.identity())));
+    }
+    
+    public TagProtocol(Option<QName> name, Vector<Protocol<XMLEvent,?>> protocols, Function<List<?>, T> produce, Vector<Function1<T, ?>> getters) {
+        this(new TagReadProtocol<>(name, protocols, produce), new TagWriteProtocol<>(name, protocols, getters));
+    }
+    
+    private TagProtocol(TagReadProtocol<T> read, TagWriteProtocol<T> write) {
+        this.read = read;
+        this.write = write;
+    }
+
+    @Override
+    public Writer<XMLEvent,T> writer() {
+        return write.writer();
+    }
+
+    @Override
+    public Class<? extends XMLEvent> getEventType() {
+        return write.getEventType();
+    }
+    
+    @Override
+    public Reader<XMLEvent,T> reader() {
+        return read.reader();
+    }
+    
+    @Override
+    public String toString() {
+        return read.toString();
+    }
+    
+    public <U> TagProtocol<T> having(Protocol<XMLEvent,U> nestedProtocol, U value) {
+        return new TagProtocol<>(read.having(nestedProtocol, value), write.having(nestedProtocol, value));
+    }
+}
+ 

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/TagReadProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/TagReadProtocol.java
@@ -1,0 +1,217 @@
+package akka.stream.alpakka.marshal.xml;
+
+import static akka.stream.alpakka.marshal.ReadProtocol.isNone;
+import static akka.stream.alpakka.marshal.ReadProtocol.none;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.XMLEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.stream.alpakka.marshal.generic.ConstantProtocol;
+import akka.stream.alpakka.marshal.ReadProtocol;
+import akka.stream.alpakka.marshal.Reader;
+import akka.stream.alpakka.marshal.generic.ValidationException;
+
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+import javaslang.control.Option;
+import javaslang.control.Try;
+
+@SuppressWarnings({"unchecked","rawtypes"})
+public class TagReadProtocol<T> implements ReadProtocol<XMLEvent,T> {
+    private static final Function<List<?>, Object> IDENTITY = list -> list.get(0);
+    private static final Logger log = LoggerFactory.getLogger(TagReadProtocol.class);
+    
+    private static <T> Function<List<?>, T> identity() {
+        return (Function<List<?>, T>) IDENTITY;
+    }
+    
+    private final Option<QName> name;
+    private final Vector<? extends ReadProtocol<XMLEvent,?>> protocols;
+    private final Function<List<?>, T> produce;
+    private final Seq<ReadProtocol<XMLEvent,ConstantProtocol.Present>> conditions;
+
+    /**
+     * Creates a new TagReadProtocol
+     * @param name Name of the tag to match, or none() to match any tag ([produce] will get another argument (at position 0) with the tag's QName in that case)
+     * @param protocols Attributes and child tags to read
+     * @param produce Function that must accept a list of (attributes.size + tags.size) objects and turn that into T
+     */
+    public TagReadProtocol(Option<QName> name, Vector<? extends ReadProtocol<XMLEvent,?>> protocols, Function<List<?>, T> produce) {
+        this(name, protocols, produce, Vector.empty());
+    }
+    
+    /**
+     * Reads a tag and one child element (tag or attribute), where the result of this tag is the result of the single child.
+     */
+    public TagReadProtocol(Option<QName> name, ReadProtocol<XMLEvent,?> protocol) {
+        this(name, Vector.of(protocol), identity(), Vector.empty());
+    }
+    
+    private TagReadProtocol(Option<QName> name, Vector<? extends ReadProtocol<XMLEvent,?>> protocols, Function<List<?>, T> produce, Seq<ReadProtocol<XMLEvent,ConstantProtocol.Present>> conditions) {
+        this.name = name;
+        this.protocols = protocols;
+        this.produce = produce;
+        this.conditions = conditions;
+    }
+    
+    @Override
+    public String toString() {
+        StringBuilder msg = new StringBuilder("<");
+        msg.append(name.map(Object::toString).getOrElse("*"));
+        msg.append(">");
+        if (!protocols.isEmpty()) {
+            msg.append(" with ");
+            msg.append(protocols.map(p -> p.toString()).mkString(", "));
+        }
+        if (!conditions.isEmpty()) {
+            if (protocols.isEmpty()) {
+                msg.append(" with ");
+            } else {
+                msg.append(", ");
+            }
+            msg.append(conditions.map(p -> p.toString()).mkString(", "));
+        }
+        return msg.toString();
+    }
+    
+    /**
+     * Returns a new protocol that, in addition, also requires the given nested protocol to be present with the given constant value
+     */
+    public <U> TagReadProtocol<T> having(ReadProtocol<XMLEvent,U> nestedProtocol, U value) {
+        return new TagReadProtocol<>(name, protocols, produce, conditions.append(ConstantProtocol.read(nestedProtocol, value)));
+    }
+    
+    private boolean isIdentity() {
+        return conditions.isEmpty() && produce == IDENTITY;
+    }
+    
+    @Override
+    public Reader<XMLEvent,T> reader() {
+        return new Reader<XMLEvent,T>() {
+            private final Seq<ReadProtocol<XMLEvent,Object>> all = protocols.map(p -> (ReadProtocol<XMLEvent,Object>)p).appendAll(conditions.map(p -> ReadProtocol.widen(p)));
+            private final List<Reader<XMLEvent,Object>> readers = all.map(p -> p.reader()).toJavaList();
+            private final Try<Object>[] values = new Try[readers.size()];
+            
+            private int level = 0;
+            private boolean match = false;
+            
+            {
+                reset();
+            }
+            
+            @Override
+            public Try<T> reset() {
+                level = 0;
+                match = false;
+                readers.forEach(r -> r.reset());
+                Arrays.fill(values, none());
+                for (int i = 0; i < protocols.size(); i++) {
+                    values[i] = (Try<Object>) protocols.get(i).empty();
+                    log.debug("{} init to {}", protocols.get(i), values[i]);
+                }
+                return none();
+            }
+            
+            @Override
+            public Try<T> apply(XMLEvent evt) {
+                if (level == 0) {
+                    if (evt.isStartElement() && name.filter(n -> !n.equals(evt.asStartElement().getName())).isEmpty()) {
+                        level++;
+                        match = true;
+                        //forward all attributes as attribute events to all sub-readers
+                        Iterator i = evt.asStartElement().getAttributes();
+                        while (i.hasNext()) {
+                            // default JDK implementation doesn't set Location for attributes...
+                            Attribute src = (Attribute) i.next();
+                            forward(new AttributeDelegate(src, evt.getLocation()));
+                        }
+                        return none();
+                    } else if (evt.isStartElement()) {
+                        level++;
+                        return none();
+                    } else { // character data or other non-tag, just skip
+                        return none();
+                    }
+                } else if (match && level == 1 && evt.isEndElement()) {
+                    // Wrap up and emit result
+                    
+                    AtomicReference<Throwable> failure = new AtomicReference<>();
+                    boolean includeName = name.isEmpty() && !isIdentity();
+                    Object[] args = new Object[includeName ? values.length + 1: values.length];
+                    
+                    if (includeName) {
+                        args[0] = evt.asEndElement().getName();
+                    }
+                    
+                    for (int i = protocols.size(); i < values.length; i++) {
+                        if (isNone(values[i])) {
+                            failure.set(new ValidationException("must have " + conditions.get(i - protocols.size())));
+                        }
+                    }
+                    
+                    for (int i = 0; i < all.size(); i++) {
+                        Try<Object> r = readers.get(i).reset();
+                        log.debug("{} reset: {}", all.get(i), r);
+                        if (!isNone(r) && values[i].eq(all.get(i).empty())) {
+                            values[i] = r;
+                        }
+                    }
+                    for (int i = 0; i < all.size(); i++) {
+                        log.debug("wrapup: {} -> {}", all.get(i), values[i]);
+                    }
+                    
+                    for (int i = 0; i < protocols.size(); i++) {
+                        Try<Object> t = values[i];
+                        t.failed().forEach(failure::set);
+                        args[includeName ? i+1 : i] = t.getOrElse((Object)null);
+                    }
+                    
+                    Try<T> result = (failure.get() != null) ? Try.failure(failure.get()) : Try.success(produce.apply(Arrays.asList(args)));
+                    reset();
+                    log.debug("{} emitting {}", TagReadProtocol.this, result);
+                    return result;
+                } else {
+                    Try<T> result = none();
+                    if (match) {
+                        if (isIdentity()) {
+                            result = (Try<T>) readers.get(0).apply(evt);
+                        } else {
+                            forward(evt);
+                        }
+                    }
+                    
+                    if (evt.isStartElement()) {
+                        level++;
+                    } else if (evt.isEndElement()) {
+                        level--;
+                    }
+                    
+                    return result;
+                }
+            }
+
+            private void forward(XMLEvent evt) {
+                for (int i = 0; i < readers.size(); i++) {
+                    Reader<XMLEvent,Object> r = readers.get(i);
+                    log.debug("Sending {} to {}", evt, all.get(i));
+                    Try<Object> result = r.apply(evt);
+                    log.debug("{} apply: {}", all.get(i), result);
+                    if (!ReadProtocol.isNone(result)) {
+                        values[i] = result;
+                        log.debug("   -> {}", values[i]);
+                    }
+                }
+            }
+        };
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/TagWriteProtocol.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/TagWriteProtocol.java
@@ -1,0 +1,140 @@
+package akka.stream.alpakka.marshal.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.EndElement;
+import javax.xml.stream.events.XMLEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.stream.alpakka.marshal.WriteProtocol;
+import akka.stream.alpakka.marshal.Writer;
+
+import javaslang.Function1;
+import javaslang.Tuple2;
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+import javaslang.control.Option;
+
+@SuppressWarnings("unchecked")
+public class TagWriteProtocol<T> implements WriteProtocol<XMLEvent,T> {
+    private static final Logger log = LoggerFactory.getLogger(TagWriteProtocol.class);
+    private static final XMLEventFactory factory = XMLEventFactory.newFactory();
+    
+    private final Function<T,QName> getName;
+    private final Seq<WriteProtocol<XMLEvent,?>> attrProtocols;
+    private final Seq<WriteProtocol<XMLEvent,?>> otherProtocols;
+    private final Seq<Function1<T,?>> attrGetters;
+    private final Seq<Function1<T,?>> otherGetters;
+    private final Option<QName> name;
+    
+    /**
+     * @param name The qualified name of the tag to write, or none() to have the last item of [getters] deliver a {@link QName}.
+     * @param getters Getter function for each sub-protocol to write (and additional first element delivering a QName, if name == none())
+     * @param protocols Protocols to use to write each of the getter elements
+     */
+    public TagWriteProtocol(Option<QName> name, Vector<? extends WriteProtocol<XMLEvent,?>> protocols, Vector<Function1<T, ?>> g) {
+        if (name.isDefined() && (protocols.size() != g.size()) ||
+            name.isEmpty() && (protocols.size() != g.size() - 1)) {
+            throw new IllegalArgumentException ("Number of protocols and getters does not match");
+        }
+        this.name = name;
+        this.getName = t -> name.getOrElse(() -> (QName) g.head().apply(t));
+        
+        Vector<Function1<T, ?>> getters = (name.isEmpty()) ? g.drop(1) : g;
+        
+        Tuple2<Vector<Tuple2<WriteProtocol<XMLEvent,?>, Function1<T, ?>>>, Vector<Tuple2<WriteProtocol<XMLEvent,?>, Function1<T, ?>>>> partition =
+            ((Vector<WriteProtocol<XMLEvent,?>>)protocols).zip(getters)
+            .partition(t -> Attribute.class.isAssignableFrom(t._1.getEventType()));
+        
+        this.attrProtocols = partition._1().map(t -> t._1());
+        this.attrGetters = partition._1().map(t -> t._2());
+        this.otherProtocols = partition._2().map(t -> t._1());
+        this.otherGetters = partition._2().map(t -> t._2());
+    }
+
+    private TagWriteProtocol(Option<QName> name, Function<T, QName> getName, Seq<WriteProtocol<XMLEvent,?>> attrProtocols,
+        Seq<WriteProtocol<XMLEvent,?>> otherProtocols, Seq<Function1<T, ?>> attrGetters, Seq<Function1<T, ?>> otherGetters) {
+        this.name = name;
+        this.getName = getName;
+        this.attrProtocols = attrProtocols;
+        this.otherProtocols = otherProtocols;
+        this.attrGetters = attrGetters;
+        this.otherGetters = otherGetters;
+    }
+    
+    public <U> TagWriteProtocol<T> having(WriteProtocol<XMLEvent,U> nestedProtocol, U value) {
+        return Attribute.class.isAssignableFrom(nestedProtocol.getEventType())
+            ? new TagWriteProtocol<>(name, getName, attrProtocols.append(nestedProtocol), otherProtocols, attrGetters.append(t -> value), otherGetters)
+            : new TagWriteProtocol<>(name, getName, attrProtocols, otherProtocols.append(nestedProtocol), attrGetters, otherGetters.append(t -> value));
+    }
+
+    @Override
+    public Writer<XMLEvent,T> writer() {
+        return new Writer<XMLEvent, T>() {
+            boolean started = false;
+            private EndElement endElement;
+            
+            @Override
+            public Seq<XMLEvent> apply(T value) {
+                log.debug("{}: Writing {}", TagWriteProtocol.this, value);
+                Seq<XMLEvent> prefix = (started) ? Vector.empty() : Vector.of(startElement(value));
+                started = true;
+                endElement = factory.createEndElement(getName.apply(value), null);
+                
+                return prefix.appendAll(
+                    Vector.range(0, otherProtocols.size()).map(i -> {
+                        Writer<XMLEvent,Object> w = (Writer<XMLEvent,Object>) otherProtocols.get(i).writer();
+                        return w.applyAndReset(otherGetters.get(i).apply(value));
+                    }).flatMap(Function.identity())
+                );
+            }
+
+            @Override
+            public Seq<XMLEvent> reset() {
+                log.debug("{}: Resetting", TagWriteProtocol.this);
+                if (started) {
+                    started = false;
+                    return Vector.of(endElement);
+                } else {
+                    return Vector.empty();
+                }
+            }
+        };
+    }
+    
+    @Override
+    public Class<? extends XMLEvent> getEventType() {
+        return XMLEvent.class;
+    }
+    
+    @Override
+    public String toString() {
+        StringBuilder msg = new StringBuilder("<");
+        msg.append(name.map(Object::toString).getOrElse("*"));
+        msg.append(">");
+        Seq<WriteProtocol<XMLEvent,?>> protocols = attrProtocols.appendAll(otherProtocols);
+        if (!protocols.isEmpty()) {
+            msg.append(" with ");
+            msg.append(protocols.map(p -> p.toString()).mkString(", "));
+        }
+        return msg.toString();
+   }
+    
+    private XMLEvent startElement(T value) {
+        List<Attribute> attributes = new ArrayList<>();
+        for (int i = 0; i < attrGetters.size(); i++) {
+            Object o = attrGetters.get(i).apply(value);
+            WriteProtocol<XMLEvent,Object> attributeProtocol = (WriteProtocol<XMLEvent,Object>) attrProtocols.get(i);
+            attributeProtocol.writer().apply(o).map(Attribute.class::cast).forEach(attributes::add);
+        }
+        return factory.createStartElement(getName.apply(value), attributes.iterator(), null);
+    }
+}
+ 

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/XMLReadException.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/XMLReadException.java
@@ -1,0 +1,19 @@
+package akka.stream.alpakka.marshal.xml;
+
+import javax.xml.stream.Location;
+
+public class XMLReadException extends IllegalArgumentException {
+    private static final long serialVersionUID = 1L;
+
+    public static XMLReadException wrap(RuntimeException cause, Location location) {
+        if (cause instanceof XMLReadException) {
+            return (XMLReadException) cause;
+        } else {
+            return new XMLReadException(cause, location);
+        }
+    }
+    
+    private XMLReadException(RuntimeException cause, Location location) {
+        super(cause.getMessage() + " at " + location.getLineNumber() + ":" + location.getColumnNumber(), cause);
+    }
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/impl/AbstractStaxHandler.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/impl/AbstractStaxHandler.java
@@ -1,0 +1,280 @@
+package akka.stream.alpakka.marshal.xml.impl;
+
+// from spring-core
+
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.ext.LexicalHandler;
+
+/**
+ * Abstract base class for SAX {@code ContentHandler} and {@code LexicalHandler}
+ * implementations that use StAX as a basis. All methods delegate to internal template
+ * methods, capable of throwing a {@code XMLStreamException}. Additionally, an namespace
+ * context stack is used to keep track of declared namespaces.
+ *
+ * @author Arjen Poutsma
+ * @since 4.0.3
+ */
+abstract class AbstractStaxHandler implements ContentHandler, LexicalHandler {
+
+    private final List<Map<String, String>> namespaceMappings = new ArrayList<>();
+
+    private boolean inCData;
+
+
+    @Override
+    public final void startDocument() throws SAXException {
+        removeAllNamespaceMappings();
+        newNamespaceMapping();
+        try {
+            startDocumentInternal();
+        }
+        catch (XMLStreamException ex) {
+            throw new SAXException("Could not handle startDocument: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public final void endDocument() throws SAXException {
+        removeAllNamespaceMappings();
+        try {
+            endDocumentInternal();
+        }
+        catch (XMLStreamException ex) {
+            throw new SAXException("Could not handle endDocument: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public final void startPrefixMapping(String prefix, String uri) {
+        currentNamespaceMapping().put(prefix, uri);
+    }
+
+    @Override
+    public final void endPrefixMapping(String prefix) {
+    }
+
+    @Override
+    public final void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
+        try {
+            if (namespaceMappings.isEmpty()) {
+                // getting startElement without a previous startDocument. We must be writing an XML fragment.
+                newNamespaceMapping();
+            }
+            startElementInternal(toQName(uri, qName), atts, currentNamespaceMapping());
+            newNamespaceMapping();
+        }
+        catch (XMLStreamException ex) {
+            throw new SAXException("Could not handle startElement: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public final void endElement(String uri, String localName, String qName) throws SAXException {
+        try {
+            endElementInternal(toQName(uri, qName), currentNamespaceMapping());
+            removeNamespaceMapping();
+        }
+        catch (XMLStreamException ex) {
+            throw new SAXException("Could not handle endElement: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public final void characters(char ch[], int start, int length) throws SAXException {
+        try {
+            String data = new String(ch, start, length);
+            if (!this.inCData) {
+                charactersInternal(data);
+            }
+            else {
+                cDataInternal(data);
+            }
+        }
+        catch (XMLStreamException ex) {
+            throw new SAXException("Could not handle characters: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public final void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
+        try {
+            ignorableWhitespaceInternal(new String(ch, start, length));
+        }
+        catch (XMLStreamException ex) {
+            throw new SAXException(
+                    "Could not handle ignorableWhitespace:" + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public final void processingInstruction(String target, String data) throws SAXException {
+        try {
+            processingInstructionInternal(target, data);
+        }
+        catch (XMLStreamException ex) {
+            throw new SAXException("Could not handle processingInstruction: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public final void skippedEntity(String name) throws SAXException {
+        try {
+            skippedEntityInternal(name);
+        }
+        catch (XMLStreamException ex) {
+            throw new SAXException("Could not handle skippedEntity: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public final void startDTD(String name, String publicId, String systemId) throws SAXException {
+        try {
+            StringBuilder builder = new StringBuilder("<!DOCTYPE ");
+            builder.append(name);
+            if (publicId != null) {
+                builder.append(" PUBLIC \"");
+                builder.append(publicId);
+                builder.append("\" \"");
+            }
+            else {
+                builder.append(" SYSTEM \"");
+            }
+            builder.append(systemId);
+            builder.append("\">");
+
+            dtdInternal(builder.toString());
+        }
+        catch (XMLStreamException ex) {
+            throw new SAXException("Could not handle startDTD: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public final void endDTD() throws SAXException {
+    }
+
+    @Override
+    public final void startCDATA() throws SAXException {
+        this.inCData = true;
+    }
+
+    @Override
+    public final void endCDATA() throws SAXException {
+        this.inCData = false;
+    }
+
+    @Override
+    public final void comment(char[] ch, int start, int length) throws SAXException {
+        try {
+            commentInternal(new String(ch, start, length));
+        }
+        catch (XMLStreamException ex) {
+            throw new SAXException("Could not handle comment: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public void startEntity(String name) throws SAXException {
+    }
+
+    @Override
+    public void endEntity(String name) throws SAXException {
+    }
+
+    /**
+     * Convert a namespace URI and DOM or SAX qualified name to a {@code QName}. The
+     * qualified name can have the form {@code prefix:localname} or {@code localName}.
+     * @param namespaceUri the namespace URI
+     * @param qualifiedName the qualified name
+     * @return a QName
+     */
+    protected QName toQName(String namespaceUri, String qualifiedName) {
+        int idx = qualifiedName.indexOf(':');
+        if (idx == -1) {
+            return new QName(namespaceUri, qualifiedName);
+        }
+        else {
+            String prefix = qualifiedName.substring(0, idx);
+            String localPart = qualifiedName.substring(idx + 1);
+            return new QName(namespaceUri, localPart, prefix);
+        }
+    }
+
+    protected boolean isNamespaceDeclaration(QName qName) {
+        String prefix = qName.getPrefix();
+        String localPart = qName.getLocalPart();
+        return (XMLConstants.XMLNS_ATTRIBUTE.equals(localPart) && prefix.length() == 0) ||
+                (XMLConstants.XMLNS_ATTRIBUTE.equals(prefix) && localPart.length() != 0);
+    }
+
+
+    private Map<String, String> currentNamespaceMapping() {
+        return this.namespaceMappings.get(this.namespaceMappings.size() - 1);
+    }
+
+    private void newNamespaceMapping() {
+        this.namespaceMappings.add(new HashMap<>());
+    }
+
+    private void removeNamespaceMapping() {
+        this.namespaceMappings.remove(this.namespaceMappings.size() - 1);
+    }
+
+    private void removeAllNamespaceMappings() {
+        this.namespaceMappings.clear();
+    }
+
+
+    protected abstract void startDocumentInternal() throws XMLStreamException;
+
+    protected abstract void endDocumentInternal() throws XMLStreamException;
+
+    protected abstract void startElementInternal(QName name, Attributes attributes,
+            Map<String, String> namespaceMapping) throws XMLStreamException;
+
+    protected abstract void endElementInternal(QName name, Map<String, String> namespaceMapping)
+            throws XMLStreamException;
+
+    protected abstract void charactersInternal(String data) throws XMLStreamException;
+
+    protected abstract void cDataInternal(String data) throws XMLStreamException;
+
+    protected abstract void ignorableWhitespaceInternal(String data) throws XMLStreamException;
+
+    protected abstract void processingInstructionInternal(String target, String data)
+            throws XMLStreamException;
+
+    protected abstract void skippedEntityInternal(String name) throws XMLStreamException;
+
+    protected abstract void dtdInternal(String dtd) throws XMLStreamException;
+
+    protected abstract void commentInternal(String comment) throws XMLStreamException;
+
+}

--- a/marshal/src/main/java/akka/stream/alpakka/marshal/xml/impl/StaxEventHandler.java
+++ b/marshal/src/main/java/akka/stream/alpakka/marshal/xml/impl/StaxEventHandler.java
@@ -1,0 +1,199 @@
+package akka.stream.alpakka.marshal.xml.impl;
+
+// from spring-core
+
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.Location;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.XMLEventWriter;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.Namespace;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.Locator;
+import org.xml.sax.ext.LexicalHandler;
+
+/**
+ * SAX {@link org.xml.sax.ContentHandler} and {@link LexicalHandler}
+ * that writes to a {@link javax.xml.stream.util.XMLEventConsumer}.
+ *
+ * @author Arjen Poutsma
+ * @since 4.0.3
+ */
+public class StaxEventHandler extends AbstractStaxHandler {
+
+    private final XMLEventFactory eventFactory;
+
+    private final XMLEventWriter eventWriter;
+
+
+    /**
+     * Construct a new instance of the {@code StaxEventContentHandler} that writes to the
+     * given {@code XMLEventWriter}. A default {@code XMLEventFactory} will be created.
+     * @param eventWriter the writer to write events to
+     */
+    public StaxEventHandler(XMLEventWriter eventWriter) {
+        this.eventFactory = XMLEventFactory.newInstance();
+        this.eventWriter = eventWriter;
+    }
+
+    /**
+     * Construct a new instance of the {@code StaxEventContentHandler} that uses the given
+     * event factory to create events and writes to the given {@code XMLEventConsumer}.
+     * @param eventWriter the writer to write events to
+     * @param factory the factory used to create events
+     */
+    public StaxEventHandler(XMLEventWriter eventWriter, XMLEventFactory factory) {
+        this.eventFactory = factory;
+        this.eventWriter = eventWriter;
+    }
+
+
+    @Override
+    public void setDocumentLocator(Locator locator) {
+        if (locator != null) {
+            this.eventFactory.setLocation(new LocatorLocationAdapter(locator));
+        }
+    }
+
+    @Override
+    protected void startDocumentInternal() throws XMLStreamException {
+        this.eventWriter.add(this.eventFactory.createStartDocument());
+    }
+
+    @Override
+    protected void endDocumentInternal() throws XMLStreamException {
+        this.eventWriter.add(this.eventFactory.createEndDocument());
+    }
+
+    @Override
+    protected void startElementInternal(QName name, Attributes atts,
+            Map<String, String> namespaceMapping) throws XMLStreamException {
+
+        List<Attribute> attributes = getAttributes(atts);
+        List<Namespace> namespaces = getNamespaces(namespaceMapping);
+        this.eventWriter.add(
+                this.eventFactory.createStartElement(name, attributes.iterator(), namespaces.iterator()));
+
+    }
+
+    private List<Namespace> getNamespaces(Map<String, String> namespaceMapping) {
+        List<Namespace> result = new ArrayList<>();
+        for (Map.Entry<String, String> entry : namespaceMapping.entrySet()) {
+            String prefix = entry.getKey();
+            String namespaceUri = entry.getValue();
+            result.add(this.eventFactory.createNamespace(prefix, namespaceUri));
+        }
+        return result;
+    }
+
+    private List<Attribute> getAttributes(Attributes attributes) {
+        List<Attribute> result = new ArrayList<>();
+        for (int i = 0; i < attributes.getLength(); i++) {
+            QName attrName = toQName(attributes.getURI(i), attributes.getQName(i));
+            if (!isNamespaceDeclaration(attrName)) {
+                result.add(this.eventFactory.createAttribute(attrName, attributes.getValue(i)));
+            }
+        }
+        return result;
+    }
+
+    @Override
+    protected void endElementInternal(QName name, Map<String, String> namespaceMapping) throws XMLStreamException {
+        List<Namespace> namespaces = getNamespaces(namespaceMapping);
+        this.eventWriter.add(this.eventFactory.createEndElement(name, namespaces.iterator()));
+    }
+
+    @Override
+    protected void charactersInternal(String data) throws XMLStreamException {
+        this.eventWriter.add(this.eventFactory.createCharacters(data));
+    }
+
+    @Override
+    protected void cDataInternal(String data) throws XMLStreamException {
+        this.eventWriter.add(this.eventFactory.createCData(data));
+    }
+
+    @Override
+    protected void ignorableWhitespaceInternal(String data) throws XMLStreamException {
+        this.eventWriter.add(this.eventFactory.createIgnorableSpace(data));
+    }
+
+    @Override
+    protected void processingInstructionInternal(String target, String data) throws XMLStreamException {
+        this.eventWriter.add(this.eventFactory.createProcessingInstruction(target, data));
+    }
+
+    @Override
+    protected void dtdInternal(String dtd) throws XMLStreamException {
+        this.eventWriter.add(this.eventFactory.createDTD(dtd));
+    }
+
+    @Override
+    protected void commentInternal(String comment) throws XMLStreamException {
+        this.eventWriter.add(this.eventFactory.createComment(comment));
+    }
+
+    // Ignored
+
+    @Override
+    protected void skippedEntityInternal(String name) throws XMLStreamException {
+    }
+
+
+    private static final class LocatorLocationAdapter implements Location {
+
+        private final Locator locator;
+
+        public LocatorLocationAdapter(Locator locator) {
+            this.locator = locator;
+        }
+
+        @Override
+        public int getLineNumber() {
+            return this.locator.getLineNumber();
+        }
+
+        @Override
+        public int getColumnNumber() {
+            return this.locator.getColumnNumber();
+        }
+
+        @Override
+        public int getCharacterOffset() {
+            return -1;
+        }
+
+        @Override
+        public String getPublicId() {
+            return this.locator.getPublicId();
+        }
+
+        @Override
+        public String getSystemId() {
+            return this.locator.getSystemId();
+        }
+    }
+
+}

--- a/marshal/src/main/scala/com/tradeshift/reaktive/akka/AsyncMarshallers.scala
+++ b/marshal/src/main/scala/com/tradeshift/reaktive/akka/AsyncMarshallers.scala
@@ -1,0 +1,14 @@
+package com.tradeshift.reaktive.akka
+
+import akka.http.javadsl.marshalling.Marshaller
+
+object AsyncMarshallers {
+  /**
+   * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
+   * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
+   */
+  def oneOf[A, B](m1: Marshaller[A, B], m2: Marshaller[A, B]): Marshaller[A, B] = {
+    Marshaller.fromScala(akka.http.scaladsl.marshalling.Marshaller.oneOf(m1.asScala, m2.asScala))
+  }
+
+}

--- a/marshal/src/main/scala/com/tradeshift/reaktive/akka/AsyncUnmarshallers.scala
+++ b/marshal/src/main/scala/com/tradeshift/reaktive/akka/AsyncUnmarshallers.scala
@@ -1,0 +1,24 @@
+package com.tradeshift.reaktive.akka
+
+import akka.japi.function.Function3
+import scala.concurrent.ExecutionContext
+import akka.stream.Materializer
+import akka.http.javadsl.unmarshalling.Unmarshaller
+import java.util.concurrent.CompletionStage
+import scala.compat.java8.FutureConverters._
+import akka.http.javadsl.model.HttpEntity
+import akka.stream.javadsl.Source
+import akka.util.ByteString
+import akka.NotUsed
+
+object AsyncUnmarshallers {
+  // FIXME find out of these are still needed, otherwise create a PR into akka-http itself.
+  
+  def withMaterializer[A, B](f: Function3[ExecutionContext, Materializer, A, CompletionStage[B]]): Unmarshaller[A, B] =
+    akka.http.scaladsl.unmarshalling.Unmarshaller.withMaterializer(ctx => mat => a => f.apply(ctx, mat, a).toScala)
+    
+  def entityToStream(): Unmarshaller[HttpEntity, Source[ByteString, NotUsed]] = 
+    Unmarshaller.sync(new java.util.function.Function[HttpEntity, Source[ByteString, NotUsed]] {
+      override def apply(entity: HttpEntity) = entity.getDataBytes().asScala.mapMaterializedValue(obj => NotUsed).asJava
+    })
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,6 +28,20 @@ object Dependencies {
     )
   )
 
+  val Marshal = Seq(
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka"     %% "akka-http"     % AkkaHttpVersion,
+      "org.slf4j" % "slf4j-log4j12" % "1.7.12",
+      "io.javaslang" % "javaslang" % "2.0.5",
+      "com.fasterxml.jackson.core" % "jackson-core" % "2.7.4",
+      "com.fasterxml" % "aalto-xml" % "1.0.0",
+      "de.undercouch" % "actson" % "1.1.0",
+      "org.assertj" % "assertj-core" % "3.2.0" % "test",
+      "org.forgerock.cuppa" % "cuppa" % "1.3.1" % "test",
+      "org.forgerock.cuppa" % "cuppa-junit" % "1.3.1" % "test"
+    )
+  )
+
   val Amqp = Seq(
     libraryDependencies ++= Seq(
       "com.rabbitmq" % "amqp-client" % "3.6.1" // APLv2


### PR DESCRIPTION
Moved over from [ts-reaktive](https://github.com/Tradeshift/ts-reaktive/tree/master/ts-reaktive-marshal) as discussed in akka-http call https://github.com/akka/akka-meta/issues/43 .

Features:
- Reactive parsers and generators, converting `Source[ByteString]` into `Source[*Event]` and vice-versa, with `*` being JSON, XML and CSV
- DSL for reactive (un)marshalling of such events, converting `Source[*Event]` into `Source[T]` and vice-versa (without the need to do any framing)

This will enable the following example use cases:
- Handling streams of nested JSON / XML / CSV objects that can't be easily framed, e.g. `{"items": {"a": 1, "b": 2, ...etc...}}`
- Binding a single data class to both JSON and XML, with "nice" formats for both, without using reflection
- The `alpakka-s3` module can use this to implement listing a bucket without waiting for a 300KB http response to be fully parsed

**TODO**
- [ ] Merge `AaltoReader` with the existing aalto wrapper already in alpakka, use the existing `XMLEvent` case classes, but add location information to them
- [ ] Compare the CSV parser in this PR to the one already in alpakka, and select which one to keep
- [ ] Decide on packaging / module structure. Should `alpakka-csv` and `alpakka-xml` both have the xml- and csv- specific marshalling classes, and then make those modules depend on a generic `alpakka-marshal`? Which would mean introducing `alpakka-json` as well.
- [ ] Decide whether to add a [Scala DSL](https://github.com/Tradeshift/ts-reaktive/pull/56) in this PR, or later
- [ ] Move over the unit tests
- [ ] Use sbt-boilerplate to generate the N-ary combinators for JSON `object` and XML `tag`.