### PR TITLE
Alphabetically order dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,19 +18,16 @@ object Dependencies {
     )
   )
 
-  val S3 = Seq(
-    libraryDependencies ++= Seq(
-      "com.typesafe.akka"     %% "akka-http"     % AkkaHttpVersion,
-      "com.typesafe.akka"     %% "akka-http-xml" % AkkaHttpVersion,
-      // in-memory filesystem for file related tests
-      "com.google.jimfs"       % "jimfs"         % "1.1"   % Test, // ApacheV2
-      "com.github.tomakehurst" % "wiremock"      % "2.5.1" % Test //ApacheV2
-    )
-  )
-
   val Amqp = Seq(
     libraryDependencies ++= Seq(
       "com.rabbitmq" % "amqp-client" % "3.6.1" // APLv2
+    )
+  )
+
+  val AwsLambda = Seq(
+    libraryDependencies ++= Seq(
+      "com.amazonaws"   % "aws-java-sdk-lambda"    % "1.11.105", // ApacheV2
+      "org.mockito"   % "mockito-core"     % "2.7.17"    % Test  // MIT
     )
   )
 
@@ -48,48 +45,10 @@ object Dependencies {
 
   val Csv = Seq()
 
-  val Geode = {
-    val geodeVersion = "1.1.1"
-    Seq(
-      libraryDependencies ++= Seq("com.chuusai" %% "shapeless" % "2.3.2") ++
-        Seq("geode-core","geode-cq")
-        .map("org.apache.geode" % _ % geodeVersion exclude("org.slf4j", "slf4j-log4j12")) ++
-        Seq("org.slf4j" % "log4j-over-slf4j" % "1.7.21" % Test, // MIT like: http://www.slf4j.org/license.html
-          "org.slf4j" % "slf4j-api" % "1.7.21" % Test, // MIT like: http://www.slf4j.org/license.html
-          "ch.qos.logback" % "logback-classic" % "1.1.7" % Test, // Eclipse Public License 1.0: http://logback.qos.ch/license.html
-          "ch.qos.logback" % "logback-core" % "1.1.7" % Test // Eclipse Public License 1.0: http://logback.qos.ch/license.html
-        )
-
-    )
-  }
-
-  val HBase = {
-    val hbaseVersion = "1.2.4"
-    val hadoopVersion = "2.5.1"
-    Seq(
-      libraryDependencies ++= Seq(
-        "org.apache.hbase" % "hbase-client" % hbaseVersion exclude("log4j", "log4j") exclude("org.slf4j", "slf4j-log4j12"), // ApacheV2,
-        "org.apache.hbase" % "hbase-common" % hbaseVersion exclude("log4j", "log4j") exclude("org.slf4j", "slf4j-log4j12"), // ApacheV2,
-        "org.apache.hadoop" % "hadoop-common" % hadoopVersion exclude("log4j", "log4j") exclude("org.slf4j", "slf4j-log4j12"), // ApacheV2,
-        "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion exclude("log4j", "log4j") exclude("org.slf4j", "slf4j-log4j12"), // ApacheV2,
-        "org.slf4j" % "log4j-over-slf4j" % "1.7.21" % Test, // MIT like: http://www.slf4j.org/license.html
-        "org.slf4j" % "slf4j-api" % "1.7.21" % Test, // MIT like: http://www.slf4j.org/license.html
-        "ch.qos.logback" % "logback-classic" % "1.1.7" % Test, // Eclipse Public License 1.0: http://logback.qos.ch/license.html
-        "ch.qos.logback" % "logback-core" % "1.1.7" % Test // Eclipse Public License 1.0: http://logback.qos.ch/license.html
-      )
-    )
-  }
-
   val DynamoDB = Seq(
     libraryDependencies ++= Seq(
       "com.amazonaws"     % "aws-java-sdk-dynamodb" % "1.11.106",          // ApacheV2
       "com.typesafe.akka" %% "akka-http"            % AkkaHttpVersion
-    )
-  )
-
-  val Mqtt = Seq(
-    libraryDependencies ++= Seq(
-      "org.eclipse.paho" % "org.eclipse.paho.client.mqttv3" % "1.1.0" // Eclipse Public License 1.0
     )
   )
 
@@ -112,11 +71,77 @@ object Dependencies {
     )
   )
 
-  val Sse = Seq(
+  val Geode = {
+    val geodeVersion = "1.1.1"
+    Seq(
+      libraryDependencies ++= Seq("com.chuusai" %% "shapeless" % "2.3.2") ++
+        Seq("geode-core","geode-cq")
+        .map("org.apache.geode" % _ % geodeVersion exclude("org.slf4j", "slf4j-log4j12")) ++
+        Seq("org.slf4j" % "log4j-over-slf4j" % "1.7.21" % Test, // MIT like: http://www.slf4j.org/license.html
+          "org.slf4j" % "slf4j-api" % "1.7.21" % Test, // MIT like: http://www.slf4j.org/license.html
+          "ch.qos.logback" % "logback-classic" % "1.1.7" % Test, // Eclipse Public License 1.0: http://logback.qos.ch/license.html
+          "ch.qos.logback" % "logback-core" % "1.1.7" % Test // Eclipse Public License 1.0: http://logback.qos.ch/license.html
+        )
+
+    )
+  }
+
+  val GooglePubSub = Seq(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-http"         % AkkaHttpVersion,
-      "de.heikoseeberger" %% "akka-sse"          % "3.0.0", // ApacheV2
-      "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test
+      "com.typesafe.akka"     %% "akka-http"     % AkkaHttpVersion,
+      "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+      "org.mockito"   % "mockito-core"     % "2.3.7"    % Test, // MIT
+      "com.github.tomakehurst" % "wiremock"      % "2.5.1" % Test //ApacheV2
+    )
+  )
+
+  val HBase = {
+    val hbaseVersion = "1.2.4"
+    val hadoopVersion = "2.5.1"
+    Seq(
+      libraryDependencies ++= Seq(
+        "org.apache.hbase" % "hbase-client" % hbaseVersion exclude("log4j", "log4j") exclude("org.slf4j", "slf4j-log4j12"), // ApacheV2,
+        "org.apache.hbase" % "hbase-common" % hbaseVersion exclude("log4j", "log4j") exclude("org.slf4j", "slf4j-log4j12"), // ApacheV2,
+        "org.apache.hadoop" % "hadoop-common" % hadoopVersion exclude("log4j", "log4j") exclude("org.slf4j", "slf4j-log4j12"), // ApacheV2,
+        "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion exclude("log4j", "log4j") exclude("org.slf4j", "slf4j-log4j12"), // ApacheV2,
+        "org.slf4j" % "log4j-over-slf4j" % "1.7.21" % Test, // MIT like: http://www.slf4j.org/license.html
+        "org.slf4j" % "slf4j-api" % "1.7.21" % Test, // MIT like: http://www.slf4j.org/license.html
+        "ch.qos.logback" % "logback-classic" % "1.1.7" % Test, // Eclipse Public License 1.0: http://logback.qos.ch/license.html
+        "ch.qos.logback" % "logback-core" % "1.1.7" % Test // Eclipse Public License 1.0: http://logback.qos.ch/license.html
+      )
+    )
+  }
+
+  val IronMq = Seq(
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka"   %% "akka-http"                        % AkkaHttpVersion,
+      "de.heikoseeberger"   %% "akka-http-circe"                  % "1.11.0"  // ApacheV2
+    )
+  )
+
+  val Jms = Seq(
+    libraryDependencies ++= Seq(
+      "javax.jms" % "jms" % "1.1" % Provided, // CDDL + GPLv2
+      "org.apache.activemq" % "activemq-broker" % "5.14.1" % Test, // ApacheV2
+      "org.apache.activemq" % "activemq-client" % "5.14.1" % Test // ApacheV2
+    ),
+    // Having JBoss as a first resolver is a workaround for https://github.com/coursier/coursier/issues/200
+    externalResolvers := ("jboss" at "https://repository.jboss.org/nexus/content/groups/public") +: externalResolvers.value
+  )
+
+  val Mqtt = Seq(
+    libraryDependencies ++= Seq(
+      "org.eclipse.paho" % "org.eclipse.paho.client.mqttv3" % "1.1.0" // Eclipse Public License 1.0
+    )
+  )
+
+  val S3 = Seq(
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka"     %% "akka-http"     % AkkaHttpVersion,
+      "com.typesafe.akka"     %% "akka-http-xml" % AkkaHttpVersion,
+      // in-memory filesystem for file related tests
+      "com.google.jimfs"       % "jimfs"         % "1.1"   % Test, // ApacheV2
+      "com.github.tomakehurst" % "wiremock"      % "2.5.1" % Test //ApacheV2
     )
   )
 
@@ -142,36 +167,11 @@ object Dependencies {
     )
   )
 
-  val Jms = Seq(
+  val Sse = Seq(
     libraryDependencies ++= Seq(
-      "javax.jms" % "jms" % "1.1" % Provided, // CDDL + GPLv2
-      "org.apache.activemq" % "activemq-broker" % "5.14.1" % Test, // ApacheV2
-      "org.apache.activemq" % "activemq-client" % "5.14.1" % Test // ApacheV2
-    ),
-    // Having JBoss as a first resolver is a workaround for https://github.com/coursier/coursier/issues/200
-    externalResolvers := ("jboss" at "https://repository.jboss.org/nexus/content/groups/public") +: externalResolvers.value
-  )
-
-  val AwsLambda = Seq(
-    libraryDependencies ++= Seq(
-      "com.amazonaws"   % "aws-java-sdk-lambda"    % "1.11.105", // ApacheV2
-      "org.mockito"   % "mockito-core"     % "2.7.17"    % Test  // MIT
-    )
-  )
-
-  val GooglePubSub = Seq(
-    libraryDependencies ++= Seq(
-      "com.typesafe.akka"     %% "akka-http"     % AkkaHttpVersion,
-      "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-      "org.mockito"   % "mockito-core"     % "2.3.7"    % Test, // MIT
-      "com.github.tomakehurst" % "wiremock"      % "2.5.1" % Test //ApacheV2
-    )
-  )
-
-  val IronMq = Seq(
-    libraryDependencies ++= Seq(
-      "com.typesafe.akka"   %% "akka-http"                        % AkkaHttpVersion,
-      "de.heikoseeberger"   %% "akka-http-circe"                  % "1.11.0"  // ApacheV2
+      "com.typesafe.akka" %% "akka-http"         % AkkaHttpVersion,
+      "de.heikoseeberger" %% "akka-sse"          % "3.0.0", // ApacheV2
+      "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test
     )
   )
 


### PR DESCRIPTION
https://github.com/akka/alpakka/issues/309

Looks like the projects in ´build.sbt´ are already ordered, and the dependencies are obviously in an ´Object´, so all that's left of this issue is to order the projects ´Dependencies.scala´