### PR TITLE
Make amqp recover from broker errors and set as default

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
@@ -52,7 +52,7 @@ final class AmqpSourceStage(settings: AmqpSourceSettings, bufferSize: Int)
         channel.basicQos(bufferSize, true)
         val consumerCallback = getAsyncCallback(handleDelivery)
         val shutdownCallback = getAsyncCallback[Option[ShutdownSignalException]] {
-          case Some(ex) => failStage(ex)
+          case Some(ex) => if (!autoRecoverEnabled) failStage(ex)
           case None => completeStage()
         }
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
@@ -159,8 +159,8 @@ final case class AmqpConnectionDetails(
     handshakeTimeout: Option[Int] = None,
     shutdownTimeout: Option[Int] = None,
     networkRecoveryInterval: Option[Int] = None,
-    automaticRecoveryEnabled: Option[Boolean] = None,
-    topologyRecoveryEnabled: Option[Boolean] = None,
+    automaticRecoveryEnabled: Option[Boolean] = Some(true),
+    topologyRecoveryEnabled: Option[Boolean] = Some(true),
     exceptionHandler: Option[ExceptionHandler] = None
 ) extends AmqpConnectionSettings {
 


### PR DESCRIPTION
The stream fails on an amqp broker failure. Amqp is now able to recover from broker failures, so the stream should keep running while the broker recovers and continue processing when amqp comes back.