### PR TITLE
S3: Bug fix around host header when using Proxy

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -118,8 +118,8 @@ private[alpakka] object HttpRequests {
     }
     val uri = Uri(path = path, authority = Authority(requestHost(bucket, conf.s3Region)))
     conf.proxy match {
-      case None => uri.withScheme("https")
-      case Some(proxy) => uri.withPort(proxy.port).withScheme(proxy.scheme)
+      case None => uri.withScheme("https").withHost(requestHost(bucket, conf.s3Region))
+      case Some(proxy) => uri.withPort(proxy.port).withScheme(proxy.scheme).withHost(proxy.host)
     }
   }
 }


### PR DESCRIPTION
Whether you are using a proxy or not, the host header should always be the proper amazon URL. When you are using a proxy, you want the URI to include your proxy host. 