### PR TITLE
Fix #343 by handling preStart failures explicitly

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpRpcFlowStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpRpcFlowStage.scala
@@ -185,6 +185,13 @@ final class AmqpRpcFlowStage(settings: AmqpSinkSettings, bufferSize: Int, respon
           }
         }
       )
+      override def postStop(): Unit = {
+        promise.tryFailure(new RuntimeException("stage stopped unexpectedly"))
+        super.postStop()
+      }
+
+      override def onFailure(ex: Throwable): Unit =
+        promise.tryFailure(ex)
     }, promise.future)
   }
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSinkStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSinkStage.scala
@@ -91,6 +91,15 @@ final class AmqpSinkStage(settings: AmqpSinkSettings)
           }
         }
       )
+
+      override def postStop(): Unit = {
+        promise.tryFailure(new RuntimeException("stage stopped unexpectedly"))
+        super.postStop()
+      }
+
+      override def onFailure(ex: Throwable): Unit =
+        promise.tryFailure(ex)
+
     }, promise.future)
   }
 
@@ -148,6 +157,9 @@ final class AmqpReplyToSinkStage(settings: AmqpReplyToSinkSettings)
         super.postStop()
       }
 
+      override def onFailure(ex: Throwable): Unit =
+        promise.tryFailure(ex)
+
       setHandler(
         in,
         new InHandler {
@@ -186,6 +198,7 @@ final class AmqpReplyToSinkStage(settings: AmqpReplyToSinkSettings)
           }
         }
       )
+
     }, promise.future)
   }
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
@@ -129,7 +129,7 @@ final class AmqpSourceStage(settings: AmqpSourceSettings, bufferSize: Int)
           false // just this single message
         )
       }
-
+      override def onFailure(ex: Throwable): Unit = {}
     }
 
 }

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -50,7 +50,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
 
       //#run-sink
       val input = Vector("one", "two", "three", "four", "five")
-      Source(input).map(s => ByteString(s)).runWith(amqpSink)
+      Source(input).map(s => ByteString(s)).runWith(amqpSink).futureValue shouldEqual Done
       //#run-sink
 
       //#run-source
@@ -81,7 +81,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       val (rpcQueueF, probe) =
         Source(input).map(s => ByteString(s)).viaMat(amqpRpcFlow)(Keep.right).toMat(TestSink.probe)(Keep.both).run
       //#run-rpc-flow
-      val rpqCqueue = rpcQueueF.futureValue
+      rpcQueueF.futureValue
 
       val amqpSink = AmqpSink.replyTo(
         AmqpReplyToSinkSettings(DefaultAmqpConnection)
@@ -111,7 +111,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       val input = Vector("one", "two", "three", "four", "five")
       val (rpcQueueF, probe) =
         Source(input).map(s => ByteString(s)).viaMat(amqpRpcFlow)(Keep.right).toMat(TestSink.probe)(Keep.both).run
-      val rpqCqueue = rpcQueueF.futureValue
+      rpcQueueF.futureValue
 
       val amqpSink = AmqpSink.replyTo(
         AmqpReplyToSinkSettings(DefaultAmqpConnection)


### PR DESCRIPTION
If an error happened in preStart, the future wouldn't be completed and anyone mapping on the result would just hang on that future.