### PR TITLE
Add Setting to configure TimeToLive for the JmsProducer in JmsSink

### DIFF
--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -47,7 +47,7 @@ final case class JmsSinkSettings(connectionFactory: ConnectionFactory,
   def withCredential(credentials: Credentials) = copy(credentials = Some(credentials))
   def withQueue(name: String) = copy(destination = Some(Queue(name)))
   def withTopic(name: String) = copy(destination = Some(Topic(name)))
-  def withTimeToLive(ttl: Duration)  = copy(timeToLive = Some(ttl))
+  def withTimeToLive(ttl: Duration) = copy(timeToLive = Some(ttl))
 }
 
 final case class Credentials(username: String, password: String)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -3,6 +3,7 @@
  */
 package akka.stream.alpakka.jms
 
+import java.time.Duration
 import javax.jms.ConnectionFactory
 
 sealed trait JmsSettings {
@@ -40,11 +41,13 @@ object JmsSinkSettings {
 
 final case class JmsSinkSettings(connectionFactory: ConnectionFactory,
                                  destination: Option[Destination] = None,
-                                 credentials: Option[Credentials] = None)
+                                 credentials: Option[Credentials] = None,
+                                 timeToLive: Option[Duration] = None)
     extends JmsSettings {
   def withCredential(credentials: Credentials) = copy(credentials = Some(credentials))
   def withQueue(name: String) = copy(destination = Some(Queue(name)))
   def withTopic(name: String) = copy(destination = Some(Topic(name)))
+  def withTimeToLive(ttl: Duration)  = copy(timeToLive = Some(ttl))
 }
 
 final case class Credentials(username: String, password: String)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsSinkStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsSinkStage.scala
@@ -27,7 +27,7 @@ final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[SinkShape
       override def preStart(): Unit = {
         jmsSession = openSession()
         jmsProducer = jmsSession.session.createProducer(jmsSession.destination)
-        if(settings.timeToLive.nonEmpty){
+        if (settings.timeToLive.nonEmpty) {
           jmsProducer.setTimeToLive(settings.timeToLive.get.toMillis)
         }
         pull(in)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsSinkStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsSinkStage.scala
@@ -8,7 +8,7 @@ import javax.jms.{MessageProducer, TextMessage}
 import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler}
 import akka.stream.{ActorAttributes, Attributes, Inlet, SinkShape}
 
-final class JmsSinkStage(settings: JmsSettings) extends GraphStage[SinkShape[String]] {
+final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[SinkShape[String]] {
 
   private val in = Inlet[String]("JmsSink.in")
 
@@ -27,6 +27,9 @@ final class JmsSinkStage(settings: JmsSettings) extends GraphStage[SinkShape[Str
       override def preStart(): Unit = {
         jmsSession = openSession()
         jmsProducer = jmsSession.session.createProducer(jmsSession.destination)
+        if(settings.timeToLive.nonEmpty){
+          jmsProducer.setTimeToLive(settings.timeToLive.get.toMillis)
+        }
         pull(in)
       }
 


### PR DESCRIPTION
Fixes  #350 

* Adds timeToLive (Duration) to JmsSinkSettings
* Sets timeToLive on the jmsProducer