### PR TITLE
fix #374 correctly encodes non-ascii characters for signing s3 requests

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/auth/CanonicalRequest.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/auth/CanonicalRequest.scala
@@ -8,8 +8,6 @@ import java.net.URLEncoder
 import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
 
-import scala.annotation.tailrec
-
 // Documentation: http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
 private[alpakka] case class CanonicalRequest(method: String,
                                              uri: String,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/auth/CanonicalRequest.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/auth/CanonicalRequest.scala
@@ -59,7 +59,13 @@ private[alpakka] object CanonicalRequest {
       pathEncodeRec(builder ++= uriEncodePath(head), tail)
   }
 
-  private def toHexUtf8(ch: Char): String = "%" + Integer.toHexString(ch.toInt)
+  private def toHexUtf8(ch: Char): String = ch match {
+    case asciiChar if ch >= 0 && ch <= 127 =>
+      "%" + Integer.toHexString(asciiChar.toInt).toUpperCase
+    case otherChar =>
+      // I guess this adds quite some overhead but the detailed api is not public
+      Path(otherChar.toString).toString()
+  }
 
   // translated from java example at http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
   private def uriEncodePath(input: String, encodeSlash: Boolean = true): String =
@@ -73,4 +79,5 @@ private[alpakka] object CanonicalRequest {
       case ch =>
         toHexUtf8(ch)
     }
+
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/auth/CanonicalRequestSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/auth/CanonicalRequestSpec.scala
@@ -73,4 +73,26 @@ class CanonicalRequestSpec extends FlatSpec with Matchers {
         |testhash""".stripMargin
     )
   }
+
+  it should "correctly build a canonicalString with special characters in the path" in {
+    // this corresponds with not encode path: /føldęrü/1234()[]><!? .TXT
+    val req = HttpRequest(
+      HttpMethods.GET,
+      Uri("https://mytestbucket.s3.amazonaws.com/f%C3%B8ld%C4%99r%C3%BC/1234()%5B%5D%3E%3C!%3F%20.TXT")
+    ).withHeaders(
+      RawHeader("x-amz-content-sha256", "testhash"),
+      `Content-Type`(ContentTypes.`application/json`)
+    )
+    val canonical = CanonicalRequest.from(req)
+    canonical.canonicalString should equal(
+      """GET
+        |/f%C3%B8ld%C4%99r%C3%BC/1234%28%29%5B%5D%3E%3C%21%3F%20.TXT
+        |
+        |content-type:application/json
+        |x-amz-content-sha256:testhash
+        |
+        |content-type;x-amz-content-sha256
+        |testhash""".stripMargin
+    )
+  }
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/auth/SignerSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/auth/SignerSpec.scala
@@ -62,22 +62,21 @@ class SignerSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLik
 
     val srFuture =
       Signer.signedRequest(req, signingKey, LocalDateTime.of(2015, 8, 30, 12, 36, 0).atZone(ZoneOffset.UTC))
-    whenReady(srFuture) {
-      case signedRequest =>
-        signedRequest should equal(
-          HttpRequest(HttpMethods.GET)
-            .withUri("https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08")
-            .withHeaders(
-              Host("iam.amazonaws.com"),
-              RawHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8"),
-              RawHeader("x-amz-date", "20150830T123600Z"),
-              RawHeader("x-amz-content-sha256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
-              RawHeader(
-                "Authorization",
-                "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=dd479fa8a80364edf2119ec24bebde66712ee9c9cb2b0d92eb3ab9ccdc0c3947"
-              )
+    whenReady(srFuture) { signedRequest =>
+      signedRequest should equal(
+        HttpRequest(HttpMethods.GET)
+          .withUri("https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08")
+          .withHeaders(
+            Host("iam.amazonaws.com"),
+            RawHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8"),
+            RawHeader("x-amz-date", "20150830T123600Z"),
+            RawHeader("x-amz-content-sha256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+            RawHeader(
+              "Authorization",
+              "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=dd479fa8a80364edf2119ec24bebde66712ee9c9cb2b0d92eb3ab9ccdc0c3947"
             )
-        )
+          )
+      )
     }
   }
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3NoMock.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3NoMock.scala
@@ -17,7 +17,6 @@ import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Ignore, Matchers}
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-
 /*
  * This is an integration test and ignored by default
  *

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3NoMock.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3NoMock.scala
@@ -17,6 +17,21 @@ import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Ignore, Matchers}
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
+
+/*
+ * This is an integration test and ignored by default
+ *
+ * For running the tests you need to create 2 buckets:
+ *  - one in region us-east-1
+ *  - one in an other region (eg eu-central-1)
+ * Update the bucket name and regions in the code below
+ *
+ * Set your keys aws access-key-id and secret-access-key in src/test/resources/application.conf
+ *
+ * Comment @ignore and run the tests
+ * (tests that do listing counts might need some tweaking)
+ *
+ */
 @Ignore
 class S3NoMock extends FlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures {
 


### PR DESCRIPTION
fix #374 correctly encodes non-ascii characters for signing s3 requests