### PR TITLE
S3 - Fix signature bug when the 'Range' header is used (fixes #384)

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -98,7 +98,7 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
   def request(s3Location: S3Location, rangeOption: Option[ByteRange] = None): Future[HttpResponse] = {
     val downloadRequest = getDownloadRequest(s3Location)
     signAndGet(rangeOption match {
-      case Some(range) => downloadRequest.withHeaders(headers.Range(range))
+      case Some(range) => downloadRequest.addHeader(headers.Range(range))
       case _ => downloadRequest
     })
   }


### PR DESCRIPTION
When a ByteRange is provided for a download request, the "Range" header was replacing the "Host" instead of being concatenated, this caused the request signer to generate an invalid signature.