### PR TITLE
fix #380 handling IOExceptions in FTP sink onPush

### DIFF
--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpIOGraphStage.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpIOGraphStage.scala
@@ -138,19 +138,21 @@ private[ftp] trait FtpIOSinkStage[FtpClient, S <: RemoteFileSettings]
       setHandler(
         in,
         new InHandler {
-          override def onPush(): Unit =
+          override def onPush(): Unit = {
             try {
               write(grab(in))
-              pull(in)
             } catch {
               case NonFatal(e) ⇒
                 matFailure(e)
                 try osOpt.foreach(_.close())
-                catch { case NonFatal(_) ⇒ }
+                catch {
+                  case NonFatal(_) ⇒
+                }
                 osOpt = None
                 throw e
             }
-
+            pull(in)
+          }
           override def onUpstreamFinish(): Unit =
             try {
               osOpt.foreach(_.close())

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -15,6 +15,7 @@ import scala.util.Random
 import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.{Files, Paths}
 import java.net.InetAddress
+import org.scalatest.concurrent.Eventually
 
 final class FtpStageSpec extends BaseFtpSpec with CommonFtpStageSpec
 final class SftpStageSpec extends BaseSftpSpec with CommonFtpStageSpec
@@ -65,7 +66,7 @@ final class StrictHostCheckingSftpSourceSpec extends BaseSftpSpec with CommonFtp
   )
 }
 
-trait CommonFtpStageSpec extends BaseSpec {
+trait CommonFtpStageSpec extends BaseSpec with Eventually {
 
   implicit val system = getSystem
   implicit val mat = getMaterializer
@@ -242,6 +243,22 @@ trait CommonFtpStageSpec extends BaseSpec {
       val result = brokenSource.runWith(storeToPath(s"/$fileName", append = false)).futureValue
 
       result.status.failed.get shouldBe a[ArithmeticException]
+    }
+
+    "fail and report the exception in the result status if connection fails" in {
+      val fileName = "sample_io"
+      val infiniteSource = Source.repeat(ByteString(0x00))
+
+      val future = infiniteSource.runWith(storeToPath(s"/$fileName", append = false))
+      eventually {
+        noException should be thrownBy getFtpFileContents(FtpBaseSupport.FTP_ROOT_DIR, fileName)
+        getFtpFileContents(FtpBaseSupport.FTP_ROOT_DIR, fileName).length shouldBe >(0)
+      }
+      stopServer()
+      val result = future.futureValue
+      startServer()
+
+      result.status.failed.get shouldBe a[Exception]
     }
   }
 }

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -246,14 +246,17 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
     }
 
     "fail and report the exception in the result status if connection fails" in {
+      def waitForUploadToStart(fileName: String) =
+        eventually {
+          noException should be thrownBy getFtpFileContents(FtpBaseSupport.FTP_ROOT_DIR, fileName)
+          getFtpFileContents(FtpBaseSupport.FTP_ROOT_DIR, fileName).length shouldBe >(0)
+        }
+
       val fileName = "sample_io"
       val infiniteSource = Source.repeat(ByteString(0x00))
 
       val future = infiniteSource.runWith(storeToPath(s"/$fileName", append = false))
-      eventually {
-        noException should be thrownBy getFtpFileContents(FtpBaseSupport.FTP_ROOT_DIR, fileName)
-        getFtpFileContents(FtpBaseSupport.FTP_ROOT_DIR, fileName).length shouldBe >(0)
-      }
+      waitForUploadToStart(fileName)
       stopServer()
       val result = future.futureValue
       startServer()


### PR DESCRIPTION
This pull request fixes the problem detailed in #380. There are two issues addressed:
* IOExceptions thrown by the ftp client during onPush were not being handled, the interpreter handles the exception and calls postStop on the graph stage, which by default completes the IOResult promise with a success. This is fixed by intercepting the the exception in onPush and failing the promise with the exception. 
* postStop was throwing an additional exception, in the case of a failure in onPush, as by default it closes the OutputStream which is in a failed state. This seems unnecessary, so this change fixes that by cleaning up the IOStream in the exception handling in onPush.

 