### PR TITLE
FTP Homogenize model

### DIFF
--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
@@ -4,8 +4,7 @@
 package akka.stream.alpakka.ftp.impl
 
 import akka.stream.alpakka.ftp.FtpCredentials.{AnonFtpCredentials, NonAnonFtpCredentials}
-import akka.stream.alpakka.ftp.{FtpFileSettings, RemoteFileSettings, SftpSettings}
-import akka.stream.alpakka.ftp.RemoteFileSettings._
+import akka.stream.alpakka.ftp.{FtpFileSettings, FtpSettings, FtpsSettings, RemoteFileSettings, SftpSettings}
 import net.schmizz.sshj.SSHClient
 import org.apache.commons.net.ftp.FTPClient
 import java.net.InetAddress
@@ -109,7 +108,7 @@ private[ftp] trait FtpDefaultSettings {
   ): FtpSettings =
     FtpSettings(
       InetAddress.getByName(hostname),
-      DefaultFtpPort,
+      FtpSettings.DefaultFtpPort,
       if (username.isDefined)
         NonAnonFtpCredentials(username.get, password.getOrElse(""))
       else
@@ -125,7 +124,7 @@ private[ftp] trait FtpsDefaultSettings {
   ): FtpsSettings =
     FtpsSettings(
       InetAddress.getByName(hostname),
-      DefaultFtpsPort,
+      FtpsSettings.DefaultFtpsPort,
       if (username.isDefined)
         NonAnonFtpCredentials(username.get, password.getOrElse(""))
       else
@@ -141,7 +140,7 @@ private[ftp] trait SftpDefaultSettings {
   ): SftpSettings =
     SftpSettings(
       InetAddress.getByName(hostname),
-      DefaultSftpPort,
+      SftpSettings.DefaultSftpPort,
       if (username.isDefined)
         NonAnonFtpCredentials(username.get, password.getOrElse(""))
       else

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -46,51 +46,82 @@ sealed abstract class FtpFileSettings extends RemoteFileSettings {
   def passiveMode: Boolean
 }
 
-object RemoteFileSettings {
+/**
+ * FTP settings
+ *
+ * @param host host
+ * @param port port
+ * @param credentials credentials (username and password)
+ * @param binary specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false)
+ * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
+ */
+final case class FtpSettings(
+    host: InetAddress,
+    port: Int = FtpSettings.DefaultFtpPort,
+    credentials: FtpCredentials = AnonFtpCredentials,
+    binary: Boolean = false,
+    passiveMode: Boolean = false
+) extends FtpFileSettings {
+  def withPort(port: Int): FtpSettings =
+    copy(port = port)
+
+  def withCredentials(credentials: FtpCredentials): FtpSettings =
+    copy(credentials = credentials)
+
+  def withBinary(binary: Boolean): FtpSettings =
+    copy(binary = binary)
+
+  def withPassiveMode(passiveMode: Boolean): FtpSettings =
+    copy(passiveMode = passiveMode)
+}
+
+object FtpSettings {
 
   /** Default FTP port */
   final val DefaultFtpPort = 21
 
+  /** Java API */
+  def create(host: InetAddress): FtpSettings =
+    FtpSettings(host)
+}
+
+/**
+ * FTPs settings
+ *
+ * @param host host
+ * @param port port
+ * @param credentials credentials (username and password)
+ * @param binary specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false)
+ * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
+ */
+final case class FtpsSettings(
+    host: InetAddress,
+    port: Int = FtpsSettings.DefaultFtpsPort,
+    credentials: FtpCredentials = AnonFtpCredentials,
+    binary: Boolean = false,
+    passiveMode: Boolean = false
+) extends FtpFileSettings {
+  def withPort(port: Int): FtpsSettings =
+    copy(port = port)
+
+  def withCredentials(credentials: FtpCredentials): FtpsSettings =
+    copy(credentials = credentials)
+
+  def withBinary(binary: Boolean): FtpsSettings =
+    copy(binary = binary)
+
+  def withPassiveMode(passiveMode: Boolean): FtpsSettings =
+    copy(passiveMode = passiveMode)
+}
+
+object FtpsSettings {
+
   /** Default FTPs port */
   final val DefaultFtpsPort = 2222
 
-  /** Default SFTP port */
-  final val DefaultSftpPort = 22
-
-  /**
-   * FTP settings
-   *
-   * @param host host
-   * @param port port
-   * @param credentials credentials (username and password)
-   * @param binary specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false)
-   * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
-   */
-  final case class FtpSettings(
-      host: InetAddress,
-      port: Int = DefaultFtpPort,
-      credentials: FtpCredentials = AnonFtpCredentials,
-      binary: Boolean = false,
-      passiveMode: Boolean = false
-  ) extends FtpFileSettings
-
-  /**
-   * FTPs settings
-   *
-   * @param host host
-   * @param port port
-   * @param credentials credentials (username and password)
-   * @param binary specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false)
-   * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
-   */
-  final case class FtpsSettings(
-      host: InetAddress,
-      port: Int = DefaultFtpsPort,
-      credentials: FtpCredentials = AnonFtpCredentials,
-      binary: Boolean = false,
-      passiveMode: Boolean = false
-  ) extends FtpFileSettings
-
+  /** Java API */
+  def create(host: InetAddress): FtpsSettings =
+    FtpsSettings(host)
 }
 
 /**
@@ -104,7 +135,7 @@ object RemoteFileSettings {
  */
 final case class SftpSettings(
     host: InetAddress,
-    port: Int = RemoteFileSettings.DefaultSftpPort,
+    port: Int = SftpSettings.DefaultSftpPort,
     credentials: FtpCredentials = AnonFtpCredentials,
     strictHostKeyChecking: Boolean = true,
     knownHosts: Option[String] = None,
@@ -127,12 +158,13 @@ final case class SftpSettings(
 }
 
 object SftpSettings {
+
+  /** Default SFTP port */
+  final val DefaultSftpPort = 22
+
+  /** Java API */
   def create(host: InetAddress): SftpSettings =
     SftpSettings(host)
-
-  def createEmptyIdentity(): Option[SftpIdentity] = None
-
-  def createEmptyKnownHosts(): Option[String] = None
 }
 
 /**

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java
@@ -5,7 +5,6 @@ package akka.stream.alpakka.ftp;
 
 import akka.NotUsed;
 import akka.stream.IOResult;
-import akka.stream.alpakka.ftp.RemoteFileSettings.FtpSettings;
 import akka.stream.alpakka.ftp.javadsl.Ftp;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
@@ -5,7 +5,6 @@ package akka.stream.alpakka.ftp;
 
 import akka.NotUsed;
 import akka.stream.IOResult;
-import akka.stream.alpakka.ftp.RemoteFileSettings.FtpsSettings;
 import akka.stream.alpakka.ftp.javadsl.Ftps;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
@@ -6,11 +6,9 @@ package akka.stream.alpakka.ftp
 import akka.NotUsed
 import akka.stream.IOResult
 import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.alpakka.ftp.RemoteFileSettings.FtpSettings
 import akka.stream.alpakka.ftp.FtpCredentials.AnonFtpCredentials
 import akka.stream.alpakka.ftp.scaladsl.Ftp
 import akka.util.ByteString
-
 import scala.concurrent.Future
 import java.net.InetAddress
 

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
@@ -4,7 +4,6 @@
 package akka.stream.alpakka.ftp
 
 import akka.NotUsed
-import akka.stream.alpakka.ftp.RemoteFileSettings.FtpsSettings
 import akka.stream.alpakka.ftp.FtpCredentials.AnonFtpCredentials
 import akka.stream.alpakka.ftp.scaladsl.Ftps
 import akka.stream.IOResult

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -71,7 +71,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
   implicit val system = getSystem
   implicit val mat = getMaterializer
   implicit val defaultPatience =
-    PatienceConfig(timeout = Span(10, Seconds), interval = Span(300, Millis))
+    PatienceConfig(timeout = Span(30, Seconds), interval = Span(600, Millis))
 
   "FtpBrowserSource" should {
     "list all files from root" in {


### PR DESCRIPTION
This is a proposal to make the model of the FTP component more homogeneous. It remains to be decided if we want to replicate in `FTP` and` FTPs` the [fluent API](https://github.com/akka/alpakka/blob/master/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala#L116) that has been defined in `sFTP`, especially for Java use. Feedback is appreciated.

Closes #395 