### PR TITLE
Explicitly expect some logging

### DIFF
--- a/ftp/src/test/resources/application.conf
+++ b/ftp/src/test/resources/application.conf
@@ -1,1 +1,2 @@
 akka.test.single-expect-default = 30 seconds
+akka.loggers = [akka.testkit.TestEventListener]

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -17,7 +17,6 @@ import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.{Files, Paths}
 import java.net.InetAddress
 import org.scalatest.concurrent.Eventually
-import net.schmizz.sshj.sftp.SFTPException
 
 final class FtpStageSpec extends BaseFtpSpec with CommonFtpStageSpec
 final class SftpStageSpec extends BaseSftpSpec with CommonFtpStageSpec
@@ -259,7 +258,9 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
 
       val resultFuture = infiniteSource.runWith(storeToPath(s"/$fileName", append = false))
       waitForUploadToStart(fileName)
-      EventFilter[SFTPException](occurrences = 1) intercept {
+
+      // Could be an SFTPException or a SocketException
+      EventFilter[Exception](occurrences = 1) intercept {
         stopServer()
       }
       startServer()


### PR DESCRIPTION
Makes explicit that we expect this logging, and suppresses it
when running the tests.

We still see some errors in the logging because sshj also logs
to slf4j itself. Perhaps we want something similar for that
output? Not sure if slf4j also has a kind of testkit/approach for
this?