### PR TITLE
Don't use `***` in the sbt header

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val alpakka = project
   .settings(
     onLoadMessage :=
       """
-        |*** Welcome to the sbt build definition for Alpakka! ***
+        |** Welcome to the sbt build definition for Alpakka! **
         |
         |Useful sbt tasks:
         |


### PR DESCRIPTION
Makes it harder to search for `***` to find test failures