### PR TITLE
FTP testing stability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,9 @@ lazy val ftp = project
     name := "akka-stream-alpakka-ftp",
     Dependencies.Ftp,
     parallelExecution in Test := false,
-    fork in Test := true
+    fork in Test := true,
+    // To avoid potential blocking in machines with low entropy (default is `/dev/random`)
+    javaOptions in Test += "-Djava.security.egd=file:/dev/./urandom"
   )
 
 lazy val geode = project

--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -110,3 +110,7 @@ Java
     sbt
     > ftp/test
     ```
+
+@@@ warning
+When using the `SFTP` API, take into account that JVM relies on `/dev/random` for random number generation by default. This might potentially block the process on some operating systems as `/dev/random` waits for a certain amount of entropy to be generated on the host machine before returning a result. In such case, please consider providing the parameter `-Djava.security.egd = file:/dev/./urandom` into the execution context. Further information can be found [here](https://www.2uo.de/myths-about-urandom/).
+@@@

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpBaseSupport.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpBaseSupport.java
@@ -44,7 +44,7 @@ abstract class FtpBaseSupport implements FtpSupport, AkkaSupport {
             usersFile =
                     new File(getClass().getClassLoader().getResource("users.properties").getFile());
             port = AvailablePortFinder.getNextAvailable(BASE_PORT);
-            system = ActorSystem.create("default");
+            system = ActorSystem.create("alpakka-ftp");
             materializer = ActorMaterializer.create(system);
         } finally {
             port = BASE_PORT;

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,10 +60,11 @@ object Dependencies {
 
   val Ftp = Seq(
     libraryDependencies ++= Seq(
-      "commons-net"          % "commons-net"     % "3.5",           // ApacheV2
+      "commons-net"          % "commons-net"     % "3.6",           // ApacheV2
       "com.hierynomus"       % "sshj"            % "0.21.1",        // ApacheV2
       "org.apache.ftpserver" % "ftpserver-core"  % "1.1.1"  % Test, // ApacheV2
-      "org.apache.sshd"      % "sshd-core"       % "1.4.0"  % Test, // ApacheV2
+      "org.apache.sshd"      % "sshd-core"       % "1.6.0"  % Test, // ApacheV2
+      "net.i2p.crypto"       % "eddsa"           % "0.2.0"  % Test, // CC0 1.0 Universal
       "com.google.jimfs"     % "jimfs"           % "1.1"    % Test, // ApacheV2
       "org.slf4j"            % "slf4j-api"       % "1.7.21" % Test, // MIT
       "ch.qos.logback"       % "logback-classic" % "1.1.7"  % Test, // Eclipse Public License 1.0


### PR DESCRIPTION
This PR improves testing stability on FTP connector. The key change has been to add a new jvm configuration parameter that enables a less strict random generator device on Travis Linux VMs. The previous one would hang the main process if the machine is not able to generate enough entropy. Aditionally, some test dependencies have been updated.

/cc @raboof 

#422 