### PR TITLE
fix GCP pub/sub auth issue - remore redundant apikey param

### DIFF
--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/HttpApi.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/HttpApi.scala
@@ -101,8 +101,8 @@ private trait HttpApi {
       materializer: Materializer
   ): Future[immutable.Seq[String]] = {
     import materializer.executionContext
-
-    val url: Uri = s"$PubSubGoogleApisHost/v1/projects/$project/topics/$topic:publish?key=$apiKey"
+    
+    val url: Uri = s"$PubSubGoogleApisHost/v1/projects/$project/topics/$topic:publish"
 
     for {
       request <- Marshal((HttpMethods.POST, url, request)).to[HttpRequest]

--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/HttpApi.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/HttpApi.scala
@@ -101,7 +101,7 @@ private trait HttpApi {
       materializer: Materializer
   ): Future[immutable.Seq[String]] = {
     import materializer.executionContext
-    
+
     val url: Uri = s"$PubSubGoogleApisHost/v1/projects/$project/topics/$topic:publish"
 
     for {

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/HttpApiSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/HttpApiSpec.scala
@@ -80,7 +80,7 @@ class HttpApiSpec extends FlatSpec with BeforeAndAfterAll with ScalaFutures with
     mock.register(
       WireMock
         .post(
-          urlEqualTo(s"/v1/projects/${TestCredentials.projectId}/topics/topic1:publish?key=${TestCredentials.apiKey}")
+          urlEqualTo(s"/v1/projects/${TestCredentials.projectId}/topics/topic1:publish")
         )
         .withRequestBody(WireMock.equalTo(expectedPublishRequest))
         .withHeader("Authorization", WireMock.equalTo("Bearer " + accessToken))


### PR DESCRIPTION
* remove 'apikey' param from HTTP request URL for GCP Pub/Sub publish request.