### PR TITLE
fix #404 S3 correct encoding for path containing colon

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/auth/CanonicalRequest.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/auth/CanonicalRequest.scala
@@ -49,7 +49,7 @@ private[alpakka] object CanonicalRequest {
     if (path.isEmpty) "/"
     else
       path.toString().flatMap {
-        case ch if "!$&'()*+,;=".contains(ch) => "%" + Integer.toHexString(ch.toInt).toUpperCase
+        case ch if "!$&'()*+,;:=".contains(ch) => "%" + Integer.toHexString(ch.toInt).toUpperCase
         case other => other.toString
       }
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/auth/CanonicalRequestSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/auth/CanonicalRequestSpec.scala
@@ -34,7 +34,7 @@ class CanonicalRequestSpec extends FlatSpec with Matchers {
   it should "correctly build a canonicalString for us-east-1" in {
     val req = HttpRequest(
       HttpMethods.GET,
-      Uri("https://mytestbucket.s3.amazonaws.com/test%20folder/test%20file%20(1).txt")
+      Uri("https://mytestbucket.s3.amazonaws.com/test%20folder/test%20file%20(1):.txt")
         .withQuery(Query("partNumber" -> "2", "uploadId" -> "testUploadId"))
     ).withHeaders(
       RawHeader("x-amz-content-sha256", "testhash"),
@@ -43,7 +43,7 @@ class CanonicalRequestSpec extends FlatSpec with Matchers {
     val canonical = CanonicalRequest.from(req)
     canonical.canonicalString should equal(
       """GET
-        |/test%20folder/test%20file%20%281%29.txt
+        |/test%20folder/test%20file%20%281%29%3A.txt
         |partNumber=2&uploadId=testUploadId
         |content-type:application/json
         |x-amz-content-sha256:testhash

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3NoMock.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3NoMock.scala
@@ -159,9 +159,9 @@ class S3NoMock extends FlatSpecLike with BeforeAndAfterAll with Matchers with Sc
     downloaded shouldBe objectValue
   }
 
-  it should "upload and download with speical characters in the key in non us-east-1 zone" in {
+  it should "upload and download with special characters in the key in non us-east-1 zone" in {
     // we want ASCII and other UTF-8 characters!
-    val objectKey = "føldęrü/1234()[]><!? .TXT"
+    val objectKey = "føldęrü/1234()[]><!?: .TXT"
     val source: Source[ByteString, Any] = Source(ByteString(objectValue) :: Nil)
 
     val results = for {


### PR DESCRIPTION
fix #404 S3 correct encoding for path containing colon