### PR TITLE
#199 Support other datatypes than String for JMS-Sink

### DIFF
--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -16,8 +16,6 @@ sealed trait Destination
 final case class Topic(name: String) extends Destination
 final case class Queue(name: String) extends Destination
 
-
-
 object JmsSourceSettings {
 
   def create(connectionFactory: ConnectionFactory) = JmsSourceSettings(connectionFactory)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -3,8 +3,6 @@
  */
 package akka.stream.alpakka.jms
 
-import scala.collection.JavaConversions._
-import java.util
 import java.time.Duration
 import javax.jms.ConnectionFactory
 
@@ -18,26 +16,7 @@ sealed trait Destination
 final case class Topic(name: String) extends Destination
 final case class Queue(name: String) extends Destination
 
-final case class JmsTextMessage(body: String, properties: Map[String, Any] = Map.empty) {
 
-  /**
-   * Java API: add  [[JmsTextMessage]]
-   */
-  def add(name: String, value: Any) = copy(properties = properties + (name -> value))
-}
-
-object JmsTextMessage {
-
-  /**
-   * Java API: create  [[JmsTextMessage]]
-   */
-  def create(body: String) = JmsTextMessage(body, Map.empty)
-
-  /**
-   * Java API: create  [[JmsTextMessage]]
-   */
-  def create(body: String, properties: util.Map[String, Any]) = JmsTextMessage(body, properties.toMap)
-}
 
 object JmsSourceSettings {
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsMessages.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsMessages.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.jms
+
+import scala.collection.JavaConverters._
+import java.util
+
+sealed trait JmsMessage {
+
+  def properties(): Map[String, Any]
+
+  /**
+   * Java API: add  [[JmsMessage]]
+   */
+  def add(name: String, value: Any): JmsMessage
+}
+
+final case class JmsTextMessage(body: String, properties: Map[String, Any] = Map.empty) extends JmsMessage {
+
+  override def add(name: String, value: Any): JmsTextMessage = copy(properties = properties + (name -> value))
+}
+
+final case class JmsByteMessage(bytes: Array[Byte], properties: Map[String, Any] = Map.empty) extends JmsMessage {
+
+  override def add(name: String, value: Any): JmsByteMessage = copy(properties = properties + (name -> value))
+}
+
+final case class JmsMapMessage(body: Map[String, Any], properties: Map[String, Any] = Map.empty) extends JmsMessage {
+
+  override def add(name: String, value: Any): JmsMapMessage = copy(properties = properties + (name -> value))
+
+}
+
+final case class JmsObjectMessage(serializable: java.io.Serializable, properties: Map[String, Any] = Map.empty)
+    extends JmsMessage {
+
+  override def add(name: String, value: Any): JmsObjectMessage = copy(properties = properties + (name -> value))
+}
+
+object JmsMessage {
+
+  /**
+   * Java API: create  [[JmsTextMessage]]
+   */
+  def create(body: String) = JmsTextMessage(body, Map.empty)
+
+  /**
+   * Java API: create  [[JmsTextMessage]] with properties
+   */
+  def create(body: String, properties: util.Map[String, Any]) = JmsTextMessage(body, properties.asScala.toMap)
+
+  /**
+   * Java API: create  [[JmsByteMessage]]
+   */
+  def create(bytes: Array[Byte]) = JmsByteMessage(bytes, Map.empty)
+
+  /**
+   * Java API: create  [[JmsByteMessage]] with properties
+   */
+  def create(bytes: Array[Byte], properties: util.Map[String, Any]) = JmsByteMessage(bytes, properties.asScala.toMap)
+
+  /**
+   * Java API: create  [[JmsMapMessage]]
+   */
+  def create(map: Map[String, Any]) = JmsMapMessage(map, Map.empty)
+
+  /**
+   * Java API: create  [[JmsMapMessage]] with properties
+   */
+  def create(map: Map[String, Any], properties: util.Map[String, Any]) = JmsMapMessage(map, properties.asScala.toMap)
+
+  /**
+   * Java API: create  [[JmsMapMessage]]
+   */
+  def create(serializable: Serializable) = JmsObjectMessage(serializable, Map.empty)
+
+  /**
+   * Java API: create  [[JmsMapMessage]] with properties
+   */
+  def create(serializable: Serializable, properties: util.Map[String, Any]) =
+    JmsObjectMessage(serializable, properties.asScala.toMap)
+
+}

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsMessages.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsMessages.scala
@@ -38,7 +38,7 @@ final case class JmsObjectMessage(serializable: java.io.Serializable, properties
   override def add(name: String, value: Any): JmsObjectMessage = copy(properties = properties + (name -> value))
 }
 
-object JmsMessage {
+object JmsMessageFactory {
 
   /**
    * Java API: create  [[JmsTextMessage]]

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsSinkStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsSinkStage.scala
@@ -3,16 +3,16 @@
  */
 package akka.stream.alpakka.jms
 
-import javax.jms.{MessageProducer, TextMessage}
+import javax.jms.{Message, MessageProducer}
 
 import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler}
 import akka.stream.{ActorAttributes, Attributes, Inlet, SinkShape}
 
-final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[SinkShape[JmsTextMessage]] {
+final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[SinkShape[JmsMessage]] {
 
-  private val in = Inlet[JmsTextMessage]("JmsSink.in")
+  private val in = Inlet[JmsMessage]("JmsSink.in")
 
-  override def shape: SinkShape[JmsTextMessage] = SinkShape.of(in)
+  override def shape: SinkShape[JmsMessage] = SinkShape.of(in)
 
   override protected def initialAttributes: Attributes =
     ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher")
@@ -37,28 +37,64 @@ final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[SinkShape
         in,
         new InHandler {
           override def onPush(): Unit = {
-            val elem: JmsTextMessage = grab(in)
-            val textMessage: TextMessage = jmsSession.session.createTextMessage(elem.body)
-            elem.properties.foreach {
-              case (key, v) =>
-                v match {
-                  case v: String => textMessage.setStringProperty(key, v)
-                  case v: Int => textMessage.setIntProperty(key, v)
-                  case v: Boolean => textMessage.setBooleanProperty(key, v)
-                  case v: Byte => textMessage.setByteProperty(key, v)
-                  case v: Short => textMessage.setShortProperty(key, v)
-                  case v: Long => textMessage.setLongProperty(key, v)
-                  case v: Double => textMessage.setDoubleProperty(key, v)
-                }
-            }
-            jmsProducer.send(textMessage)
+            val elem: JmsMessage = grab(in)
+            val message: Message = createMessage(jmsSession, elem)
+            populateMessageProperties(message, elem.properties())
+            jmsProducer.send(message)
             pull(in)
           }
         }
       )
 
-      override def postStop(): Unit =
-        Option(jmsSession).foreach(_.closeSession())
+      private def createMessage(jmsSession: JmsSession, element: JmsMessage): Message =
+        element match {
+
+          case textMessage: JmsTextMessage => jmsSession.session.createTextMessage(textMessage.body)
+
+          case byteMessage: JmsByteMessage =>
+            val newMessage = jmsSession.session.createBytesMessage()
+            newMessage.writeBytes(byteMessage.bytes)
+            newMessage
+
+          case mapMessage: JmsMapMessage =>
+            val newMessage = jmsSession.session.createMapMessage()
+            populateMapMessage(newMessage, mapMessage.body)
+            newMessage
+
+          case objectMessage: JmsObjectMessage => jmsSession.session.createObjectMessage(objectMessage.serializable)
+
+        }
+
+      private def populateMapMessage(message: javax.jms.MapMessage, map: Map[String, Any]): Unit =
+        map.foreach {
+          case (key, v) =>
+            v match {
+              case v: String => message.setString(key, v)
+              case v: Int => message.setInt(key, v)
+              case v: Boolean => message.setBoolean(key, v)
+              case v: Byte => message.setByte(key, v)
+              case v: Short => message.setShort(key, v)
+              case v: Long => message.setLong(key, v)
+              case v: Double => message.setDouble(key, v)
+              case v: Array[Byte] => message.setBytes(key, v)
+            }
+        }
+
+      private def populateMessageProperties(message: javax.jms.Message, properties: Map[String, Any]): Unit =
+        properties.foreach {
+          case (key, v) =>
+            v match {
+              case v: String => message.setStringProperty(key, v)
+              case v: Int => message.setIntProperty(key, v)
+              case v: Boolean => message.setBooleanProperty(key, v)
+              case v: Byte => message.setByteProperty(key, v)
+              case v: Short => message.setShortProperty(key, v)
+              case v: Long => message.setLongProperty(key, v)
+              case v: Double => message.setDoubleProperty(key, v)
+            }
+        }
+
+      override def postStop(): Unit = Option(jmsSession).foreach(_.closeSession())
     }
 
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
@@ -14,7 +14,7 @@ object JmsSink {
   /**
    * Java API: Creates an [[JmsSink]] for [[JmsMessage]]s
    */
-  def  create[R <: JmsMessage](jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[R, NotUsed] =
+  def create[R <: JmsMessage](jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[R, NotUsed] =
     akka.stream.javadsl.Sink.fromGraph(new JmsSinkStage(jmsSinkSettings))
 
   /**
@@ -23,30 +23,27 @@ object JmsSink {
   def textSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[String, NotUsed] =
     akka.stream.alpakka.jms.scaladsl.JmsSink.textSink(jmsSinkSettings).asJava
 
-
   /**
-    * Java API: Creates an [[JmsSink]] for bytes
-    */
+   * Java API: Creates an [[JmsSink]] for bytes
+   */
   def bytesSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[Array[Byte], NotUsed] =
     akka.stream.alpakka.jms.scaladsl.JmsSink.bytesSink(jmsSinkSettings).asJava
 
-
   /**
-    * Java API: Creates an [[JmsSink]] for maps with primitive datatypes as value
-    */
+   * Java API: Creates an [[JmsSink]] for maps with primitive datatypes as value
+   */
   def mapSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[java.util.Map[String, Any], NotUsed] = {
 
     val scalaSink = akka.stream.alpakka.jms.scaladsl.JmsSink.mapSink(jmsSinkSettings)
-    val javaToScalaConversion = Flow.fromFunction((javaMap : java.util.Map[String, Any]) => JavaConverters.mapAsScalaMap(javaMap).toMap)
+    val javaToScalaConversion =
+      Flow.fromFunction((javaMap: java.util.Map[String, Any]) => JavaConverters.mapAsScalaMap(javaMap).toMap)
     javaToScalaConversion.to(scalaSink).asJava
   }
 
-
   /**
-    * Java API: Creates an [[JmsSink]] for serializable objects
-    */
+   * Java API: Creates an [[JmsSink]] for serializable objects
+   */
   def objectSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[java.io.Serializable, NotUsed] =
     akka.stream.alpakka.jms.scaladsl.JmsSink.objectSink(jmsSinkSettings).asJava
-
 
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
@@ -7,7 +7,7 @@ import akka.NotUsed
 import akka.stream.alpakka.jms.{JmsMessage, JmsSinkSettings, JmsSinkStage}
 import akka.stream.scaladsl.Flow
 
-import scala.collection.JavaConverters
+import scala.collection.JavaConversions
 
 object JmsSink {
 
@@ -36,7 +36,7 @@ object JmsSink {
 
     val scalaSink = akka.stream.alpakka.jms.scaladsl.JmsSink.mapSink(jmsSinkSettings)
     val javaToScalaConversion =
-      Flow.fromFunction((javaMap: java.util.Map[String, Any]) => JavaConverters.mapAsScalaMap(javaMap).toMap)
+      Flow.fromFunction((javaMap: java.util.Map[String, Any]) => JavaConversions.mapAsScalaMap(javaMap).toMap)
     javaToScalaConversion.to(scalaSink).asJava
   }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
@@ -4,20 +4,49 @@
 package akka.stream.alpakka.jms.javadsl
 
 import akka.NotUsed
-import akka.stream.alpakka.jms.{JmsSinkSettings, JmsSinkStage, JmsTextMessage}
-import akka.stream.scaladsl.{Flow, Sink}
+import akka.stream.alpakka.jms.{JmsMessage, JmsSinkSettings, JmsSinkStage}
+import akka.stream.scaladsl.Flow
+
+import scala.collection.JavaConverters
 
 object JmsSink {
 
   /**
-   * Java API: Creates an [[JmsSink]]
+   * Java API: Creates an [[JmsSink]] for [[JmsMessage]]s
    */
-  def create(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[JmsTextMessage, NotUsed] =
+  def  create[R <: JmsMessage](jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[R, NotUsed] =
     akka.stream.javadsl.Sink.fromGraph(new JmsSinkStage(jmsSinkSettings))
 
   /**
-   * Java API: Creates an [[JmsSink]]
+   * Java API: Creates an [[JmsSink]] for strings
    */
   def textSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[String, NotUsed] =
     akka.stream.alpakka.jms.scaladsl.JmsSink.textSink(jmsSinkSettings).asJava
+
+
+  /**
+    * Java API: Creates an [[JmsSink]] for bytes
+    */
+  def bytesSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[Array[Byte], NotUsed] =
+    akka.stream.alpakka.jms.scaladsl.JmsSink.bytesSink(jmsSinkSettings).asJava
+
+
+  /**
+    * Java API: Creates an [[JmsSink]] for maps with primitive datatypes as value
+    */
+  def mapSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[java.util.Map[String, Any], NotUsed] = {
+
+    val scalaSink = akka.stream.alpakka.jms.scaladsl.JmsSink.mapSink(jmsSinkSettings)
+    val javaToScalaConversion = Flow.fromFunction((javaMap : java.util.Map[String, Any]) => JavaConverters.mapAsScalaMap(javaMap).toMap)
+    javaToScalaConversion.to(scalaSink).asJava
+  }
+
+
+  /**
+    * Java API: Creates an [[JmsSink]] for serializable objects
+    */
+  def objectSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[java.io.Serializable, NotUsed] =
+    akka.stream.alpakka.jms.scaladsl.JmsSink.objectSink(jmsSinkSettings).asJava
+
+
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSource.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSource.scala
@@ -8,18 +8,39 @@ import javax.jms.Message
 import akka.NotUsed
 import akka.stream.alpakka.jms.{JmsSourceSettings, JmsSourceStage}
 
+import scala.collection.JavaConverters
+
 object JmsSource {
 
   /**
-   * Java API: Creates an [[JmsSource]]
+   * Java API: Creates an [[JmsSource]] for [[javax.jms.Message]]
    */
   def create(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[Message, NotUsed] =
     akka.stream.javadsl.Source.fromGraph(new JmsSourceStage(jmsSourceSettings))
 
   /**
-   * Java API: Creates an [[JmsSource]]
+   * Java API: Creates an [[JmsSource]] for texts
    */
   def textSource(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[String, NotUsed] =
     akka.stream.alpakka.jms.scaladsl.JmsSource.textSource(jmsSourceSettings).asJava
 
+  /**
+    * Java API: Creates an [[JmsSource]] for byte arrays
+    */
+  def bytesSource(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[Array[Byte], NotUsed] =
+    akka.stream.alpakka.jms.scaladsl.JmsSource.bytesSource(jmsSourceSettings).asJava
+
+  /**
+    * Java API: Creates an [[JmsSource]] for Maps with primitive data types
+    */
+  def mapSource(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[java.util.Map[String, Any], NotUsed] =
+    akka.stream.alpakka.jms.scaladsl.JmsSource.mapSource(jmsSourceSettings)
+      .map( scalaMap => JavaConverters.mapAsJavaMap(scalaMap))
+      .asJava
+
+  /**
+    * Java API: Creates an [[JmsSource]] for serializable objects
+    */
+  def objectSource(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[java.io.Serializable, NotUsed] =
+    akka.stream.alpakka.jms.scaladsl.JmsSource.objectSource(jmsSourceSettings).asJava
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSource.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSource.scala
@@ -8,7 +8,7 @@ import javax.jms.Message
 import akka.NotUsed
 import akka.stream.alpakka.jms.{JmsSourceSettings, JmsSourceStage}
 
-import scala.collection.JavaConverters
+import scala.collection.JavaConversions
 
 object JmsSource {
 
@@ -38,7 +38,7 @@ object JmsSource {
   ): akka.stream.javadsl.Source[java.util.Map[String, Any], NotUsed] =
     akka.stream.alpakka.jms.scaladsl.JmsSource
       .mapSource(jmsSourceSettings)
-      .map(scalaMap => JavaConverters.mapAsJavaMap(scalaMap))
+      .map(scalaMap => JavaConversions.mapAsJavaMap(scalaMap))
       .asJava
 
   /**

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSource.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSource.scala
@@ -25,22 +25,25 @@ object JmsSource {
     akka.stream.alpakka.jms.scaladsl.JmsSource.textSource(jmsSourceSettings).asJava
 
   /**
-    * Java API: Creates an [[JmsSource]] for byte arrays
-    */
+   * Java API: Creates an [[JmsSource]] for byte arrays
+   */
   def bytesSource(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[Array[Byte], NotUsed] =
     akka.stream.alpakka.jms.scaladsl.JmsSource.bytesSource(jmsSourceSettings).asJava
 
   /**
-    * Java API: Creates an [[JmsSource]] for Maps with primitive data types
-    */
-  def mapSource(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[java.util.Map[String, Any], NotUsed] =
-    akka.stream.alpakka.jms.scaladsl.JmsSource.mapSource(jmsSourceSettings)
-      .map( scalaMap => JavaConverters.mapAsJavaMap(scalaMap))
+   * Java API: Creates an [[JmsSource]] for Maps with primitive data types
+   */
+  def mapSource(
+      jmsSourceSettings: JmsSourceSettings
+  ): akka.stream.javadsl.Source[java.util.Map[String, Any], NotUsed] =
+    akka.stream.alpakka.jms.scaladsl.JmsSource
+      .mapSource(jmsSourceSettings)
+      .map(scalaMap => JavaConverters.mapAsJavaMap(scalaMap))
       .asJava
 
   /**
-    * Java API: Creates an [[JmsSource]] for serializable objects
-    */
+   * Java API: Creates an [[JmsSource]] for serializable objects
+   */
   def objectSource(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[java.io.Serializable, NotUsed] =
     akka.stream.alpakka.jms.scaladsl.JmsSource.objectSource(jmsSourceSettings).asJava
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSink.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSink.scala
@@ -4,22 +4,47 @@
 package akka.stream.alpakka.jms.scaladsl
 
 import akka.NotUsed
-import akka.stream.alpakka.jms.{JmsSinkSettings, JmsSinkStage, JmsTextMessage}
-import akka.stream.scaladsl.{Flow, Keep, Sink}
+import akka.stream.alpakka.jms._
+import akka.stream.scaladsl.{Flow, Sink}
 
 object JmsSink {
 
   /**
-   * Scala API: Creates an [[JmsSink]]
+   * Scala API: Creates an [[JmsSink]] for [[JmsMessage]]s
    */
-  def apply(jmsSettings: JmsSinkSettings): Sink[JmsTextMessage, NotUsed] =
+  def apply(jmsSettings: JmsSinkSettings): Sink[JmsMessage, NotUsed] =
     Sink.fromGraph(new JmsSinkStage(jmsSettings))
 
   /**
-   * Scala API: Creates an [[JmsSink]]
+   * Scala API: Creates an [[JmsSink]] for strings
    */
   def textSink(jmsSettings: JmsSinkSettings): Sink[String, NotUsed] = {
     val jmsMsgSink = Sink.fromGraph(new JmsSinkStage(jmsSettings))
     Flow.fromFunction((s: String) => JmsTextMessage(s)).to(jmsMsgSink)
   }
+
+  /**
+   * Scala API: Creates an [[JmsSink]] for bytes
+   */
+  def bytesSink(jmsSettings: JmsSinkSettings): Sink[Array[Byte], NotUsed] = {
+    val jmsMsgSink = Sink.fromGraph(new JmsSinkStage(jmsSettings))
+    Flow.fromFunction((s: Array[Byte]) => JmsByteMessage(s)).to(jmsMsgSink)
+  }
+
+  /**
+   * Scala API: Creates an [[JmsSink]] for maps with primitive data types
+   */
+  def mapSink(jmsSettings: JmsSinkSettings): Sink[Map[String, Any], NotUsed] = {
+    val jmsMsgSink = Sink.fromGraph(new JmsSinkStage(jmsSettings))
+    Flow.fromFunction((s: Map[String, Any]) => JmsMapMessage(s)).to(jmsMsgSink)
+  }
+
+  /**
+   * Scala API: Creates an [[JmsSink]] for serializable objects
+   */
+  def objectSink(jmsSettings: JmsSinkSettings): Sink[java.io.Serializable, NotUsed] = {
+    val jmsMsgSink = Sink.fromGraph(new JmsSinkStage(jmsSettings))
+    Flow.fromFunction((s: java.io.Serializable) => JmsObjectMessage(s)).to(jmsMsgSink)
+  }
+
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSource.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSource.scala
@@ -3,24 +3,56 @@
  */
 package akka.stream.alpakka.jms.scaladsl
 
-import javax.jms.{Message, TextMessage}
+import javax.jms._
 
 import akka.NotUsed
 import akka.stream.alpakka.jms.{JmsSourceSettings, JmsSourceStage}
 import akka.stream.scaladsl.Source
 
+import scala.collection.JavaConverters
+
 object JmsSource {
 
   /**
-   * Scala API: Creates an [[JmsSource]]
+   * Scala API: Creates an [[JmsSource]] for [[javax.jms.Message]] instances
    */
   def apply(jmsSettings: JmsSourceSettings): Source[Message, NotUsed] =
     Source.fromGraph(new JmsSourceStage(jmsSettings))
 
   /**
-   * Scala API: Creates an [[JmsSource]]
+   * Scala API: Creates an [[JmsSource]] for texts
    */
   def textSource(jmsSettings: JmsSourceSettings): Source[String, NotUsed] =
-    Source.fromGraph(new JmsSourceStage(jmsSettings)).map(msg => msg.asInstanceOf[TextMessage].getText)
+    apply(jmsSettings).map(msg => msg.asInstanceOf[TextMessage].getText)
+
+  /**
+   * Scala API: Creates an [[JmsSource]] for Maps with primitive datatypes
+   */
+  def mapSource(jmsSettings: JmsSourceSettings): Source[Map[String, Any], NotUsed] =
+    apply(jmsSettings).map { msg =>
+      val mapMessage = msg.asInstanceOf[MapMessage]
+      JavaConverters.enumerationAsScalaIterator(mapMessage.getMapNames).foldLeft(Map[String, Any]()) { (result, key) =>
+        val keyAsString = key.toString
+        val value = mapMessage.getObject(keyAsString)
+        result.+(keyAsString -> value)
+      }
+    }
+
+  /**
+   * Scala API: Creates an [[JmsSource]] for byte arrays
+   */
+  def bytesSource(jmsSettings: JmsSourceSettings): Source[Array[Byte], NotUsed] =
+    apply(jmsSettings).map { msg =>
+      val byteMessage = msg.asInstanceOf[BytesMessage]
+      val byteArray = new Array[Byte](byteMessage.getBodyLength.toInt)
+      byteMessage.readBytes(byteArray)
+      byteArray
+    }
+
+  /**
+   * Scala API: Creates an [[JmsSource]] for serializable objects
+   */
+  def objectSource(jmsSettings: JmsSourceSettings): Source[java.io.Serializable, NotUsed] =
+    apply(jmsSettings).map(msg => msg.asInstanceOf[ObjectMessage].getObject)
 
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSource.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSource.scala
@@ -9,7 +9,7 @@ import akka.NotUsed
 import akka.stream.alpakka.jms.{JmsSourceSettings, JmsSourceStage}
 import akka.stream.scaladsl.Source
 
-import scala.collection.JavaConverters
+import scala.collection.JavaConversions._
 
 object JmsSource {
 
@@ -31,7 +31,8 @@ object JmsSource {
   def mapSource(jmsSettings: JmsSourceSettings): Source[Map[String, Any], NotUsed] =
     apply(jmsSettings).map { msg =>
       val mapMessage = msg.asInstanceOf[MapMessage]
-      JavaConverters.enumerationAsScalaIterator(mapMessage.getMapNames).foldLeft(Map[String, Any]()) { (result, key) =>
+
+      mapMessage.getMapNames.foldLeft(Map[String, Any]()) { (result, key) =>
         val keyAsString = key.toString
         val value = mapMessage.getObject(keyAsString)
         result.+(keyAsString -> value)

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
@@ -44,7 +44,6 @@ final class DummyJavaTests implements java.io.Serializable{
 
     @Override
     public boolean equals(Object o) {
-
         if (this == o){
             return true;
         }

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
@@ -7,10 +7,7 @@ import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
-import akka.stream.alpakka.jms.JmsMessage;
-import akka.stream.alpakka.jms.JmsSinkSettings;
-import akka.stream.alpakka.jms.JmsSourceSettings;
-import akka.stream.alpakka.jms.JmsTextMessage;
+import akka.stream.alpakka.jms.*;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.JavaTestKit;
@@ -21,7 +18,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.jms.Message;
-import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.*;
 import java.util.concurrent.CompletionStage;
@@ -72,7 +68,7 @@ public class JmsConnectorsTest {
             properties.put("IsOdd", n % 2 == 1);
             properties.put("IsEven", n % 2 == 0);
 
-            msgsIn.add(JmsMessage.create(n.toString(), properties));
+            msgsIn.add(JmsMessageFactory.create(n.toString(), properties));
         }
 
         return msgsIn;

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
@@ -16,8 +16,7 @@ import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-
-final case class DummyObject(payload : String)
+final case class DummyObject(payload: String)
 
 class JmsConnectorsSpec extends JmsSpec {
 
@@ -126,7 +125,7 @@ class JmsConnectorsSpec extends JmsSpec {
       //#connection-factory
 
       //#create-map-sink
-      val jmsSink: Sink[Map[String,Any], NotUsed] = JmsSink.mapSink(
+      val jmsSink: Sink[Map[String, Any], NotUsed] = JmsSink.mapSink(
         JmsSinkSettings(connectionFactory).withQueue("test")
       )
       //#create-map-sink
@@ -134,15 +133,16 @@ class JmsConnectorsSpec extends JmsSpec {
       //#run-map-sink
       val in = List(
         Map[String, Any](
-        "string" -> "value",
-        "int value"     -> 42,
-        "double value"  -> 43.toDouble,
-        "short value"   -> 7.toShort,
-        "boolean value" -> true,
-        "long value"    -> 7.toLong,
-         "bytearray"     -> "AStringAsByteArray".getBytes(Charset.forName("UTF-8")),
-        "byte"          -> 1.toByte
-      ))
+          "string" -> "value",
+          "int value" -> 42,
+          "double value" -> 43.toDouble,
+          "short value" -> 7.toShort,
+          "boolean value" -> true,
+          "long value" -> 7.toLong,
+          "bytearray" -> "AStringAsByteArray".getBytes(Charset.forName("UTF-8")),
+          "byte" -> 1.toByte
+        )
+      )
 
       Source(in).runWith(jmsSink)
       //#run-map-sink
@@ -157,8 +157,8 @@ class JmsConnectorsSpec extends JmsSpec {
       val result = jmsSource.take(1).runWith(Sink.seq)
       //#run-map-source
 
-      result.futureValue.zip(in).foreach{
-        case (out,in ) =>
+      result.futureValue.zip(in).foreach {
+        case (out, in) =>
           out("string") shouldEqual in("string")
           out("int value") shouldEqual in("int value")
           out("double value") shouldEqual in("double value")

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
@@ -3,16 +3,21 @@
  */
 package akka.stream.alpakka.jms.scaladsl
 
-import javax.jms.{JMSException, Message, TextMessage}
+import java.nio.charset.Charset
+import javax.jms.{JMSException, Message}
 
 import akka.NotUsed
 import akka.stream.ThrottleMode
 import akka.stream.alpakka.jms._
-import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.stream.scaladsl.{Sink, Source}
 import org.apache.activemq.ActiveMQConnectionFactory
 
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
 import scala.concurrent.duration._
-import collection.JavaConverters._
+
+
+final case class DummyObject(payload : String)
 
 class JmsConnectorsSpec extends JmsSpec {
 
@@ -49,6 +54,124 @@ class JmsConnectorsSpec extends JmsSpec {
       result.futureValue shouldEqual in
     }
 
+    "publish and consume serializable objects through a queue" in withServer() { ctx =>
+      val url: String = ctx.url
+      //#connection-factory
+      val connectionFactory = new ActiveMQConnectionFactory(url)
+
+      // This is done here to send arbitrary objects. Otherwise activemq would forbid it.
+      // See therefore http://activemq.apache.org/objectmessage.html
+      connectionFactory.setTrustAllPackages(true)
+      //#connection-factory
+
+      //#create-object-sink
+      val jmsSink: Sink[Serializable, NotUsed] = JmsSink.objectSink(
+        JmsSinkSettings(connectionFactory).withQueue("test")
+      )
+      //#create-object-sink
+
+      //#run-object-sink
+
+      val in = DummyObject("ThisIsATest")
+      Source.single(in).runWith(jmsSink)
+      //#run-object-sink
+
+      //#create-object-source
+      val jmsSource: Source[java.io.Serializable, NotUsed] = JmsSource.objectSource(
+        JmsSourceSettings(connectionFactory).withQueue("test")
+      )
+      //#create-object-source
+
+      //#run-object-source
+      val result = jmsSource.take(1).runWith(Sink.head)
+      //#run-object-source
+
+      result.futureValue shouldEqual in
+    }
+
+    "publish and consume bytearray through a queue" in withServer() { ctx =>
+      val url: String = ctx.url
+      //#connection-factory
+      val connectionFactory = new ActiveMQConnectionFactory(url)
+      //#connection-factory
+
+      //#create-bytearray-sink
+      val jmsSink: Sink[Array[Byte], NotUsed] = JmsSink.bytesSink(
+        JmsSinkSettings(connectionFactory).withQueue("test")
+      )
+      //#create-bytearray-sink
+
+      //#run-bytearray-sink
+      val in = "ThisIsATest".getBytes(Charset.forName("UTF-8"))
+      Source.single(in).runWith(jmsSink)
+      //#run-bytearray-sink
+
+      //#create-bytearray-source
+      val jmsSource: Source[Array[Byte], NotUsed] = JmsSource.bytesSource(
+        JmsSourceSettings(connectionFactory).withQueue("test")
+      )
+      //#create-bytearray-source
+
+      //#run-bytearray-source
+      val result = jmsSource.take(1).runWith(Sink.head)
+      //#run-bytearray-source
+
+      result.futureValue shouldEqual in
+    }
+
+    "publish and consume map through a queue" in withServer() { ctx =>
+      val url: String = ctx.url
+      //#connection-factory
+      val connectionFactory = new ActiveMQConnectionFactory(url)
+      //#connection-factory
+
+      //#create-map-sink
+      val jmsSink: Sink[Map[String,Any], NotUsed] = JmsSink.mapSink(
+        JmsSinkSettings(connectionFactory).withQueue("test")
+      )
+      //#create-map-sink
+
+      //#run-map-sink
+      val in = List(
+        Map[String, Any](
+        "string" -> "value",
+        "int value"     -> 42,
+        "double value"  -> 43.toDouble,
+        "short value"   -> 7.toShort,
+        "boolean value" -> true,
+        "long value"    -> 7.toLong,
+         "bytearray"     -> "AStringAsByteArray".getBytes(Charset.forName("UTF-8")),
+        "byte"          -> 1.toByte
+      ))
+
+      Source(in).runWith(jmsSink)
+      //#run-map-sink
+
+      //#create-map-source
+      val jmsSource: Source[Map[String, Any], NotUsed] = JmsSource.mapSource(
+        JmsSourceSettings(connectionFactory).withQueue("test")
+      )
+      //#create-map-source
+
+      //#run-map-source
+      val result = jmsSource.take(1).runWith(Sink.seq)
+      //#run-map-source
+
+      result.futureValue.zip(in).foreach{
+        case (out,in ) =>
+          out("string") shouldEqual in("string")
+          out("int value") shouldEqual in("int value")
+          out("double value") shouldEqual in("double value")
+          out("short value") shouldEqual in("short value")
+          out("boolean value") shouldEqual in("boolean value")
+          out("long value") shouldEqual in("long value")
+          out("byte") shouldEqual in("byte")
+
+          val outBytes = out("bytearray").asInstanceOf[Array[Byte]]
+          new String(outBytes, Charset.forName("UTF-8")) shouldBe "AStringAsByteArray"
+      }
+    }
+
     "publish and consume JMS text messages with properties through a queue" in withServer() { ctx =>
       val url: String = ctx.url
       val connectionFactory = new ActiveMQConnectionFactory(url)
@@ -74,7 +197,7 @@ class JmsConnectorsSpec extends JmsSpec {
       //#create-jms-source
 
       //#run-jms-source
-      val result = jmsSource.take(msgsIn.size).runWith(Sink.seq)
+      val result: Future[Seq[Message]] = jmsSource.take(msgsIn.size).runWith(Sink.seq)
       //#run-jms-source
 
       // The sent message and the receiving one should have the same properties


### PR DESCRIPTION
Please take a look and let me know if something is missing. The JmsSink and JmsSource supports now Byte-, Map- and ObjectMessages according to the Jms spec. 

Therefore  a JmsMessage trait is introduced and refactored out to a separate file. 
The logic to create and populate the Jms messages is still inside the JmsSinkStage. I would move it from there to another place, but I don't know which direction to go... 

- Passing the Java.jms.Session to the JmsMessages,so that this classes could create their javax message representation 

or    

-  introduce a MessageFactory (or something like that)