### PR TITLE
Add Kinesis KCL Source

### DIFF
--- a/docs/src/main/paradox/kinesis.md
+++ b/docs/src/main/paradox/kinesis.md
@@ -1,6 +1,6 @@
 # AWS Kinesis Connector
 
-The AWS Kinesis connector provides an Akka Stream Source for consuming Kinesis Stream records.
+The AWS Kinesis connector provides Akka Stream Sources for consuming and producing Kinesis Stream records.
 
 For more information about Kinesis please visit the [official documentation](https://aws.amazon.com/documentation/kinesis/).
 
@@ -66,9 +66,7 @@ Scala
 Java
 : @@snip ($alpakka$/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/Examples.java) { #source-list }
 
-The constructed `Source` will return [Record](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_Record.html)
-
-objects by calling [GetRecords](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html) at the specified interval and according to the downstream demand.
+The constructed `Source` will return [Record](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_Record.html) objects by calling [GetRecords](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html) at the specified interval and according to the downstream demand.
 
 ### Using the Put Flow/Sink
 
@@ -80,7 +78,7 @@ Batching has a drawback: message order cannot be guaranteed, as some records wit
 More information can be found [here](http://docs.aws.amazon.com/streams/latest/dev/developing-producers-with-sdk.html#kinesis-using-sdk-java-putrecords) and [here](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html).
 @@@
 
-Publishing to a Kinesis stream requires an instance of `KinesisFlowSettings`, although a default instance with sane values and a method that returns settings based on the stream shard number are also available:
+Publishing to a Kinesis stream requires an `AmazonKinesisAsync` and an instance of `KinesisFlowSettings`, although a default instance with sane values and a method that returns settings based on the stream shard number are also available:
 
 Scala
 : @@snip ($alpakka$/kinesis/src/test/scala/akka/stream/alpakka/kinesis/scaladsl/Examples.scala) { #flow-settings }
@@ -100,3 +98,40 @@ Scala
 Java
 : @@snip ($alpakka$/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/Examples.java) { #flow-sink }
 
+# AWS KCL Worker Source & checkpointer
+
+The KCL Source can read from several shards and rebalance automatically when other Workers are started or stopped. It also handles record sequence checkpoints.
+
+For more information about KCL please visit the [official documentation](http://docs.aws.amazon.com/streams/latest/dev/developing-consumers-with-kcl.html).
+
+## Usage
+
+The KCL Worker Source needs to create and manage Worker instances in order to consume records from Kinesis Streams.
+
+In order to use it, you need to provide a Worker builder and the Source settings:
+
+Scala
+: @@snip (../../../../kinesis/src/test/scala/akka/stream/alpakka/kinesis/scaladsl/Examples.scala) { #worker-settings }
+
+Java
+: @@snip (../../../../kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/Examples.java) { #worker-settings }
+
+The Source also needs an `ExecutionContext` to run the Worker's thread and to execute record checkpoints. Then the Source can be created as usual:
+
+Scala
+: @@snip (../../../../kinesis/src/test/scala/akka/stream/alpakka/kinesis/scaladsl/Examples.scala) { #worker-source }
+
+Java
+: @@snip (../../../../kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/Examples.java) { #worker-source }
+
+## Committing records
+
+The KCL Worker Source publishes messages downstream that can be committed in order to mark progression of consumers by shard. This process can be done manually or using the provided checkpointer Flow.
+
+In order to use the Flow you can provide additional settings:
+
+Scala
+: @@snip (../../../../kinesis/src/test/scala/akka/stream/alpakka/kinesis/scaladsl/Examples.scala) { #checkpoint }
+
+Java
+: @@snip (../../../../kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/Examples.java) { #checkpoint }

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisErrors.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisErrors.scala
@@ -21,4 +21,7 @@ object KinesisErrors {
       extends RuntimeException(s"Unable to publish records after $attempts attempts")
       with KinesisFlowErrors
 
+  sealed trait KinesisWorkerSourceError extends NoStackTrace
+  case object WorkerUnexpectedShutdown extends KinesisWorkerSourceError
+
 }

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisWorkerSettings.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisWorkerSettings.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesis
+
+import scala.concurrent.duration._
+
+case class KinesisWorkerSourceSettings(bufferSize: Int, checkWorkerPeriodicity: FiniteDuration) {
+  require(
+    bufferSize >= 1,
+    "Buffer size must be greater than 0; use size 1 to disable stage buffering"
+  )
+}
+case class KinesisWorkerCheckpointSettings(maxBatchSize: Int, maxBatchWait: FiniteDuration) {
+  require(
+    maxBatchSize >= 1,
+    "Batch size must be greater than 0; use size 1 to commit records one at a time"
+  )
+}
+
+object KinesisWorkerSourceSettings {
+
+  val defaultInstance = KinesisWorkerSourceSettings(1000, 1.minute)
+
+  /**
+   * Java API
+   */
+  def create(bufferSize: Int, checkWorkerPeriodicity: FiniteDuration): KinesisWorkerSourceSettings =
+    KinesisWorkerSourceSettings(bufferSize, checkWorkerPeriodicity)
+
+}
+
+object KinesisWorkerCheckpointSettings {
+
+  val defaultInstance = KinesisWorkerCheckpointSettings(1000, 10.seconds)
+
+  /**
+   * Java API
+   */
+  def create(maxBatchSize: Int, maxBatchWait: FiniteDuration): KinesisWorkerCheckpointSettings =
+    KinesisWorkerCheckpointSettings(maxBatchSize, maxBatchWait)
+
+}

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisWorkerSourceStage.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisWorkerSourceStage.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesis
+
+import java.util
+import java.util.concurrent.Semaphore
+
+import akka.stream.alpakka.kinesis.KinesisErrors.WorkerUnexpectedShutdown
+import akka.stream.alpakka.kinesis.worker.{CommittableRecord, IRecordProcessor}
+import akka.stream.stage._
+import akka.stream.{Attributes, Outlet, SourceShape}
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessorFactory
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+
+class KinesisWorkerSourceStage(
+    bufferSize: Int,
+    checkWorkerPeriodicity: FiniteDuration,
+    workerBuilder: IRecordProcessorFactory => Worker
+)(implicit executor: ExecutionContext)
+    extends GraphStage[SourceShape[CommittableRecord]] {
+
+  private val out: Outlet[CommittableRecord] = Outlet("KinesisWorkerSourceStage.out")
+  override val shape: SourceShape[CommittableRecord] = SourceShape(out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new TimerGraphStageLogic(shape) with StageLogging {
+      private val buffer = new util.ArrayDeque[CommittableRecord]()
+      // We're transmitting backpressure to the worker with a semaphore instance
+      // semaphore.acquire ~> callback ~> push downstream ~> semaphore.release
+      private var semaphore: Semaphore = _
+      private var worker: Worker = _
+
+      private def tryToProduce(): Unit =
+        if (!buffer.isEmpty && isAvailable(out)) {
+          push(out, buffer.poll())
+          semaphore.release()
+        }
+
+      override protected def onTimer(timerKey: Any): Unit =
+        if (worker.hasGracefulShutdownStarted && isAvailable(out)) {
+          failStage(WorkerUnexpectedShutdown)
+        }
+
+      override def preStart(): Unit = {
+        semaphore = new Semaphore(bufferSize)
+
+        val callback = getAsyncCallback[CommittableRecord] { record =>
+          buffer.offer(record)
+          tryToProduce()
+        }
+        worker = workerBuilder(
+          new IRecordProcessorFactory {
+            override def createProcessor(): IRecordProcessor =
+              new IRecordProcessor(record => {
+                semaphore.acquire()
+                callback.invoke(record)
+              })
+          }
+        )
+        log.info(s"Created Worker instance {} of application {}", worker, worker.getApplicationName)
+        schedulePeriodically("check-worker-shutdown", checkWorkerPeriodicity)
+        executor.execute(worker)
+      }
+
+      override def postStop(): Unit = {
+        buffer.clear()
+        Future(worker.shutdown())
+        log.info(s"Shut down Worker instance {} of application {}", worker, worker.getApplicationName)
+      }
+
+      setHandler(out, new OutHandler {
+        override def onPull(): Unit =
+          tryToProduce()
+      })
+    }
+
+}

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/javadsl/KinesisWorker.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/javadsl/KinesisWorker.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesis.javadsl
+
+import java.util.concurrent.Executor
+
+import akka.NotUsed
+import akka.stream.alpakka.kinesis.worker.CommittableRecord
+import akka.stream.alpakka.kinesis.{scaladsl, _}
+import akka.stream.javadsl.{Flow, Sink, Source}
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessorFactory
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker
+import com.amazonaws.services.kinesis.model.Record
+
+import scala.concurrent.ExecutionContext
+
+object KinesisWorker {
+
+  abstract class WorkerBuilder {
+    def build(r: IRecordProcessorFactory): Worker
+  }
+
+  def create(
+      workerBuilder: WorkerBuilder,
+      settings: KinesisWorkerSourceSettings,
+      workerExecutor: Executor
+  ): Source[CommittableRecord, NotUsed] =
+    scaladsl.KinesisWorker
+      .apply(workerBuilder.build, settings)(ExecutionContext.fromExecutor(workerExecutor))
+      .asJava
+
+  def create(
+      workerBuilder: WorkerBuilder,
+      workerExecutor: Executor
+  ): Source[CommittableRecord, NotUsed] =
+    create(workerBuilder, KinesisWorkerSourceSettings.defaultInstance, workerExecutor)
+
+  def checkpointRecordsFlow(
+      settings: KinesisWorkerCheckpointSettings
+  ): Flow[CommittableRecord, Record, NotUsed] =
+    scaladsl.KinesisWorker.checkpointRecordsFlow(settings).asJava
+
+  def checkpointRecordsFlow(): Flow[CommittableRecord, Record, NotUsed] =
+    checkpointRecordsFlow(KinesisWorkerCheckpointSettings.defaultInstance)
+
+  def checkpointRecordsSink(
+      settings: KinesisWorkerCheckpointSettings
+  ): Sink[CommittableRecord, NotUsed] =
+    scaladsl.KinesisWorker.checkpointRecordsSink(settings).asJava
+
+  def checkpointRecordsSink(): Sink[CommittableRecord, NotUsed] =
+    checkpointRecordsSink(KinesisWorkerCheckpointSettings.defaultInstance)
+}

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisWorker.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisWorker.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesis.scaladsl
+
+import akka.NotUsed
+import akka.stream.Supervision.{Resume, Stop}
+import akka.stream.alpakka.kinesis.worker.CommittableRecord
+import akka.stream.alpakka.kinesis.{
+  KinesisWorkerCheckpointSettings,
+  KinesisWorkerSourceSettings,
+  KinesisWorkerSourceStage
+}
+import akka.stream.{scaladsl, ActorAttributes, FlowShape}
+import akka.stream.scaladsl.{Flow, GraphDSL, Sink, Source, Zip}
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessorFactory
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker
+import com.amazonaws.services.kinesis.model.Record
+
+import scala.collection.immutable
+import scala.concurrent.{ExecutionContext, Future}
+
+object KinesisWorker {
+
+  def apply(
+      workerBuilder: IRecordProcessorFactory => Worker,
+      settings: KinesisWorkerSourceSettings = KinesisWorkerSourceSettings.defaultInstance
+  )(implicit workerExecutor: ExecutionContext): Source[CommittableRecord, NotUsed] =
+    Source.fromGraph(new KinesisWorkerSourceStage(settings.bufferSize, settings.checkWorkerPeriodicity, workerBuilder))
+
+  def checkpointRecordsFlow(
+      settings: KinesisWorkerCheckpointSettings = KinesisWorkerCheckpointSettings.defaultInstance
+  ): Flow[CommittableRecord, Record, NotUsed] =
+    Flow[CommittableRecord]
+      .groupBy(MAX_KINESIS_SHARDS, _.shardId)
+      .groupedWithin(settings.maxBatchSize, settings.maxBatchWait)
+      .via(GraphDSL.create() { implicit b ⇒
+        import GraphDSL.Implicits._
+
+        val `{` = b.add(scaladsl.Broadcast[immutable.Seq[CommittableRecord]](2))
+        val `}` = b.add(Zip[Unit, immutable.Seq[CommittableRecord]])
+        val `=` = b.add(Flow[Record])
+
+        `{`.out(0)
+          .map(_.max)
+          .mapAsync(1)(r => if (r.canBeCheckpointed()) r.checkpoint() else Future.successful(())) ~> `}`.in0
+        `{`.out(1) ~> `}`.in1
+
+        `}`.out.map(_._2).mapConcat(identity).map(_.record) ~> `=`
+
+        FlowShape(`{`.in, `=`.out)
+      })
+      .mergeSubstreams
+      .withAttributes(ActorAttributes.supervisionStrategy {
+        case _: com.amazonaws.services.kinesis.clientlibrary.exceptions.ShutdownException => Resume
+        case _ => Stop
+      })
+
+  def checkpointRecordsSink(
+      settings: KinesisWorkerCheckpointSettings = KinesisWorkerCheckpointSettings.defaultInstance
+  ): Sink[CommittableRecord, NotUsed] =
+    checkpointRecordsFlow(settings).to(Sink.ignore)
+
+  // http://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html
+  private val MAX_KINESIS_SHARDS = 500
+
+}

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/worker/CommittableRecord.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/worker/CommittableRecord.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesis.worker
+
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason
+import com.amazonaws.services.kinesis.clientlibrary.types.ExtendedSequenceNumber
+import com.amazonaws.services.kinesis.model.Record
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CommittableRecord(
+    val shardId: String,
+    val recordProcessorStartingSequenceNumber: ExtendedSequenceNumber,
+    val millisBehindLatest: Long,
+    val record: Record,
+    recordProcessor: IRecordProcessor,
+    checkpointer: IRecordProcessorCheckpointer
+)(implicit executor: ExecutionContext) {
+
+  val sequenceNumber: String = record.getSequenceNumber
+
+  def recordProcessorShutdownReason(): Option[ShutdownReason] =
+    recordProcessor.shutdown
+  def canBeCheckpointed(): Boolean =
+    recordProcessorShutdownReason().isEmpty
+  def checkpoint(): Future[Unit] =
+    Future(checkpointer.checkpoint(record))
+
+}
+
+object CommittableRecord {
+
+  implicit val orderBySequenceNumber: Ordering[CommittableRecord] = Ordering.by(_.sequenceNumber)
+
+}

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/worker/IRecordProcessor.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/worker/IRecordProcessor.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesis.worker
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason
+import com.amazonaws.services.kinesis.clientlibrary.types.{
+  ExtendedSequenceNumber,
+  InitializationInput,
+  ProcessRecordsInput,
+  ShutdownInput
+}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+
+private[kinesis] class IRecordProcessor(
+    callback: CommittableRecord => Unit
+)(implicit executionContext: ExecutionContext)
+    extends com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor {
+  private var shardId: String = _
+  private var extendedSequenceNumber: ExtendedSequenceNumber = _
+
+  var shutdown: Option[ShutdownReason] = None
+
+  override def initialize(initializationInput: InitializationInput): Unit = {
+    this.shardId = initializationInput.getShardId
+    this.extendedSequenceNumber = initializationInput.getExtendedSequenceNumber
+  }
+
+  override def processRecords(processRecordsInput: ProcessRecordsInput): Unit =
+    processRecordsInput.getRecords.asScala.foreach { record =>
+      callback(
+        new CommittableRecord(
+          shardId,
+          extendedSequenceNumber,
+          processRecordsInput.getMillisBehindLatest,
+          record,
+          recordProcessor = this,
+          processRecordsInput.getCheckpointer
+        )
+      )
+    }
+
+  override def shutdown(shutdownInput: ShutdownInput): Unit =
+    shutdown = Some(shutdownInput.getShutdownReason)
+
+}

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/DefaultTestContext.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/DefaultTestContext.scala
@@ -4,26 +4,36 @@
 
 package akka.stream.alpakka.kinesis
 
+import java.util.concurrent.{Executors, TimeoutException}
+
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
 import com.amazonaws.services.kinesis.AmazonKinesisAsync
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker
 import org.mockito.Mockito.reset
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.concurrent.{blocking, Await, ExecutionContext}
 
 trait DefaultTestContext extends BeforeAndAfterAll with BeforeAndAfterEach with MockitoSugar { this: Suite =>
 
   implicit protected val system: ActorSystem = ActorSystem()
   implicit protected val materializer: Materializer = ActorMaterializer()
+  private val threadPool = Executors.newFixedThreadPool(10)
+  implicit protected val executionContext = ExecutionContext.fromExecutor(threadPool)
+
   implicit protected val amazonKinesisAsync: AmazonKinesisAsync = mock[AmazonKinesisAsync]
 
   override protected def beforeEach(): Unit =
     reset(amazonKinesisAsync)
 
-  override protected def afterAll(): Unit =
+  override protected def afterAll(): Unit = {
     Await.ready(system.terminate(), 5.seconds)
+    threadPool.shutdown()
+    if (!blocking(threadPool.awaitTermination(5, SECONDS))) throw new TimeoutException()
+  }
 
 }

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisWorkerSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisWorkerSpec.scala
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesis
+
+import java.nio.ByteBuffer
+import java.util.Date
+import java.util.concurrent.Semaphore
+
+import akka.stream.KillSwitches
+import akka.stream.alpakka.kinesis.KinesisErrors.WorkerUnexpectedShutdown
+import akka.stream.alpakka.kinesis.scaladsl.KinesisWorker
+import akka.stream.alpakka.kinesis.worker.{CommittableRecord, IRecordProcessor}
+import akka.stream.scaladsl.Keep
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessorFactory
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.{v2, IRecordProcessorCheckpointer}
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{ShutdownReason, Worker}
+import com.amazonaws.services.kinesis.clientlibrary.types.{
+  ExtendedSequenceNumber,
+  InitializationInput,
+  ProcessRecordsInput,
+  ShutdownInput
+}
+import com.amazonaws.services.kinesis.model.Record
+import org.mockito.Mockito._
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{Matchers, WordSpecLike}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+
+class KinesisWorkerSpec extends WordSpecLike with Matchers with DefaultTestContext with Eventually {
+
+  "KinesisWorker Source" must {
+
+    "publish records downstream" in new KinesisWorkerContext with TestData {
+      recordProcessor.initialize(initializationInput)
+      recordProcessor.processRecords(recordsInput)
+
+      val producedRecord = sinkProbe.requestNext()
+      producedRecord.recordProcessorStartingSequenceNumber shouldBe initializationInput.getExtendedSequenceNumber
+      producedRecord.shardId shouldBe initializationInput.getShardId
+      producedRecord.millisBehindLatest shouldBe recordsInput.getMillisBehindLatest
+      producedRecord.record shouldBe record
+
+      killSwitch.shutdown()
+
+      sinkProbe.expectComplete()
+    }
+
+    "publish records downstream using different IRecordProcessor incarnations" in new KinesisWorkerContext
+    with TestData {
+      recordProcessor.initialize(initializationInput)
+      recordProcessor.processRecords(recordsInput)
+
+      var producedRecord = sinkProbe.requestNext()
+      producedRecord.recordProcessorStartingSequenceNumber shouldBe initializationInput.getExtendedSequenceNumber
+      producedRecord.shardId shouldBe initializationInput.getShardId
+      producedRecord.millisBehindLatest shouldBe recordsInput.getMillisBehindLatest
+      producedRecord.record shouldBe record
+
+      val newRecordProcessor = recordProcessorFactory.createProcessor()
+
+      newRecordProcessor.initialize(initializationInput)
+      newRecordProcessor.processRecords(recordsInput)
+
+      producedRecord = sinkProbe.requestNext()
+      producedRecord.recordProcessorStartingSequenceNumber shouldBe initializationInput.getExtendedSequenceNumber
+      producedRecord.shardId shouldBe initializationInput.getShardId
+      producedRecord.millisBehindLatest shouldBe recordsInput.getMillisBehindLatest
+      producedRecord.record shouldBe record
+
+      killSwitch.shutdown()
+
+      sinkProbe.expectComplete()
+    }
+
+    "backpressure the IRecordProcessor when the downstream backpressures and the buffer size gets full" in {
+      pending
+    }
+
+    "call Worker shutdown on stage completion" in new KinesisWorkerContext {
+      killSwitch.shutdown()
+
+      sinkProbe.expectComplete()
+      eventually {
+        verify(worker).run()
+        verify(worker).shutdown()
+      }
+    }
+
+    "complete the stage if the Worker is shutdown" in new KinesisWorkerContext(workerShuttingDown = true) {
+      sinkProbe.expectError(WorkerUnexpectedShutdown)
+      eventually {
+        verify(worker).run()
+      }
+    }
+  }
+
+  private abstract class KinesisWorkerContext(workerShuttingDown: Boolean = false) {
+    protected val worker = org.mockito.Mockito.mock(classOf[Worker])
+    if (workerShuttingDown) when(worker.hasGracefulShutdownStarted()).thenReturn(true)
+
+    val semaphore = new Semaphore(0)
+
+    var recordProcessorFactory: IRecordProcessorFactory = _
+    var recordProcessor: v2.IRecordProcessor = _
+    val workerBuilder = { x: IRecordProcessorFactory =>
+      recordProcessorFactory = x
+      recordProcessor = x.createProcessor()
+      semaphore.release()
+      worker
+    }
+    val (killSwitch, sinkProbe) =
+      KinesisWorker(workerBuilder, KinesisWorkerSourceSettings(bufferSize = 10, checkWorkerPeriodicity = 1 second))
+        .viaMat(KillSwitches.single)(Keep.right)
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+    sinkProbe.ensureSubscription()
+    sinkProbe.request(1)
+
+    semaphore.acquire()
+  }
+
+  private trait TestData {
+    protected val checkpointer = org.mockito.Mockito.mock(classOf[IRecordProcessorCheckpointer])
+
+    val initializationInput =
+      new InitializationInput()
+        .withShardId("shardId")
+        .withExtendedSequenceNumber(ExtendedSequenceNumber.AT_TIMESTAMP)
+    val record =
+      new Record()
+        .withApproximateArrivalTimestamp(new Date())
+        .withEncryptionType("encryption")
+        .withPartitionKey("partitionKey")
+        .withSequenceNumber("sequenceNum")
+        .withData(ByteBuffer.wrap(Array[Byte](1)))
+    val recordsInput =
+      new ProcessRecordsInput()
+        .withCheckpointer(checkpointer)
+        .withMillisBehindLatest(1L)
+        .withRecords(List(record).asJava)
+  }
+
+  "KinesisWorker checkpoint Flow " must {
+
+    "checkpoint batch of records of different shards" in new KinesisWorkerCheckpointContext {
+      val recordProcessor = new IRecordProcessor(_ => ())
+
+      val checkpointerShard1 = org.mockito.Mockito.mock(classOf[IRecordProcessorCheckpointer])
+      var latestRecordShard1: Record = _
+      for (i <- 1 to 3) {
+        val record = org.mockito.Mockito.mock(classOf[Record])
+        when(record.getSequenceNumber).thenReturn(i.toString)
+        sourceProbe.sendNext(
+          new CommittableRecord(
+            "shard-1",
+            org.mockito.Mockito.mock(classOf[ExtendedSequenceNumber]),
+            1L,
+            record,
+            recordProcessor,
+            checkpointerShard1
+          )
+        )
+        latestRecordShard1 = record
+      }
+      val checkpointerShard2 = org.mockito.Mockito.mock(classOf[IRecordProcessorCheckpointer])
+      var latestRecordShard2: Record = _
+      for (i <- 1 to 3) {
+        val record = org.mockito.Mockito.mock(classOf[Record])
+        when(record.getSequenceNumber).thenReturn(i.toString)
+        sourceProbe.sendNext(
+          new CommittableRecord(
+            "shard-2",
+            org.mockito.Mockito.mock(classOf[ExtendedSequenceNumber]),
+            1L,
+            record,
+            recordProcessor,
+            checkpointerShard2
+          )
+        )
+        latestRecordShard2 = record
+      }
+
+      for (_ <- 1 to 6) sinkProbe.requestNext()
+
+      eventually {
+        verify(checkpointerShard1).checkpoint(latestRecordShard1)
+        verify(checkpointerShard2).checkpoint(latestRecordShard2)
+      }
+
+      sourceProbe.sendComplete()
+      sinkProbe.expectComplete()
+    }
+
+    "not checkpoint the batch if the IRecordProcessor has been shutdown" in new KinesisWorkerCheckpointContext {
+      val recordProcessor = new IRecordProcessor(_ => ())
+      recordProcessor.shutdown(new ShutdownInput().withShutdownReason(ShutdownReason.TERMINATE))
+      val record = org.mockito.Mockito.mock(classOf[Record])
+      when(record.getSequenceNumber).thenReturn("1")
+      val committableRecord = new CommittableRecord(
+        "shard-1",
+        org.mockito.Mockito.mock(classOf[ExtendedSequenceNumber]),
+        1L,
+        record,
+        recordProcessor,
+        org.mockito.Mockito.mock(classOf[IRecordProcessorCheckpointer])
+      )
+      sourceProbe.sendNext(committableRecord)
+
+      sinkProbe.requestNext()
+
+      sourceProbe.sendComplete()
+      sinkProbe.expectComplete()
+    }
+
+    "fail with Exception if checkpoint action fails" in new KinesisWorkerCheckpointContext {
+      val recordProcessor = new IRecordProcessor(_ => ())
+      val record = org.mockito.Mockito.mock(classOf[Record])
+      when(record.getSequenceNumber).thenReturn("1")
+      val checkpointer = org.mockito.Mockito.mock(classOf[IRecordProcessorCheckpointer])
+      val committableRecord = new CommittableRecord(
+        "shard-1",
+        org.mockito.Mockito.mock(classOf[ExtendedSequenceNumber]),
+        1L,
+        record,
+        recordProcessor,
+        checkpointer
+      )
+      sourceProbe.sendNext(committableRecord)
+
+      val failure = new RuntimeException()
+      when(checkpointer.checkpoint(record)).thenThrow(failure)
+
+      sinkProbe.request(1)
+
+      sinkProbe.expectError(failure)
+    }
+
+  }
+
+  private trait KinesisWorkerCheckpointContext {
+    val (sourceProbe, sinkProbe) =
+      TestSource
+        .probe[CommittableRecord]
+        .via(
+          KinesisWorker
+            .checkpointRecordsFlow(KinesisWorkerCheckpointSettings(maxBatchSize = 100, maxBatchWait = 500 millis))
+        )
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -232,7 +232,8 @@ object Dependencies {
   val Kinesis = Seq(
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-java-sdk-kinesis" % AwsSdkVersion, // ApacheV2
-      "org.mockito" % "mockito-core" % "2.7.11" % Test // MIT
+      "com.amazonaws" % "amazon-kinesis-client" % "1.8.8", // Amazon Software License
+      "org.mockito"   % "mockito-core"     % "2.7.11"    % Test // MIT
     )
   )
 }


### PR DESCRIPTION
Kinesis Source using KCL library. Tests pending, early reviews are much welcome.

The motivation behind this is that it'll allow alpakka users to automatically handle sharding among clients of Kinesis streams, simplified checkpoint of records' sequence using Dynamo and the potential usage of the KPL library for higher throughput (with local dynamic buffering and batching).