### PR TITLE
Change DynamoClient to accept Materializer instead of ActorMaterializer

### DIFF
--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
@@ -13,7 +13,7 @@ import akka.http.scaladsl.model.{ContentType, HttpEntity, _}
 import akka.stream.alpakka.dynamodb.AwsOp
 import akka.stream.alpakka.dynamodb.impl.AwsClient.{AwsConnect, AwsRequestMetadata}
 import akka.stream.scaladsl.Flow
-import akka.stream.{ActorAttributes, ActorMaterializer, Supervision}
+import akka.stream.{ActorAttributes, Materializer, Supervision}
 import com.amazonaws.auth.{AWS4Signer, DefaultAWSCredentialsProviderChain}
 import com.amazonaws.http.{HttpMethodName, HttpResponseHandler, HttpResponse => AWSHttpResponse}
 import com.amazonaws.{DefaultRequest, HttpMethod => _, _}
@@ -34,7 +34,7 @@ private[alpakka] trait AwsClient[S <: ClientSettings] {
 
   protected implicit def system: ActorSystem
 
-  protected implicit def materializer: ActorMaterializer
+  protected implicit def materializer: Materializer
 
   protected implicit def ec: ExecutionContext
 

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoClientImpl.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoClientImpl.scala
@@ -7,7 +7,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.MediaType.NotCompressible
 import akka.http.scaladsl.model.{ContentType, MediaType}
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.alpakka.dynamodb.AwsOp
 import akka.stream.alpakka.dynamodb.impl.AwsClient.{AwsConnect, AwsRequestMetadata}
 import akka.stream.scaladsl.{Sink, Source}
@@ -17,7 +17,7 @@ import com.amazonaws.http.HttpResponseHandler
 class DynamoClientImpl(
     val settings: DynamoSettings,
     val errorResponseHandler: HttpResponseHandler[AmazonServiceException]
-)(implicit protected val system: ActorSystem, implicit protected val materializer: ActorMaterializer)
+)(implicit protected val system: ActorSystem, implicit protected val materializer: Materializer)
     extends AwsClient[DynamoSettings] {
 
   override protected val service = "dynamodb"

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/javadsl/DynamoClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/javadsl/DynamoClient.scala
@@ -4,7 +4,7 @@
 package akka.stream.alpakka.dynamodb.javadsl
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.alpakka.dynamodb.AwsOp
 import akka.stream.alpakka.dynamodb.impl.{DynamoClientImpl, DynamoSettings}
 import akka.stream.alpakka.dynamodb.scaladsl.DynamoImplicits
@@ -14,11 +14,11 @@ import com.amazonaws.services.dynamodbv2.model._
 import scala.concurrent.Future
 
 object DynamoClient {
-  def create(settings: DynamoSettings, system: ActorSystem, materializer: ActorMaterializer) =
+  def create(settings: DynamoSettings, system: ActorSystem, materializer: Materializer) =
     new DynamoClient(settings)(system, materializer)
 }
 
-final class DynamoClient(settings: DynamoSettings)(implicit system: ActorSystem, materializer: ActorMaterializer) {
+final class DynamoClient(settings: DynamoSettings)(implicit system: ActorSystem, materializer: Materializer) {
 
   private val client = new DynamoClientImpl(settings, DynamoImplicits.errorResponseHandler)
   private implicit val ec = system.dispatcher

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoClient.scala
@@ -4,17 +4,17 @@
 package akka.stream.alpakka.dynamodb.scaladsl
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.alpakka.dynamodb.AwsOp
 import akka.stream.alpakka.dynamodb.impl.{DynamoClientImpl, DynamoSettings}
 import akka.stream.scaladsl.{Sink, Source}
 
 object DynamoClient {
-  def apply(settings: DynamoSettings)(implicit system: ActorSystem, materializer: ActorMaterializer) =
+  def apply(settings: DynamoSettings)(implicit system: ActorSystem, materializer: Materializer) =
     new DynamoClient(settings)
 }
 
-final class DynamoClient(settings: DynamoSettings)(implicit system: ActorSystem, materializer: ActorMaterializer) {
+final class DynamoClient(settings: DynamoSettings)(implicit system: ActorSystem, materializer: Materializer) {
   private val client = new DynamoClientImpl(settings, DynamoImplicits.errorResponseHandler)
 
   val flow = client.flow


### PR DESCRIPTION
`DynamoClientImpl` accepts an `ActorMaterializer` when it could use the more specific type of `Materializer` (see: https://github.com/akka/alpakka/blob/master/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoClientImpl.scala#L20).

Other clients, such as the s3 client use a `Materializer` instead (see: https://github.com/akka/alpakka/blob/master/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala#L48).

See: #437