### PR TITLE
FTP: include imports in examples

### DIFF
--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -41,10 +41,10 @@ Gradle
 In order to establish a connection with the remote server, you need to provide a specialized version of a @scaladoc[RemoteFileSettings](akka.stream.alpakka.ftp.RemoteFileSettings) instance. It's specialized as it depends on the kind of server you're connecting to: FTP, FTPs or SFTP.
 
 Scala
-: @@snip (../../../../ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala) { #create-settings }
+: @@snip (../../../../ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #create-settings }
 
 Java
-: @@snip (../../../../ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java) { #create-settings }
+: @@snip (../../../../ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpSettingsExample.java) { #create-settings }
 
 The configuration above will create an anonymous connection with a remote FTP server in passive mode. For both FTPs and SFTP servers, you will need to provide the specialized versions of these settings: @scaladoc[FtpsSettings](akka.stream.alpakka.ftp.RemoteFileSettings$$FtpsSettings) or @scaladoc[SftpSettings](akka.stream.alpakka.ftp.RemoteFileSettings$$SftpSettings)
 respectively.
@@ -58,10 +58,10 @@ For connection using a private key, please provide an instance of @scaladoc[Sftp
 In order to traverse a remote folder recursively, you need to use the `ls` method in the FTP API:
 
 Scala
-: @@snip (../../../../ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala) { #traversing }
+: @@snip (../../../../ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #traversing }
 
 Java
-: @@snip (../../../../ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java) { #traversing }
+: @@snip (../../../../ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpTraversingExample.java) { #traversing }
 
 This source will emit @scaladoc[FtpFile](akka.stream.alpakka.ftp.FtpFile) elements with no significant materialization.
 
@@ -72,10 +72,10 @@ For both FTPs and SFTP servers, you will need to use the `FTPs` and `SFTP` API r
 In order to retrieve a remote file as a stream of bytes, you need to use the `fromPath` method in the FTP API:
 
 Scala
-: @@snip (../../../../ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala) { #retrieving }
+: @@snip (../../../../ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #retrieving }
 
 Java
-: @@snip (../../../../ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java) { #retrieving }
+: @@snip (../../../../ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpRetrievingExample.java) { #retrieving }
 
 This source will emit @scaladoc[ByteString](akka.util.ByteString) elements and materializes to @scaladoc[Future](scala.concurrent.Future) in Scala API and @extref[CompletionStage](java-api:java/util/concurrent/CompletionStage) in Java API of @scaladoc[IOResult](akka.stream.IOResult) when the stream finishes.
 
@@ -86,10 +86,10 @@ For both FTPs and SFTP servers, you will need to use the `FTPs` and `SFTP` API r
 In order to store a remote file from a stream of bytes, you need to use the `toPath` method in the FTP API:
 
 Scala
-: @@snip (../../../../ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala) { #storing }
+: @@snip (../../../../ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #storing }
 
 Java
-: @@snip (../../../../ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java) { #storing }
+: @@snip (../../../../ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpWritingExample.java) { #storing }
 
 This sink will consume @scaladoc[ByteString](akka.util.ByteString) elements and materializes to @scaladoc[Future](scala.concurrent.Future) in Scala API and @extref[CompletionStage](java-api:java/util/concurrent/CompletionStage) in Java API of @scaladoc[IOResult](akka.stream.IOResult) when the stream finishes.
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java
@@ -30,26 +30,19 @@ public class FtpStageTest extends PlainFtpSupportImpl implements CommonFtpStageT
     CommonFtpStageTest.super.toPath();
   }
 
-  //#traversing
   public Source<FtpFile, NotUsed> getBrowserSource(String basePath) throws Exception {
     return Ftp.ls(basePath, settings());
   }
-  //#traversing
 
-  //#retrieving
   public Source<ByteString, CompletionStage<IOResult>> getIOSource(String path) throws Exception {
     return Ftp.fromPath(path, settings());
   }
-  //#retrieving
 
-  //#storing
   public Sink<ByteString, CompletionStage<IOResult>> getIOSink(String path) throws Exception {
     return Ftp.toPath(path, settings());
   }
-  //#storing
 
   private FtpSettings settings() throws Exception {
-    //#create-settings
     final FtpSettings settings = new FtpSettings(
             InetAddress.getByName("localhost"),
             getPort(),
@@ -57,7 +50,6 @@ public class FtpStageTest extends PlainFtpSupportImpl implements CommonFtpStageT
             false, // binary
             true   // passiveMode
     );
-    //#create-settings
     return settings;
   }
 }

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpRetrievingExample.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpRetrievingExample.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.ftp.examples;
+
+//#retrieving
+import akka.stream.IOResult;
+import akka.stream.alpakka.ftp.FtpSettings;
+import akka.stream.alpakka.ftp.javadsl.Ftp;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+import java.util.concurrent.CompletionStage;
+
+public class FtpRetrievingExample {
+
+    public Source<ByteString, CompletionStage<IOResult>> retrieveFromPath(String path, FtpSettings settings) throws Exception {
+        return Ftp.fromPath(path, settings);
+    }
+}
+//#retrieving

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpSettingsExample.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpSettingsExample.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.ftp.examples;
+
+//#create-settings
+import akka.stream.alpakka.ftp.FtpCredentials;
+import akka.stream.alpakka.ftp.FtpSettings;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class FtpSettingsExample {
+    private FtpSettings settings;
+
+    public FtpSettingsExample() {
+        try {
+            settings =  new FtpSettings(
+                    InetAddress.getByName("localhost"),
+                    FtpSettings.DefaultFtpPort(),
+                    FtpCredentials.createAnonCredentials(),
+                    false, // binary
+                    true // passiveMode
+            );
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
+    }
+}
+//#create-settings

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpTraversingExample.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpTraversingExample.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.ftp.examples;
+
+//#traversing
+import akka.NotUsed;
+import akka.stream.alpakka.ftp.FtpFile;
+import akka.stream.alpakka.ftp.FtpSettings;
+import akka.stream.alpakka.ftp.javadsl.Ftp;
+import akka.stream.javadsl.Source;
+
+public class FtpTraversingExample {
+
+    public Source<FtpFile, NotUsed> listFiles(String basePath, FtpSettings settings) throws Exception {
+        return Ftp.ls(basePath, settings);
+    }
+}
+//#traversing

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpWritingExample.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpWritingExample.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.ftp.examples;
+
+//#storing
+import akka.stream.IOResult;
+import akka.stream.alpakka.ftp.FtpSettings;
+import akka.stream.alpakka.ftp.javadsl.Ftp;
+import akka.stream.javadsl.Sink;
+import akka.util.ByteString;
+
+import java.util.concurrent.CompletionStage;
+
+public class FtpWritingExample {
+
+    public Sink<ByteString, CompletionStage<IOResult>> storeToPath(String path, FtpSettings settings) throws Exception {
+        return Ftp.toPath(path, settings);
+    }
+}
+//#storing

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
@@ -14,7 +14,6 @@ import java.net.InetAddress
 
 trait BaseFtpSpec extends PlainFtpSupportImpl with BaseSpec {
 
-  //#create-settings
   val settings = FtpSettings(
     InetAddress.getByName("localhost"),
     getPort,
@@ -22,20 +21,13 @@ trait BaseFtpSpec extends PlainFtpSupportImpl with BaseSpec {
     binary = true,
     passiveMode = true
   )
-  //#create-settings
 
-  //#traversing
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =
     Ftp.ls(basePath, settings)
-  //#traversing
 
-  //#retrieving
   protected def retrieveFromPath(path: String): Source[ByteString, Future[IOResult]] =
     Ftp.fromPath(path, settings)
-  //#retrieving
 
-  //#storing
   protected def storeToPath(path: String, append: Boolean): Sink[ByteString, Future[IOResult]] =
     Ftp.toPath(path, settings, append)
-  //#storing
 }

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.ftp
+
+object scalaExamples {
+
+  // settings
+  object settings {
+    //#create-settings
+    import akka.stream.alpakka.ftp.FtpCredentials.AnonFtpCredentials
+    import java.net.InetAddress
+
+    val settings = FtpSettings(
+      InetAddress.getByName("localhost"),
+      credentials = AnonFtpCredentials,
+      binary = true,
+      passiveMode = true
+    )
+    //#create-settings
+  }
+
+  object traversing {
+    //#traversing
+    import akka.NotUsed
+    import akka.stream.alpakka.ftp.scaladsl.Ftp
+    import akka.stream.scaladsl.Source
+
+    def listFiles(basePath: String, settings: FtpSettings): Source[FtpFile, NotUsed] =
+      Ftp.ls(basePath, settings)
+
+    //#traversing
+  }
+
+  object retrieving {
+    //#retrieving
+    import akka.stream.IOResult
+    import akka.stream.alpakka.ftp.scaladsl.Ftp
+    import akka.stream.scaladsl.Source
+    import akka.util.ByteString
+    import scala.concurrent.Future
+
+    def retrieveFromPath(path: String, settings: FtpSettings): Source[ByteString, Future[IOResult]] =
+      Ftp.fromPath(path, settings)
+
+    //#retrieving
+  }
+
+  object storing {
+    //#storing
+    import akka.stream.IOResult
+    import akka.stream.alpakka.ftp.scaladsl.Ftp
+    import akka.stream.scaladsl.Sink
+    import akka.util.ByteString
+    import scala.concurrent.Future
+
+    def storeToPath(path: String, settings: FtpSettings, append: Boolean): Sink[ByteString, Future[IOResult]] =
+      Ftp.toPath(path, settings, append)
+    //#storing
+  }
+}


### PR DESCRIPTION
Documentation improved by adding imports on examples.

closes #396 