### PR TITLE
Support for ibm cloud object storage

### DIFF
--- a/docs/src/main/paradox/s3.md
+++ b/docs/src/main/paradox/s3.md
@@ -120,4 +120,4 @@ Scala
 : @@snip (../../../../s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/DocSnippets.scala) { #scala-bluemix-example }
 
 Java
-: @@snip (../../../../s3/src/test/java/akka/stream/alpakka/s3/javadsl/DocSnippets.java) { #scala-bluemix-example }
+: @@snip (../../../../s3/src/test/java/akka/stream/alpakka/s3/javadsl/DocSnippets.java) { #java-bluemix-example }

--- a/docs/src/main/paradox/s3.md
+++ b/docs/src/main/paradox/s3.md
@@ -98,3 +98,26 @@ Java
     sbt
     > s3/test
     ```
+
+# Bluemix Cloud Object Storage with S3 API
+
+The Alpakka S3 connector can connect to a range of S3 compatible services. One of them is IBM Bluemix Cloud Object Storage, which supports a dialect of the AWS S3 API.
+Most functionality provided by the Alpakka S3 connector is compatible with Cloud Object Store, but there are a few limitations, which are listed below.
+
+## Connection limitations
+
+- This S3 connector does not support domain-style access for Cloud Object Store, so only path-style access is supported.
+- Regions in COS are always part of the host/endpoint, therefore leave the s3Region field in S3Settings empty
+- The object proxy, containing host/endpoint, port and scheme, must always be specified.
+
+## External references 
+
+[IBM Cloud Object Storage Documentation](https://ibm-public-cos.github.io/crs-docs/api-reference)
+
+## Example
+
+Scala
+: @@snip (../../../../s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/DocSnippets.scala) { #scala-bluemix-example }
+
+Java
+: @@snip (../../../../s3/src/test/java/akka/stream/alpakka/s3/javadsl/DocSnippets.java) { #scala-bluemix-example }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
@@ -16,7 +16,7 @@ private[alpakka] object Marshalling {
   import ScalaXmlSupport._
 
   implicit val multipartUploadUnmarshaller: FromEntityUnmarshaller[MultipartUpload] = {
-    nodeSeqUnmarshaller(ContentTypes.`application/octet-stream`) map {
+    nodeSeqUnmarshaller(MediaTypes.`application/xml`, ContentTypes.`application/octet-stream`) map {
       case NodeSeq.Empty => throw Unmarshaller.NoContentException
       case x =>
         MultipartUpload(S3Location((x \ "Bucket").text, (x \ "Key").text), (x \ "UploadId").text)

--- a/s3/src/test/java/akka/stream/alpakka/s3/javadsl/DocSnippets.java
+++ b/s3/src/test/java/akka/stream/alpakka/s3/javadsl/DocSnippets.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.s3.javadsl;
+
+import akka.NotUsed;
+import akka.http.javadsl.model.Uri;
+import akka.http.javadsl.model.headers.ByteRange;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.alpakka.s3.BufferType;
+import akka.stream.alpakka.s3.MemoryBufferType;
+import akka.stream.alpakka.s3.Proxy;
+import akka.stream.alpakka.s3.S3Settings;
+import akka.stream.alpakka.s3.auth.AWSCredentials;
+import akka.stream.alpakka.s3.auth.BasicCredentials;
+import akka.stream.alpakka.s3.scaladsl.S3WireMockBase;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+import org.junit.Test;
+
+import scala.Option;
+import scala.Some;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DocSnippets extends S3WireMockBase {
+
+    final Materializer materializer = ActorMaterializer.create(system());
+
+    // Documentation snippet only
+    public void connectBluemix() {
+        final Materializer mat = ActorMaterializer.create(system());
+        // #scala-bluemix-example
+        final String host = "s3.eu-geo.objectstorage.softlayer.net";
+        final int port = 443;
+
+        final AWSCredentials credentials = new BasicCredentials( "myAccessKeyId","mySecretAccessKey");
+        final Proxy proxy = new Proxy(host, port, "https");
+
+        // Set pathStyleAccess to true and specify proxy, leave region blank
+        final S3Settings settings = new S3Settings(MemoryBufferType.getInstance(), "", Some.apply(proxy), credentials, "", true);
+        final S3Client s3Client = new S3Client(settings,system(), mat);
+        // #scala-bluemix-example
+    }
+}

--- a/s3/src/test/java/akka/stream/alpakka/s3/javadsl/DocSnippets.java
+++ b/s3/src/test/java/akka/stream/alpakka/s3/javadsl/DocSnippets.java
@@ -37,7 +37,7 @@ public class DocSnippets extends S3WireMockBase {
     // Documentation snippet only
     public void connectBluemix() {
         final Materializer mat = ActorMaterializer.create(system());
-        // #scala-bluemix-example
+        // #java-bluemix-example
         final String host = "s3.eu-geo.objectstorage.softlayer.net";
         final int port = 443;
 
@@ -47,6 +47,6 @@ public class DocSnippets extends S3WireMockBase {
         // Set pathStyleAccess to true and specify proxy, leave region blank
         final S3Settings settings = new S3Settings(MemoryBufferType.getInstance(), "", Some.apply(proxy), credentials, "", true);
         final S3Client s3Client = new S3Client(settings,system(), mat);
-        // #scala-bluemix-example
+        // #java-bluemix-example
     }
 }

--- a/s3/src/test/resources/application.conf
+++ b/s3/src/test/resources/application.conf
@@ -2,12 +2,42 @@ akka {
   loggers = ["akka.testkit.TestEventListener"]
 }
 
-akka.stream.alpakka.s3 {
+aws {
+  akka.stream.alpakka.s3 {
 
-  debug-logging = true
+    debug-logging = true
+    buffer = "memory"
+    disk-buffer-path = ""
+    proxy = {
+      host = ""
+      port = 443
+      secure = true
+    }
+    aws = {
+      access-key-id = ""
+      secret-access-key = ""
+      default-region = "us-east-1"
+    }
+    path-style-access = false
+  }
+}
 
-  aws = {
-    access-key-id = ""
-    secret-access-key = ""
+bluemix {
+  akka.stream.alpakka.s3 {
+
+    debug-logging = true
+    buffer = "memory"
+    disk-buffer-path = ""
+    proxy = {
+      host = ""
+      port = 443
+      secure = true
+    }
+    aws = {
+      access-key-id = ""
+      secret-access-key = ""
+      default-region = ""
+    }
+    path-style-access = true
   }
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/DocSnippets.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/DocSnippets.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.s3.scaladsl
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.s3.{MemoryBufferType, Proxy, S3Settings}
+import akka.stream.alpakka.s3.auth.AWSCredentials
+
+object DoucmentationSnippets {
+
+  def connectBluemix {
+    implicit val system = ActorSystem()
+    implicit val materializer = ActorMaterializer()
+
+    // #scala-bluemix-example
+    val host = "s3.eu-geo.objectstorage.softlayer.net"
+    val port = 443
+
+    val credentials = AWSCredentials(accessKeyId = "myAccessKeyId", secretAccessKey = "mySecretAccessKey")
+    val proxy = Some(Proxy(host, port, "https"))
+
+    // Set pathStyleAccess to true and specify proxy, leave region blank
+    val settings = new S3Settings(MemoryBufferType, "", proxy, credentials, "", true)
+    val s3Client = new S3Client(settings)(system, materializer)
+    // #scala-bluemix-example
+  }
+}

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3NoMock.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3NoMock.scala
@@ -5,7 +5,9 @@ package akka.stream.alpakka.s3.scaladsl
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.stream.alpakka.s3.{MemoryBufferType, Proxy}
 import akka.stream.alpakka.s3.S3Settings
+import akka.stream.alpakka.s3.auth.AWSCredentials
 import akka.stream.alpakka.s3.impl.MetaHeaders
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
@@ -20,6 +22,7 @@ import scala.concurrent.duration._
 /*
  * This is an integration test and ignored by default
  *
+ * AWS:
  * For running the tests you need to create 2 buckets:
  *  - one in region us-east-1
  *  - one in an other region (eg eu-central-1)
@@ -27,157 +30,245 @@ import scala.concurrent.duration._
  *
  * Set your keys aws access-key-id and secret-access-key in src/test/resources/application.conf
  *
+ * Bluemix: To run the tests create two buckets, leave the region field empty
+ * since it is specified within the endpoint.Update the bucket name in the code
+ * below.
+ *
+ * Set your bluemix keys access-key-id and secret-access-key in src/test/resources/application.conf
+ *
  * Comment @ignore and run the tests
  * (tests that do listing counts might need some tweaking)
  *
  */
-@Ignore
+case class S3ConnectionProperties(
+    name: String,
+    defaultRegion: String,
+    defaultRegionBucket: String,
+    otherRegion: String,
+    otherRegionBucket: String,
+    settings: S3Settings,
+    otherRegionSettings: S3Settings,
+    defaultRegionClient: S3Client,
+    otherRegionClient: S3Client,
+    objectKey: String,
+    objectValue: String,
+    metaHeaders: Map[String, String]
+)
+
 class S3NoMock extends FlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures {
 
   implicit val actorSystem = ActorSystem()
   implicit val materializer = ActorMaterializer()
   implicit val ec = materializer.executionContext
 
-  implicit val defaultPatience =
-    PatienceConfig(timeout = Span(5, Seconds), interval = Span(30, Millis))
+  implicit val defaultPatience = PatienceConfig(timeout = Span(5, Seconds), interval = Span(30, Millis))
 
-  val defaultRegion = "us-east-1"
-  val defaultRegionBucket = "my-test-us-east-1"
+  def createAWSConnectionProperties = {
 
-  val otherRegion = "eu-central-1"
-  val otherRegionBucket = "my.test.frankfurt" // with dots forcing path style access
+    val defaultRegion = "us-east-1"
+    val defaultRegionBucket = "fad437a8-b37a-43c8-9fb8-eb18821b8d99"
 
-  val settings = S3Settings(ConfigFactory.load()).copy(s3Region = defaultRegion)
-  val otherRegionSettings = settings.copy(pathStyleAccess = true, s3Region = otherRegion)
+    val otherRegion = "eu-central-1"
+    val otherRegionBucket = "fad437a8-b37a-43c8-9fb8-eb18821b8d95"
 
-  val defaultRegionClient = new S3Client(settings)
-  val otherRegionClient = new S3Client(otherRegionSettings)
+    val settings = S3Settings(ConfigFactory.load().getConfig("aws")).copy(s3Region = defaultRegion)
+    val otherRegionSettings = settings.copy(pathStyleAccess = true, s3Region = otherRegion)
 
-  val objectKey = "test"
+    val defaultRegionClient = new S3Client(settings)
+    val otherRegionClient = new S3Client(otherRegionSettings)
 
-  val objectValue = "Some String"
-  val metaHeaders: Map[String, String] = Map("location" -> "Africa", "datatype" -> "image")
+    val objectKey = "test"
 
-  it should "list with real credentials" in {
-    val result = defaultRegionClient.listBucket(defaultRegionBucket, None).runWith(Sink.seq)
+    val objectValue = "Some String"
+    val metaHeaders: Map[String, String] = Map("location" -> "Africa", "datatype" -> "image")
 
-    val listingResult = result.futureValue
-    listingResult.size shouldBe 3
+    S3ConnectionProperties(
+      "AWS",
+      defaultRegion,
+      defaultRegionBucket,
+      otherRegion,
+      otherRegionBucket,
+      settings,
+      otherRegionSettings,
+      defaultRegionClient,
+      otherRegionClient,
+      objectKey,
+      objectValue,
+      metaHeaders
+    )
   }
 
-  it should "list with real credentials in non us-east-1 zone" in {
-    val result = otherRegionClient.listBucket(otherRegionBucket, None).runWith(Sink.seq)
+  def createBluemixConnectionProperties = {
 
-    val listingResult = result.futureValue
-    listingResult.size shouldBe 2
+    val defaultRegionBucket = "fad437a8-b37a-43c8-9fb8-eb18821b8d99"
+    val otherRegionBucket = "fad437a8-b37a-43c8-9fb8-eb18821b8d99"
+
+    val settings = S3Settings(ConfigFactory.load().getConfig("bluemix")).copy(
+      proxy = Some(Proxy(host = "s3.eu-geo.objectstorage.softlayer.net", port = 443, scheme = "https")),
+      pathStyleAccess = true,
+      s3Region = ""
+    )
+    val otherRegionSettings = settings.copy(
+      proxy = Some(Proxy(host = "s3.ams-eu-geo.objectstorage.softlayer.net", port = 443, scheme = "https")),
+      pathStyleAccess = true,
+      s3Region = ""
+    )
+
+    val defaultRegionClient = new S3Client(settings)
+    val otherRegionClient = new S3Client(otherRegionSettings)
+
+    val objectKey = "test"
+
+    val objectValue = "Some String"
+
+    S3ConnectionProperties(
+      "Bluemix",
+      "",
+      defaultRegionBucket,
+      "",
+      otherRegionBucket,
+      settings,
+      otherRegionSettings,
+      defaultRegionClient,
+      otherRegionClient,
+      objectKey,
+      objectValue,
+      Map()
+    )
   }
 
-  it should "upload with real credentials" in {
+  List(createAWSConnectionProperties, createBluemixConnectionProperties).map { settings =>
+    it should s"list with real credentials (${settings.name})" in {
+      val result = settings.defaultRegionClient.listBucket(settings.defaultRegionBucket, None).runWith(Sink.seq)
 
-    val source: Source[ByteString, Any] = Source(ByteString(objectValue) :: Nil)
-    //val source: Source[ByteString, Any] = FileIO.fromPath(Paths.get("/tmp/IMG_0470.JPG"))
+      val listingResult = result.futureValue
+      listingResult.size shouldBe 3
+    }
 
-    val result =
-      source.runWith(
-        defaultRegionClient.multipartUpload(defaultRegionBucket, objectKey, metaHeaders = MetaHeaders(metaHeaders))
-      )
+    it should s"list with real credentials in other region (${settings.name})" in {
+      val result = settings.otherRegionClient.listBucket(settings.otherRegionBucket, None).runWith(Sink.seq)
 
-    val multipartUploadResult = Await.ready(result, 90.seconds).futureValue
-    multipartUploadResult.bucket shouldBe defaultRegionBucket
-    multipartUploadResult.key shouldBe objectKey
-  }
+      val listingResult = result.futureValue
+      listingResult.size shouldBe 3
+    }
 
-  it should "download with real credentials" in {
+    it should s"upload with real credentials (${settings.name})" in {
 
-    val download = defaultRegionClient.download(defaultRegionBucket, objectKey)
+      val source: Source[ByteString, Any] = Source(ByteString(settings.objectValue) :: Nil)
+      //val source: Source[ByteString, Any] = FileIO.fromPath(Paths.get("/tmp/IMG_0470.JPG"))
 
-    val result = download.map(_.decodeString("utf8")).runWith(Sink.head)
+      val result =
+        source.runWith(
+          settings.defaultRegionClient.multipartUpload(settings.defaultRegionBucket,
+                                                       settings.objectKey,
+                                                       metaHeaders = MetaHeaders(settings.metaHeaders))
+        )
 
-    Await.ready(result, 5.seconds).futureValue shouldBe objectValue
-  }
+      val multipartUploadResult = Await.ready(result, 90.seconds).futureValue
+      multipartUploadResult.bucket shouldBe settings.defaultRegionBucket
+      multipartUploadResult.key shouldBe settings.objectKey
+    }
 
-  it should "upload and download with spaces in the key" in {
-    val objectKey = "test folder/test file.txt"
-    val source: Source[ByteString, Any] = Source(ByteString(objectValue) :: Nil)
+    it should s"download with real credentials (${settings.name})" in {
 
-    val results = for {
-      upload <- source.runWith(
-        defaultRegionClient.multipartUpload(defaultRegionBucket, objectKey, metaHeaders = MetaHeaders(metaHeaders))
-      )
-      download <- defaultRegionClient
-        .download(defaultRegionBucket, objectKey)
-        .map(_.decodeString("utf8"))
-        .runWith(Sink.head)
-    } yield (upload, download)
+      val download = settings.defaultRegionClient.download(settings.defaultRegionBucket, settings.objectKey)
 
-    val (multipartUploadResult, downloaded) = Await.result(results, 10.seconds)
+      val result = download.map(_.decodeString("utf8")).runWith(Sink.head)
 
-    multipartUploadResult.bucket shouldBe defaultRegionBucket
-    multipartUploadResult.key shouldBe objectKey
-    downloaded shouldBe objectValue
-  }
+      Await.ready(result, 5.seconds).futureValue shouldBe settings.objectValue
+    }
 
-  it should "upload and download with brackets in the key" in {
-    val objectKey = "abc/DEF/2017/06/15/1234 (1).TXT"
-    val source: Source[ByteString, Any] = Source(ByteString(objectValue) :: Nil)
+    it should s"upload and download with spaces in the key (${settings.name})" in {
+      val objectKey = "test folder/test file.txt"
+      val source: Source[ByteString, Any] = Source(ByteString(settings.objectValue) :: Nil)
 
-    val results = for {
-      upload <- source.runWith(
-        defaultRegionClient.multipartUpload(defaultRegionBucket, objectKey, metaHeaders = MetaHeaders(metaHeaders))
-      )
-      download <- defaultRegionClient
-        .download(defaultRegionBucket, objectKey)
-        .map(_.decodeString("utf8"))
-        .runWith(Sink.head)
-    } yield (upload, download)
+      val results = for {
+        upload <- source.runWith(
+          settings.defaultRegionClient.multipartUpload(settings.defaultRegionBucket,
+                                                       settings.objectKey,
+                                                       metaHeaders = MetaHeaders(settings.metaHeaders))
+        )
+        download <- settings.defaultRegionClient
+          .download(settings.defaultRegionBucket, settings.objectKey)
+          .map(_.decodeString("utf8"))
+          .runWith(Sink.head)
+      } yield (upload, download)
 
-    val (multipartUploadResult, downloaded) = Await.result(results, 10.seconds)
+      val (multipartUploadResult, downloaded) = Await.result(results, 10.seconds)
 
-    multipartUploadResult.bucket shouldBe defaultRegionBucket
-    multipartUploadResult.key shouldBe objectKey
-    downloaded shouldBe objectValue
-  }
+      multipartUploadResult.bucket shouldBe settings.defaultRegionBucket
+      multipartUploadResult.key shouldBe settings.objectKey
+      downloaded shouldBe settings.objectValue
+    }
 
-  it should "upload and download with spaces in the key in non us-east-1 zone" in {
-    val objectKey = "test folder/test file.txt"
-    val source: Source[ByteString, Any] = Source(ByteString(objectValue) :: Nil)
+    it should s"upload and download with brackets in the key (${settings.name})" in {
+      val objectKey = "abc/DEF/2017/06/15/1234 (1).TXT"
+      val source: Source[ByteString, Any] = Source(ByteString(settings.objectValue) :: Nil)
 
-    val results = for {
-      upload <- source.runWith(
-        otherRegionClient.multipartUpload(otherRegionBucket, objectKey, metaHeaders = MetaHeaders(metaHeaders))
-      )
-      download <- otherRegionClient
-        .download(otherRegionBucket, objectKey)
-        .map(_.decodeString("utf8"))
-        .runWith(Sink.head)
-    } yield (upload, download)
+      val results = for {
+        upload <- source.runWith(
+          settings.defaultRegionClient.multipartUpload(settings.defaultRegionBucket,
+                                                       settings.objectKey,
+                                                       metaHeaders = MetaHeaders(settings.metaHeaders))
+        )
+        download <- settings.defaultRegionClient
+          .download(settings.defaultRegionBucket, settings.objectKey)
+          .map(_.decodeString("utf8"))
+          .runWith(Sink.head)
+      } yield (upload, download)
 
-    val (multipartUploadResult, downloaded) = Await.result(results, 10.seconds)
+      val (multipartUploadResult, downloaded) = Await.result(results, 10.seconds)
 
-    multipartUploadResult.bucket shouldBe otherRegionBucket
-    multipartUploadResult.key shouldBe objectKey
-    downloaded shouldBe objectValue
-  }
+      multipartUploadResult.bucket shouldBe settings.defaultRegionBucket
+      multipartUploadResult.key shouldBe settings.objectKey
+      downloaded shouldBe settings.objectValue
+    }
 
-  it should "upload and download with special characters in the key in non us-east-1 zone" in {
-    // we want ASCII and other UTF-8 characters!
-    val objectKey = "føldęrü/1234()[]><!?: .TXT"
-    val source: Source[ByteString, Any] = Source(ByteString(objectValue) :: Nil)
+    it should s"upload and download with spaces in the key in other region (${settings.name})" in {
+      val objectKey = "test folder/test file.txt"
+      val source: Source[ByteString, Any] = Source(ByteString(settings.objectValue) :: Nil)
 
-    val results = for {
-      upload <- source.runWith(
-        otherRegionClient.multipartUpload(otherRegionBucket, objectKey, metaHeaders = MetaHeaders(metaHeaders))
-      )
-      download <- otherRegionClient
-        .download(otherRegionBucket, objectKey)
-        .map(_.decodeString("utf8"))
-        .runWith(Sink.head)
-    } yield (upload, download)
+      val results = for {
+        upload <- source.runWith(
+          settings.otherRegionClient.multipartUpload(settings.otherRegionBucket,
+                                                     settings.objectKey,
+                                                     metaHeaders = MetaHeaders(settings.metaHeaders))
+        )
+        download <- settings.otherRegionClient
+          .download(settings.otherRegionBucket, settings.objectKey)
+          .map(_.decodeString("utf8"))
+          .runWith(Sink.head)
+      } yield (upload, download)
 
-    val (multipartUploadResult, downloaded) = Await.result(results, 10.seconds)
+      val (multipartUploadResult, downloaded) = Await.result(results, 10.seconds)
 
-    multipartUploadResult.bucket shouldBe otherRegionBucket
-    multipartUploadResult.key shouldBe objectKey
-    downloaded shouldBe objectValue
+      multipartUploadResult.bucket shouldBe settings.otherRegionBucket
+      multipartUploadResult.key shouldBe settings.objectKey
+      downloaded shouldBe settings.objectValue
+    }
+
+    it should s"upload and download with special characters in the key in non other region (${settings.name})" in {
+      // we want ASCII and other UTF-8 characters!
+      val objectKey = "føldęrü/1234()[]><!?: .TXT"
+      val source: Source[ByteString, Any] = Source(ByteString(settings.objectValue) :: Nil)
+
+      val results = for {
+        upload <- source.runWith(
+          settings.otherRegionClient.multipartUpload(settings.otherRegionBucket,
+                                                     settings.objectKey,
+                                                     metaHeaders = MetaHeaders(settings.metaHeaders))
+        )
+        download <- settings.otherRegionClient
+          .download(settings.otherRegionBucket, settings.objectKey)
+          .map(_.decodeString("utf8"))
+          .runWith(Sink.head)
+      } yield (upload, download)
+
+      val (multipartUploadResult, downloaded) = Await.result(results, 10.seconds)
+
+      multipartUploadResult.bucket shouldBe settings.otherRegionBucket
+      multipartUploadResult.key shouldBe settings.objectKey
+      downloaded shouldBe settings.objectValue
+    }
   }
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3NoMock.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3NoMock.scala
@@ -55,6 +55,7 @@ case class S3ConnectionProperties(
     metaHeaders: Map[String, String]
 )
 
+@Ignore
 class S3NoMock extends FlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures {
 
   implicit val actorSystem = ActorSystem()


### PR DESCRIPTION
- Added an accepted content type to the unmarshaller of the inital response to a
  mutlipart upload.
- Updated the documentation with COS specific information.
- Rewrote the integration test in S3NoMock.scala

https://github.com/akka/alpakka/issues/464