### PR TITLE
Support for relational databases (JDBC) through Slick

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ lazy val alpakka = project
     mqtt,
     s3,
     simpleCodecs,
+    slick,
     sns,
     sqs,
     sse,
@@ -182,6 +183,13 @@ lazy val simpleCodecs = project
     // This should not impact the total test time as we don't expect to hit this
     // timeout, and indeed it doesn't appear to.
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-F", "4")
+  )
+
+lazy val slick = project
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(
+    name := "akka-stream-alpakka-slick",
+    Dependencies.Slick
   )
 
 lazy val sns = project

--- a/docs/src/main/paradox/connectors.md
+++ b/docs/src/main/paradox/connectors.md
@@ -20,6 +20,7 @@
 * [JMS Connectors](jms.md)
 * [MQTT Connector](mqtt.md)
 * [Server-sent Events (SSE)](sse.md)
+* [Slick (JDBC) Connector](slick.md)
 
 @@@
 

--- a/docs/src/main/paradox/slick.md
+++ b/docs/src/main/paradox/slick.md
@@ -1,0 +1,148 @@
+# Slick (JDBC) Connector
+
+The Slick connector provides Scala and Java DSLs to create a `Source` to stream the results of a SQL database query and a `Flow`/`Sink` to perform SQL actions (like inserts, updates, and deletes) for each element in a stream. It is built on the [Slick](http://slick.lightbend.com/) library to interact with a long list of [supported relational databases](http://slick.lightbend.com/doc/3.2.1/supported-databases.html).
+
+## Artifacts
+
+sbt
+:   @@@vars
+    ```scala
+    libraryDependencies += "com.lightbend.akka" %% "akka-stream-alpakka-slick" % "$version$"
+    ```
+    @@@
+
+Maven
+:   @@@vars
+    ```xml
+    <dependency>
+      <groupId>com.lightbend.akka</groupId>
+      <artifactId>akka-stream-alpakka-slick_$scalaBinaryVersion$</artifactId>
+      <version>$version$</version>
+    </dependency>
+    ```
+    @@@
+
+Gradle
+:   @@@vars
+    ```gradle
+    dependencies {
+      compile group: "com.lightbend.akka", name: "akka-stream-alpakka-slick_$scalaBinaryVersion$", version: "$version$"
+    }
+    ```
+    @@@
+
+You will also need to add the JDBC driver(s) for the specific relational database(s) to your project. Most of those database have drivers that are not available from public repositories so unfortunately some manual steps will probably be required. The Slick documentation has [information on where to download the drivers](http://slick.lightbend.com/doc/3.2.1/supported-databases.html).
+
+## Usage
+
+As always, before we get started we will need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and a @scaladoc[Materializer](akka.stream.Materializer).
+
+Scala
+: @@snip (../../../../slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/SlickSpec.scala) { #init-mat }
+
+Java
+: @@snip (../../../../slick/src/test/java/akka/stream/alpakka/slick/javadsl/SlickTest.java) { #init-mat }
+
+You will also always need the following important imports:
+
+Scala
+: @@snip (../../../../slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/DocSnippets.scala) { #important-imports }
+
+Java
+: @@snip (../../../../slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetSource.java) { #important-imports }
+
+The full examples for using the `Source`, `Sink`, and `Flow` (listed further down) also include all required imports.
+
+### Starting a Database Session
+
+All functionality provided by this connector requires the user to first create an instance of `SlickSession`, which is a thin wrapper around Slick's database connection management and database profile API.
+
+Scala
+: @@snip (../../../../slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/SlickSpec.scala) { #init-session }
+
+Java
+: @@snip (../../../../slick/src/test/java/akka/stream/alpakka/slick/javadsl/SlickTest.java) { #init-session }
+
+As you can see, this requires you to configure your database using [typesafe-config](https://github.com/typesafehub/config) by adding a named configuration to your application.conf and then referring to that configuration when starting the session.
+
+Here is an example configuration for the H2 database, which is used for the unit tests of the Slick connector itself:
+
+Configuration
+: @@snip (../../../../slick/src/test/resources/application.conf) { #config-h2 }
+
+You can specify multiple different database configurations, as long as you use unique names. These can then be loaded by fully qualified configuration name using the `SlickSession.forConfig()` method described above.
+
+The Slick connector supports all the various ways Slick allows you to configure your JDBC database drivers, connection pools, etc., but we strongly recommend using the so-called ["DatabaseConfig"](http://slick.lightbend.com/doc/3.2.1/database.html#databaseconfig) method of configuration, which is the only method explicitly tested to work with the Slick connector.
+
+Below are a few configuration examples for other databases. The Slick connector supports all [databases supported by Slick](http://slick.lightbend.com/doc/3.2.1/supported-databases.html) (as of Slick 3.2.x)
+
+Postgres
+: @@snip (../../../../slick/src/test/resources/application.conf) { #config-postgres }
+
+MySQL
+: @@snip (../../../../slick/src/test/resources/application.conf) { #config-mysql }
+
+DB2
+: @@snip (../../../../slick/src/test/resources/application.conf) { #config-db2 }
+
+Oracle
+: @@snip (../../../../slick/src/test/resources/application.conf) { #config-oracle }
+
+SQL Server
+: @@snip (../../../../slick/src/test/resources/application.conf) { #config-sqlserver }
+
+Of course these are just examples. Please visit the [Slick documentation for `DatabaseConfig.fromConfig`](http://slick.lightbend.com/doc/3.2.1/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader):Database) for the full list of things to configure.
+
+### Closing a Database Session
+Slick requires you to eventually close your database session to free up connection pool resources. You would usually do this when terminating the `ActorSystem`, by registering a termination handler like this:
+
+Scala
+: @@snip (../../../../slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/SlickSpec.scala) { #close-session }
+
+Java
+: @@snip (../../../../slick/src/test/java/akka/stream/alpakka/slick/javadsl/SlickTest.java) { #close-session }
+
+### Using a Slick Source
+The Slick connector allows you to perform a SQL query and expose the resulting stream of results as an Akka Streams `Source[T]`. Where `T` is any type that can be constructed using a database row.
+
+#### Plain SQL queries
+Both the Scala and Java DSLs support the use of [plain SQL queries](http://slick.lightbend.com/doc/3.2.1/concepts.html#plain-sql-statements).
+
+The Scala DSL expects you to use the special `sql"..."`, `sqlu"..."`, and `sqlt"..."` [String interpolators provided by Slick](http://slick.lightbend.com/doc/3.2.1/sql.html#string-interpolation) to construct queries.
+
+Unfortunately, String interpolation is a Scala language feature that cannot be directly translated to Java. This means that query strings in the Java DSL will need to be manually prepared using plain Java Strings (or a `StringBuilder`).
+
+The following examples put it all together to perform a simple streaming query. The full source code for these examples can be found together with the unit tests of the Slick connector [on Github](https://github.com/akka/alpakka/tree/master/slick/src/test).
+
+Scala
+: @@snip (../../../../slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/DocSnippets.scala) { #source-example }
+
+Java
+: @@snip (../../../../slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetSource.java) { #source-example }
+
+
+#### Typed Queries
+The Scala DSL also supports the use of [Slick Scala queries](http://slick.lightbend.com/doc/3.2.1/concepts.html#scala-queries), which are more type-safe then their plain SQL equivalent. The code will look very similar to the plain SQL example.
+
+Scala
+: @@snip (../../../../slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/DocSnippets.scala) { #source-with-typed-query }
+
+
+### Using a Slick Flow or Sink
+If you want to take stream of elements and turn them into side-effecting actions in a relational database, the Slick connector allows you to perform any DML or DDL statement using either a `Sink` or a `Flow`. This includes the typical `insert`/`update`/`delete` statements but also `create table`, `drop table`, etc. The unit tests have a couple of good examples of the latter usage.
+
+The following example show the use of a Slick `Sink` to take a stream of elements and insert them into the database. There is an optional `parallelism` argument to specify how many concurrent streams will be sent to the database. The unit tests for the slick connector have example of performing parallel inserts.
+
+Scala
+: @@snip (../../../../slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/DocSnippets.scala) { #sink-example }
+
+Java
+: @@snip (../../../../slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetSink.java) { #sink-example }
+
+For completeness, the Slick connector also exposes a `Flow` that has the exact same functionality as the `Sink` but it allows you to continue the stream for further processing. The return value of every executed statement, e.g. the element values is an `Int` denoting the number of updated/inserted/deleted rows.
+
+Scala
+: @@snip (../../../../slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/DocSnippets.scala) { #flow-example }
+
+Java
+: @@snip (../../../../slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetFlow.java) { #flow-example }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -149,6 +149,16 @@ object Dependencies {
     )
   )
 
+  val Slick = Seq(
+    libraryDependencies ++= Seq(
+      "com.typesafe.slick" %% "slick"           % "3.2.1", // BSD 2-clause "Simplified" License
+      "com.typesafe.slick" %% "slick-hikaricp"  % "3.2.1", // BSD 2-clause "Simplified" License
+      "com.typesafe.akka"  %% "akka-slf4j"      % AkkaVersion % Test,
+      "com.h2database"      % "h2"              % "1.4.196"   % Test, // Eclipse Public License 1.0
+      "ch.qos.logback"      % "logback-classic" % "1.2.3"     % Test  // Eclipse Public License 1.0
+    )
+  )
+
   val Sns = Seq(
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-java-sdk-sns" % "1.11.95", // ApacheV2

--- a/slick/src/main/scala/akka/stream/alpakka/slick/javadsl/Slick.scala
+++ b/slick/src/main/scala/akka/stream/alpakka/slick/javadsl/Slick.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.slick.javadsl
+
+import java.util.concurrent.CompletionStage
+import java.util.function.{Function => JFunction}
+
+import scala.compat.java8.FunctionConverters._
+import scala.compat.java8.FutureConverters._
+
+import akka.Done
+import akka.NotUsed
+import akka.stream.javadsl._
+
+import slick.dbio.DBIO
+import slick.jdbc.GetResult
+import slick.jdbc.SQLActionBuilder
+import slick.jdbc.SetParameter
+
+import akka.stream.alpakka.slick.scaladsl.{Slick => ScalaSlick}
+
+object Slick {
+
+  /**
+   * Java API: creates a Source that performs the specified query against
+   *           the specified Slick database and streams the results through
+   *           the specified mapper function to turn database each row
+   *           element into an instance of T.
+   *
+   * @param session The database session to use.
+   * @param query The query string to execute. There is currently no Java
+   *              DSL support for parameter substitution so you will have
+   *              to build the full query statement before passing it in.
+   * @param mapper A function that takes an individual result row and
+   *               transforms it to an instance of T.
+   */
+  def source[T](
+      session: SlickSession,
+      query: String,
+      mapper: JFunction[SlickRow, T]
+  ): Source[T, NotUsed] = {
+    val streamingAction = SQLActionBuilder(query, SetParameter.SetUnit).as[T](toSlick(mapper))
+
+    ScalaSlick
+      .source[T](streamingAction)(session)
+      .asJava
+  }
+
+  /**
+   * Java API: creates a Flow that takes a stream of elements of
+   *           type T, transforms each element to a SQL statement
+   *           using the specified function, and then executes
+   *           those statements against the specified Slick database.
+   *
+   * @param session The database session to use.
+   * @param toStatement A function that creeates the SQL statement to
+   *                    execute from the current element. Any DML or
+   *                    DDL statement is acceptable.
+   */
+  def flow[T](
+      session: SlickSession,
+      toStatement: JFunction[T, String] // TODO: or use the akka japi Function2 interface?
+  ): Flow[T, java.lang.Integer, NotUsed] =
+    flow(session, 1, toStatement)
+
+  /**
+   * Java API: creates a Flow that takes a stream of elements of
+   *           type T, transforms each element to a SQL statement
+   *           using the specified function, and then executes
+   *           those statements against the specified Slick database.
+   *
+   * @param session The database session to use.
+   * @param parallelism How many parallel asynchronous streams should be
+   *                    used to send statements to the database. Use a
+   *                    value of 1 for sequential execution.
+   * @param toStatement A function that creeates the SQL statement to
+   *                    execute from the current element. Any DML or
+   *                    DDL statement is acceptable.
+   */
+  def flow[T](
+      session: SlickSession,
+      parallelism: Int,
+      toStatement: JFunction[T, String]
+  ): Flow[T, java.lang.Integer, NotUsed] =
+    ScalaSlick
+      .flow[T](parallelism, toDBIO(toStatement))(session)
+      .map(Int.box(_))
+      .asJava
+
+  /**
+   * Java API: creates a Sink that takes a stream of elements of
+   *           type T, transforms each element to a SQL statement
+   *           using the specified function, and then executes
+   *           those statements against the specified Slick database.
+   *
+   * @param session The database session to use.
+   * @param toStatement A function that creeates the SQL statement to
+   *                    execute from the current element. Any DML or
+   *                    DDL statement is acceptable.
+   */
+  def sink[T](
+      session: SlickSession,
+      toStatement: JFunction[T, String] // TODO: or use the akka japi Function2 interface?
+  ): Sink[T, CompletionStage[Done]] =
+    sink(session, 1, toStatement)
+
+  /**
+   * Java API: creates a Sink that takes a stream of elements of
+   *           type T, transforms each element to a SQL statement
+   *           using the specified function, and then executes
+   *           those statements against the specified Slick database.
+   *
+   * @param session The database session to use.
+   * @param parallelism How many parallel asynchronous streams should be
+   *                    used to send statements to the database. Use a
+   *                    value of 1 for sequential execution.
+   * @param toStatement A function that creeates the SQL statement to
+   *                    execute from the current element. Any DML or
+   *                    DDL statement is acceptable.
+   */
+  def sink[T](
+      session: SlickSession,
+      parallelism: Int,
+      toStatement: JFunction[T, String]
+  ): Sink[T, CompletionStage[Done]] =
+    ScalaSlick
+      .sink[T](parallelism, toDBIO(toStatement))(session)
+      .mapMaterializedValue(_.toJava)
+      .asJava
+
+  /**
+   * Java API: creates a Sink that takes a stream of complete SQL
+   *           statements (e.g. a stream of Strings) to execute
+   *           against the specified Slick database.
+   *
+   * @param session The database session to use.
+   */
+  def sink(
+      session: SlickSession
+  ): Sink[String, CompletionStage[Done]] =
+    sink[String](session, 1, JFunction.identity[String]())
+
+  /**
+   * Java API: creates a Sink that takes a stream of complete SQL
+   *           statements (e.g. a stream of Strings) to execute
+   *           against the specified Slick database.
+   *
+   * @param session The database session to use.
+   * @param parallelism How many parallel asynchronous streams should be
+   *                    used to send statements to the database. Use a
+   *                    value of 1 for sequential execution.
+   */
+  def sink(
+      session: SlickSession,
+      parallelism: Int
+  ): Sink[String, CompletionStage[Done]] =
+    sink[String](session, parallelism, JFunction.identity[String]())
+
+  private def toSlick[T](mapper: JFunction[SlickRow, T]): GetResult[T] =
+    GetResult(pr => mapper(new SlickRow(pr)))
+
+  private def toDBIO[T](javaDml: JFunction[T, String]): T => DBIO[Int] = { t =>
+    SQLActionBuilder(javaDml.asScala(t), SetParameter.SetUnit).asUpdate
+  }
+}

--- a/slick/src/main/scala/akka/stream/alpakka/slick/javadsl/package.scala
+++ b/slick/src/main/scala/akka/stream/alpakka/slick/javadsl/package.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.slick.javadsl
+
+import slick.basic.DatabaseConfig
+import slick.jdbc.JdbcBackend
+import slick.jdbc.JdbcProfile
+import slick.jdbc.PositionedResult
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+
+/**
+ * Java API: Represents an "open" Slick database and its database (type) profile.
+ *
+ * <b>NOTE</b>: these databases need to be closed after creation to
+ * avoid leaking database resources like active connection pools, etc.
+ */
+sealed abstract class SlickSession {
+  val db: JdbcBackend#Database
+  val profile: JdbcProfile
+
+  /**
+   * You are responsible for closing the database after use!!
+   */
+  def close(): Unit = db.close()
+}
+
+/**
+ * Java API: Methods for "opening" Slick databases for use.
+ *
+ * <b>NOTE</b>: databases created through these methods will need to be
+ * closed after creation to avoid leaking database resources like active
+ * connection pools, etc.
+ */
+object SlickSession {
+  private final class SlickSessionImpl(val slick: DatabaseConfig[JdbcProfile]) extends SlickSession {
+    val db: JdbcBackend#Database = slick.db
+    val profile: JdbcProfile = slick.profile
+  }
+
+  def forConfig(path: String): SlickSession = forConfig(path, ConfigFactory.load())
+  def forConfig(config: Config): SlickSession = forConfig("", config)
+  def forConfig(path: String, config: Config): SlickSession = new SlickSessionImpl(
+    DatabaseConfig.forConfig[JdbcProfile](path, config)
+  )
+}
+
+/**
+ * Java API: A class representing a slick resultset row, which is used
+ *          in SlickSource to map result set rows back to Java objects.
+ */
+final class SlickRow private[javadsl] (delegate: PositionedResult) {
+  final def nextBoolean(): java.lang.Boolean = delegate.nextBoolean()
+  final def nextBigDecimal(): java.math.BigDecimal = delegate.nextBigDecimal().bigDecimal
+  final def nextBlob(): java.sql.Blob = delegate.nextBlob()
+  final def nextByte(): java.lang.Byte = delegate.nextByte()
+  final def nextBytes(): Array[java.lang.Byte] = delegate.nextBytes().map(Byte.box(_))
+  final def nextClob(): java.sql.Clob = delegate.nextClob()
+  final def nextDate(): java.sql.Date = delegate.nextDate()
+  final def nextDouble(): java.lang.Double = delegate.nextDouble()
+  final def nextFloat(): java.lang.Float = delegate.nextFloat()
+  final def nextInt(): java.lang.Integer = delegate.nextInt()
+  final def nextLong(): java.lang.Long = delegate.nextLong()
+  final def nextObject(): java.lang.Object = delegate.nextObject()
+  final def nextShort(): java.lang.Short = delegate.nextShort()
+  final def nextString(): java.lang.String = delegate.nextString()
+  final def nextTime(): java.sql.Time = delegate.nextTime()
+  final def nextTimestamp(): java.sql.Timestamp = delegate.nextTimestamp()
+}

--- a/slick/src/main/scala/akka/stream/alpakka/slick/scaladsl/Slick.scala
+++ b/slick/src/main/scala/akka/stream/alpakka/slick/scaladsl/Slick.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.slick.scaladsl
+
+import scala.concurrent.Future
+
+import akka.Done
+import akka.NotUsed
+
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+
+import slick.dbio.DBIO
+import slick.dbio.StreamingDBIO
+
+/**
+ * Methods for interacting with relational databases using Slick and akka-stream.
+ */
+object Slick {
+
+  /**
+   * Scala API: creates a Source[T, NotUsed] that performs the
+   *            specified query against the (implicitly) specified
+   *            Slick database and streams the results.
+   *            This works for both "typed" Slick queries
+   *            and "plain SQL" queries.
+   *
+   * @param streamingQuery The Slick query to execute, which can
+   *                       be either a "typed" query or a "plain SQL"
+   *                       query produced by one of the Slick "sql..."
+   *                       String interpolators
+   * @param session The database session to use.
+   */
+  def source[T](
+      streamingQuery: StreamingDBIO[Seq[T], T]
+  )(implicit session: SlickSession): Source[T, NotUsed] =
+    Source.fromPublisher(session.db.stream(streamingQuery))
+
+  /**
+   * Scala API: creates a Flow that takes a stream of elements of
+   *            type T, transforms each element to a SQL statement
+   *            using the specified function, and then executes
+   *            those statements against the specified Slick database.
+   *
+   * @param toStatement A function to produce the SQL statement to
+   *                    execute based on the current element.
+   * @param session The database session to use.
+   */
+  def flow[T](
+      toStatement: T => DBIO[Int]
+  )(implicit session: SlickSession): Flow[T, Int, NotUsed] = flow(1, toStatement)
+
+  /**
+   * Scala API: creates a Flow that takes a stream of elements of
+   *            type T, transforms each element to a SQL statement
+   *            using the specified function, and then executes
+   *            those statements against the specified Slick database.
+   *
+   * @param toStatement A function to produce the SQL statement to
+   *                    execute based on the current element.
+   * @param parallelism How many parallel asynchronous streams should be
+   *                    used to send statements to the database. Use a
+   *                    value of 1 for sequential execution.
+   * @param session The database session to use.
+   */
+  def flow[T](
+      parallelism: Int,
+      toStatement: T => DBIO[Int]
+  )(implicit session: SlickSession): Flow[T, Int, NotUsed] =
+    Flow[T]
+      .mapAsync(parallelism) { t =>
+        session.db.run(toStatement(t))
+      }
+
+  /**
+   * Scala API: creates a Sink that takes a stream of elements of
+   *            type T, transforms each element to a SQL statement
+   *            using the specified function, and then executes
+   *            those statements against the specified Slick database.
+   *
+   * @param toStatement A function to produce the SQL statement to
+   *                    execute based on the current element.
+   * @param session The database session to use.
+   */
+  def sink[T](
+      toStatement: T => DBIO[Int]
+  )(implicit session: SlickSession): Sink[T, Future[Done]] =
+    flow[T](1, toStatement).toMat(Sink.ignore)(Keep.right)
+
+  /**
+   * Scala API: creates a Sink that takes a stream of elements of
+   *            type T, transforms each element to a SQL statement
+   *            using the specified function, and then executes
+   *            those statements against the specified Slick database.
+   *
+   * @param toStatement A function to produce the SQL statement to
+   *                    execute based on the current element.
+   * @param parallelism How many parallel asynchronous streams should be
+   *                    used to send statements to the database. Use a
+   *                    value of 1 for sequential execution.
+   * @param session The database session to use.
+   */
+  def sink[T](
+      parallelism: Int,
+      toStatement: T => DBIO[Int]
+  )(implicit session: SlickSession): Sink[T, Future[Done]] =
+    flow[T](parallelism, toStatement).toMat(Sink.ignore)(Keep.right)
+}

--- a/slick/src/main/scala/akka/stream/alpakka/slick/scaladsl/package.scala
+++ b/slick/src/main/scala/akka/stream/alpakka/slick/scaladsl/package.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.slick
+
+package object scaladsl {
+
+  /**
+   * Scala API: Represents an "open" Slick database and its database (type) profile.
+   *
+   * <b>NOTE</b>: these databases need to be closed after creation to
+   * avoid leaking database resources like active connection pools, etc.
+   */
+  type SlickSession = javadsl.SlickSession
+
+  /**
+   * Scala API: Methods for "opening" Slick databases for use.
+   *
+   * <b>NOTE</b>: databases created through these methods will need to be
+   * closed after creation to avoid leaking database resources like active
+   * connection pools, etc.
+   */
+  val SlickSession = javadsl.SlickSession
+}

--- a/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetFlow.java
+++ b/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetFlow.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package example;
+
+//#flow-example
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import akka.Done;
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+
+import akka.stream.javadsl.*;
+import akka.stream.alpakka.slick.javadsl.*;
+
+public class DocSnippetFlow {
+  public static void main(String[] args) throws Exception {
+    final ActorSystem system = ActorSystem.create();
+    final Materializer materializer = ActorMaterializer.create(system);
+
+    final SlickSession session = SlickSession.forConfig("slick-h2");
+
+    final List<User> users = IntStream.range(0, 42).boxed().map((i) -> new User(i, "Name"+i)).collect(Collectors.toList());
+
+    final CompletionStage<Done> done =
+      Source
+        .from(users)
+        .via(
+          Slick.<User>flow(
+            session,
+            // add an optional second argument to specify the parallism factor (int)
+            (user) -> "INSERT INTO ALPAKKA_SLICK_JAVADSL_TEST_USERS VALUES (" + user.id + ", '" + user.name + "')"
+          )
+        )
+        .log("nr-of-updated-rows")
+        .runWith(Sink.ignore(), materializer);
+
+    done.whenComplete((value, exception) -> {
+      session.close();
+      system.terminate();
+    });
+  }
+}
+//#flow-example

--- a/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetSink.java
+++ b/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetSink.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package example;
+
+//#sink-example
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import akka.Done;
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+
+import akka.stream.javadsl.*;
+import akka.stream.alpakka.slick.javadsl.*;
+
+public class DocSnippetSink {
+  public static void main(String[] args) throws Exception {
+    final ActorSystem system = ActorSystem.create();
+    final Materializer materializer = ActorMaterializer.create(system);
+
+    final SlickSession session = SlickSession.forConfig("slick-h2");
+
+    final List<User> users = IntStream.range(0, 42).boxed().map((i) -> new User(i, "Name"+i)).collect(Collectors.toList());
+
+    final CompletionStage<Done> done =
+      Source
+        .from(users)
+        .runWith(
+          Slick.<User>sink(
+            session,
+            // add an optional second argument to specify the parallism factor (int)
+            (user) -> "INSERT INTO ALPAKKA_SLICK_JAVADSL_TEST_USERS VALUES (" + user.id + ", '" + user.name + "')"
+          ),
+          materializer
+        );
+
+    done.whenComplete((value, exception) -> {
+      session.close();
+      system.terminate();
+    });
+  }
+}
+//#sink-example

--- a/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetSource.java
+++ b/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetSource.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package example;
+
+//#important-imports
+import akka.stream.javadsl.*;
+import akka.stream.alpakka.slick.javadsl.*;
+//#important-imports
+
+//#source-example
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import akka.Done;
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+
+import akka.stream.javadsl.*;
+import akka.stream.alpakka.slick.javadsl.*;
+
+public class DocSnippetSource {
+  public static void main(String[] args) throws Exception {
+    final ActorSystem system = ActorSystem.create();
+    final Materializer materializer = ActorMaterializer.create(system);
+
+    final SlickSession session = SlickSession.forConfig("slick-h2");
+
+    final CompletionStage<Done> done =
+      Slick
+        .source(
+          session,
+          "SELECT ID, NAME FROM ALPAKKA_SLICK_JAVADSL_TEST_USERS",
+          (SlickRow row) -> new User(row.nextInt(), row.nextString())
+        )
+        .log("user")
+        .runWith(Sink.ignore(), materializer);
+
+    done.whenComplete((value, exception) -> {
+      session.close();
+      system.terminate();
+    });
+  }
+}
+//#source-example

--- a/slick/src/test/java/akka/stream/alpakka/slick/javadsl/SlickTest.java
+++ b/slick/src/test/java/akka/stream/alpakka/slick/javadsl/SlickTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.slick.javadsl;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import akka.Done;
+import akka.NotUsed;
+
+import akka.actor.ActorSystem;
+import akka.japi.Pair;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.testkit.*;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * This unit test is run using a local H2 database using
+ * `/tmp/alpakka-slick-h2-test` for temporary storage.
+ */
+public class SlickTest {
+  private static ActorSystem system;
+  private static Materializer materializer;
+
+  //#init-session
+  private static final SlickSession session = SlickSession.forConfig("slick-h2");
+  //#init-session
+
+  private static final Set<User> users = IntStream.range(0, 40).boxed().map((i) -> new User(i, "Name"+i)).collect(Collectors.toSet());
+  private static final Source<User, NotUsed> usersSource = Source.from(users);
+
+  private static final Function<User, String> insertUser = (user) -> {
+    return "INSERT INTO ALPAKKA_SLICK_JAVADSL_TEST_USERS VALUES (" + user.id + ", '" + user.name + "')";
+  };
+
+  private static final String selectAllUsers = "SELECT ID, NAME FROM ALPAKKA_SLICK_JAVADSL_TEST_USERS";
+
+
+  @BeforeClass
+  public static void setup() {
+    //#init-mat
+    system = ActorSystem.create();
+    materializer = ActorMaterializer.create(system);
+    //#init-mat
+
+    executeStatement("CREATE TABLE ALPAKKA_SLICK_JAVADSL_TEST_USERS(ID INTEGER, NAME VARCHAR(50))", session, materializer);
+  }
+
+  @After
+  public void cleanUp() {
+    executeStatement("DELETE FROM ALPAKKA_SLICK_JAVADSL_TEST_USERS", session, materializer);
+  }
+
+  @AfterClass
+  public static void teardown() {
+    executeStatement("DROP TABLE ALPAKKA_SLICK_JAVADSL_TEST_USERS", session, materializer);
+
+    //#close-session
+    system.registerOnTermination( () -> session.close() );
+    //#close-session
+
+    JavaTestKit.shutdownActorSystem(system);
+  }
+
+  @Test
+  public void testSinkWithoutParallelismAndReadBackWithSource() throws Exception {
+    final Sink<User, CompletionStage<Done>> slickSink = Slick.<User>sink(session, insertUser);
+    final CompletionStage<Done> insertionResultFuture = usersSource.runWith(slickSink, materializer);
+
+    insertionResultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    final Source<User, NotUsed> slickSource = Slick.source(
+      session,
+      selectAllUsers,
+      (SlickRow row) -> new User(row.nextInt(), row.nextString())
+    );
+
+    final CompletionStage<List<User>> foundUsersFuture = slickSource.runWith(Sink.seq(), materializer);
+    final Set<User> foundUsers = foundUsersFuture.toCompletableFuture().get(3, TimeUnit.SECONDS).stream().collect(Collectors.toSet());
+
+    assertEquals(foundUsers, users);
+  }
+
+  @Test
+  public void testSinkWithParallelismOf4AndReadBackWithSource() throws Exception {
+    final Sink<User, CompletionStage<Done>> slickSink = Slick.<User>sink(session, 4, insertUser);
+    final CompletionStage<Done> insertionResultFuture = usersSource.runWith(slickSink, materializer);
+
+    insertionResultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    final Source<User, NotUsed> slickSource = Slick.source(
+      session,
+      selectAllUsers,
+      (SlickRow row) -> new User(row.nextInt(), row.nextString())
+    );
+
+    final CompletionStage<List<User>> foundUsersFuture = slickSource.runWith(Sink.seq(), materializer);
+    final Set<User> foundUsers = foundUsersFuture.toCompletableFuture().get(3, TimeUnit.SECONDS).stream().collect(Collectors.toSet());
+
+    assertEquals(foundUsers, users);
+  }
+
+  @Test
+  public void testFlowWithoutParallelismAndReadBackWithSource() throws Exception {
+    final Flow<User, Integer, NotUsed> slickFlow = Slick.<User>flow(session, insertUser);
+    final CompletionStage<List<Integer>> insertionResultFuture = usersSource.via(slickFlow).runWith(Sink.seq(), materializer);
+    final List<Integer> insertionResult = insertionResultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertEquals(users.size(), insertionResult.size());
+
+    final Source<User, NotUsed> slickSource = Slick.source(
+      session,
+      selectAllUsers,
+      (SlickRow row) -> new User(row.nextInt(), row.nextString())
+    );
+
+    final CompletionStage<List<User>> foundUsersFuture = slickSource.runWith(Sink.seq(), materializer);
+    final Set<User> foundUsers = foundUsersFuture.toCompletableFuture().get(3, TimeUnit.SECONDS).stream().collect(Collectors.toSet());
+
+    assertEquals(foundUsers, users);
+  }
+
+  @Test
+  public void testFlowWithParallelismOf4AndReadBackWithSource() throws Exception {
+    final Flow<User, Integer, NotUsed> slickFlow = Slick.<User>flow(session, 4, insertUser);
+    final CompletionStage<List<Integer>> insertionResultFuture = usersSource.via(slickFlow).runWith(Sink.seq(), materializer);
+    final List<Integer> insertionResult = insertionResultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertEquals(users.size(), insertionResult.size());
+
+    final Source<User, NotUsed> slickSource = Slick.source(
+      session,
+      selectAllUsers,
+      (SlickRow row) -> new User(row.nextInt(), row.nextString())
+    );
+
+    final CompletionStage<List<User>> foundUsersFuture = slickSource.runWith(Sink.seq(), materializer);
+    final Set<User> foundUsers = foundUsersFuture.toCompletableFuture().get(3, TimeUnit.SECONDS).stream().collect(Collectors.toSet());
+
+    assertEquals(foundUsers, users);
+  }
+
+  private static void executeStatement(String statement, SlickSession session, Materializer materializer) {
+    try {
+      Source
+        .single(statement)
+        .runWith(Slick.sink(session), materializer)
+        .toCompletableFuture()
+        .get(3, TimeUnit.SECONDS);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+  }
+}

--- a/slick/src/test/java/akka/stream/alpakka/slick/javadsl/User.java
+++ b/slick/src/test/java/akka/stream/alpakka/slick/javadsl/User.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.slick.javadsl;
+
+public class User {
+  public final Integer id;
+  public final String name;
+
+  public User(Integer _id, String _name) {
+    id = _id;
+    name = _name;
+  }
+
+  @Override
+  public int hashCode() {
+      int hash = 3;
+      hash = 53 * hash + (this.name != null ? this.name.hashCode() : 0);
+      hash = 53 * hash + this.id;
+      return hash;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if(obj == null) {
+      return false;
+    }
+    if (!User.class.isAssignableFrom(obj.getClass())) {
+      return false;
+    }
+    final User other = (User) obj;
+    if ((this.name == null) ? (other.name != null) : !this.name.equals(other.name)) {
+        return false;
+    }
+    if (this.id != other.id) {
+        return false;
+    }
+    return true;
+  }
+}

--- a/slick/src/test/resources/application.conf
+++ b/slick/src/test/resources/application.conf
@@ -1,0 +1,134 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  loglevel = "WARNING"
+  stdout-loglevel = "WARNING"
+}
+
+# This database configuration is used for all unit tests.
+# It will create the following file: /tmp/alpakka-slick-h2-test
+#config-h2
+# Load using SlickSession.forConfig("slick-h2")
+slick-h2 {
+  profile = "slick.jdbc.H2Profile$"
+  db {
+    connectionPool = disabled
+    dataSourceClass = "slick.jdbc.DriverDataSource"
+    properties = {
+      driver = "org.h2.Driver"
+      url = "jdbc:h2:/tmp/alpakka-slick-h2-test"
+    }
+  }
+}
+#config-h2
+
+# This is an example DB2 database configuration that can be
+# used to run the unit tests against DB2.
+# It assumes a local DB2 database running on port 50000.
+#
+# We used the IBM DB2Express-C Docker image.
+# Go to https://hub.docker.com/r/ibmcom/db2express-c/ and
+# follow the instructions to set up a local DB2 database
+# using Docker.
+#
+# In the configuration listed below we have reset the database
+# password to "db2-admin-password" instead of the password used
+# in the docker image instructions.
+#
+# In order to run the unit tests with this database configuration,
+# you will need to download the DB2 JDBC driver from IBM and copy
+# it to a `lib` directory in the project root for SBT to
+# automatically pick it up.
+#
+# http://www-01.ibm.com/support/docview.wss?uid=swg21363866
+#
+# This connector has been tested using the db2jcc4 4.19.66
+# version of the DB2 driver.
+#
+#config-db2
+# Load using SlickSession.forConfig("slick-db2")
+slick-db2 {
+  profile = "slick.jdbc.DB2Profile$"
+  db {
+    dataSourceClass = "slick.jdbc.DriverDataSource"
+    properties = {
+      driver = "com.ibm.db2.jcc.DB2Driver"
+      url = "jdbc:db2://localhost:50000/sample"
+      user = "db2inst1"
+      password = "db2-admin-password"
+    }
+  }
+}
+#config-db2
+
+# An example Postgres database configuration.
+#
+#config-postgres
+# Load using SlickSession.forConfig("slick-postgres")
+slick-postgres {
+  profile = "slick.jdbc.PostgresProfile$"
+  db {
+    dataSourceClass = "slick.jdbc.DriverDataSource"
+    properties = {
+      driver = "org.postgresql.Driver"
+      url = "jdbc:postgresql://127.0.0.1/slickdemo"
+      user = slick
+      password = ""
+    }
+  }
+}
+#config-postgres
+
+# An example Oracle database configuration.
+#
+#config-oracle
+# Load using SlickSession.forConfig("slick-oracle")
+slick-oracle {
+  profile = "slick.jdbc.OracleProfile$"
+  db {
+    dataSourceClass = "slick.jdbc.DriverDataSource"
+    properties = {
+      driver = "oracle.jdbc.OracleDriver"
+      url = "jdbc:oracle:thin:@//localhost:49161/xe"
+      user = slick
+      password = ""
+    }
+  }
+}
+#config-oracle
+
+# An example SQL Server database configuration.
+#
+#config-sqlserver
+# Load using SlickSession.forConfig("slick-sqlserver")
+slick-sqlserver {
+  profile = "slick.jdbc.SQLServerProfile$"
+  db {
+    dataSourceClass = "slick.jdbc.DriverDataSource"
+    properties = {
+      driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+      url = "jdbc:sqlserver://localhost:1433"
+      user = slick
+      password = ""
+    }
+  }
+}
+#config-sqlserver
+
+# An example MySQL database configuration.
+#
+#config-mysql
+# Load using SlickSession.forConfig("slick-mysql")
+slick-mysql {
+  profile = "slick.jdbc.MySQLProfile$"
+  db {
+    dataSourceClass = "slick.jdbc.DriverDataSource"
+    properties = {
+      driver = "com.mysql.jdbc.Driver"
+      url = "jdbc:mysql://localhost:3306/"
+      user = slick
+      password = ""
+    }
+  }
+}
+#config-mysql

--- a/slick/src/test/resources/logback.xml
+++ b/slick/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
+
+  <logger name="akka" level="${LOGLEVEL_AKKA:-WARN}" />
+
+  <root level="${LOGLEVEL_ROOT:-WARN}">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+      <target>System.out</target>
+      <encoder>
+        <pattern>%d{ISO8601} %-5level [%logger{0}] - %msg%n</pattern>
+      </encoder>
+    </appender>
+  </root>
+</configuration>

--- a/slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/DocSnippets.scala
+++ b/slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/DocSnippets.scala
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package example
+
+//#important-imports
+import akka.stream.scaladsl._
+import akka.stream.alpakka.slick.scaladsl._
+//#important-imports
+
+//#source-example
+import scala.concurrent.Future
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+
+import akka.stream.scaladsl._
+import akka.stream.alpakka.slick.scaladsl._
+
+import slick.jdbc.GetResult
+
+object SlickSourceWithPlainSQLQueryExample extends App {
+  implicit val system = ActorSystem()
+  implicit val mat = ActorMaterializer()
+  implicit val ec = system.dispatcher
+
+  implicit val session = SlickSession.forConfig("slick-h2")
+
+  // The example domain
+  case class User(id: Int, name: String)
+
+  // We need this to automatically transform result rows
+  // into instances of the User class.
+  // Please import slick.jdbc.GetResult
+  // See also: "http://slick.lightbend.com/doc/3.2.1/sql.html#result-sets"
+  implicit val getUserResult = GetResult(r => User(r.nextInt, r.nextString))
+
+  // This import enables the use of the Slick sql"...",
+  // sqlu"...", and sqlt"..." String interpolators.
+  // See also: "http://slick.lightbend.com/doc/3.2.1/sql.html#string-interpolation"
+  import session.profile.api._
+
+  // Stream the results of a query
+  val done: Future[Done] =
+    Slick
+      .source(sql"SELECT ID, NAME FROM ALPAKKA_SLICK_SCALADSL_TEST_USERS".as[User])
+      .log("user")
+      .runWith(Sink.ignore)
+
+  done.onComplete {
+    case _ =>
+      session.close()
+      system.terminate()
+  }
+}
+//#source-example
+
+//#source-with-typed-query
+import scala.concurrent.Future
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+
+import akka.stream.scaladsl._
+import akka.stream.alpakka.slick.scaladsl._
+
+object SlickSourceWithTypedQueryExample extends App {
+  implicit val system = ActorSystem()
+  implicit val mat = ActorMaterializer()
+  implicit val ec = system.dispatcher
+
+  implicit val session = SlickSession.forConfig("slick-h2")
+
+  // This import brings everything you need into scope
+  import session.profile.api._
+
+  // The example domain
+  class Users(tag: Tag) extends Table[(Int, String)](tag, "ALPAKKA_SLICK_SCALADSL_TEST_USERS") {
+    def id = column[Int]("ID")
+    def name = column[String]("NAME")
+    def * = (id, name)
+  }
+
+  // Stream the results of a query
+  val done: Future[Done] =
+    Slick
+      .source(TableQuery[Users].result)
+      .log("user")
+      .runWith(Sink.ignore)
+
+  done.onComplete {
+    case _ =>
+      session.close()
+      system.terminate()
+  }
+}
+//#source-with-typed-query
+
+//#sink-example
+import scala.concurrent.Future
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+
+import akka.stream.scaladsl._
+import akka.stream.alpakka.slick.scaladsl._
+
+object SlickSinkExample extends App {
+  implicit val system = ActorSystem()
+  implicit val mat = ActorMaterializer()
+  implicit val ec = system.dispatcher
+
+  implicit val session = SlickSession.forConfig("slick-h2")
+
+  // The example domain
+  case class User(id: Int, name: String)
+  val users = (1 to 42).map(i => User(i, s"Name$i"))
+
+  // This import enables the use of the Slick sql"...",
+  // sqlu"...", and sqlt"..." String interpolators.
+  // See "http://slick.lightbend.com/doc/3.2.1/sql.html#string-interpolation"
+  import session.profile.api._
+
+  // Stream the users into the database as insert statements
+  val done: Future[Done] =
+    Source(users)
+      .runWith(
+        // add an optional first argument to specify the parallism factor (Int)
+        Slick.sink(user => sqlu"INSERT INTO ALPAKKA_SLICK_SCALADSL_TEST_USERS VALUES(${user.id}, ${user.name})")
+      )
+
+  done.onComplete {
+    case _ =>
+      session.close()
+      system.terminate()
+  }
+}
+//#sink-example
+
+//#flow-example
+import scala.concurrent.Future
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+
+import akka.stream.scaladsl._
+import akka.stream.alpakka.slick.scaladsl._
+
+object SlickFlowExample extends App {
+  implicit val system = ActorSystem()
+  implicit val mat = ActorMaterializer()
+  implicit val ec = system.dispatcher
+
+  implicit val session = SlickSession.forConfig("slick-h2")
+
+  // The example domain
+  case class User(id: Int, name: String)
+  val users = (1 to 42).map(i => User(i, s"Name$i"))
+
+  // This import enables the use of the Slick sql"...",
+  // sqlu"...", and sqlt"..." String interpolators.
+  // See "http://slick.lightbend.com/doc/3.2.1/sql.html#string-interpolation"
+  import session.profile.api._
+
+  // Stream the users into the database as insert statements
+  val done: Future[Done] =
+    Source(users)
+      .via(
+        // add an optional first argument to specify the parallism factor (Int)
+        Slick.flow(user => sqlu"INSERT INTO ALPAKKA_SLICK_SCALADSL_TEST_USERS VALUES(${user.id}, ${user.name})")
+      )
+      .log("nr-of-updated-rows")
+      .runWith(Sink.ignore)
+
+  done.onComplete {
+    case _ =>
+      session.close()
+      system.terminate()
+  }
+}
+//#flow-example

--- a/slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/SlickSpec.scala
+++ b/slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/SlickSpec.scala
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.slick.scaladsl
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl._
+import akka.testkit.TestKit
+
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+
+import slick.jdbc.GetResult
+
+/**
+ * This unit test is run using a local H2 database using
+ * `/tmp/alpakka-slick-h2-test` for temporary storage.
+ */
+class SlickSpec extends WordSpec with ScalaFutures with BeforeAndAfterEach with BeforeAndAfterAll with MustMatchers {
+  //#init-mat
+  implicit val system = ActorSystem()
+  implicit val mat = ActorMaterializer()
+  //#init-mat
+
+  //#init-session
+  implicit val session = SlickSession.forConfig("slick-h2")
+  //#init-session
+
+  import session.profile.api._
+
+  case class User(id: Int, name: String)
+  class Users(tag: Tag) extends Table[(Int, String)](tag, "ALPAKKA_SLICK_SCALADSL_TEST_USERS") {
+    def id = column[Int]("ID")
+    def name = column[String]("NAME")
+    def * = (id, name)
+  }
+
+  implicit val ec = system.dispatcher
+  implicit val defaultPatience = PatienceConfig(timeout = 3.seconds, interval = 50.millis)
+  implicit val getUserResult = GetResult(r => User(r.nextInt, r.nextString))
+
+  val users = (1 to 40).map(i => User(i, s"Name$i")).toSet
+
+  val createTable = sqlu"""CREATE TABLE ALPAKKA_SLICK_SCALADSL_TEST_USERS(ID INTEGER, NAME VARCHAR(50))"""
+  val dropTable = sqlu"""DROP TABLE ALPAKKA_SLICK_SCALADSL_TEST_USERS"""
+  val selectAllUsers = sql"SELECT ID, NAME FROM ALPAKKA_SLICK_SCALADSL_TEST_USERS".as[User]
+  val typedSelectAllUsers = TableQuery[Users].result
+
+  def insertUser(user: User): DBIO[Int] =
+    sqlu"INSERT INTO ALPAKKA_SLICK_SCALADSL_TEST_USERS VALUES(${user.id}, ${user.name})"
+
+  def getAllUsersFromDb: Future[Set[User]] = Slick.source(selectAllUsers).runWith(Sink.seq).map(_.toSet)
+  def populate() = {
+    val actions = users.map(insertUser)
+
+    // This uses the standard Slick API exposed by the Slick session
+    // on purpose, just to double-check that inserting data through
+    // our Alpakka connectors is equivalent to inserting it the Slick way.
+    session.db.run(DBIO.seq(actions.toList: _*)).futureValue
+  }
+
+  override def beforeEach(): Unit = session.db.run(createTable).futureValue
+  override def afterEach(): Unit = session.db.run(dropTable).futureValue
+
+  override def afterAll(): Unit = {
+    //#close-session
+    system.registerOnTermination(() => session.close())
+    //#close-session
+
+    TestKit.shutdownActorSystem(system)
+  }
+
+  "Slick.source(...)" must {
+    def tupleToUser(columns: (Int, String)): User = User(columns._1, columns._2)
+
+    "stream the result of a Slick plain SQL query" in {
+      populate()
+
+      getAllUsersFromDb.futureValue mustBe users
+    }
+
+    "stream the result of a Slick plain SQL query that results in no data" in {
+      getAllUsersFromDb.futureValue mustBe empty
+    }
+
+    "stream the result of a Slick typed query" in {
+      populate()
+
+      val foundUsers =
+        Slick
+          .source(typedSelectAllUsers)
+          .map(tupleToUser)
+          .runWith(Sink.seq)
+          .futureValue
+
+      foundUsers must contain theSameElementsAs users
+    }
+
+    "stream the result of a Slick typed query that results in no data" in {
+      val foundUsers =
+        Slick
+          .source(typedSelectAllUsers)
+          .runWith(Sink.seq)
+          .futureValue
+
+      foundUsers mustBe empty
+    }
+
+    "support multiple materializations" in {
+      populate()
+
+      val source = Slick.source(selectAllUsers)
+
+      source.runWith(Sink.seq).futureValue.toSet mustBe users
+      source.runWith(Sink.seq).futureValue.toSet mustBe users
+    }
+  }
+
+  "Slick.flow(..)" must {
+    "insert 40 records into a table (no parallelism)" in {
+      val inserted = Source(users)
+        .via(Slick.flow(insertUser))
+        .runWith(Sink.seq)
+        .futureValue
+
+      inserted must have size (users.size)
+      inserted.toSet mustBe Set(1)
+
+      getAllUsersFromDb.futureValue mustBe users
+    }
+
+    "insert 40 records into a table (parallelism = 4)" in {
+      val inserted = Source(users)
+        .via(Slick.flow(parallelism = 4, insertUser))
+        .runWith(Sink.seq)
+        .futureValue
+
+      inserted must have size (users.size)
+      inserted.toSet mustBe Set(1)
+
+      getAllUsersFromDb.futureValue mustBe users
+    }
+
+    "insert 40 records into a table faster using Flow.grouped (n = 10, parallelism = 4)" in {
+      val inserted = Source(users)
+        .grouped(10)
+        .via(
+          Slick.flow(parallelism = 4, (group: Seq[User]) => group.map(insertUser(_)).reduceLeft(_.andThen(_)))
+        )
+        .runWith(Sink.seq)
+        .futureValue
+
+      inserted must have size (4)
+      // we do single inserts without auto-commit but it only returns the result of the last insert
+      inserted.toSet mustBe Set(1)
+
+      getAllUsersFromDb.futureValue mustBe users
+    }
+  }
+
+  "Slick.sink(..)" must {
+    "insert 40 records into a table (no parallelism)" in {
+      Source(users)
+        .runWith(Slick.sink(insertUser))
+        .futureValue
+
+      getAllUsersFromDb.futureValue mustBe users
+    }
+
+    "insert 40 records into a table (parallelism = 4)" in {
+      Source(users)
+        .runWith(Slick.sink(parallelism = 4, insertUser))
+        .futureValue
+
+      getAllUsersFromDb.futureValue mustBe users
+    }
+
+    "insert 40 records into a table faster using Flow.grouped (n = 10, parallelism = 4)" in {
+      Source(users)
+        .grouped(10)
+        .runWith(
+          Slick.sink(parallelism = 4, (group: Seq[User]) => group.map(insertUser(_)).reduceLeft(_.andThen(_)))
+        )
+        .futureValue
+
+      getAllUsersFromDb.futureValue mustBe users
+    }
+  }
+}


### PR DESCRIPTION
This adds support for a new "slick" connector, which uses the Slick library to enable interaction with all major (and quite a few minor) relational databases.

Since Slick is Scala only, the Java DSL is a little less powerful and required a few thin wrappers.

This PR contains contributions by @rayroestenburg.