### PR TITLE
[DDB] Support for AWS Session Credentials - Using the Token  session auth

### DIFF
--- a/dynamodb/src/main/resources/reference.conf
+++ b/dynamodb/src/main/resources/reference.conf
@@ -5,7 +5,7 @@ akka.stream.alpakka.dynamodb {
   # The AWS host
   host = ""
 
-  # The AWS port
+  # The AWS port, https is used as default scheme - 443 will result in not using port in url
   port: -1
 
   # Max number of in flight requests from the AwsClient

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
@@ -108,7 +108,7 @@ private[alpakka] trait AwsClient[S <: ClientSettings] {
         headers.RawHeader("x-amz-date", amzHeaders.get("X-Amz-Date")),
         headers.RawHeader("authorization", amzHeaders.get("Authorization")),
         headers.RawHeader("x-amz-target", amzHeaders.get("X-Amz-Target"))
-      ), // ++ tokenHeader,
+      ) ++ tokenHeader,
       entity = HttpEntity(defaultContentType, body)
     )
 

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
@@ -64,7 +64,11 @@ private[alpakka] trait AwsClient[S <: ClientSettings] {
     case HttpMethodName.PATCH => HttpMethods.PATCH
   }
 
-  private val signableUrl = Uri("https://" + settings.host + "/")
+  private val url = s"https://${settings.host}/"
+
+  private val signableUrl = Uri(url)
+
+  private val uri = new java.net.URI(url)
 
   private val decider: Supervision.Decider = { case _ => Supervision.Stop }
 
@@ -80,13 +84,22 @@ private[alpakka] trait AwsClient[S <: ClientSettings] {
 
   private def toAwsRequest(s: AwsOp): (HttpRequest, AwsRequestMetadata) = {
     val original = s.marshaller.marshall(s.request)
-    original.setEndpoint(new java.net.URI("https://" + settings.host + "/"))
+    original.setEndpoint(uri)
     original.getHeaders.remove("Content-Type")
     original.getHeaders.remove("Content-Length")
     signer.sign(original, credentials.getCredentials)
 
     val amzHeaders = original.getHeaders
     val body = read(original.getContent)
+
+    val tokenHeader: List[headers.RawHeader] = {
+      credentials.getCredentials() match {
+        case sessionCredentials: auth.AWSSessionCredentials =>
+          Some(headers.RawHeader("x-amz-security-token", amzHeaders.get("X-Amz-Security-Token")))
+        case other =>
+          None
+      }
+    }.toList
 
     val httpr = HttpRequest(
       uri = signableUrl,
@@ -95,7 +108,7 @@ private[alpakka] trait AwsClient[S <: ClientSettings] {
         headers.RawHeader("x-amz-date", amzHeaders.get("X-Amz-Date")),
         headers.RawHeader("authorization", amzHeaders.get("Authorization")),
         headers.RawHeader("x-amz-target", amzHeaders.get("X-Amz-Target"))
-      ),
+      ), // ++ tokenHeader,
       entity = HttpEntity(defaultContentType, body)
     )
 

--- a/dynamodb/src/test/resources/application.conf
+++ b/dynamodb/src/test/resources/application.conf
@@ -1,6 +1,6 @@
 akka.stream.alpakka.dynamodb {
   host = "localhost"
-  port: 8000
+  port: 8001
   region = "us-east-1"
   parallelism = 5
 }

--- a/dynamodb/src/test/resources/application.conf
+++ b/dynamodb/src/test/resources/application.conf
@@ -1,6 +1,6 @@
 akka.stream.alpakka.dynamodb {
   host = "localhost"
-  port: 8001
+  port: 8000
   region = "us-east-1"
   parallelism = 5
 }


### PR DESCRIPTION
Current implementation uses the DefaultAWSCredentialsProviderChain which provides support for obtaining the credentials from the instance. 

When the headers are added on the http request the  "X-Amz-Security-Token" is ommited but it is required.

Small DRY of the host address and update for the documentation for the port settings.

Tested in AWS. Any suggestion how to test it locally welcome.

See #276 