### PR TITLE
Fix timing issue in Elasticsearch tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,6 +93,7 @@ lazy val elasticsearch = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "akka-stream-alpakka-elasticsearch",
+    parallelExecution in ThisBuild := false,
     Dependencies.Elasticsearch
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -93,8 +93,9 @@ lazy val elasticsearch = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "akka-stream-alpakka-elasticsearch",
-    parallelExecution in ThisBuild := false,
-    Dependencies.Elasticsearch
+    Dependencies.Elasticsearch,
+    // For elasticsearch-cluster-runner https://github.com/akka/alpakka/issues/479
+    parallelExecution in Test := false
   )
 
 lazy val files = project // The name file is taken by `sbt.file`!

--- a/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
+++ b/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
@@ -41,13 +41,13 @@ public class ElasticsearchTest {
   public static void setup() throws IOException {
     runner = new ElasticsearchClusterRunner();
     runner.build(ElasticsearchClusterRunner.newConfigs()
-        .baseHttpPort(9210)
-        .baseTransportPort(9310)
+        .baseHttpPort(9200)
+        .baseTransportPort(9300)
         .numOfNode(1));
     runner.ensureYellow();
 
     //#init-client
-    client = RestClient.builder(new HttpHost("localhost", 9211)).build();
+    client = RestClient.builder(new HttpHost("localhost", 9201)).build();
     //#init-client
 
     //#init-mat

--- a/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
+++ b/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
@@ -40,7 +40,10 @@ public class ElasticsearchTest {
   @BeforeClass
   public static void setup() throws IOException {
     runner = new ElasticsearchClusterRunner();
-    runner.build(ElasticsearchClusterRunner.newConfigs().baseHttpPort(9210).baseTransportPort(9310).numOfNode(1));
+    runner.build(ElasticsearchClusterRunner.newConfigs()
+        .baseHttpPort(9210)
+        .baseTransportPort(9310)
+        .numOfNode(1));
     runner.ensureYellow();
 
     //#init-client

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
@@ -235,6 +235,4 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
     }
   }
 
-
-
 }

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
@@ -39,7 +39,13 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
   //#define-class
 
   override def beforeAll() = {
-    runner.build(ElasticsearchClusterRunner.newConfigs().baseHttpPort(9200).baseTransportPort(9300).numOfNode(1))
+    runner.build(
+      ElasticsearchClusterRunner
+        .newConfigs()
+        .baseHttpPort(9200)
+        .baseTransportPort(9300)
+        .numOfNode(1)
+    )
     runner.ensureYellow()
 
     register("source", "Akka in Action")
@@ -228,5 +234,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       )
     }
   }
+
+
 
 }


### PR DESCRIPTION
Disables parallel test because [elasticsearch-cluster-runner](https://github.com/codelibs/elasticsearch-cluster-runner) which is used to run Elasticsearch for test doesn't support parallel execution on same JVM formally.

Fixes #479.