### PR TITLE
Allow message ack downstream

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnector.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnector.scala
@@ -66,7 +66,7 @@ private[amqp] trait AmqpConnector {
 private[amqp] trait AmqpConnectorLogic { this: GraphStageLogic =>
 
   private var connection: Connection = _
-  protected var channel: Channel = _
+  protected implicit var channel: Channel = _
 
   def settings: AmqpConnectorSettings
   def connectionFactoryFrom(settings: AmqpConnectionSettings): ConnectionFactory

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnector.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnector.scala
@@ -66,7 +66,7 @@ private[amqp] trait AmqpConnector {
 private[amqp] trait AmqpConnectorLogic { this: GraphStageLogic =>
 
   private var connection: Connection = _
-  protected implicit var channel: Channel = _
+  protected var channel: Channel = _
 
   def settings: AmqpConnectorSettings
   def connectionFactoryFrom(settings: AmqpConnectionSettings): ConnectionFactory

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpRpcFlowStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpRpcFlowStage.scala
@@ -95,21 +95,19 @@ final class AmqpRpcFlowStage(settings: AmqpSinkSettings, bufferSize: Int, respon
               new CommittableIncomingMessage {
                 override val message = IncomingMessage(ByteString(body), envelope, properties)
 
-                override def ack(multiple: Boolean) = {
+                override def ack(multiple: Boolean) =
                   Future {
                     channel.basicAck(message.envelope.getDeliveryTag, multiple)
                     commitCallback.invoke(None)
                     Done
                   }
-                }
 
-                override def nack(multiple: Boolean, requeue: Boolean) = {
+                override def nack(multiple: Boolean, requeue: Boolean) =
                   Future {
                     channel.basicNack(message.envelope.getDeliveryTag, multiple, requeue)
                     commitCallback.invoke(None)
                     Done
                   }
-                }
               }
             )
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSinkStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSinkStage.scala
@@ -4,7 +4,7 @@
 package akka.stream.alpakka.amqp
 
 import akka.Done
-import akka.stream.stage.{GraphStage, GraphStageLogic, GraphStageWithMaterializedValue, InHandler}
+import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, InHandler}
 import akka.stream.{ActorAttributes, Attributes, Inlet, SinkShape}
 import akka.util.ByteString
 import com.rabbitmq.client.AMQP.BasicProperties

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
@@ -15,7 +15,7 @@ import scala.collection.mutable
 
 final case class IncomingMessage(bytes: ByteString, envelope: Envelope, properties: BasicProperties)
 final case class CommittableIncomingMessage(message: IncomingMessage,
-                                            callback: AsyncCallback[Unit] = _ => Unit)(implicit channel: Channel) {
+                                            callback: AsyncCallback[Unit] = (_: Unit) => Unit)(implicit channel: Channel) {
   def ack(multiple: Boolean = false) = {
     channel.basicAck(message.envelope.getDeliveryTag, multiple)
     callback.invoke(Unit)

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
@@ -15,12 +15,12 @@ import scala.collection.mutable
 
 final case class IncomingMessage(bytes: ByteString, envelope: Envelope, properties: BasicProperties)
 final case class CommittableIncomingMessage(message: IncomingMessage,
-                                            callback: AsyncCallback[Unit] = _ => Unit)(implicit channel: Channel) {
-  def ack(multiple: Boolean = false) = {
+                                            callback: AsyncCallback[Unit] = (_: Unit) => Unit)(implicit channel: Channel) {
+  def ack(multiple: Boolean = false): Unit = {
     channel.basicAck(message.envelope.getDeliveryTag, multiple)
     callback.invoke(None)
   }
-  def nack(multiple: Boolean = false, requeue: Boolean = true) = {
+  def nack(multiple: Boolean = false, requeue: Boolean = true): Unit = {
     channel.basicNack(message.envelope.getDeliveryTag, multiple, requeue)
     callback.invoke(None)
   }

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
@@ -78,21 +78,19 @@ final class AmqpSourceStage(settings: AmqpSourceSettings, bufferSize: Int)
               new CommittableIncomingMessage {
                 override val message = IncomingMessage(ByteString(body), envelope, properties)
 
-                override def ack(multiple: Boolean) = {
+                override def ack(multiple: Boolean) =
                   Future {
                     channel.basicAck(message.envelope.getDeliveryTag, multiple)
                     commitCallback.invoke(None)
                     Done
                   }
-                }
 
-                override def nack(multiple: Boolean, requeue: Boolean) = {
+                override def nack(multiple: Boolean, requeue: Boolean) =
                   Future {
                     channel.basicNack(message.envelope.getDeliveryTag, multiple, requeue)
                     commitCallback.invoke(None)
                     Done
                   }
-                }
               }
             )
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
@@ -16,8 +16,11 @@ trait IncomingMessage {
   def envelope: Envelope
   def properties: BasicProperties
 }
-final case class AckedIncomingMessage(bytes: ByteString, envelope: Envelope, properties: BasicProperties) extends IncomingMessage
-final case class UnackedIncomingMessage(bytes: ByteString, envelope: Envelope, properties: BasicProperties)(implicit channel: Channel) extends IncomingMessage {
+final case class AckedIncomingMessage(bytes: ByteString, envelope: Envelope, properties: BasicProperties)
+    extends IncomingMessage
+final case class UnackedIncomingMessage(bytes: ByteString, envelope: Envelope, properties: BasicProperties)(
+    implicit channel: Channel
+) extends IncomingMessage {
   def ack() = channel.basicAck(envelope.getDeliveryTag, false)
   def nack(requeue: Boolean = true) = channel.basicNack(envelope.getDeliveryTag, false, requeue)
 }

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
@@ -15,14 +15,14 @@ import scala.collection.mutable
 
 final case class IncomingMessage(bytes: ByteString, envelope: Envelope, properties: BasicProperties)
 final case class CommittableIncomingMessage(message: IncomingMessage,
-                                            callback: AsyncCallback[Unit] = (_: Unit) => Unit)(implicit channel: Channel) {
+                                            callback: AsyncCallback[Unit] = _ => Unit)(implicit channel: Channel) {
   def ack(multiple: Boolean = false) = {
     channel.basicAck(message.envelope.getDeliveryTag, multiple)
-    callback.invoke(Unit)
+    callback.invoke(None)
   }
   def nack(multiple: Boolean = false, requeue: Boolean = true) = {
     channel.basicNack(message.envelope.getDeliveryTag, multiple, requeue)
-    callback.invoke(Unit)
+    callback.invoke(None)
   }
 }
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
@@ -14,8 +14,12 @@ import com.rabbitmq.client._
 import scala.collection.mutable
 
 final case class IncomingMessage(bytes: ByteString, envelope: Envelope, properties: BasicProperties)
-final case class CommittableIncomingMessage(message: IncomingMessage,
-                                            callback: AsyncCallback[Unit] = (_: Unit) => Unit)(implicit channel: Channel) {
+final case class CommittableIncomingMessage(
+    message: IncomingMessage,
+    callback: AsyncCallback[Unit] = new AsyncCallback[Unit] {
+      override def invoke(t: Unit): Unit = Unit
+    }
+)(implicit channel: Channel) {
   def ack(multiple: Boolean = false): Unit = {
     channel.basicAck(message.envelope.getDeliveryTag, multiple)
     callback.invoke(None)

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpRpcFlow.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpRpcFlow.scala
@@ -61,7 +61,7 @@ object AmqpRpcFlow {
 
   /**
    * Java API:
-   * Convenience for "at-most once delivery" semantics. Each message is acked to Kafka
+   * Convenience for "at-most once delivery" semantics. Each message is acked to RabbitMQ
    * before it is emitted downstream.
    */
   def atMostOnceFlow(settings: AmqpSinkSettings,
@@ -91,6 +91,7 @@ object AmqpRpcFlow {
     akka.stream.alpakka.amqp.scaladsl.AmqpRpcFlow
       .committableFlow(settings, bufferSize, repliesPerMessage)
       .mapMaterializedValue(f => f.toJava)
+      .map(cm => cm.asJava)
       .asJava
 
 }

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpRpcFlow.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpRpcFlow.scala
@@ -59,4 +59,38 @@ object AmqpRpcFlow {
       .mapMaterializedValue(f => f.toJava)
       .asJava
 
+  /**
+   * Java API:
+   * Convenience for "at-most once delivery" semantics. Each message is acked to Kafka
+   * before it is emitted downstream.
+   */
+  def atMostOnceFlow(settings: AmqpSinkSettings,
+                     bufferSize: Int,
+                     repliesPerMessage: Int = 1): Flow[OutgoingMessage, IncomingMessage, CompletionStage[String]] =
+    akka.stream.alpakka.amqp.scaladsl.AmqpRpcFlow
+      .atMostOnceFlow(settings, bufferSize, repliesPerMessage)
+      .mapMaterializedValue(f => f.toJava)
+      .asJava
+
+  /**
+   * Java API:
+   * The `committableFlow` makes it possible to commit (ack/nack) messages to RabbitMQ.
+   * This is useful when "at-least once delivery" is desired, as each message will likely be
+   * delivered one time but in failure cases could be duplicated.
+   *
+   * If you commit the offset before processing the message you get "at-most once delivery" semantics,
+   * and for that there is a [[#atMostOnceFlow]].
+   *
+   * Compared to auto-commit, this gives exact control over when a message is considered consumed.
+   */
+  def committableFlow(
+      settings: AmqpSinkSettings,
+      bufferSize: Int,
+      repliesPerMessage: Int = 1
+  ): Flow[OutgoingMessage, CommittableIncomingMessage, CompletionStage[String]] =
+    akka.stream.alpakka.amqp.scaladsl.AmqpRpcFlow
+      .committableFlow(settings, bufferSize, repliesPerMessage)
+      .mapMaterializedValue(f => f.toJava)
+      .asJava
+
 }

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpRpcFlow.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpRpcFlow.scala
@@ -39,7 +39,7 @@ object AmqpRpcFlow {
   def create(settings: AmqpSinkSettings,
              bufferSize: Int,
              repliesPerMessage: Int): Flow[OutgoingMessage, IncomingMessage, CompletionStage[String]] =
-  atMostOnceFlow(settings, bufferSize, repliesPerMessage)
+    atMostOnceFlow(settings, bufferSize, repliesPerMessage)
 
   /**
    * Java API:
@@ -59,10 +59,10 @@ object AmqpRpcFlow {
       .asJava
 
   /**
-    * Java API:
-    * Convenience for "at-most once delivery" semantics. Each message is acked to RabbitMQ
-    * before it is emitted downstream.
-    */
+   * Java API:
+   * Convenience for "at-most once delivery" semantics. Each message is acked to RabbitMQ
+   * before it is emitted downstream.
+   */
   def atMostOnceFlow(settings: AmqpSinkSettings,
                      bufferSize: Int): Flow[OutgoingMessage, IncomingMessage, CompletionStage[String]] =
     akka.stream.alpakka.amqp.scaladsl.AmqpRpcFlow

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpRpcFlow.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpRpcFlow.scala
@@ -20,9 +20,10 @@ object AmqpRpcFlow {
    *
    * This stage materializes to a CompletionStage<String>, which is the name of the private exclusive queue used for RPC communication.
    */
+  @deprecated("use atMostOnceFlow instead", "0.13")
   def create(settings: AmqpSinkSettings,
              bufferSize: Int): Flow[OutgoingMessage, IncomingMessage, CompletionStage[String]] =
-    akka.stream.alpakka.amqp.scaladsl.AmqpRpcFlow(settings, bufferSize).mapMaterializedValue(f => f.toJava).asJava
+    atMostOnceFlow(settings, bufferSize, 1)
 
   /**
    * Java API:
@@ -34,13 +35,11 @@ object AmqpRpcFlow {
    * @param repliesPerMessage The number of responses that should be expected for each message placed on the queue. This
    *                            can be overridden per message by including `expectedReplies` in the the header of the [[OutgoingMessage]]
    */
+  @deprecated("use atMostOnceFlow instead", "0.13")
   def create(settings: AmqpSinkSettings,
              bufferSize: Int,
              repliesPerMessage: Int): Flow[OutgoingMessage, IncomingMessage, CompletionStage[String]] =
-    akka.stream.alpakka.amqp.scaladsl
-      .AmqpRpcFlow(settings, bufferSize, repliesPerMessage)
-      .mapMaterializedValue(f => f.toJava)
-      .asJava
+  atMostOnceFlow(settings, bufferSize, repliesPerMessage)
 
   /**
    * Java API:
@@ -60,13 +59,25 @@ object AmqpRpcFlow {
       .asJava
 
   /**
+    * Java API:
+    * Convenience for "at-most once delivery" semantics. Each message is acked to RabbitMQ
+    * before it is emitted downstream.
+    */
+  def atMostOnceFlow(settings: AmqpSinkSettings,
+                     bufferSize: Int): Flow[OutgoingMessage, IncomingMessage, CompletionStage[String]] =
+    akka.stream.alpakka.amqp.scaladsl.AmqpRpcFlow
+      .atMostOnceFlow(settings, bufferSize)
+      .mapMaterializedValue(f => f.toJava)
+      .asJava
+
+  /**
    * Java API:
    * Convenience for "at-most once delivery" semantics. Each message is acked to RabbitMQ
    * before it is emitted downstream.
    */
   def atMostOnceFlow(settings: AmqpSinkSettings,
                      bufferSize: Int,
-                     repliesPerMessage: Int = 1): Flow[OutgoingMessage, IncomingMessage, CompletionStage[String]] =
+                     repliesPerMessage: Int): Flow[OutgoingMessage, IncomingMessage, CompletionStage[String]] =
     akka.stream.alpakka.amqp.scaladsl.AmqpRpcFlow
       .atMostOnceFlow(settings, bufferSize, repliesPerMessage)
       .mapMaterializedValue(f => f.toJava)

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
@@ -4,7 +4,7 @@
 package akka.stream.alpakka.amqp.javadsl
 
 import akka.NotUsed
-import akka.stream.alpakka.amqp.{AmqpSourceSettings, AmqpSourceStage, IncomingMessage}
+import akka.stream.alpakka.amqp.{AmqpSourceSettings, AmqpSourceStage, CommittableIncomingMessage, IncomingMessage}
 import akka.stream.javadsl.Source
 
 object AmqpSource {
@@ -13,6 +13,31 @@ object AmqpSource {
    * Java API: Creates an [[AmqpSource]] with given settings and buffer size.
    */
   def create(settings: AmqpSourceSettings, bufferSize: Int): Source[IncomingMessage, NotUsed] =
+    atMostOnceSource(settings, bufferSize)
+
+  /**
+   * Java API: Convenience for "at-most once delivery" semantics. Each message is acked to Kafka
+   * before it is emitted downstream.
+   */
+  def atMostOnceSource(settings: AmqpSourceSettings, bufferSize: Int): Source[IncomingMessage, NotUsed] =
+    committableSource(settings, bufferSize)
+      .map(cm => {
+        cm.ack()
+        cm.message
+      })
+
+  /**
+   * Java API:
+   * The `committableSource` makes it possible to commit (ack/nack) messages to RabbitMQ.
+   * This is useful when "at-least once delivery" is desired, as each message will likely be
+   * delivered one time but in failure cases could be duplicated.
+   *
+   * If you commit the offset before processing the message you get "at-most once delivery" semantics,
+   * and for that there is a [[#atMostOnceSource]].
+   *
+   * Compared to auto-commit, this gives exact control over when a message is considered consumed.
+   */
+  def committableSource(settings: AmqpSourceSettings, bufferSize: Int): Source[CommittableIncomingMessage, NotUsed] =
     Source.fromGraph(new AmqpSourceStage(settings, bufferSize))
 
 }

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
@@ -4,7 +4,7 @@
 package akka.stream.alpakka.amqp.javadsl
 
 import akka.NotUsed
-import akka.stream.alpakka.amqp.{AmqpSourceSettings, AmqpSourceStage, CommittableIncomingMessage, IncomingMessage}
+import akka.stream.alpakka.amqp.{AmqpSourceSettings, CommittableIncomingMessage, IncomingMessage}
 import akka.stream.javadsl.Source
 
 object AmqpSource {
@@ -20,11 +20,10 @@ object AmqpSource {
    * before it is emitted downstream.
    */
   def atMostOnceSource(settings: AmqpSourceSettings, bufferSize: Int): Source[IncomingMessage, NotUsed] =
-    committableSource(settings, bufferSize)
-      .map((cm: CommittableIncomingMessage) => {
-        cm.ack()
-        cm.message
-      })
+    akka.stream.alpakka.amqp.scaladsl.AmqpSource
+      .atMostOnceSource(settings, bufferSize)
+      .asJava
+
 
   /**
    * Java API:
@@ -38,6 +37,8 @@ object AmqpSource {
    * Compared to auto-commit, this gives exact control over when a message is considered consumed.
    */
   def committableSource(settings: AmqpSourceSettings, bufferSize: Int): Source[CommittableIncomingMessage, NotUsed] =
-    Source.fromGraph(new AmqpSourceStage(settings, bufferSize))
+    akka.stream.alpakka.amqp.scaladsl.AmqpSource
+      .committableSource(settings, bufferSize)
+      .asJava
 
 }

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
@@ -37,7 +37,7 @@ object AmqpSource {
    * Compared to auto-commit, this gives exact control over when a message is considered consumed.
    */
   def committableSource(settings: AmqpSourceSettings, bufferSize: Int): Source[CommittableIncomingMessage, NotUsed] =
-    try akka.stream.alpakka.amqp.scaladsl.AmqpSource
+    akka.stream.alpakka.amqp.scaladsl.AmqpSource
       .committableSource(settings, bufferSize)
       .map(cm => cm.asJava)
       .asJava

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
@@ -12,6 +12,7 @@ object AmqpSource {
   /**
    * Java API: Creates an [[AmqpSource]] with given settings and buffer size.
    */
+  @deprecated("use atMostOnceSource instead", "0.13")
   def create(settings: AmqpSourceSettings, bufferSize: Int): Source[IncomingMessage, NotUsed] =
     atMostOnceSource(settings, bufferSize)
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
@@ -24,7 +24,6 @@ object AmqpSource {
       .atMostOnceSource(settings, bufferSize)
       .asJava
 
-
   /**
    * Java API:
    * The `committableSource` makes it possible to commit (ack/nack) messages to RabbitMQ.

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
@@ -4,7 +4,7 @@
 package akka.stream.alpakka.amqp.javadsl
 
 import akka.NotUsed
-import akka.stream.alpakka.amqp.{AmqpSourceSettings, CommittableIncomingMessage, IncomingMessage}
+import akka.stream.alpakka.amqp.{AmqpSourceSettings, IncomingMessage}
 import akka.stream.javadsl.Source
 
 object AmqpSource {
@@ -16,7 +16,7 @@ object AmqpSource {
     atMostOnceSource(settings, bufferSize)
 
   /**
-   * Java API: Convenience for "at-most once delivery" semantics. Each message is acked to Kafka
+   * Java API: Convenience for "at-most once delivery" semantics. Each message is acked to RabbitMQ
    * before it is emitted downstream.
    */
   def atMostOnceSource(settings: AmqpSourceSettings, bufferSize: Int): Source[IncomingMessage, NotUsed] =
@@ -36,8 +36,9 @@ object AmqpSource {
    * Compared to auto-commit, this gives exact control over when a message is considered consumed.
    */
   def committableSource(settings: AmqpSourceSettings, bufferSize: Int): Source[CommittableIncomingMessage, NotUsed] =
-    akka.stream.alpakka.amqp.scaladsl.AmqpSource
+    try akka.stream.alpakka.amqp.scaladsl.AmqpSource
       .committableSource(settings, bufferSize)
+      .map(cm => cm.asJava)
       .asJava
 
 }

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
@@ -21,7 +21,7 @@ object AmqpSource {
    */
   def atMostOnceSource(settings: AmqpSourceSettings, bufferSize: Int): Source[IncomingMessage, NotUsed] =
     committableSource(settings, bufferSize)
-      .map(cm => {
+      .map((cm: CommittableIncomingMessage) => {
         cm.ack()
         cm.message
       })

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/CommittableIncomingMessage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/CommittableIncomingMessage.scala
@@ -1,0 +1,12 @@
+package akka.stream.alpakka.amqp.javadsl
+
+import java.util.concurrent.CompletionStage
+
+import akka.Done
+import akka.stream.alpakka.amqp.IncomingMessage
+
+trait CommittableIncomingMessage {
+  val message: IncomingMessage
+  def ack(multiple: Boolean = false): CompletionStage[Done]
+  def nack(multiple: Boolean = false, requeue: Boolean = true): CompletionStage[Done]
+}

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/CommittableIncomingMessage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/CommittableIncomingMessage.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
 package akka.stream.alpakka.amqp.javadsl
 
 import java.util.concurrent.CompletionStage

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/package.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/package.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
 package akka.stream.alpakka.amqp
 
 import java.util.concurrent.CompletionStage
@@ -6,9 +9,10 @@ import akka.Done
 import akka.stream.alpakka.amqp.scaladsl.{CommittableIncomingMessage => ScalaCommittableIncomingMessage}
 
 import scala.compat.java8.FutureConverters
+
 /**
-  * This implicit classes allow to convert the Committable and CommittableMessage between scaladsl and javadsl.
-  */
+ * This implicit classes allow to convert the Committable and CommittableMessage between scaladsl and javadsl.
+ */
 package object javadsl {
 
   import FutureConverters._
@@ -17,7 +21,8 @@ package object javadsl {
     def asJava: CommittableIncomingMessage = new CommittableIncomingMessage {
       override val message: IncomingMessage = cm.message
       override def ack(multiple: Boolean = false): CompletionStage[Done] = cm.ack(multiple).toJava
-      override def nack(multiple: Boolean = false, requeue: Boolean = true): CompletionStage[Done] = cm.nack(multiple, requeue).toJava
+      override def nack(multiple: Boolean = false, requeue: Boolean = true): CompletionStage[Done] =
+        cm.nack(multiple, requeue).toJava
     }
   }
 }

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/package.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/package.scala
@@ -1,0 +1,23 @@
+package akka.stream.alpakka.amqp
+
+import java.util.concurrent.CompletionStage
+
+import akka.Done
+import akka.stream.alpakka.amqp.scaladsl.{CommittableIncomingMessage => ScalaCommittableIncomingMessage}
+
+import scala.compat.java8.FutureConverters
+/**
+  * This implicit classes allow to convert the Committable and CommittableMessage between scaladsl and javadsl.
+  */
+package object javadsl {
+
+  import FutureConverters._
+
+  private[javadsl] implicit class RichCommittableIncomingMessage(cm: ScalaCommittableIncomingMessage) {
+    def asJava: CommittableIncomingMessage = new CommittableIncomingMessage {
+      override val message: IncomingMessage = cm.message
+      override def ack(multiple: Boolean = false): CompletionStage[Done] = cm.ack(multiple).toJava
+      override def nack(multiple: Boolean = false, requeue: Boolean = true): CompletionStage[Done] = cm.nack(multiple, requeue).toJava
+    }
+  }
+}

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
@@ -4,7 +4,6 @@
 package akka.stream.alpakka.amqp
 
 import com.rabbitmq.client.ExceptionHandler
-import scala.collection.JavaConverters._
 
 /**
  * Internal API
@@ -14,9 +13,7 @@ sealed trait AmqpConnectorSettings {
   def declarations: Seq[Declaration]
 }
 
-sealed trait AmqpSourceSettings extends AmqpConnectorSettings {
-  def autoAck: Boolean
-}
+sealed trait AmqpSourceSettings extends AmqpConnectorSettings
 
 final case class NamedQueueSourceSettings(
     connectionSettings: AmqpConnectionSettings,
@@ -25,8 +22,7 @@ final case class NamedQueueSourceSettings(
     noLocal: Boolean = false,
     exclusive: Boolean = false,
     consumerTag: String = "default",
-    arguments: Map[String, AnyRef] = Map.empty,
-    autoAck: Boolean = true
+    arguments: Map[String, AnyRef] = Map.empty
 ) extends AmqpSourceSettings {
   @annotation.varargs
   def withDeclarations(declarations: Declaration*) = copy(declarations = declarations.toList)
@@ -43,8 +39,6 @@ final case class NamedQueueSourceSettings(
   @annotation.varargs
   def withArguments(argument: akka.japi.Pair[String, AnyRef], arguments: akka.japi.Pair[String, AnyRef]*) =
     copy(arguments = (argument +: arguments).map(_.toScala).toMap)
-
-  def withAutoAck(autoAck: Boolean) = copy(autoAck = autoAck)
 }
 
 object NamedQueueSourceSettings {
@@ -60,15 +54,12 @@ final case class TemporaryQueueSourceSettings(
     connectionSettings: AmqpConnectionSettings,
     exchange: String,
     declarations: Seq[Declaration] = Seq.empty,
-    routingKey: Option[String] = None,
-    autoAck: Boolean = true
+    routingKey: Option[String] = None
 ) extends AmqpSourceSettings {
   def withRoutingKey(routingKey: String) = copy(routingKey = Some(routingKey))
 
   @annotation.varargs
   def withDeclarations(declarations: Declaration*) = copy(declarations = declarations.toList)
-
-  def withAutoAck(autoAck: Boolean) = copy(autoAck = autoAck)
 }
 
 object TemporaryQueueSourceSettings {
@@ -107,8 +98,7 @@ final case class AmqpSinkSettings(
     connectionSettings: AmqpConnectionSettings,
     exchange: Option[String] = None,
     routingKey: Option[String] = None,
-    declarations: Seq[Declaration] = Seq.empty,
-    autoAck: Boolean = true
+    declarations: Seq[Declaration] = Seq.empty
 ) extends AmqpConnectorSettings {
   def withExchange(exchange: String) = copy(exchange = Some(exchange))
 
@@ -116,8 +106,6 @@ final case class AmqpSinkSettings(
 
   @annotation.varargs
   def withDeclarations(declarations: Declaration*) = copy(declarations = declarations.toList)
-
-  def withAutoAck(autoAck: Boolean) = copy(autoAck = autoAck)
 }
 
 object AmqpSinkSettings {

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
@@ -14,7 +14,9 @@ sealed trait AmqpConnectorSettings {
   def declarations: Seq[Declaration]
 }
 
-sealed trait AmqpSourceSettings extends AmqpConnectorSettings
+sealed trait AmqpSourceSettings extends AmqpConnectorSettings {
+  def autoAck: Boolean
+}
 
 final case class NamedQueueSourceSettings(
     connectionSettings: AmqpConnectionSettings,
@@ -23,7 +25,8 @@ final case class NamedQueueSourceSettings(
     noLocal: Boolean = false,
     exclusive: Boolean = false,
     consumerTag: String = "default",
-    arguments: Map[String, AnyRef] = Map.empty
+    arguments: Map[String, AnyRef] = Map.empty,
+    autoAck: Boolean = true
 ) extends AmqpSourceSettings {
   @annotation.varargs
   def withDeclarations(declarations: Declaration*) = copy(declarations = declarations.toList)
@@ -40,6 +43,8 @@ final case class NamedQueueSourceSettings(
   @annotation.varargs
   def withArguments(argument: akka.japi.Pair[String, AnyRef], arguments: akka.japi.Pair[String, AnyRef]*) =
     copy(arguments = (argument +: arguments).map(_.toScala).toMap)
+
+  def withAutoAck(autoAck: Boolean) = copy(autoAck = autoAck)
 }
 
 object NamedQueueSourceSettings {
@@ -55,12 +60,15 @@ final case class TemporaryQueueSourceSettings(
     connectionSettings: AmqpConnectionSettings,
     exchange: String,
     declarations: Seq[Declaration] = Seq.empty,
-    routingKey: Option[String] = None
+    routingKey: Option[String] = None,
+    autoAck: Boolean = true
 ) extends AmqpSourceSettings {
   def withRoutingKey(routingKey: String) = copy(routingKey = Some(routingKey))
 
   @annotation.varargs
   def withDeclarations(declarations: Declaration*) = copy(declarations = declarations.toList)
+
+  def withAutoAck(autoAck: Boolean) = copy(autoAck = autoAck)
 }
 
 object TemporaryQueueSourceSettings {
@@ -99,7 +107,8 @@ final case class AmqpSinkSettings(
     connectionSettings: AmqpConnectionSettings,
     exchange: Option[String] = None,
     routingKey: Option[String] = None,
-    declarations: Seq[Declaration] = Seq.empty
+    declarations: Seq[Declaration] = Seq.empty,
+    autoAck: Boolean = true
 ) extends AmqpConnectorSettings {
   def withExchange(exchange: String) = copy(exchange = Some(exchange))
 
@@ -107,6 +116,8 @@ final case class AmqpSinkSettings(
 
   @annotation.varargs
   def withDeclarations(declarations: Declaration*) = copy(declarations = declarations.toList)
+
+  def withAutoAck(autoAck: Boolean) = copy(autoAck = autoAck)
 }
 
 object AmqpSinkSettings {

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpRpcFlow.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpRpcFlow.scala
@@ -3,8 +3,8 @@
  */
 package akka.stream.alpakka.amqp.scaladsl
 
-import akka.stream.alpakka.amqp.{AmqpRpcFlowStage, AmqpSinkSettings, IncomingMessage, OutgoingMessage}
-import akka.stream.scaladsl.{Flow, Keep, Sink}
+import akka.stream.alpakka.amqp._
+import akka.stream.scaladsl.{Flow, Keep}
 import akka.util.ByteString
 
 import scala.concurrent.Future
@@ -24,7 +24,7 @@ object AmqpRpcFlow {
   def simple(settings: AmqpSinkSettings, repliesPerMessage: Int = 1): Flow[ByteString, ByteString, Future[String]] =
     Flow[ByteString]
       .map(bytes => OutgoingMessage(bytes, false, false, None))
-      .viaMat(apply(settings, 1, repliesPerMessage))(Keep.right)
+      .viaMat(atMostOnceFlow(settings, 1, repliesPerMessage))(Keep.right)
       .map(_.bytes)
 
   /**
@@ -40,6 +40,36 @@ object AmqpRpcFlow {
   def apply(settings: AmqpSinkSettings,
             bufferSize: Int,
             repliesPerMessage: Int = 1): Flow[OutgoingMessage, IncomingMessage, Future[String]] =
+    atMostOnceFlow(settings, bufferSize, repliesPerMessage)
+
+  /**
+   * Scala API:
+   * Convenience for "at-most once delivery" semantics. Each message is acked to Kafka
+   * before it is emitted downstream.
+   */
+  def atMostOnceFlow(settings: AmqpSinkSettings,
+                     bufferSize: Int,
+                     repliesPerMessage: Int = 1): Flow[OutgoingMessage, IncomingMessage, Future[String]] =
+    committableFlow(settings, bufferSize, repliesPerMessage)
+      .map(cm => {
+        cm.ack()
+        cm.message
+      })
+
+  /**
+   * Scala API:
+   * The `committableFlow` makes it possible to commit (ack/nack) messages to RabbitMQ.
+   * This is useful when "at-least once delivery" is desired, as each message will likely be
+   * delivered one time but in failure cases could be duplicated.
+   *
+   * If you commit the offset before processing the message you get "at-most once delivery" semantics,
+   * and for that there is a [[#atMostOnceFlow]].
+   *
+   * Compared to auto-commit, this gives exact control over when a message is considered consumed.
+   */
+  def committableFlow(settings: AmqpSinkSettings,
+                      bufferSize: Int,
+                      repliesPerMessage: Int = 1): Flow[OutgoingMessage, CommittableIncomingMessage, Future[String]] =
     Flow.fromGraph(new AmqpRpcFlowStage(settings, bufferSize, repliesPerMessage))
 
 }

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpRpcFlow.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpRpcFlow.scala
@@ -39,6 +39,7 @@ object AmqpRpcFlow {
    * @param repliesPerMessage The number of responses that should be expected for each message placed on the queue. This
    *                            can be overridden per message by including `expectedReplies` in the the header of the [[OutgoingMessage]]
    */
+  @deprecated("use atMostOnceFlow instead", "0.13")
   def apply(settings: AmqpSinkSettings,
             bufferSize: Int,
             repliesPerMessage: Int = 1): Flow[OutgoingMessage, IncomingMessage, Future[String]] =

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpSource.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpSource.scala
@@ -4,8 +4,7 @@
 package akka.stream.alpakka.amqp.scaladsl
 
 import akka.NotUsed
-import akka.stream.alpakka.amqp.{AmqpSourceSettings, AmqpSourceStage, IncomingMessage}
-
+import akka.stream.alpakka.amqp.{AmqpSourceSettings, AmqpSourceStage, CommittableIncomingMessage, IncomingMessage}
 import akka.stream.scaladsl.Source
 
 object AmqpSource {
@@ -14,6 +13,31 @@ object AmqpSource {
    * Scala API: Creates an [[AmqpSource]] with given settings and buffer size.
    */
   def apply(settings: AmqpSourceSettings, bufferSize: Int): Source[IncomingMessage, NotUsed] =
+    atMostOnceSource(settings, bufferSize)
+
+  /**
+   * Scala API: Convenience for "at-most once delivery" semantics. Each message is acked to Kafka
+   * before it is emitted downstream.
+   */
+  def atMostOnceSource(settings: AmqpSourceSettings, bufferSize: Int): Source[IncomingMessage, NotUsed] =
+    committableSource(settings, bufferSize)
+      .map(cm => {
+        cm.ack()
+        cm.message
+      })
+
+  /**
+   * Scala API:
+   * The `committableSource` makes it possible to commit (ack/nack) messages to RabbitMQ.
+   * This is useful when "at-least once delivery" is desired, as each message will likely be
+   * delivered one time but in failure cases could be duplicated.
+   *
+   * If you commit the offset before processing the message you get "at-most once delivery" semantics,
+   * and for that there is a [[#atMostOnceSource]].
+   *
+   * Compared to auto-commit, this gives exact control over when a message is considered consumed.
+   */
+  def committableSource(settings: AmqpSourceSettings, bufferSize: Int): Source[CommittableIncomingMessage, NotUsed] =
     Source.fromGraph(new AmqpSourceStage(settings, bufferSize))
 
 }

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpSource.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpSource.scala
@@ -14,6 +14,7 @@ object AmqpSource {
   /**
    * Scala API: Creates an [[AmqpSource]] with given settings and buffer size.
    */
+  @deprecated("use atMostOnceSource instead", "0.13")
   def apply(settings: AmqpSourceSettings, bufferSize: Int): Source[IncomingMessage, NotUsed] =
     atMostOnceSource(settings, bufferSize)
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/CommittableIncomingMessage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/CommittableIncomingMessage.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.alpakka.amqp.scaladsl
+
+import akka.Done
+import akka.stream.alpakka.amqp.IncomingMessage
+
+import scala.concurrent.Future
+
+trait CommittableIncomingMessage {
+  val message: IncomingMessage
+  def ack(multiple: Boolean = false): Future[Done]
+  def nack(multiple: Boolean = false, requeue: Boolean = true): Future[Done]
+}

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
@@ -13,7 +13,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import akka.dispatch.ExecutionContexts;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -75,7 +74,7 @@ public class AmqpConnectorsTest {
 
     //#create-source
     final Integer bufferSize = 10;
-    final Source<IncomingMessage, NotUsed> amqpSource = AmqpSource.create(
+    final Source<IncomingMessage, NotUsed> amqpSource = AmqpSource.atMostOnceSource(
       NamedQueueSourceSettings.create(
         DefaultAmqpConnection.getInstance(),
         queueName
@@ -109,7 +108,7 @@ public class AmqpConnectorsTest {
     //#create-rpc-flow
 
     final Integer bufferSize = 10;
-    final Source<IncomingMessage, NotUsed> amqpSource = AmqpSource.create(
+    final Source<IncomingMessage, NotUsed> amqpSource = AmqpSource.atMostOnceSource(
         NamedQueueSourceSettings.create(
             DefaultAmqpConnection.getInstance(),
             queueName
@@ -171,7 +170,7 @@ public class AmqpConnectorsTest {
     for (Integer i = 0; i < fanoutSize; i++) {
       final Integer fanoutBranch = i;
       mergedSources = mergedSources.merge(
-        AmqpSource.create(
+        AmqpSource.atMostOnceSource(
           TemporaryQueueSourceSettings.create(
             DefaultAmqpConnection.getInstance(),
             exchangeName
@@ -248,7 +247,7 @@ public class AmqpConnectorsTest {
     final String queueName = "amqp-conn-it-spec-rpc-queue-" + System.currentTimeMillis();
     final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
 
-    final Flow<OutgoingMessage,IncomingMessage, CompletionStage<String>> ampqRpcFlow = AmqpRpcFlow.create(
+    final Flow<OutgoingMessage,IncomingMessage, CompletionStage<String>> ampqRpcFlow = AmqpRpcFlow.atMostOnceFlow(
             AmqpSinkSettings.create().withRoutingKey(queueName).withDeclarations(queueDeclaration), 10);
 
     final Integer bufferSize = 10;

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
@@ -276,7 +276,7 @@ public class AmqpConnectorsTest {
             new OutgoingMessage(b.bytes(), false, false, Some.apply(b.properties()))
     ).runWith(amqpSink, materializer);
 
-    List<IncomingMessage> probeResult = JavaConverters.seqAsJavaList(probe.toStrict(Duration.create(5, TimeUnit.SECONDS)));
+    List<IncomingMessage> probeResult = JavaConverters.seqAsJavaListConverter(probe.toStrict(Duration.create(5, TimeUnit.SECONDS))).asJava();
 
     probeResult.stream().allMatch(s -> s instanceof UnackedIncomingMessage);
     assertEquals(probeResult.stream().map(s -> s.bytes().utf8String()).collect(Collectors.toList()), input);

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/package.scala
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/package.scala
@@ -1,0 +1,20 @@
+package akka.stream.alpakka.amqp
+
+import java.util.concurrent.CompletionStage
+
+import akka.Done
+import akka.stream.alpakka.amqp.scaladsl.{CommittableIncomingMessage => ScalaCommittableIncomingMessage}
+
+import scala.compat.java8.FutureConverters
+
+package object javadsl {
+  import FutureConverters._
+
+  private[javadsl] implicit class RichCommittableIncomingMessage(cm: ScalaCommittableIncomingMessage) {
+    def asJava: CommittableIncomingMessage = new CommittableIncomingMessage {
+      override val message: IncomingMessage = cm.message
+      override def ack(multiple: Boolean = false): CompletionStage[Done] = cm.ack(multiple).toJava
+      override def nack(multiple: Boolean = false, requeue: Boolean = true): CompletionStage[Done] = cm.nack(multiple, requeue).toJava
+    }
+  }
+}

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/package.scala
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/package.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
 package akka.stream.alpakka.amqp
 
 import java.util.concurrent.CompletionStage

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/AmqpSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/AmqpSpec.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.amqp
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{AsyncWordSpec, BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 
 abstract class AmqpSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
 

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -44,7 +44,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       //#create-sink
 
       //#create-source
-      val amqpSource = AmqpSource(
+      val amqpSource = AmqpSource.atMostOnceSource(
         NamedQueueSourceSettings(connectionSettings, queueName).withDeclarations(queueDeclaration),
         bufferSize = 10
       )
@@ -73,7 +73,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       )
       //#create-rpc-flow
 
-      val amqpSource = AmqpSource(
+      val amqpSource = AmqpSource.atMostOnceSource(
         NamedQueueSourceSettings(DefaultAmqpConnection, queueName),
         bufferSize = 1
       )
@@ -105,7 +105,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
         2
       )
 
-      val amqpSource = AmqpSource(
+      val amqpSource = AmqpSource.atMostOnceSource(
         NamedQueueSourceSettings(DefaultAmqpConnection, queueName),
         bufferSize = 1
       )
@@ -184,7 +184,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
         val merge = b.add(Merge[IncomingMessage](count))
         for (n <- 0 until count) {
           val source = b.add(
-            AmqpSource(
+            AmqpSource.atMostOnceSource(
               NamedQueueSourceSettings(DefaultAmqpConnection, queueName).withDeclarations(queueDeclaration),
               bufferSize = 1
             )
@@ -253,7 +253,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
     "not ack messages unless they get consumed" in {
       val queueName = "amqp-conn-it-spec-simple-queue-2-" + System.currentTimeMillis()
       val queueDeclaration = QueueDeclaration(queueName)
-      val amqpSource = AmqpSource(
+      val amqpSource = AmqpSource.atMostOnceSource(
         NamedQueueSourceSettings(DefaultAmqpConnection, queueName).withDeclarations(queueDeclaration),
         bufferSize = 10
       )
@@ -333,7 +333,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       val mergedSources = (0 until fanoutSize).foldLeft(Source.empty[(Int, String)]) {
         case (source, fanoutBranch) =>
           source.merge(
-            AmqpSource(
+            AmqpSource.atMostOnceSource(
               TemporaryQueueSourceSettings(
                 DefaultAmqpConnection,
                 exchangeName

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -10,7 +10,6 @@ import akka.stream.scaladsl.{GraphDSL, Keep, Merge, Sink, Source}
 import akka.stream.testkit.scaladsl.TestSink
 import akka.stream.testkit.{TestPublisher, TestSubscriber}
 import akka.util.ByteString
-import org.scalatest.exceptions.TestFailedException
 
 import scala.concurrent.Promise
 import scala.concurrent.duration._
@@ -487,7 +486,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
         .take(input.size)
         .runWith(Sink.seq)
 
-      result2.isReadyWithin(200 milliseconds) shouldEqual false
+      result2.isReadyWithin(1.second) shouldEqual false
     }
 
     "publish via RPC and then consume through a simple queue again in the same JVM without autoAck" in {
@@ -526,7 +525,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
         .map(b => OutgoingMessage(b.bytes, false, false, Some(b.properties)))
         .runWith(amqpSink)
 
-      val probeResult = probe.toStrict(200 milliseconds)
+      val probeResult = probe.toStrict(1.second)
 
       all(probeResult) shouldBe an[UnackedIncomingMessage]
       probeResult.map(_.bytes.utf8String) shouldEqual input

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -474,7 +474,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
         .take(input.size)
         .runWith(Sink.seq)
 
-      result.isReadyWithin(1.second) shouldEqual false
+      result.isReadyWithin(3.second) shouldEqual false
     }
 
     "publish via RPC and then consume through a simple queue again in the same JVM without autoAck" in {
@@ -516,7 +516,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
         .map(b => OutgoingMessage(b.bytes, false, false, Some(b.properties)))
         .runWith(amqpSink)
 
-      probe.toStrict(1.second).map(_.message.bytes.utf8String) shouldEqual input
+      probe.toStrict(3.second).map(_.message.bytes.utf8String) shouldEqual input
     }
   }
 }

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -59,7 +59,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       //#run-source
 
       val resultfutureValue = result.futureValue
-      all (resultfutureValue) shouldBe an[AckedIncomingMessage]
+      all(resultfutureValue) shouldBe an[AckedIncomingMessage]
       resultfutureValue.map(_.bytes.utf8String) shouldEqual input
     }
 
@@ -364,7 +364,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       // use a list of host/port pairs where one is normally invalid, but
       // it should still work as expected,
       val connectionSettings =
-      AmqpConnectionDetails(List(("invalid", 5673))).withHostsAndPorts(("localhost", 5672))
+        AmqpConnectionDetails(List(("invalid", 5673))).withHostsAndPorts(("localhost", 5672))
 
       val queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis()
       val queueDeclaration = QueueDeclaration(queueName)
@@ -384,14 +384,17 @@ class AmqpConnectorsSpec extends AmqpSpec {
       Source(input).map(s => ByteString(s)).runWith(amqpSink).futureValue shouldEqual Done
 
       //#run-source-withoutautoack
-      val result = amqpSource.map(message => {
-        message.asInstanceOf[UnackedIncomingMessage].ack()
-        message
-      }).take(input.size).runWith(Sink.seq)
+      val result = amqpSource
+        .map(message => {
+          message.asInstanceOf[UnackedIncomingMessage].ack()
+          message
+        })
+        .take(input.size)
+        .runWith(Sink.seq)
       //#run-source-withoutautoack
 
       val resultfutureValue = result.futureValue
-      all (resultfutureValue) shouldBe an[UnackedIncomingMessage]
+      all(resultfutureValue) shouldBe an[UnackedIncomingMessage]
       resultfutureValue.map(_.bytes.utf8String) shouldEqual input
     }
 
@@ -400,7 +403,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       // use a list of host/port pairs where one is normally invalid, but
       // it should still work as expected,
       val connectionSettings =
-      AmqpConnectionDetails(List(("invalid", 5673))).withHostsAndPorts(("localhost", 5672))
+        AmqpConnectionDetails(List(("invalid", 5673))).withHostsAndPorts(("localhost", 5672))
 
       val queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis()
       val queueDeclaration = QueueDeclaration(queueName)
@@ -418,22 +421,28 @@ class AmqpConnectorsSpec extends AmqpSpec {
       Source(input).map(s => ByteString(s)).runWith(amqpSink).futureValue shouldEqual Done
 
       //#run-source-withoutautoack-and-nack
-      val result = amqpSource.map(message => {
-        message.asInstanceOf[UnackedIncomingMessage].nack()
-        message
-      }).take(input.size).runWith(Sink.seq)
+      val result = amqpSource
+        .map(message => {
+          message.asInstanceOf[UnackedIncomingMessage].nack()
+          message
+        })
+        .take(input.size)
+        .runWith(Sink.seq)
       //#run-source-withoutautoack-and-nack
 
       val resultfutureValue = result.futureValue
-      all (resultfutureValue) shouldBe an[UnackedIncomingMessage]
+      all(resultfutureValue) shouldBe an[UnackedIncomingMessage]
 
-      val result2 = amqpSource.map(message => {
-        message.asInstanceOf[UnackedIncomingMessage].ack()
-        message
-      }).take(input.size).runWith(Sink.seq)
+      val result2 = amqpSource
+        .map(message => {
+          message.asInstanceOf[UnackedIncomingMessage].ack()
+          message
+        })
+        .take(input.size)
+        .runWith(Sink.seq)
 
       val result2futureValue = result2.futureValue
-      all (result2futureValue) shouldBe an[UnackedIncomingMessage]
+      all(result2futureValue) shouldBe an[UnackedIncomingMessage]
       result2futureValue.map(_.bytes.utf8String) shouldEqual input
     }
 
@@ -442,7 +451,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       // use a list of host/port pairs where one is normally invalid, but
       // it should still work as expected,
       val connectionSettings =
-      AmqpConnectionDetails(List(("invalid", 5673))).withHostsAndPorts(("localhost", 5672))
+        AmqpConnectionDetails(List(("invalid", 5673))).withHostsAndPorts(("localhost", 5672))
 
       val queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis()
       val queueDeclaration = QueueDeclaration(queueName)
@@ -459,18 +468,24 @@ class AmqpConnectorsSpec extends AmqpSpec {
       val input = Vector("one", "two", "three", "four", "five")
       Source(input).map(s => ByteString(s)).runWith(amqpSink).futureValue shouldEqual Done
 
-      val result = amqpSource.map(message => {
-        message.asInstanceOf[UnackedIncomingMessage].nack(false)
-        message
-      }).take(input.size).runWith(Sink.seq)
+      val result = amqpSource
+        .map(message => {
+          message.asInstanceOf[UnackedIncomingMessage].nack(false)
+          message
+        })
+        .take(input.size)
+        .runWith(Sink.seq)
 
       val resultfutureValue = result.futureValue
-      all (resultfutureValue) shouldBe an[UnackedIncomingMessage]
+      all(resultfutureValue) shouldBe an[UnackedIncomingMessage]
 
-      val result2 = amqpSource.map(message => {
-        message.asInstanceOf[UnackedIncomingMessage].ack()
-        message
-      }).take(input.size).runWith(Sink.seq)
+      val result2 = amqpSource
+        .map(message => {
+          message.asInstanceOf[UnackedIncomingMessage].ack()
+          message
+        })
+        .take(input.size)
+        .runWith(Sink.seq)
 
       result2.isReadyWithin(200 milliseconds) shouldEqual false
     }
@@ -481,7 +496,10 @@ class AmqpConnectorsSpec extends AmqpSpec {
       val queueDeclaration = QueueDeclaration(queueName)
 
       val amqpRpcFlow = AmqpRpcFlow(
-        AmqpSinkSettings(DefaultAmqpConnection).withRoutingKey(queueName).withDeclarations(queueDeclaration).withAutoAck(false),
+        AmqpSinkSettings(DefaultAmqpConnection)
+          .withRoutingKey(queueName)
+          .withDeclarations(queueDeclaration)
+          .withAutoAck(false),
         bufferSize = 10
       )
 
@@ -492,9 +510,12 @@ class AmqpConnectorsSpec extends AmqpSpec {
 
       val input = Vector("one", "two", "three", "four", "five")
       val (rpcQueueF, probe) =
-        Source(input).map(s => ByteString(s))
+        Source(input)
+          .map(s => ByteString(s))
           .map(bytes => OutgoingMessage(bytes, false, false, None))
-          .viaMat(amqpRpcFlow)(Keep.right).toMat(TestSink.probe)(Keep.both).run
+          .viaMat(amqpRpcFlow)(Keep.right)
+          .toMat(TestSink.probe)(Keep.both)
+          .run
       rpcQueueF.futureValue
 
       val amqpSink = AmqpSink.replyTo(
@@ -507,7 +528,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
 
       val probeResult = probe.toStrict(200 milliseconds)
 
-      all (probeResult) shouldBe an[UnackedIncomingMessage]
+      all(probeResult) shouldBe an[UnackedIncomingMessage]
       probeResult.map(_.bytes.utf8String) shouldEqual input
     }
   }

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -298,10 +298,8 @@ class AmqpConnectorsSpec extends AmqpSpec {
       amqpSource.addAttributes(Attributes.inputBuffer(1, 1)).runWith(Sink.fromSubscriber(subscriber2))
 
       subscriber2.ensureSubscription()
-      subscriber2.request(3)
-      // MapAsync execute the provided function as it pull the elements regardless of whether they are passed
-      // downstream or not. Thus the second element is acked even though it didn't get pushed down by `subscriber`.
-      // subscriber2.expectNext().bytes.utf8String shouldEqual "two"
+      subscriber2.request(4)
+      subscriber2.expectNext().bytes.utf8String shouldEqual "two"
       subscriber2.expectNext().bytes.utf8String shouldEqual "three"
       subscriber2.expectNext().bytes.utf8String shouldEqual "four"
       subscriber2.expectNext().bytes.utf8String shouldEqual "five"

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -298,7 +298,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       amqpSource.addAttributes(Attributes.inputBuffer(1, 1)).runWith(Sink.fromSubscriber(subscriber2))
 
       subscriber2.ensureSubscription()
-      subscriber2.request(4)
+      subscriber2.request(3)
       // MapAsync execute the provided function as it pull the elements regardless of whether they are passed
       // downstream or not. Thus the second element is acked even though it didn't get pushed down by `subscriber`.
       // subscriber2.expectNext().bytes.utf8String shouldEqual "two"

--- a/docs/src/main/paradox/amqp.md
+++ b/docs/src/main/paradox/amqp.md
@@ -132,6 +132,35 @@ Scala
 Java
 : @@snip (../../../../amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java) { #run-rpc-flow }
 
+
+### Acknowledging messages downstream
+
+Create a sink with auto-ack set to false.
+
+Scala
+: @@snip (../../../../amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala) { //#create-source-withoutautoack }
+
+Java
+: @@snip (../../../../amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java) { //#create-source-withoutautoack }
+
+By default, the @scaladoc[IncomingMessage](akka.stream.alpakka.amqp.IncomingMessage) returned by Amqp consumer is of type @scaladoc[AckedIncomingMessage](akka.stream.alpakka.amqp.AckedIncomingMessage). However, when setting auto-ack to false the returned message is of type @scaladoc[UnackedIncomingMessage](akka.stream.alpakka.amqp.UnackedIncomingMessage) which exposes the methods ack and nack.
+
+Use ack to acknowledge the message back to RabbitMQ
+
+Scala
+: @@snip (../../../../amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala) { //#run-source-withoutautoack }
+
+Java
+: @@snip (../../../../amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java) { //#run-source-withoutautoack }
+
+Use nack to reject a message. nack takes an option boolean parameter indicating whether the item should be requeued or not.
+
+Scala
+: @@snip (../../../../amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala) { //#run-source-withoutautoack-and-nack }
+
+Java
+: @@snip (../../../../amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java) { //#run-source-withoutautoack-and-nack }
+
 ### Running the example code
 
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.

--- a/docs/src/main/paradox/amqp.md
+++ b/docs/src/main/paradox/amqp.md
@@ -135,7 +135,7 @@ Java
 
 ### Acknowledging messages downstream
 
-Create a sink with auto-ack set to false.
+Create a committable sink which returns 
 
 Scala
 : @@snip (../../../../amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala) { //#create-source-withoutautoack }
@@ -143,9 +143,9 @@ Scala
 Java
 : @@snip (../../../../amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java) { //#create-source-withoutautoack }
 
-By default, the @scaladoc[IncomingMessage](akka.stream.alpakka.amqp.IncomingMessage) returned by Amqp consumer is of type @scaladoc[AckedIncomingMessage](akka.stream.alpakka.amqp.AckedIncomingMessage). However, when setting auto-ack to false the returned message is of type @scaladoc[UnackedIncomingMessage](akka.stream.alpakka.amqp.UnackedIncomingMessage) which exposes the methods ack and nack.
+Committable sources return @scaladoc[CommittableIncomingMessage](akka.stream.alpakka.amqp.CommittableIncomingMessage) which wraps the @scaladoc[IncomingMessage](akka.stream.alpakka.amqp.IncomingMessage) and exposes the methods ack and nack.
 
-Use ack to acknowledge the message back to RabbitMQ
+Use ack to acknowledge the message back to RabbitMQ. Ack takes an optional boolean parameter `multiple` indicating whether you are acknowledging the individual message or all the messages up to it.
 
 Scala
 : @@snip (../../../../amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala) { //#run-source-withoutautoack }
@@ -153,7 +153,7 @@ Scala
 Java
 : @@snip (../../../../amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java) { //#run-source-withoutautoack }
 
-Use nack to reject a message. nack takes an option boolean parameter indicating whether the item should be requeued or not.
+Use nack to reject a message. Apart from the `multiple` argument, nack takes another optional boolean parameter indicating whether the item should be requeued or not.
 
 Scala
 : @@snip (../../../../amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala) { //#run-source-withoutautoack-and-nack }


### PR DESCRIPTION
Fix #97 by adding the possibility of deactivate `autoAck` and allowing to `ack` or `nack` messages downstream.

Nack allow to optionally requeue the message or not (by default it does).

I've noticed that #292 was doing the same but it seems stale and the work seems bloated to me (it introduce a lot of duplicities and unrelated changes).

This PR introduce a very minimal change.
No breaking changes at API level.
Fully tested.

Only "breaking" change is that `IncomingMessage` becomes a trait and `AckedIncomingMessage` and `UnackedIncomingMessage` are case classes extending it. (I'm any case I don't think that anyone should be using `IncomingMessage` so this shouldn't even be a real breaking change)
The advantage of having `AckedIncomingMessage` and `UnackedIncomingMessage` as case classes inheriting from `IncomingMessage` is that is minimize changes, maximize backwards compatibility and allow pattern matching to act differently depending on the type of message.