### PR TITLE
Remove coursier workaround

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -137,8 +137,7 @@ object Dependencies {
       "org.apache.activemq" % "activemq-broker" % "5.14.1" % Test, // ApacheV2
       "org.apache.activemq" % "activemq-client" % "5.14.1" % Test // ApacheV2
     ),
-    // Having JBoss as a first resolver is a workaround for https://github.com/coursier/coursier/issues/200
-    externalResolvers := ("jboss" at "https://repository.jboss.org/nexus/content/groups/public") +: externalResolvers.value
+    resolvers += ("jboss" at "https://repository.jboss.org/nexus/content/groups/public")
   )
 
   val Mqtt = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16


### PR DESCRIPTION
Not needed anymore when used with coursier 1.0.0-RC12 after https://github.com/coursier/coursier/issues/636 and https://github.com/coursier/coursier/issues/200 have been fixed.