### PR TITLE
Fix warnings occured during  Elasticsearch test execution

### DIFF
--- a/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
+++ b/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
@@ -11,6 +11,7 @@ import akka.stream.javadsl.Sink;
 import akka.testkit.JavaTestKit;
 import org.apache.http.HttpHost;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHeader;
 import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.elasticsearch.client.RestClient;
 import org.junit.AfterClass;
@@ -83,7 +84,8 @@ public class ElasticsearchTest {
     client.performRequest("POST",
     indexName + "/book",
     new HashMap<>(),
-    new StringEntity(String.format("{\"title\": \"%s\"}", title)));
+    new StringEntity(String.format("{\"title\": \"%s\"}", title)),
+    new BasicHeader("Content-Type", "application/json"));
   }
 
 

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
@@ -20,6 +20,7 @@ import scala.concurrent.duration.Duration
 import scala.collection.JavaConverters._
 import spray.json._
 import DefaultJsonProtocol._
+import org.apache.http.message.BasicHeader
 
 class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
 
@@ -72,7 +73,8 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
     client.performRequest("POST",
                           s"$indexName/book",
                           Map[String, String]().asJava,
-                          new StringEntity(s"""{"title": "$title"}"""))
+                          new StringEntity(s"""{"title": "$title"}"""),
+                          new BasicHeader("Content-Type", "application/json"))
 
   "Elasticsearch connector" should {
     "consume and publish documents as JsObject" in {


### PR DESCRIPTION
Since Elasticsearch 5.x, content type auto detection has been deprecated. So current tests cause warnings like following during execution:
```
[299 Elasticsearch-5.6.0-781a835 "Content type detection for rest requests is deprecated. Specify the content type using the [Content-Type] header." "F, 29 Sep 2017 12:02:34 GMT"]
```
This pull request adds Content-Type header to some requests in test cases to prevent this warnings.
