### PR TITLE
Throw error if the s3 bucket name contains non-LDH characters #511

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -87,9 +87,23 @@ private[alpakka] object HttpRequests {
       .withHeaders(Host(requestHost(s3Location.bucket, conf.s3Region)))
       .withUri(uriFn(requestUri(s3Location.bucket, Some(s3Location.key))))
 
+  @throws(classOf[IllegalUriException])
   private[this] def requestHost(bucket: String, region: String)(implicit conf: S3Settings): Uri.Host =
     conf.proxy match {
       case None =>
+        if (!conf.pathStyleAccess) {
+          val bucketRegex = "[^a-z0-9\\-\\.]{1,255}|[\\.]{2,}".r
+          bucketRegex.findFirstIn(bucket) match {
+            case Some(illegalCharacter) =>
+              throw IllegalUriException(
+                "Bucket name contains non-LDH characters",
+                s"""The following character is not allowed: $illegalCharacter
+                   | This may be solved by setting akka.stream.alpakka.s3.path-style-access to true in the configuration.
+                 """.stripMargin
+              )
+            case None => ()
+          }
+        }
         region match {
           case "us-east-1" =>
             if (conf.pathStyleAccess) {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -5,7 +5,7 @@ package akka.stream.alpakka.s3.impl
 
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{HttpEntity, MediaTypes}
+import akka.http.scaladsl.model.{HttpEntity, IllegalUriException, MediaTypes}
 import akka.stream.alpakka.s3.acl.CannedAcl
 import akka.stream.alpakka.s3.{BufferType, MemoryBufferType, Proxy, S3Settings}
 import akka.stream.scaladsl.Source
@@ -63,6 +63,12 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
     }
   }
 
+  it should "throw an error if path-style access is false and the bucket name contains non-LDH characters" in {
+    implicit val settings = getSettings(s3Region = "eu-west-1", pathStyleAccess = false)
+
+    assertThrows[IllegalUriException](HttpRequests.getDownloadRequest(S3Location("invalid_bucket_name", "image-1024@2x")))
+  }
+
   it should "initiate multipart upload with path-style access in region us-east-1" in {
     implicit val settings = getSettings(s3Region = "us-east-1", pathStyleAccess = true)
 
@@ -90,7 +96,6 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
 
     req.uri.authority.host.toString shouldEqual "s3-us-west-2.amazonaws.com"
     req.uri.path.toString shouldEqual "/bucket/image-1024@2x"
-
   }
 
   it should "support download requests with path-style access in other regions" in {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -66,7 +66,9 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   it should "throw an error if path-style access is false and the bucket name contains non-LDH characters" in {
     implicit val settings = getSettings(s3Region = "eu-west-1", pathStyleAccess = false)
 
-    assertThrows[IllegalUriException](HttpRequests.getDownloadRequest(S3Location("invalid_bucket_name", "image-1024@2x")))
+    assertThrows[IllegalUriException](
+      HttpRequests.getDownloadRequest(S3Location("invalid_bucket_name", "image-1024@2x"))
+    )
   }
 
   it should "initiate multipart upload with path-style access in region us-east-1" in {


### PR DESCRIPTION
Throw error if the s3 bucket name contains non-LDH characters #511

* Added a regex to validate the bucket name when the path-style-access is false