### PR TITLE
Remove javac options that confuse javadoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,9 @@ lazy val mqtt = alpakkaProject("mqtt", Dependencies.Mqtt)
 
 lazy val s3 = alpakkaProject("s3", Dependencies.S3)
 
-lazy val springWeb = alpakkaProject("spring-web", Dependencies.SpringWeb)
+lazy val springWeb = alpakkaProject("spring-web",
+  javacOptions := javacOptions.value.filter(_ != "-Xlint:unchecked"),
+  Dependencies.SpringWeb)
 
 lazy val simpleCodecs = alpakkaProject("simple-codecs")
 

--- a/build.sbt
+++ b/build.sbt
@@ -110,9 +110,7 @@ lazy val mqtt = alpakkaProject("mqtt", Dependencies.Mqtt)
 
 lazy val s3 = alpakkaProject("s3", Dependencies.S3)
 
-lazy val springWeb = alpakkaProject("spring-web",
-  javacOptions := javacOptions.value.filter(_ != "-Xlint:unchecked"),
-  Dependencies.SpringWeb)
+lazy val springWeb = alpakkaProject("spring-web", Dependencies.SpringWeb)
 
 lazy val simpleCodecs = alpakkaProject("simple-codecs")
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -40,7 +40,7 @@ object Common extends AutoPlugin {
       "-Ywarn-dead-code",
       "-Xfuture"
     ),
-    javacOptions ++= Seq(
+    javacOptions in compile ++= Seq(
       "-Xlint:unchecked"
     ),
     autoAPIMappings := true,


### PR DESCRIPTION
The javadoc tool returned an error (and failed the build) for me because of the
-Xlint:unchecked option which is passed to javadoc but not
recognized there.