### PR TITLE
#527 Increase connection to Cassandra timeout

### DIFF
--- a/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSourceSpec.scala
+++ b/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSourceSpec.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.cassandra.scaladsl
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
-import com.datastax.driver.core.{Cluster, PreparedStatement, SimpleStatement}
+import com.datastax.driver.core.{Cluster, PreparedStatement, SimpleStatement, SocketOptions}
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
@@ -30,7 +30,15 @@ class CassandraSourceSpec
   //#init-mat
 
   //#init-session
-  implicit val session = Cluster.builder.addContactPoint("127.0.0.1").withPort(9042).build.connect()
+  implicit val session = Cluster.builder
+    .addContactPoint("127.0.0.1")
+    .withPort(9042)
+    .withSocketOptions(
+      new SocketOptions()
+        .setConnectTimeoutMillis(20 * 1000)
+    )
+    .build
+    .connect()
   //#init-session
 
   implicit val defaultPatience =


### PR DESCRIPTION
Default was [5 seconds](http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/SocketOptions.html#DEFAULT_CONNECT_TIMEOUT_MILLIS).