### PR TITLE
#527 Increase acquire connection timeout

### DIFF
--- a/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSourceSpec.scala
+++ b/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSourceSpec.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.cassandra.scaladsl
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
-import com.datastax.driver.core.{Cluster, PreparedStatement, SimpleStatement, SocketOptions}
+import com.datastax.driver.core.{Cluster, PoolingOptions, PreparedStatement, SimpleStatement}
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
@@ -29,17 +29,22 @@ class CassandraSourceSpec
   implicit val mat = ActorMaterializer()
   //#init-mat
 
-  //#init-session
+  {
+    //#init-session
+    implicit val session = Cluster.builder
+      .addContactPoint("127.0.0.1")
+      .withPort(9042)
+      .build
+      .connect()
+    //#init-session
+  }
+
   implicit val session = Cluster.builder
     .addContactPoint("127.0.0.1")
     .withPort(9042)
-    .withSocketOptions(
-      new SocketOptions()
-        .setConnectTimeoutMillis(20 * 1000)
-    )
+    .withPoolingOptions(new PoolingOptions().setPoolTimeoutMillis(20 * 1000))
     .build
     .connect()
-  //#init-session
 
   implicit val defaultPatience =
     PatienceConfig(timeout = 2.seconds, interval = 50.millis)


### PR DESCRIPTION
So previous #536 did not really work. Trying again. This time increasing [connection acquire](http://docs.datastax.com/en/drivers/java/2.1/com/datastax/driver/core/PoolingOptions.html#setPoolTimeoutMillis-int-) timeout from the same default of 5 seconds.

@chbatey are we doing this right? 

We are trying to prevent spurious errors like this while testing:
```
Cause: com.datastax.driver.core.exceptions.NoHostAvailableException: All host(s) tried for query failed (tried: /127.0.0.1:9042 (com.datastax.driver.core.exceptions.DriverException: Timeout while trying to acquire available connection (you may want to increase the driver number of per-host connections)))
```

Refs #527