### PR TITLE
Make test cassandra keyspace name dynamic

### DIFF
--- a/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSourceSpec.scala
+++ b/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSourceSpec.scala
@@ -44,35 +44,36 @@ class CassandraSourceSpec
   implicit val defaultPatience =
     PatienceConfig(timeout = 2.seconds, interval = 50.millis)
 
+  var keyspaceName: String = _
+
   override def beforeEach(): Unit = {
+    keyspaceName = s"akka${System.nanoTime()}"
     session.execute(
-      """
-        |CREATE KEYSPACE IF NOT EXISTS akka_stream_scala_test WITH replication = {
+      s"""
+        |CREATE KEYSPACE $keyspaceName WITH replication = {
         |  'class': 'SimpleStrategy',
         |  'replication_factor': '1'
         |};
       """.stripMargin
     )
     session.execute(
-      """
-        |CREATE TABLE IF NOT EXISTS akka_stream_scala_test.test (
+      s"""
+        |CREATE TABLE IF NOT EXISTS $keyspaceName.test (
         |    id int PRIMARY KEY
         |);
       """.stripMargin
     )
   }
 
-  override def afterEach(): Unit = {
-    session.execute("DROP TABLE IF EXISTS akka_stream_scala_test.test;")
-    session.execute("DROP KEYSPACE IF EXISTS akka_stream_scala_test;")
-  }
+  override def afterEach(): Unit =
+    session.execute(s"DROP KEYSPACE IF EXISTS $keyspaceName;")
 
   override def afterAll(): Unit =
     Await.result(system.terminate(), 5.seconds)
 
   def populate() =
     (1 until 103).map { i =>
-      session.execute(s"INSERT INTO akka_stream_scala_test.test(id) VALUES ($i)")
+      session.execute(s"INSERT INTO $keyspaceName.test(id) VALUES ($i)")
       i
     }
 
@@ -80,7 +81,7 @@ class CassandraSourceSpec
 
     "stream the result of a Cassandra statement with one page" in {
       val data = populate()
-      val stmt = new SimpleStatement("SELECT * FROM akka_stream_scala_test.test").setFetchSize(200)
+      val stmt = new SimpleStatement(s"SELECT * FROM $keyspaceName.test").setFetchSize(200)
 
       val rows = CassandraSource(stmt).runWith(Sink.seq).futureValue
 
@@ -91,7 +92,7 @@ class CassandraSourceSpec
       val data = populate()
 
       //#statement
-      val stmt = new SimpleStatement("SELECT * FROM akka_stream_scala_test.test").setFetchSize(20)
+      val stmt = new SimpleStatement(s"SELECT * FROM $keyspaceName.test").setFetchSize(20)
       //#statement
 
       //#run-source
@@ -103,7 +104,7 @@ class CassandraSourceSpec
 
     "support multiple materializations" in {
       val data = populate()
-      val stmt = new SimpleStatement("SELECT * FROM akka_stream_scala_test.test")
+      val stmt = new SimpleStatement(s"SELECT * FROM $keyspaceName.test")
 
       val source = CassandraSource(stmt)
 
@@ -112,7 +113,7 @@ class CassandraSourceSpec
     }
 
     "stream the result of Cassandra statement that results in no data" in {
-      val stmt = new SimpleStatement("SELECT * FROM akka_stream_scala_test.test")
+      val stmt = new SimpleStatement(s"SELECT * FROM $keyspaceName.test")
 
       val rows = CassandraSource(stmt).runWith(Sink.seq).futureValue
 
@@ -125,7 +126,7 @@ class CassandraSourceSpec
       val source = Source(0 to 10).map(i => i: Integer)
 
       //#prepared-statement
-      val preparedStatement = session.prepare("INSERT INTO akka_stream_scala_test.test(id) VALUES (?)")
+      val preparedStatement = session.prepare(s"INSERT INTO $keyspaceName.test(id) VALUES (?)")
       //#prepared-statement
 
       //#statement-binder
@@ -140,7 +141,7 @@ class CassandraSourceSpec
 
       result.futureValue
 
-      val found = session.execute("select id from akka_stream_scala_test.test").all().asScala.map(_.getInt("id"))
+      val found = session.execute(s"select id from $keyspaceName.test").all().asScala.map(_.getInt("id"))
 
       found.toSet mustBe (0 to 10).toSet
     }


### PR DESCRIPTION
Cassandra does not handle the dropping/creating of a keyspcae with the
same name very well. This can lead to errors coming back and the driver
then refusing to hand out connections for that host.