### PR TITLE
S3: Make SigningKey non-constant to reflect possible token changes

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -58,7 +58,8 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
 
   implicit val conf = settings
   val MinChunkSize = 5242880 //in bytes
-  val signingKey = SigningKey(settings.credentialsProvider, CredentialScope(LocalDate.now(), settings.s3Region, "s3"))
+  // def because tokens can expire
+  def signingKey = SigningKey(settings.credentialsProvider, CredentialScope(LocalDate.now(), settings.s3Region, "s3"))
 
   def download(s3Location: S3Location, range: Option[ByteRange] = None): Source[ByteString, NotUsed] = {
     import mat.executionContext
@@ -172,6 +173,9 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
     val requestInfo: Source[(MultipartUpload, Int), NotUsed] =
       initiateUpload(s3Location, contentType, s3Headers)
 
+    // use the same key for all sub-requests (chunks)
+    val key: SigningKey = signingKey
+
     SplitAfterSize(chunkSize)(Flow.apply[ByteString])
       .via(getChunkBuffer(chunkSize)) //creates the chunks
       .concatSubstreams
@@ -182,7 +186,7 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
             uploadPartRequest(uploadInfo, chunkIndex, chunkedPayload.data, chunkedPayload.size)
           (partRequest, (uploadInfo, chunkIndex))
       }
-      .mapAsync(parallelism) { case (req, info) => Signer.signedRequest(req, signingKey).zip(Future.successful(info)) }
+      .mapAsync(parallelism) { case (req, info) => Signer.signedRequest(req, key).zip(Future.successful(info)) }
   }
 
   private def getChunkBuffer(chunkSize: Int) = settings.bufferType match {


### PR DESCRIPTION
AWS SDK credential provider supports token expiration, so the code needs to reflect that.

I was not sure how to go about scope of `def`: we can just make `akka.stream.alpakka.s3.auth.SigningKey#credentials` a `def` and leave `SigningKey` a `val`, but the key also depends on a current date. I'm not an expert in the field of security algorithms and to the extent of my understanding it it safer to recalculate the the key completely.

A better solution would be to try and use the signing mechanism provided by the AWS SDK, but I decided to keep the scope of changes smaller.