### PR TITLE
Telling elastic RestClient to use UTF-8 encoding for json (Fixes #547)

### DIFF
--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
@@ -132,7 +132,7 @@ class ElasticsearchFlowStage[T, R](
           "POST",
           "/_bulk",
           Map[String, String]().asJava,
-          new StringEntity(json),
+          new StringEntity(json, "utf-8"),
           new ResponseListener() {
             override def onFailure(exception: Exception): Unit =
               failureHandler.invoke((messages, exception))


### PR DESCRIPTION
Fixes https://github.com/akka/alpakka/issues/547