### PR TITLE
Fix Kinesis publisher test

### DIFF
--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
@@ -76,7 +76,7 @@ class KinesisFlowSpec extends WordSpecLike with Matchers with DefaultTestContext
 
       sourceProbe.sendNext(record)
 
-      sinkProbe.requestNext(settings.retryInitialTimeout + settings.retryInitialTimeout / 2) shouldBe publishedRecord
+      sinkProbe.requestNext(settings.retryInitialTimeout * 2) shouldBe publishedRecord
 
       sourceProbe.sendComplete()
       sinkProbe.expectComplete()


### PR DESCRIPTION
Timeout: from 1.5x to 2x to avoid failures due to natural async latencies.