### PR TITLE
Bump geode version to 1.3.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - "8001:8000"
   geode:
     container_name: geode
-    image: apachegeode/geode:1.2.1
+    image: apachegeode/geode:1.3.0
     hostname: geode
     mem_limit: 2g
     expose:

--- a/geode/scripts/geode.sh
+++ b/geode/scripts/geode.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-rm -rf /geode
-mkdir -p /geode/locator
-mkdir -p /geode/server
+GEODE_DATA=/geode-data
+
+rm -rf $GEODE_DATA
+mkdir -p $GEODE_DATA/locator
+mkdir -p $GEODE_DATA/server
 
 
-gfsh -e "start locator --name=$HOSTNAME-locator --dir=/geode/locator --mcast-port=0 --hostname-for-clients=0.0.0.0" -e "start server --name=$HOSTNAME-server --locators=localhost[10334] --dir=/geode/server --server-port=40404 --max-heap=1G --hostname-for-clients=0.0.0.0 --cache-xml-file=/scripts/cache.xml"
+gfsh -e "start locator --name=$HOSTNAME-locator --dir=$GEODE_DATA/locator --mcast-port=0 --hostname-for-clients=0.0.0.0" -e "start server --name=$HOSTNAME-server --locators=localhost[10334] --dir=$GEODE_DATA/server --server-port=40404 --max-heap=1G --hostname-for-clients=0.0.0.0 --cache-xml-file=/scripts/cache.xml"
 
 while true; do
     sleep 10

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,7 +83,7 @@ object Dependencies {
   )
 
   val Geode = {
-    val geodeVersion = "1.2.1"
+    val geodeVersion = "1.3.0"
     val slf4jVersion = "1.7.25"
     val logbackVersion = "1.2.3"
     Seq(


### PR DESCRIPTION
Docker startup script fixed: geode data location were overlaping with geode (new) installation layout.