### PR TITLE
SQS: More idiomatic MessageAction

### DIFF
--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckFlowStage.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckFlowStage.scala
@@ -99,7 +99,7 @@ private[sqs] final class SqsAckFlowStage(queueUrl: String, sqsClient: AmazonSQSA
             val (message, action) = grab(in)
             val responsePromise = Promise[AckResult]
             action match {
-              case Delete() =>
+              case MessageAction.Delete =>
                 sqsClient.deleteMessageAsync(
                   new DeleteMessageRequest(queueUrl, message.getReceiptHandle),
                   new AsyncHandler[DeleteMessageRequest, DeleteMessageResult] {
@@ -115,7 +115,7 @@ private[sqs] final class SqsAckFlowStage(queueUrl: String, sqsClient: AmazonSQSA
                     }
                   }
                 )
-              case ChangeMessageVisibility(visibilityTimeout) =>
+              case MessageAction.ChangeMessageVisibility(visibilityTimeout) =>
                 sqsClient
                   .changeMessageVisibilityAsync(
                     new ChangeMessageVisibilityRequest(queueUrl, message.getReceiptHandle, visibilityTimeout),
@@ -133,7 +133,7 @@ private[sqs] final class SqsAckFlowStage(queueUrl: String, sqsClient: AmazonSQSA
                       }
                     }
                   )
-              case Ignore() =>
+              case MessageAction.Ignore =>
                 responsePromise.success(AckResult(None, message.getBody))
             }
             push(out, responsePromise.future)

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSinkSettings.scala
@@ -14,10 +14,67 @@ final case class SqsAckSinkSettings(maxInFlight: Int) {
 }
 //#SqsAckSinkSettings
 
-sealed trait MessageAction
-final case class Delete() extends MessageAction
-final case class Ignore() extends MessageAction
-final case class ChangeMessageVisibility(visibilityTimeout: Int) extends MessageAction {
-  // SQS requirements
-  require(0 <= visibilityTimeout && visibilityTimeout <= 43200)
+sealed abstract class MessageAction
+
+object Delete {
+  @deprecated("Use `MessageAction.Delete` instead", "0.15")
+  def apply(): MessageAction = MessageAction.Delete
+}
+
+object Ignore {
+  @deprecated("Use `MessageAction.Ignore` instead", "0.15")
+  def apply(): MessageAction = MessageAction.Ignore
+}
+
+object ChangeMessageVisibility {
+  @deprecated("Use `MessageAction.ChangeMessageVisibility` instead", "0.15")
+  def apply(visibilityTimeout: Int): MessageAction = MessageAction.ChangeMessageVisibility(visibilityTimeout)
+}
+
+object MessageAction {
+
+  /**
+   * Delete the message from the queue.
+   *
+   * @see [https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessage.html DeleteMessage]
+   */
+  final case object Delete extends MessageAction
+
+  /**
+   * Ignore the message.
+   */
+  final case object Ignore extends MessageAction
+
+  /**
+   * Change the visibility timeout of the message.
+   * The maximum allowed timeout value is 12 hours.
+   *
+   * @param visibilityTimeout new timeout in seconds
+   *
+   * @see [https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ChangeMessageVisibility.html ChangeMessageVisibility]
+   */
+  final case class ChangeMessageVisibility(visibilityTimeout: Int) extends MessageAction {
+    // SQS requirements
+    require(
+      0 <= visibilityTimeout && visibilityTimeout <= 43200,
+      s"Invalid value ($visibilityTimeout) for visibilityTimeout. Requirement: 0 <= waitTimeSeconds <= 43200"
+    )
+  }
+
+  /**
+   * Java API: Delete the message from the queue.
+   */
+  def delete: MessageAction = Delete
+
+  /**
+   * Java API: Ignore the message.
+   */
+  def ignore: MessageAction = Ignore
+
+  /**
+   * Java API: Change the visibility timeout of the message.
+   * @param visibilityTimeout new timeout in seconds
+   */
+  def changeMessageVisibility(visibilityTimeout: Int): MessageAction = ChangeMessageVisibility(visibilityTimeout)
+
 }

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsAckSinkTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/SqsAckSinkTest.java
@@ -7,10 +7,7 @@ package akka.stream.alpakka.sqs.javadsl;
 import akka.Done;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
-import akka.stream.alpakka.sqs.Delete;
-import akka.stream.alpakka.sqs.Ignore;
 import akka.stream.alpakka.sqs.MessageAction;
-import akka.stream.alpakka.sqs.ChangeMessageVisibility;
 import akka.stream.alpakka.sqs.scaladsl.AckResult;
 import akka.stream.javadsl.Source;
 import akka.stream.javadsl.Sink;
@@ -68,7 +65,7 @@ public class SqsAckSinkTest extends BaseSqsTest {
         //#ack
         Tuple2<Message, MessageAction> pair = new Tuple2<>(
                 new Message().withBody("test"),
-                new Delete()
+                MessageAction.delete()
         );
         CompletionStage<Done> done = Source
                 .single(pair)
@@ -96,7 +93,7 @@ public class SqsAckSinkTest extends BaseSqsTest {
         //#flow-ack
         Tuple2<Message, MessageAction> pair = new Tuple2<>(
                 new Message().withBody("test-ack-flow"),
-                new Delete()
+                MessageAction.delete()
         );
         CompletionStage<Done> done = Source
                 .single(pair)
@@ -125,7 +122,7 @@ public class SqsAckSinkTest extends BaseSqsTest {
         //#requeue
         Tuple2<Message, MessageAction> pair = new Tuple2<>(
                 new Message().withBody("test"),
-                new ChangeMessageVisibility(12)
+                MessageAction.changeMessageVisibility(12)
         );
         CompletionStage<Done> done = Source
                 .single(pair)
@@ -148,7 +145,7 @@ public class SqsAckSinkTest extends BaseSqsTest {
         //#ignore
         Tuple2<Message, MessageAction> pair = new Tuple2<>(
                 new Message().withBody("test"),
-                new Ignore()
+                MessageAction.ignore()
         );
         CompletionStage<AckResult> stage = Source
                 .single(pair)

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/ChangeMessageVisibilitySpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/ChangeMessageVisibilitySpec.scala
@@ -4,25 +4,25 @@
 
 package akka.stream.alpakka.sqs.scaladsl
 
-import akka.stream.alpakka.sqs.ChangeMessageVisibility
+import akka.stream.alpakka.sqs.MessageAction
 import org.scalatest.{FlatSpec, Matchers}
 
 class ChangeMessageVisibilitySpec extends FlatSpec with Matchers {
 
   it should "require valid visibility" in {
     a[IllegalArgumentException] should be thrownBy {
-      ChangeMessageVisibility(43201)
+      MessageAction.ChangeMessageVisibility(43201)
     }
     a[IllegalArgumentException] should be thrownBy {
-      ChangeMessageVisibility(-1)
+      MessageAction.ChangeMessageVisibility(-1)
     }
   }
 
   it should "accept valid parameters" in {
-    ChangeMessageVisibility(300)
+    MessageAction.ChangeMessageVisibility(300)
   }
 
   it should "allow terminating visibility" in {
-    ChangeMessageVisibility(0)
+    MessageAction.ChangeMessageVisibility(0)
   }
 }

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/MessageAttributeNameSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/MessageAttributeNameSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.sqs.scaladsl
 
-import akka.stream.alpakka.sqs.{MessageAttributeName, SqsSourceSettings}
+import akka.stream.alpakka.sqs.MessageAttributeName
 import org.scalatest.{FlatSpec, Matchers}
 
 class MessageAttributeNameSpec extends FlatSpec with Matchers {

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.sqs.scaladsl
 
 import akka.Done
-import akka.stream.alpakka.sqs.{ChangeMessageVisibility, Delete, Ignore, SqsSourceSettings}
+import akka.stream.alpakka.sqs.{MessageAction, SqsSourceSettings}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.TestSink
 import com.amazonaws.handlers.AsyncHandler
@@ -62,7 +62,7 @@ class SqsSpec extends FlatSpec with Matchers with DefaultTestContext {
     val future = SqsSource(queue)(awsSqsClient)
       .take(1)
       .map { m: Message =>
-        (m, Delete())
+        (m, MessageAction.Delete)
       }
       .runWith(SqsAckSink(queue)(awsSqsClient))
     //#ack
@@ -80,7 +80,7 @@ class SqsSpec extends FlatSpec with Matchers with DefaultTestContext {
     val future = SqsSource(queue)(awsSqsClient)
       .take(1)
       .map { m: Message =>
-        (m, Delete())
+        (m, MessageAction.Delete)
       }
       .via(SqsAckFlow(queue)(awsSqsClient))
       .runWith(Sink.ignore)
@@ -116,7 +116,7 @@ class SqsSpec extends FlatSpec with Matchers with DefaultTestContext {
     val future = SqsSource(queue)(awsSqsClient)
       .take(1)
       .map { m: Message =>
-        (m, ChangeMessageVisibility(5))
+        (m, MessageAction.ChangeMessageVisibility(5))
       }
       .runWith(SqsAckSink(queue)(awsSqsClient))
     //#requeue
@@ -137,7 +137,7 @@ class SqsSpec extends FlatSpec with Matchers with DefaultTestContext {
     val result = SqsSource(queue)(awsSqsClient)
       .take(1)
       .map { m: Message =>
-        (m, Ignore())
+        (m, MessageAction.Ignore)
       }
       .via(SqsAckFlow(queue)(awsSqsClient))
       .runWith(TestSink.probe[AckResult])


### PR DESCRIPTION
Fix #574.

Note that this is not backward compatible. It will break Java and ~~Scala~~ sources that use the `Ack` feature of SQS.

Edit: Only the Java sources are broken with the new PR.