### PR TITLE
CSV: Fail parsing for too long lines

### DIFF
--- a/csv/src/main/java/akka/stream/alpakka/csv/javadsl/CsvParsing.java
+++ b/csv/src/main/java/akka/stream/alpakka/csv/javadsl/CsvParsing.java
@@ -32,6 +32,6 @@ public class CsvParsing {
     public static Flow<ByteString, Collection<ByteString>, NotUsed> lineScanner(byte delimiter, byte quoteChar, byte escapeChar, int maximumLineLength) {
         return akka.stream.alpakka.csv.scaladsl.CsvParsing
                 .lineScanner(delimiter, quoteChar, escapeChar, maximumLineLength).asJava()
-                .map(JavaConverters::asJavaCollection);
+                .map(c -> JavaConverters.asJavaCollectionConverter(c).asJavaCollection());
     }
 }

--- a/csv/src/main/java/akka/stream/alpakka/csv/javadsl/CsvParsing.java
+++ b/csv/src/main/java/akka/stream/alpakka/csv/javadsl/CsvParsing.java
@@ -7,7 +7,7 @@ package akka.stream.alpakka.csv.javadsl;
 import akka.NotUsed;
 import akka.stream.javadsl.Flow;
 import akka.util.ByteString;
-import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 
 import java.util.Collection;
 
@@ -19,14 +19,19 @@ public class CsvParsing {
     public static final byte COLON = ':';
     public static final byte TAB = '\t';
     public static final byte DOUBLE_QUOTE = '"';
+    public static final int MAXIMUM_LINE_LENGTH_DEFAULT = 10 * 1024;
 
     public static Flow<ByteString, Collection<ByteString>, NotUsed> lineScanner() {
-        return lineScanner(COMMA, DOUBLE_QUOTE, BACKSLASH);
+        return lineScanner(COMMA, DOUBLE_QUOTE, BACKSLASH, MAXIMUM_LINE_LENGTH_DEFAULT);
     }
 
     public static Flow<ByteString, Collection<ByteString>, NotUsed> lineScanner(byte delimiter, byte quoteChar, byte escapeChar) {
+        return lineScanner(delimiter, quoteChar, escapeChar, MAXIMUM_LINE_LENGTH_DEFAULT);
+    }
+
+    public static Flow<ByteString, Collection<ByteString>, NotUsed> lineScanner(byte delimiter, byte quoteChar, byte escapeChar, int maximumLineLength) {
         return akka.stream.alpakka.csv.scaladsl.CsvParsing
-                .lineScanner(delimiter, quoteChar, escapeChar).asJava()
-                .map(JavaConversions::asJavaCollection);
+                .lineScanner(delimiter, quoteChar, escapeChar, maximumLineLength).asJava()
+                .map(JavaConverters::asJavaCollection);
     }
 }

--- a/csv/src/main/scala/akka/stream/alpakka/csv/CsvParser.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/CsvParser.scala
@@ -32,7 +32,7 @@ private[csv] object CsvParser {
 /**
  * INTERNAL API: Use [[akka.stream.alpakka.csv.scaladsl.CsvParsing]] instead.
  */
-private[csv] final class CsvParser(delimiter: Byte, quoteChar: Byte, escapeChar: Byte) {
+private[csv] final class CsvParser(delimiter: Byte, quoteChar: Byte, escapeChar: Byte, maximumLineLength: Int) {
 
   import CsvParser._
 
@@ -145,6 +145,10 @@ private[csv] final class CsvParser(delimiter: Byte, quoteChar: Byte, escapeChar:
     }
 
     while (state != LineEnd && pos < buf.length) {
+      if (pos >= maximumLineLength)
+        throw new MalformedCsvException(
+          s"no line end encountered within $maximumLineLength bytes on line $currentLineNo"
+        )
       val byte = buf(pos)
       state match {
         case LineStart =>

--- a/csv/src/main/scala/akka/stream/alpakka/csv/CsvParsingStage.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/CsvParsingStage.scala
@@ -15,7 +15,7 @@ import scala.util.control.NonFatal
 /**
  * Internal API: Use [[akka.stream.alpakka.csv.scaladsl.CsvParsing]] instead.
  */
-private[csv] class CsvParsingStage(delimiter: Byte, quoteChar: Byte, escapeChar: Byte)
+private[csv] class CsvParsingStage(delimiter: Byte, quoteChar: Byte, escapeChar: Byte, maximumLineLength: Int)
     extends GraphStage[FlowShape[ByteString, List[ByteString]]] {
 
   private val in = Inlet[ByteString](Logging.simpleName(this) + ".in")
@@ -26,7 +26,7 @@ private[csv] class CsvParsingStage(delimiter: Byte, quoteChar: Byte, escapeChar:
 
   override def createLogic(inheritedAttributes: Attributes) =
     new GraphStageLogic(shape) with InHandler with OutHandler {
-      private[this] val buffer = new CsvParser(delimiter, quoteChar, escapeChar)
+      private[this] val buffer = new CsvParser(delimiter, quoteChar, escapeChar, maximumLineLength)
 
       setHandlers(in, out, this)
 

--- a/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvFormatting.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvFormatting.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.csv.scaladsl
 import java.nio.charset.{Charset, StandardCharsets}
 
 import akka.NotUsed
-import akka.stream.alpakka.csv.{javadsl, CsvFormatter}
+import akka.stream.alpakka.csv.CsvFormatter
 import akka.stream.scaladsl.{Flow, Source}
 import akka.util.ByteString
 

--- a/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvParsing.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvParsing.scala
@@ -17,12 +17,14 @@ object CsvParsing {
   val Colon: Byte = ':'
   val Tab: Byte = '\t'
   val DoubleQuote: Byte = '"'
+  val maximumLineLengthDefault: Int = 10 * 1024
 
   /** Creates CSV parsing flow that reads CSV lines from incoming
    * [[akka.util.ByteString]] objects.
    */
   def lineScanner(delimiter: Byte = Comma,
                   quoteChar: Byte = DoubleQuote,
-                  escapeChar: Byte = Backslash): Flow[ByteString, List[ByteString], NotUsed] =
-    Flow.fromGraph(new CsvParsingStage(delimiter, quoteChar, escapeChar))
+                  escapeChar: Byte = Backslash,
+                  maximumLineLength: Int = maximumLineLengthDefault): Flow[ByteString, List[ByteString], NotUsed] =
+    Flow.fromGraph(new CsvParsingStage(delimiter, quoteChar, escapeChar, maximumLineLength))
 }

--- a/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
@@ -13,6 +13,8 @@ import org.scalatest.{Matchers, OptionValues, WordSpec}
 
 class CsvParserSpec extends WordSpec with Matchers with OptionValues {
 
+  val maximumLineLength = 10 * 1024
+
   "CSV parser" should {
     "read comma separated values into a list" in {
       expectInOut("one,two,three\n", List("one", "two", "three"))
@@ -32,7 +34,7 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
 
     "parse empty input to None" in {
       val in = ByteString.empty
-      val parser = new CsvParser(',', '-', '.')
+      val parser = new CsvParser(',', '-', '.', maximumLineLength)
       parser.offer(in)
       parser.poll(requireLineEnd = true) should be('empty)
     }
@@ -88,7 +90,7 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
 
     "fail on escaped quote as quotes are escaped by doubled quote chars" in {
       val in = ByteString("a,\\\",c\n")
-      val parser = new CsvParser(',', '"', '\\')
+      val parser = new CsvParser(',', '"', '\\', maximumLineLength)
       parser.offer(in)
       val exception = the[MalformedCsvException] thrownBy {
         parser.poll(requireLineEnd = true)
@@ -98,7 +100,7 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
 
     "fail on escape at line end" in {
       val in = ByteString("""a,\""")
-      val parser = new CsvParser(',', '"', '\\')
+      val parser = new CsvParser(',', '"', '\\', maximumLineLength)
       parser.offer(in)
       val exception = the[MalformedCsvException] thrownBy {
         parser.poll(requireLineEnd = true)
@@ -108,7 +110,7 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
 
     "fail on escape within field at line end" in {
       val in = ByteString("""a,b\""")
-      val parser = new CsvParser(',', '"', '\\')
+      val parser = new CsvParser(',', '"', '\\', maximumLineLength)
       parser.offer(in)
       val exception = the[MalformedCsvException] thrownBy {
         parser.poll(requireLineEnd = true)
@@ -118,7 +120,7 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
 
     "fail on escape within quoted field at line end" in {
       val in = ByteString("""a,"\""")
-      val parser = new CsvParser(',', '"', '\\')
+      val parser = new CsvParser(',', '"', '\\', maximumLineLength)
       parser.offer(in)
       val exception = the[MalformedCsvException] thrownBy {
         parser.poll(requireLineEnd = true)
@@ -144,7 +146,7 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
 
     "allow Unicode L SEP 0x2028 as line separator" ignore {
       val in = ByteString("abc\u2028")
-      val parser = new CsvParser(',', '"', '\\')
+      val parser = new CsvParser(',', '"', '\\', maximumLineLength)
       parser.offer(in)
       val res = parser.poll(requireLineEnd = true)
       res.value.map(_.utf8String) should be(List("abc"))
@@ -186,6 +188,18 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
                                                                           quoteChar = '$',
                                                                           escapeChar = '\\')
     }
+
+    "fail on a very 'long' line" in {
+      val in = ByteString("a,b,c\n1,3,5,7,9,1\n")
+      val parser = new CsvParser(',', '"', '\\', 11)
+      parser.offer(in)
+      parser.poll(requireLineEnd = true)
+      val exception = the[MalformedCsvException] thrownBy {
+        parser.poll(requireLineEnd = true)
+      }
+      exception.getMessage should be("no line end encountered within 11 bytes on line 2")
+    }
+
   }
 
   "CSV parsing with Byte Order Mark" should {
@@ -227,7 +241,7 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
                                                                quoteChar: Byte = '"',
                                                                escapeChar: Byte = '\\',
                                                                requireLineEnd: Boolean = true): Unit = {
-    val parser = new CsvParser(delimiter, quoteChar, escapeChar)
+    val parser = new CsvParser(delimiter, quoteChar, escapeChar, maximumLineLength)
     parser.offer(bsIn)
     expected.foreach { out =>
       parser.poll(requireLineEnd).value.map(_.utf8String) should be(out)

--- a/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvFormattingSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvFormattingSpec.scala
@@ -6,7 +6,6 @@ package akka.stream.alpakka.csv.scaladsl
 
 import java.nio.charset.StandardCharsets
 
-import akka.NotUsed
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.util.ByteString
 

--- a/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvParsingSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvParsingSpec.scala
@@ -7,27 +7,14 @@ package akka.stream.alpakka.csv.scaladsl
 import java.nio.file.Paths
 
 import akka.NotUsed
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{FileIO, Flow, Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
-import akka.testkit.TestKit
 import akka.util.ByteString
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike}
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration.DurationInt
 
-class CsvParsingSpec
-    extends TestKit(ActorSystem(classOf[CsvParsingSpec].getSimpleName))
-    with WordSpecLike
-    with Matchers
-    with BeforeAndAfterAll
-    with BeforeAndAfterEach
-    with ScalaFutures {
-
-  implicit val materializer = ActorMaterializer()
+class CsvParsingSpec extends CsvSpec {
 
   def documentation(): Unit = {
     import CsvParsing._


### PR DESCRIPTION
Introduce `maximumLineLength` in CSV parsing so that the parser fails when
no line break is encountered for a reasonably long line (defaults to 10 kB).

Fixes #509