### PR TITLE
Doc links to GitHub & Javadoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,6 +141,11 @@ val defaultParadoxSettings: Seq[Setting[_]] = Seq(
     "extref.java-api.base_url" -> "https://docs.oracle.com/javase/8/docs/api/index.html?%s.html",
     "extref.javaee-api.base_url" -> "https://docs.oracle.com/javaee/7/api/index.html?%s.html",
     "extref.paho-api.base_url" -> "https://www.eclipse.org/paho/files/javadoc/index.html?%s.html",
+    "javadoc.base_url" -> "https://docs.oracle.com/javase/8/docs/api/",
+    "javadoc.javax.jms.base_url" -> "https://docs.oracle.com/javaee/7/api/",
+    "javadoc.akka.base_url" -> s"http://doc.akka.io/japi/akka/${Dependencies.AkkaVersion}/",
+    "javadoc.akka.http.base_url" -> s">http://doc.akka.io/japi/akka-http/${Dependencies.AkkaHttpVersion}/",
+    "scaladoc.scala.base_url" -> s"http://www.scala-lang.org/api/current/",
     "scaladoc.akka.base_url" -> s"http://doc.akka.io/api/akka/${Dependencies.AkkaVersion}",
     "scaladoc.akka.stream.alpakka.base_url" -> s"http://developer.lightbend.com/docs/api/alpakka/${version.value}"
   ),

--- a/docs/src/main/paradox/data-transformations/csv.md
+++ b/docs/src/main/paradox/data-transformations/csv.md
@@ -57,6 +57,10 @@ Scala
 Java
 : @@snip (../../../../../csv/src/test/java/akka/stream/alpakka/csv/javadsl/CsvParsingTest.java) { #line-scanner }
 
+@scala[@github[Source on Github](/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvParsingSpec.scala)]
+@java[@github[Source on Github](/csv/src/test/java/akka/stream/alpakka/csv/javadsl/CsvParsingTest.java)]
+
+
 ## CSV conversion into a map
 
 The column-based nature of CSV files can be used to read it into a map of column names
@@ -87,6 +91,10 @@ Scala
 
 Java
 : @@snip (../../../../../csv/src/test/java/akka/stream/alpakka/csv/javadsl/CsvToMapTest.java) { #column-names }
+
+@scala[@github[Source on Github](/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvToMapSpec.scala)]
+@java[@github[Source on Github](/csv/src/test/java/akka/stream/alpakka/csv/javadsl/CsvToMapTest.java)]
+
 
 ## CSV formatting
 
@@ -120,3 +128,6 @@ Scala
 
 Java
 : @@snip (../../../../../csv/src/test/java/akka/stream/alpakka/csv/javadsl/CsvFormattingTest.java) { #formatting }
+
+@scala[@github[Source on Github](/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvFormattingSpec.scala)]
+@java[@github[Source on Github](/csv/src/test/java/akka/stream/alpakka/csv/javadsl/CsvFormattingTest.java)]

--- a/docs/src/main/paradox/data-transformations/recordio.md
+++ b/docs/src/main/paradox/data-transformations/recordio.md
@@ -45,6 +45,9 @@ We obtain:
 Scala
 : @@snip (../../../../../simple-codecs/src/test/scala/akka/stream/alpakka/recordio/RecordIOFramingSpec.scala) { #result }
 
+@scala[@github[Source on Github](simple-codecs/src/test/scala/akka/stream/alpakka/recordio/RecordIOFramingSpec.scala)]
+
+
 ### Running the example code
 
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.

--- a/docs/src/main/paradox/data-transformations/xml.md
+++ b/docs/src/main/paradox/data-transformations/xml.md
@@ -20,6 +20,10 @@ Scala
 Java
 : @@snip (../../../../../xml/src/test/java/akka/stream/alpakka/xml/javadsl/XmlParsingTest.java) { #parser }
 
+@scala[@github[Source on Github](/xml/src/test/scala/akka/stream/alpakka/xml/scaladsl/XmlProcessingTest.scala) { #parser }]
+@java[@github[Source on Github](/xml/src/test/java/akka/stream/alpakka/xml/javadsl/XmlParsingTest.java) { #parser }]
+
+
 To parse an XML document run XML document source with this parser.
 
 Scala
@@ -37,6 +41,10 @@ Scala
 
 Java
 : @@snip (../../../../../xml/src/test/java/akka/stream/alpakka/xml/javadsl/XmlWritingTest.java) { #writer }
+
+@scala[@github[Source on Github](/xml/src/test/scala/akka/stream/alpakka/xml/scaladsl/XmlWritingTest.scala) { #writer }]
+@java[@github[Source on Github](/xml/src/test/java/akka/stream/alpakka/xml/javadsl/XmlWritingTest.java) { #writer }]
+
 
 To write an XML document run XML document source with this writer.
 
@@ -56,6 +64,10 @@ Scala
 
 Java
 : @@snip (../../../../../xml/src/test/java/akka/stream/alpakka/xml/javadsl/XmlParsingTest.java) { #subslice }
+
+@scala[@github[Source on Github](/xml/src/test/scala/akka/stream/alpakka/xml/scaladsl/XmlSubsliceTest.scala) { #subslice }]
+@java[@github[Source on Github](/xml/src/test/java/akka/stream/alpakka/xml/javadsl/XmlParsingTest.java) { #subslice }]
+
 
 To get a subslice of an XML document run XML document source with this parser.
 

--- a/docs/src/main/paradox/file.md
+++ b/docs/src/main/paradox/file.md
@@ -32,6 +32,9 @@ Scala
 Java
 : @@snip (../../../../file/src/test/java/akka/stream/alpakka/file/javadsl/FileTailSourceTest.java) { #simple-lines }
 
+@scala[@github[Source on Github](/file/src/test/scala/akka/stream/alpakka/file/scaladsl/FileTailSourceSpec.scala) { #simple-lines }]
+@java[@github[Source on Github](/file/src/test/java/akka/stream/alpakka/file/javadsl/FileTailSourceTest.java) { #simple-lines }]
+
 
 ### Directory
 
@@ -53,6 +56,9 @@ Scala
 Java
 : @@snip (../../../../file/src/test/java/akka/stream/alpakka/file/javadsl/DirectoryTest.java) { #walk }
 
+@scala[@github[Source on Github](/file/src/test/scala/akka/stream/alpakka/file/scaladsl/DirectorySpec.scala)]
+@java[@github[Source on Github](/file/src/test/java/akka/stream/alpakka/file/javadsl/DirectoryTest.java)]
+
 
 ### DirectoryChangesSource
 
@@ -67,6 +73,10 @@ Scala
 
 Java
 : @@snip (../../../../file/src/test/java/akka/stream/alpakka/file/javadsl/DirectoryChangesSourceTest.java) { #minimal-sample }
+
+@scala[@github[Source on Github](/file/src/test/scala/akka/stream/alpakka/file/scaladsl/DirectoryChangesSourceSpec.scala) { #minimal-sample }]
+@java[@github[Source on Github](/file/src/test/java/akka/stream/alpakka/file/javadsl/DirectoryChangesSourceTest.java) { #minimal-sample }]
+
 
 ### LogRotationSink
 
@@ -88,15 +98,24 @@ In this sample we create a size based rotation function:
 
 Scala
 : @@snip (../../../../file/src/test/scala/akka/stream/alpakka/file/scaladsl/LogRotatorSinkSpec.scala) { #LogRotationSink-filesize-sample }
+
 Java
 : @@snip (../../../../file/src/test/java/akka/stream/alpakka/file/javadsl/LogRotatorSinkTest.java) { #LogRotationSink-filesize-sample }
+
+@scala[@github[Source on Github](/file/src/test/scala/akka/stream/alpakka/file/scaladsl/LogRotatorSinkSpec.scala) { #LogRotationSink-filesize-sample }]
+@java[@github[Source on Github](/file/src/test/java/akka/stream/alpakka/file/javadsl/LogRotatorSinkTest.java) { #LogRotationSink-filesize-sample }]
+
 
 In this sample we create a time based rotation function:
 
 Scala
 : @@snip (../../../../file/src/test/scala/akka/stream/alpakka/file/scaladsl/LogRotatorSinkSpec.scala) { #LogRotationSink-timebased-sample }
+
 Java
 : @@snip (../../../../file/src/test/java/akka/stream/alpakka/file/javadsl/LogRotatorSinkTest.java) { #LogRotationSink-timebased-sample }
+
+@scala[@github[Source on Github](/file/src/test/scala/akka/stream/alpakka/file/scaladsl/LogRotatorSinkSpec.scala) { #LogRotationSink-timebased-sample }]
+@java[@github[Source on Github](/file/src/test/java/akka/stream/alpakka/file/javadsl/LogRotatorSinkTest.java) { #LogRotationSink-timebased-sample }]
 
 
 ### Running the example code

--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -42,6 +42,10 @@ Scala
 Java
 : @@snip (../../../../ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpTraversingExample.java) { #traversing }
 
+@scala[@github[Source on Github](/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #traversing }]
+@java[@github[Source on Github](/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpTraversingExample.java) { #traversing }]
+
+
 This source will emit @scaladoc[FtpFile](akka.stream.alpakka.ftp.FtpFile) elements with no significant materialization.
 
 For both FTPs and SFTP servers, you will need to use the `FTPs` and `SFTP` API respectively.
@@ -56,6 +60,10 @@ Scala
 Java
 : @@snip (../../../../ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpRetrievingExample.java) { #retrieving }
 
+@scala[@github[Source on Github](/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #retrieving }]
+@java[@github[Source on Github](/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpRetrievingExample.java) { #retrieving }]
+
+
 This source will emit @scaladoc[ByteString](akka.util.ByteString) elements and materializes to @scaladoc[Future](scala.concurrent.Future) in Scala API and @extref[CompletionStage](java-api:java/util/concurrent/CompletionStage) in Java API of @scaladoc[IOResult](akka.stream.IOResult) when the stream finishes.
 
 For both FTPs and SFTP servers, you will need to use the `FTPs` and `SFTP` API respectively.
@@ -69,6 +77,10 @@ Scala
 
 Java
 : @@snip (../../../../ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpWritingExample.java) { #storing }
+
+@scala[@github[Source on Github](/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #storing }]
+@java[@github[Source on Github](/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpWritingExample.java) { #storing }]
+
 
 This sink will consume @scaladoc[ByteString](akka.util.ByteString) elements and materializes to @scaladoc[Future](scala.concurrent.Future) in Scala API and @extref[CompletionStage](java-api:java/util/concurrent/CompletionStage) in Java API of @scaladoc[IOResult](akka.stream.IOResult) when the stream finishes.
 

--- a/docs/src/main/paradox/jms.md
+++ b/docs/src/main/paradox/jms.md
@@ -40,13 +40,13 @@ Gradle
 
 ## Usage
 
-The JMS message model supports several types of message body (see @extref(javaee-api:javax.jms.Message)) and Alpakka currently supports messages with a body containing a @extref[String](java-api:java.lang.String) object.
+The JMS message model supports several types of message body (see @javadoc[javax.jms.Message](javax.jms.Message)) and Alpakka currently supports messages with a body containing a @javadoc[String](java.lang.String) object.
 
 Use the case class @scaladoc[JmsTextMessage](akka.stream.alpakka.jms.JmsTextMessage$) to wrap the messages you want to send and optionally set their properties (see below for an example).
 
 ### Sending messages to a JMS provider
 
-First define a jms `ConnectionFactory` depending on the implementation you're using. Here we're using Active MQ.
+First define a jms @javadoc[javax.jms.ConnectionFactory](javax.jms.ConnectionFactory) depending on the implementation you're using. Here we're using Active MQ.
 
 Scala
 : @@snip (../../../../jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #connection-factory }
@@ -55,7 +55,7 @@ Java
 : @@snip (../../../../jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #connection-factory }
 
 
-Create a sink, that accepts and forwards @extref[String](java-api:java.lang.String)s to the JMS provider.
+Create a sink, that accepts and forwards @javadoc[String](java.lang.String)s to the JMS provider.
 
 Scala
 : @@snip (../../../../jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #create-text-sink }
@@ -63,7 +63,7 @@ Scala
 Java
 : @@snip (../../../../jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-text-sink }
 
-@scaladoc[JmsSink](akka.stream.alpakka.jms.JmsSink$) contains factory methods to facilitate the creation of sinks.
+@java[@scaladoc[JmsSink](akka.stream.alpakka.jms.javadsl.JmsSink$)]@scala[@scaladoc[JmsSink](akka.stream.alpakka.jms.scaladsl.JmsSink$)] contains factory methods to facilitate the creation of sinks.
 
 Last step is to @extref[materialize](akka-docs:scala/stream/stream-flows-and-basics) and run the sink(s) we have created.
 
@@ -83,7 +83,7 @@ Scala
 Java
 : @@snip (../../../../jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-test-message-list #create-messages-with-properties }
 
-### Receiving @extref[String](java-api:java.lang.String) messages from a JMS provider
+### Receiving @javadoc[String](java.lang.String) messages from a JMS provider
 
 Create a source:
 
@@ -103,9 +103,9 @@ Scala
 Java
 : @@snip (../../../../jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #run-text-source }
 
-### Receiving @extref[javax.jms.Message](javaee-api:javax.jms.Message)s from a JMS provider
+### Receiving @javadoc[javax.jms.Message](javax.jms.Message)s from a JMS provider
 
-Create a @extref[javax.jms.Message](javaee-api:javax.jms.Message) source:
+Create a @javadoc[javax.jms.Message](javax.jms.Message) source:
 
 Scala
 : @@snip (../../../../jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #create-jms-source }
@@ -123,9 +123,9 @@ Scala
 Java
 : @@snip (../../../../jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #run-jms-source }
 
-### Receiving @extref[javax.jms.Message](javaee-api:javax.jms.Message)s messages from a JMS provider with Client Acknowledgement
+### Receiving @javadoc[javax.jms.Message](javax.jms.Message)s messages from a JMS provider with Client Acknowledgement
 
-Create a @extref[javax.jms.Message](javaee-api:javax.jms.Message) source:
+Create a @javadoc[javax.jms.Message](javax.jms.Message) source:
 
 Scala
 : @@snip (../../../../jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #create-jms-source-client-ack }
@@ -133,7 +133,7 @@ Scala
 Java
 : @@snip (../../../../jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-jms-source-client-ack }
 
-The `acknowledgeMode` parameter controls the JMS acknowledge mode parameter, see @extref[javax.jms.Connection#createSession](javaee-api:javax.jms.Connection#createSession).
+The `acknowledgeMode` (@scaladoc[AcknowledgeMode](akka.stream.alpakka.jms.AcknowledgeMode$)) parameter controls the JMS acknowledge mode parameter, see @javadoc[javax.jms.Connection.createSession](javax.jms.Connection#createSession-boolean-int-).
 
 Run the source and take the same amount of messages as we previously sent to it acknowledging them.
 
@@ -143,9 +143,9 @@ Scala
 Java
 : @@snip (../../../../jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #run-jms-source-with-ack }
 
-### Receiving @extref[javax.jms.Message](javaee-api:javax.jms.Message)s from a JMS provider with a selector
+### Receiving @javadoc[javax.jms.Message](javax.jms.Message)s from a JMS provider with a selector
 
-Create a @extref[javax.jms.Message](javaee-api:javax.jms.Message) source specifying a [JMS selector expression](https://docs.oracle.com/cd/E19798-01/821-1841/bncer/index.html):
+Create a @javadoc[javax.jms.Message](javax.jms.Message) source specifying a [JMS selector expression](https://docs.oracle.com/cd/E19798-01/821-1841/bncer/index.html):
 
 Scala
 : @@snip (../../../../jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) {             #create-jms-source-with-selector }


### PR DESCRIPTION
More Paradox directives in the documentation: 
* `@scala`, `@java` to show text depending on the language selected
* `@github` for links to the Github repo
* `@javadoc` (with config in build.sbt) will find the best URL depending on the package name

Took CSV docs to start with. 

JMS docs had a couple of broken links.