### PR TITLE
Elasticsearch streamable flow stage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+scalaVersion in ThisBuild := "2.12.4"
+
 lazy val alpakka = project
   .in(file("."))
   .enablePlugins(PublishUnidoc)

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchStreamableFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchStreamableFlowStage.scala
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.elasticsearch
+
+import java.nio.charset.StandardCharsets
+
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream.stage._
+import org.apache.http.entity.StringEntity
+import org.elasticsearch.client.{Response, ResponseListener, RestClient}
+
+import scala.collection.mutable
+import scala.collection.JavaConverters._
+import spray.json._
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import ElasticsearchStreamableFlowStage._
+import akka.NotUsed
+import akka.stream.alpakka.elasticsearch.scaladsl.ElasticsearchSinkSettings
+import org.apache.http.message.BasicHeader
+import org.apache.http.util.EntityUtils
+import scala.collection.JavaConverters._
+import java.util.{List => JavaList}
+
+trait StreamableIncomingMessage {
+  def id: Option[String]
+  def json: String
+}
+
+final case class StreamableIncomingMessagesResult[T <: StreamableIncomingMessage](
+    success: Seq[T],
+    failed: Seq[T]
+) {
+  // Java-API
+  def getSuccessList(): JavaList[T] = success.toList.asJava
+  // Java-API
+  def getFailedList(): JavaList[T] = failed.toList.asJava
+}
+
+class ElasticsearchStreamableFlowStage[T <: StreamableIncomingMessage](
+    indexName: String,
+    typeName: String,
+    client: RestClient,
+    settings: ElasticsearchSinkSettings
+) extends GraphStage[FlowShape[T, Future[StreamableIncomingMessagesResult[T]]]] {
+
+  private val in = Inlet[T]("messages")
+  private val out = Outlet[Future[StreamableIncomingMessagesResult[T]]]("result")
+  override val shape = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new TimerGraphStageLogic(shape) with InHandler with OutHandler {
+
+      private var state: State = Idle
+      private val queue = new mutable.Queue[T]()
+      private val failureHandler = getAsyncCallback[(Seq[T], Throwable)](handleFailure)
+      private val responseHandler = getAsyncCallback[(Seq[T], Response)](handleResponse)
+      private var failedMessages: Seq[T] = Nil
+      private var retryCount: Int = 0
+
+      override def preStart(): Unit =
+        pull(in)
+
+      private def tryPull(): Unit =
+        if (queue.size < settings.bufferSize && !isClosed(in) && !hasBeenPulled(in)) {
+          pull(in)
+        }
+
+      override def onTimer(timerKey: Any): Unit = {
+        sendBulkUpdateRequest(failedMessages)
+        failedMessages = Nil
+      }
+
+      private def handleFailure(args: (Seq[T], Throwable)): Unit = {
+        val (messages, exception) = args
+        if (retryCount >= settings.maxRetry) {
+          failStage(exception)
+        } else {
+          retryCount = retryCount + 1
+          failedMessages = messages
+          scheduleOnce(NotUsed, settings.retryInterval.millis)
+        }
+      }
+
+      private def handleSuccess(): Unit =
+        completeStage()
+
+      private def handleResponse(args: (Seq[T], Response)): Unit = {
+        val (messages, response) = args
+        val responseJson = EntityUtils.toString(response.getEntity).parseJson
+
+        // If some commands in bulk request failed, pass failed messages to follows.
+        val items = responseJson.asJsObject.fields("items").asInstanceOf[JsArray]
+        val messageResults = items.elements.zip(messages).map {
+          case (item, message) =>
+            item.asJsObject.fields("index").asJsObject.fields.get("error") match {
+              case Some(errorMessage) => (message, false)
+              case None => (message, true)
+            }
+        }
+
+        val successMsgs = messageResults.filter(_._2).map(_._1)
+        val failedMsgs = messageResults.filter(!_._2).map(_._1)
+
+        if (failedMsgs.nonEmpty && settings.retryPartialFailure && retryCount < settings.maxRetry) {
+          // Retry partial failed messages
+          retryCount = retryCount + 1
+          failedMessages = failedMsgs
+          scheduleOnce(NotUsed, settings.retryInterval.millis)
+
+          if (successMsgs.nonEmpty) {
+            // push the messages that DID succeed
+            push(out, Future.successful(StreamableIncomingMessagesResult[T](successMsgs, Seq())))
+          }
+
+        } else {
+          retryCount = 0
+          // Push failed
+          push(out, Future.successful(StreamableIncomingMessagesResult[T](successMsgs, failedMsgs)))
+
+          // Fetch next messages from queue and send them
+          val nextMessages = (1 to settings.bufferSize).flatMap { _ =>
+            queue.dequeueFirst(_ => true)
+          }
+
+          if (nextMessages.isEmpty) {
+            state match {
+              case Finished => handleSuccess()
+              case _ => state = Idle
+            }
+          } else {
+            sendBulkUpdateRequest(nextMessages)
+          }
+        }
+      }
+
+      private def sendBulkUpdateRequest(messages: Seq[T]): Unit = {
+        val json = messages
+          .map { message =>
+            JsObject(
+              "index" -> JsObject(
+                Seq(
+                  Option("_index" -> JsString(indexName)),
+                  Option("_type" -> JsString(typeName)),
+                  message.id.map { id =>
+                    "_id" -> JsString(id)
+                  }
+                ).flatten: _*
+              )
+            ).toString + "\n" + message.json
+          }
+          .mkString("", "\n", "\n")
+
+        client.performRequestAsync(
+          "POST",
+          "/_bulk",
+          Map[String, String]().asJava,
+          new StringEntity(json, StandardCharsets.UTF_8),
+          new ResponseListener() {
+            override def onFailure(exception: Exception): Unit =
+              failureHandler.invoke((messages, exception))
+            override def onSuccess(response: Response): Unit =
+              responseHandler.invoke((messages, response))
+          },
+          new BasicHeader("Content-Type", "application/x-ndjson")
+        )
+      }
+
+      setHandlers(in, out, this)
+
+      override def onPull(): Unit = tryPull()
+
+      override def onPush(): Unit = {
+        val message = grab(in)
+        queue.enqueue(message)
+
+        state match {
+          case Idle => {
+            state = Sending
+            val messages = (1 to settings.bufferSize).flatMap { _ =>
+              queue.dequeueFirst(_ => true)
+            }
+            sendBulkUpdateRequest(messages)
+          }
+          case _ => ()
+        }
+
+        tryPull()
+      }
+
+      override def onUpstreamFailure(exception: Throwable): Unit =
+        failStage(exception)
+
+      override def onUpstreamFinish(): Unit =
+        state match {
+          case Idle => handleSuccess()
+          case Sending => state = Finished
+          case Finished => ()
+        }
+    }
+
+}
+
+object ElasticsearchStreamableFlowStage {
+
+  private sealed trait State
+  private case object Idle extends State
+  private case object Sending extends State
+  private case object Finished extends State
+
+}

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchStreamableFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchStreamableFlowStage.scala
@@ -113,13 +113,13 @@ class ElasticsearchStreamableFlowStage[T <: StreamableIncomingMessage](
 
           if (successMsgs.nonEmpty) {
             // push the messages that DID succeed
-            push(out, Future.successful(StreamableIncomingMessagesResult[T](successMsgs, Seq())))
+            emit(out, Future.successful(StreamableIncomingMessagesResult[T](successMsgs, Seq())))
           }
 
         } else {
           retryCount = 0
           // Push failed
-          push(out, Future.successful(StreamableIncomingMessagesResult[T](successMsgs, failedMsgs)))
+          emit(out, Future.successful(StreamableIncomingMessagesResult[T](successMsgs, failedMsgs)))
 
           // Fetch next messages from queue and send them
           val nextMessages = (1 to settings.bufferSize).flatMap { _ =>

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
@@ -26,6 +26,20 @@ object ElasticsearchFlow {
   ): akka.stream.javadsl.Flow[IncomingMessage[JavaMap[String, Object]], JavaList[
     IncomingMessage[JavaMap[String, Object]]
   ], NotUsed] =
+    create(indexName, typeName, settings, client, new ObjectMapper())
+
+  /**
+   * Java API: creates a [[ElasticsearchFlowStage]] that accepts as JsObject
+   */
+  def create(
+      indexName: String,
+      typeName: String,
+      settings: ElasticsearchSinkSettings,
+      client: RestClient,
+      objectMapper: ObjectMapper
+  ): akka.stream.javadsl.Flow[IncomingMessage[JavaMap[String, Object]], JavaList[
+    IncomingMessage[JavaMap[String, Object]]
+  ], NotUsed] =
     Flow
       .fromGraph(
         new ElasticsearchFlowStage[JavaMap[String, Object], JavaList[IncomingMessage[JavaMap[String, Object]]]](
@@ -34,7 +48,7 @@ object ElasticsearchFlow {
           client,
           settings.asScala,
           _.asJava,
-          new JacksonWriter[JavaMap[String, Object]]()
+          new JacksonWriter[JavaMap[String, Object]](objectMapper)
         )
       )
       .mapAsync(1)(identity)
@@ -49,6 +63,18 @@ object ElasticsearchFlow {
       settings: ElasticsearchSinkSettings,
       client: RestClient
   ): akka.stream.javadsl.Flow[IncomingMessage[T], JavaList[IncomingMessage[T]], NotUsed] =
+    typed(indexName, typeName, settings, client, new ObjectMapper())
+
+  /**
+   * Java API: creates a [[ElasticsearchFlowStage]] that accepts specific type
+   */
+  def typed[T](
+      indexName: String,
+      typeName: String,
+      settings: ElasticsearchSinkSettings,
+      client: RestClient,
+      objectMapper: ObjectMapper
+  ): akka.stream.javadsl.Flow[IncomingMessage[T], JavaList[IncomingMessage[T]], NotUsed] =
     Flow
       .fromGraph(
         new ElasticsearchFlowStage[T, JavaList[IncomingMessage[T]]](indexName,
@@ -56,14 +82,12 @@ object ElasticsearchFlow {
                                                                     client,
                                                                     settings.asScala,
                                                                     _.asJava,
-                                                                    new JacksonWriter[T]())
+                                                                    new JacksonWriter[T](objectMapper))
       )
       .mapAsync(1)(identity)
       .asJava
 
-  private class JacksonWriter[T] extends MessageWriter[T] {
-
-    private val mapper = new ObjectMapper()
+  private class JacksonWriter[T](mapper: ObjectMapper) extends MessageWriter[T] {
 
     override def convert(message: T): String =
       mapper.writeValueAsString(message)

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSink.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSink.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletionStage
 import akka.{Done, NotUsed}
 import akka.stream.alpakka.elasticsearch._
 import akka.stream.javadsl._
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.elasticsearch.client.RestClient
 
 object ElasticsearchSink {
@@ -27,6 +28,20 @@ object ElasticsearchSink {
       .toMat(Sink.ignore, Keep.right[NotUsed, CompletionStage[Done]])
 
   /**
+   * Java API: creates a sink based on [[ElasticsearchFlowStage]] that accepts as JsObject
+   */
+  def create(
+      indexName: String,
+      typeName: String,
+      settings: ElasticsearchSinkSettings,
+      client: RestClient,
+      objectMapper: ObjectMapper
+  ): akka.stream.javadsl.Sink[IncomingMessage[java.util.Map[String, Object]], CompletionStage[Done]] =
+    ElasticsearchFlow
+      .create(indexName, typeName, settings, client, objectMapper)
+      .toMat(Sink.ignore, Keep.right[NotUsed, CompletionStage[Done]])
+
+  /**
    * Java API: creates a sink based on [[ElasticsearchFlowStage]] that accepts as specific type
    */
   def typed[T](indexName: String,
@@ -35,6 +50,18 @@ object ElasticsearchSink {
                client: RestClient): akka.stream.javadsl.Sink[IncomingMessage[T], CompletionStage[Done]] =
     ElasticsearchFlow
       .typed(indexName, typeName, settings, client)
+      .toMat(Sink.ignore, Keep.right[NotUsed, CompletionStage[Done]])
+
+  /**
+   * Java API: creates a sink based on [[ElasticsearchFlowStage]] that accepts as specific type
+   */
+  def typed[T](indexName: String,
+               typeName: String,
+               settings: ElasticsearchSinkSettings,
+               client: RestClient,
+               objectMapper: ObjectMapper): akka.stream.javadsl.Sink[IncomingMessage[T], CompletionStage[Done]] =
+    ElasticsearchFlow
+      .typed(indexName, typeName, settings, client, objectMapper)
       .toMat(Sink.ignore, Keep.right[NotUsed, CompletionStage[Done]])
 
 }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchStreamableFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchStreamableFlow.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.elasticsearch.javadsl
+
+import java.util.{List => JavaList, Map => JavaMap}
+
+import akka.NotUsed
+import akka.stream.alpakka.elasticsearch.javadsl.ElasticsearchFlow.JacksonWriter
+import akka.stream.alpakka.elasticsearch._
+import akka.stream.scaladsl.Flow
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.elasticsearch.client.RestClient
+
+import scala.collection.JavaConverters._
+
+object ElasticsearchStreamableFlow {
+
+  /**
+   * Java API
+   */
+  def create[T <: StreamableIncomingMessage](
+      indexName: String,
+      typeName: String,
+      settings: ElasticsearchSinkSettings,
+      client: RestClient,
+      objectMapper: ObjectMapper
+  ): akka.stream.javadsl.Flow[T, StreamableIncomingMessagesResult[T], NotUsed] =
+    Flow
+      .fromGraph(
+        new ElasticsearchStreamableFlowStage[T](indexName, typeName, client, settings.asScala)
+      )
+      .mapAsync(1)(identity)
+      .asJava
+}

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchStreamableFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchStreamableFlow.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.elasticsearch.scaladsl
+
+import akka.NotUsed
+import akka.stream.alpakka.elasticsearch._
+import akka.stream.scaladsl.Flow
+import org.elasticsearch.client.RestClient
+import spray.json._
+
+object ElasticsearchStreamableFlow {
+
+  /**
+   * Scala API: creates a [[ElasticsearchStreamableFlow]]
+   */
+  def apply[T <: StreamableIncomingMessage](indexName: String, typeName: String, settings: ElasticsearchSinkSettings)(
+      implicit client: RestClient
+  ): Flow[T, StreamableIncomingMessagesResult[T], NotUsed] =
+    Flow
+      .fromGraph(
+        new ElasticsearchStreamableFlowStage[T](
+          indexName,
+          typeName,
+          client,
+          settings
+        )
+      )
+      .mapAsync(1) { x =>
+        x
+      }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,6 +10,7 @@ object Dependencies {
 
   val Common = Seq(
     libraryDependencies ++= Seq(
+      "org.scala-lang" % "scala-library" % scalaVersion.value % Compile,
       "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
       "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
       "org.scalatest" %% "scalatest" % "3.0.1" % Test, // ApacheV2


### PR DESCRIPTION
The existing ElasticsearchFlowStage only forwards failed messages.
This makes it impossible to do many stream-related operations. Some examples:

- Chain posting to multiple Elastic indexes
- Commit to kafka AFTER messages has been posted to elastic.

In this PR I've created ElasticsearchStreamableFlowStage which (is not perfect at all), but since it returns both messages that have failed and succeeded, it is much more flexible.

This is how I use it in a Java-project (using Project Lombok) at work, where I stream from Kafka to Elastic:

```Java
        val elasticFlow = ElasticsearchStreamableFlow.<PojoAndKafkaOffset>create(elasticIndexName_currentState, elasticTypeName, elasticSettings, elasticClient, objectMapper);

        val thisActor = self();

        Consumer.<byte[], String>committableSource(consumerSettings, Subscriptions.topics(kafkaTopic))
                .map(msg -> { // deserialize json
                    final String json = msg.record().value();
                    //log().info(kafkaTopic+": received: " + json);
                    val pojo = objectMapper.readValue(json, CompanyPojoMetadataComplete.class);
                    val id = Long.toString(pojo.getPojoId());
                    return new PojoAndKafkaOffset( pojo, json, msg.committableOffset());
                })
                .via(elasticFlow) // Send to elastic
                .map( result -> {

                    if ( result.getFailedList().size() > 0) {
                        throw new Exception("Error posting to elastic");
                    }

                    // Build single batch-commit
                    ConsumerMessage.CommittableOffsetBatch batchCommit = ConsumerMessage.emptyCommittableOffsetBatch();
                    for ( val m : result.getSuccessList()) {
                        batchCommit = batchCommit.updated( m.getKafkaOffset() );
                    }

                    return batchCommit;
                })
                .mapAsync(3, c -> {
                    log().info("Committing to kafka: " + c);
                    return c.commitJavadsl();
                }) // Do the actual commit
                .runWith(Sink.ignore(), mat)
                .toCompletableFuture()
                .whenComplete( (done, cause) -> {

                    final Exception exception;
                    if ( cause == null ) {
                        exception = new Exception("The kafka->elastic stream stopped without exception");
                    } else {
                        // Tell actor that something went wrong
                        exception = new Exception("The kafka-elastic stream stopped with error: " + cause.toString(), cause);
                    }
                    // Send exception to actor so that it can log and restart
                    thisActor.tell( exception, null);
                });
```

The Java-pojo ("case class") I use to transport the message through ElasticsearchStreamableFlow looks like this:

```Java
@Value
class PojoAndKafkaOffset implements StreamableIncomingMessage {
    CompanyPojoMetadataComplete pojo;
    String json;
    ConsumerMessage.CommittableOffset kafkaOffset;

    @Override
    public Option<String> id() {
        return Option.apply(Long.toString(pojo.getPojoId()));
    }

    @Override
    public String json() {
        return json;
    }
}
```