### PR TITLE
Connector for orientdb #595

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ lazy val modules: Seq[ProjectReference] = Seq(
   kinesis,
   mongodb,
   mqtt,
+  orientdb,
   s3,
   springWeb,
   simpleCodecs,
@@ -109,6 +110,9 @@ lazy val kinesis = alpakkaProject("kinesis",
 lazy val mongodb = alpakkaProject("mongodb", Dependencies.MongoDb)
 
 lazy val mqtt = alpakkaProject("mqtt", Dependencies.Mqtt)
+
+lazy val orientdb =
+  alpakkaProject("orientdb", Dependencies.OrientDB, fork in Test := true, parallelExecution in Test := false)
 
 lazy val s3 = alpakkaProject("s3", Dependencies.S3)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,13 @@ services:
     image: cassandra:3.0.15
     ports:
       - "9042:9042"
+  orientdb:
+    image: orientdb:latest
+    ports:
+      - "2424:2424"
+    environment:
+      - "ORIENTDB_ROOT_PASSWORD=root"
+    command: /orientdb/bin/server.sh -Dmemory.chunk.size=268435456
   dynamodb:
     image: deangiberson/aws-dynamodb-local
     ports:

--- a/docs/src/main/paradox/orientdb.md
+++ b/docs/src/main/paradox/orientdb.md
@@ -1,0 +1,134 @@
+# OrientDB Connector
+
+The OrientDB connector provides Akka Stream sources and sinks for OrientDB.
+
+For more information about OrientDB please visit the [official documentation](http://orientdb.com/orientdb/).
+
+## Artifacts
+
+@@dependency [sbt,Maven,Gradle] {
+  group=com.lightbend.akka
+  artifact=akka-stream-alpakka-orientdb_$scalaBinaryVersion$
+  version=$version$
+}
+
+## Usage
+
+Sources, Flows and Sinks provided by this connector need dbUrl & credentials to access to OrientDB.
+
+Scala
+: @@snip ($alpakka$/orientdb/src/test/scala/akka/stream/alpakka/orientdb/OrientDBSpec.scala) { #init-settings }
+
+Java
+: @@snip ($alpakka$/orientdb/src/test/java/akka/stream/alpakka/orientdb/OrientDBTest.java) { #init-settings }
+
+We will also need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and an @scaladoc[ActorMaterializer](akka.stream.ActorMaterializer).
+
+Scala
+: @@snip ($alpakka$/orientdb/src/test/scala/akka/stream/alpakka/orientdb/OrientDBSpec.scala) { #init-mat }
+
+Java
+: @@snip ($alpakka$/orientdb/src/test/java/akka/stream/alpakka/orientdb/OrientDBTest.java) { #init-mat }
+
+This is all preparation that we are going to need.
+
+## ODocument message
+
+Now we can stream messages which contain OrientDB's `ODocument` (in Scala or Java)
+from or to OrientDB by providing the `ODatabaseDocumentTx` to the
+@scaladoc[OrientDBSource](akka.stream.alpakka.orientdb.scaladsl.OrientDBSource$) or the
+@scaladoc[OrientDBSink](akka.stream.alpakka.orientdb.scaladsl.OrientDBSink$).
+
+Scala
+: @@snip ($alpakka$/orientdb/src/test/scala/akka/stream/alpakka/orientdb/OrientDBSpec.scala) { #run-odocument }
+
+Java
+: @@snip ($alpakka$/orientdb/src/test/java/akka/stream/alpakka/orientdb/OrientDBTest.java) { #run-odocument }
+
+
+## Typed messages
+
+Also, it's possible to stream messages which contains any classes. 
+
+Java
+: @@snip ($alpakka$/orientdb/src/test/java/akka/stream/alpakka/orientdb/OrientDBTest.java) { #define-class }
+
+
+Use `OrientDBSource.typed` and `OrientDBSink.typed` to create source and sink instead.
+
+Java
+: @@snip ($alpakka$/orientdb/src/test/java/akka/stream/alpakka/orientdb/OrientDBTest.java) { #run-typed }
+
+
+## Configuration
+
+We can configure the source by `OrientDBSourceSettings`.
+
+Scala (source)
+: @@snip ($alpakka$/orientdb/src/main/scala/akka/stream/alpakka/orientdb/OrientDBSourceSettings.scala) { #source-settings }
+
+| Parameter        | Default | Description                                                                                                              |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
+| maxPartitionSize |         | `OrientDBSource` and `OrientDBSink` uses this for initializing DB Connections. |
+| maxPoolSize      |    -1   | `OrientDBSource` and `OrientDBSink` uses this for initializing DB Connections. |
+| skip             |         | `OrientDBSource` uses this property to fetch data from the DB. |
+| limit            |         | `OrientDBSource` uses this property to fetch data from the DB. |
+| dbUrl            |         | url to the OrientDB database. |
+| username         |         | username to connect to OrientDB. |
+| password         |         | password to connect to OrientDB. | 
+
+Also, we can configure the sink by `OrientDBUpdateSettings`.
+
+Scala (sink)
+: @@snip ($alpakka$/orientdb/src/main/scala/akka/stream/alpakka/orientdb/OrientDBUpdateSettings.scala) { #sink-settings }
+
+| Parameter           | Default | Description                                                                                            |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| maxPartitionSize |         | `OrientDBSource` and `OrientDBSink` uses this for initializing DB Connections. |
+| maxPoolSize      |    -1   | `OrientDBSource` and `OrientDBSink` uses this for initializing DB Connections. |
+| maxRetry         |     1   | `OrientDBSink` uses this for retrying write operations to OrientDB. |
+| retryInterval    |  5000   | `OrientDBSink` uses this for retrying write operations to OrientDB. |
+| bufferSize       |         | `OrientDBSink` uses this for retrieving data from DB. |
+| dbUrl            |         | url to the OrientDB database. |
+| username         |         | username to connect to OrientDB. |
+| password         |         | password to connect to OrientDB. | 
+
+## Using OrientDB as a Flow
+
+You can also build flow stages. The API is similar to creating Sinks.
+
+Scala (flow)
+: @@snip ($alpakka$/orientdb/src/test/scala/akka/stream/alpakka/orientdb/OrientDBSpec.scala) { #run-flow }
+
+Java (flow)
+: @@snip ($alpakka$/orientdb/src/test/java/akka/stream/alpakka/orientdb/OrientDBTest.java) { #run-flow }
+
+### Passing data through OrientDBFlow
+
+When streaming documents from Kafka, you might want to commit to Kafka **AFTER** the document has been written to OrientDB.
+
+Scala
+: @@snip ($alpakka$/orientdb/src/test/scala/akka/stream/alpakka/orientdb/OrientDBSpec.scala) { #kafka-example }
+
+Java
+: @@snip ($alpakka$/orientdb/src/test/java/akka/stream/alpakka/orientdb/OrientDBTest.java) { #kafka-example } 
+
+## Running the example code
+
+The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
+
+  > Test code requires OrientDB server running in the background. You can start one quickly using docker:
+  >		  
+  > `docker run --rm -p 2424:2424 orientdb:latest`
+
+Scala
+:   ```
+    sbt
+    > orientdb/testOnly *.OrientDBSpec
+    ```
+
+Java
+:   ```
+    sbt
+    > orientdb/testOnly *.OrientDBTest
+    ```

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/OrientDBFlowStage.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/OrientDBFlowStage.scala
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.orientdb
+
+import akka.NotUsed
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream.stage._
+import com.orientechnologies.orient.`object`.db.OObjectDatabaseTx
+import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx
+import com.orientechnologies.orient.core.record.ORecord
+import com.orientechnologies.orient.core.record.impl.ODocument
+import com.orientechnologies.orient.core.tx.OTransaction
+
+import scala.collection.mutable
+import scala.concurrent.Future
+
+object OIncomingMessage {
+  // Apply method to use when not using passThrough
+  def apply[T](oDocument: T): OIncomingMessage[T, NotUsed] =
+    OIncomingMessage(oDocument, NotUsed)
+
+  // Java-api - without passThrough
+  def create[T](oDocument: T): OIncomingMessage[T, NotUsed] =
+    OIncomingMessage(oDocument, NotUsed)
+
+  // Java-api - with passThrough
+  def create[T, C](oDocument: T, passThrough: C) =
+    OIncomingMessage(oDocument, passThrough)
+}
+
+final case class OIncomingMessage[T, C](oDocument: T, passThrough: C)
+
+private[orientdb] class OrientDBFlowStage[T, C, R](
+    className: String,
+    settings: OrientDBUpdateSettings,
+    pusher: Seq[OIncomingMessage[T, C]] => R,
+    clazz: Option[Class[T]]
+) extends GraphStage[FlowShape[OIncomingMessage[T, C], Future[R]]] {
+
+  private val in = Inlet[OIncomingMessage[T, C]]("messages")
+  private val out = Outlet[Future[R]]("failed")
+  override val shape = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new TimerGraphStageLogic(shape) with InHandler with OutHandler {
+
+      private val queue = new mutable.Queue[OIncomingMessage[T, C]]()
+      private val failureHandler = getAsyncCallback[(Seq[OIncomingMessage[T, C]], Throwable)](handleFailure)
+      private val responseHandler = getAsyncCallback[(Seq[OIncomingMessage[T, C]], Option[String])](handleResponse)
+      private var failedMessages: Seq[OIncomingMessage[T, C]] = Nil
+      private var retryCount: Int = 0
+
+      private var client: ODatabaseDocumentTx = _
+      private var oObjectClient: OObjectDatabaseTx = _
+
+      override def preStart(): Unit = {
+        client = settings.oDatabasePool.acquire()
+        oObjectClient = new OObjectDatabaseTx(client)
+        pull(in)
+      }
+
+      override def postStop(): Unit = {
+        oObjectClient.close()
+        client.close()
+      }
+
+      private def tryPull(): Unit =
+        if (queue.size < settings.bufferSize && !isClosed(in) && !hasBeenPulled(in)) {
+          pull(in)
+        }
+
+      override def onTimer(timerKey: Any): Unit = {
+        sendOSQLBulkInsertRequest(failedMessages)
+        failedMessages = Nil
+      }
+
+      private def handleFailure(args: (Seq[OIncomingMessage[T, C]], Throwable)): Unit = {
+        val (messages, exception) = args
+        if (retryCount >= settings.maxRetry) {
+          failStage(exception)
+        } else {
+          retryCount = retryCount + 1
+          failedMessages = messages
+          scheduleOnce(NotUsed, settings.retryInterval)
+        }
+      }
+
+      private def handleSuccess(): Unit =
+        completeStage()
+
+      private def handleResponse(args: (Seq[OIncomingMessage[T, C]], Option[String])): Unit = {
+        retryCount = 0
+        val (messages, error) = args
+
+        val failedMessages = messages.flatMap {
+          case message =>
+            if (error.isEmpty) {
+              None
+            } else {
+              Some(message)
+            }
+        }
+
+        val nextMessages = (1 to settings.bufferSize).flatMap { _ =>
+          queue.dequeueFirst(_ => true)
+        }
+
+        if (nextMessages.isEmpty) {
+          handleSuccess()
+        } else {
+          sendOSQLBulkInsertRequest(nextMessages)
+        }
+
+        push(out, Future.successful(pusher(failedMessages)))
+      }
+
+      private def sendOSQLBulkInsertRequest(messages: Seq[OIncomingMessage[T, C]]): Unit =
+        try {
+          ODatabaseRecordThreadLocal.instance().set(client)
+          if (clazz.isEmpty) {
+            if (!client.getMetadata.getSchema.existsClass(className)) {
+              client.getMetadata.getSchema.createClass(className)
+            }
+            client.begin(OTransaction.TXTYPE.OPTIMISTIC)
+
+            var faultyMessages: List[OIncomingMessage[T, C]] = List()
+            var successfulMessages: List[OIncomingMessage[T, C]] = List()
+            messages.foreach {
+              case OIncomingMessage(oDocument: ODocument, passThrough: C) =>
+                val document = new ODocument()
+                oDocument
+                  .asInstanceOf[ODocument]
+                  .fieldNames()
+                  .zip(oDocument.asInstanceOf[ODocument].fieldValues())
+                  .foreach {
+                    case (fieldName, fieldVal) =>
+                      document.field(fieldName, fieldVal)
+                      ()
+                  }
+                document.setClassName(className)
+                client.save(document)
+                successfulMessages = successfulMessages ++ List(
+                  OIncomingMessage(oDocument.asInstanceOf[T], passThrough)
+                )
+                ()
+              case OIncomingMessage(oRecord: ORecord, passThrough: C) =>
+                client.save(oRecord)
+                successfulMessages = successfulMessages ++ List(OIncomingMessage(oRecord.asInstanceOf[T], passThrough))
+                ()
+              case OIncomingMessage(others: AnyRef, passThrough: C) =>
+                faultyMessages = faultyMessages ++ List(OIncomingMessage(others.asInstanceOf[T], passThrough))
+                ()
+            }
+            client.commit()
+            if (faultyMessages.nonEmpty) {
+              responseHandler.invoke((faultyMessages, Some("Records are invalid OrientDB Records")))
+            } else {
+              emit(out, Future.successful(pusher(successfulMessages)))
+              responseHandler.invoke((Seq(), None))
+            }
+          } else {
+            client.setDatabaseOwner(oObjectClient)
+            oObjectClient.getEntityManager.registerEntityClass(
+              clazz.getOrElse(throw new RuntimeException("Typed stream class is invalid"))
+            )
+
+            var faultyMessages: List[OIncomingMessage[T, C]] = List()
+            var successfulMessages: List[OIncomingMessage[T, C]] = List()
+            messages.foreach {
+              case OIncomingMessage(typeRecord: T, passThrough: C) =>
+                oObjectClient.save(typeRecord)
+                successfulMessages = successfulMessages ++ List(OIncomingMessage(typeRecord, passThrough))
+                ()
+              case OIncomingMessage(others: AnyRef, passThrough: C) =>
+                faultyMessages = faultyMessages ++ List(OIncomingMessage(others.asInstanceOf[T], passThrough))
+                ()
+            }
+
+            if (faultyMessages.nonEmpty) {
+              responseHandler.invoke((faultyMessages, Some("Records are invalid OrientDB Records")))
+            } else {
+              emit(out, Future.successful(pusher(successfulMessages)))
+              responseHandler.invoke((Seq(), None))
+            }
+          }
+        } catch {
+          case exception: Exception =>
+            failureHandler.invoke((messages, exception))
+        }
+
+      setHandlers(in, out, this)
+
+      override def onPull(): Unit = tryPull()
+
+      override def onPush(): Unit = {
+        val message = grab(in)
+        queue.enqueue(message)
+
+        val messages = (1 to settings.bufferSize).flatMap { _ =>
+          queue.dequeueFirst(_ => true)
+        }
+        sendOSQLBulkInsertRequest(messages)
+
+        tryPull()
+      }
+
+      override def onUpstreamFailure(exception: Throwable): Unit =
+        failStage(exception)
+
+      override def onUpstreamFinish(): Unit = handleSuccess()
+    }
+}

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/OrientDBSourceSettings.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/OrientDBSourceSettings.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.orientdb
+
+import com.orientechnologies.orient.core.db.OPartitionedDatabasePool
+
+//#source-settings
+final case class OrientDBSourceSettings(oDatabasePool: OPartitionedDatabasePool,
+                                        maxPartitionSize: Int = Runtime.getRuntime.availableProcessors(),
+                                        maxPoolSize: Int = -1,
+                                        skip: Int = 0,
+                                        limit: Int = 10)
+//#source-settings
+{
+
+  def withMaxPartitionSize(maxPartitionSize: Int): OrientDBSourceSettings =
+    copy(maxPartitionSize = maxPartitionSize)
+
+  def withMaxPoolSize(maxPoolSize: Int): OrientDBSourceSettings =
+    copy(maxPoolSize = maxPoolSize)
+
+  def withSkipAndLimit(skip: Int, limit: Int): OrientDBSourceSettings =
+    copy(skip = skip, limit = limit)
+
+  def withOrientDBCredentials(oDatabasePool: OPartitionedDatabasePool): OrientDBSourceSettings =
+    copy(oDatabasePool = oDatabasePool)
+}
+
+object OrientDBSourceSettings {
+
+  def create(oDatabasePool: OPartitionedDatabasePool) =
+    OrientDBSourceSettings(oDatabasePool)
+}

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/OrientDBSourceStage.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/OrientDBSourceStage.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.orientdb
+
+import akka.stream.{Attributes, Outlet, SourceShape}
+import akka.stream.stage.{GraphStage, GraphStageLogic, OutHandler}
+import com.orientechnologies.orient.`object`.db.OObjectDatabaseTx
+import com.orientechnologies.orient.core.command.OCommandResultListener
+import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx
+import com.orientechnologies.orient.core.sql.query.{OSQLNonBlockingQuery, OSQLSynchQuery}
+
+import scala.collection.JavaConverters._
+
+final case class OOutgoingMessage[T](oDocument: T)
+
+case class OSQLResponse[T](error: Option[String], result: Option[OSQLResult[T]])
+case class OSQLResult[T](records: Seq[OOutgoingMessage[T]])
+
+trait MessageReader[T] {
+  def convert(oDocs: List[T]): OSQLResponse[T]
+}
+
+private[orientdb] final class OrientDBSourceStage[T](className: String,
+                                                     query: Option[String],
+                                                     settings: OrientDBSourceSettings,
+                                                     reader: MessageReader[T],
+                                                     clazz: Option[Class[T]] = None)
+    extends GraphStage[SourceShape[OOutgoingMessage[T]]] {
+
+  val out: Outlet[OOutgoingMessage[T]] = Outlet("OrientDBSource.out")
+  override val shape = SourceShape(out)
+
+  override def createLogic(inheritedAttributes: Attributes) =
+    new OrientDBSourceLogic[T](className,
+                               query,
+                               settings,
+                               out,
+                               shape,
+                               reader,
+                               SkipAndLimit(settings.skip, settings.limit),
+                               clazz)
+}
+
+private[orientdb] sealed class OrientDBSourceLogic[T](className: String,
+                                                      query: Option[String],
+                                                      settings: OrientDBSourceSettings,
+                                                      out: Outlet[OOutgoingMessage[T]],
+                                                      shape: SourceShape[OOutgoingMessage[T]],
+                                                      reader: MessageReader[T],
+                                                      skipAndLimit: SkipAndLimit,
+                                                      clazz: Option[Class[T]] = None)
+    extends GraphStageLogic(shape)
+    with OutHandler {
+
+  private val responseHandler = getAsyncCallback[List[T]](handleResponse)
+  private val failureHandler = getAsyncCallback[Throwable](handleFailure)
+
+  private var client: ODatabaseDocumentTx = _
+  private var oObjectClient: OObjectDatabaseTx = _
+
+  override def preStart(): Unit = {
+    client = settings.oDatabasePool.acquire()
+    oObjectClient = new OObjectDatabaseTx(client)
+  }
+
+  override def postStop(): Unit = {
+    oObjectClient.close()
+    client.close()
+  }
+
+  def sendOSQLRequest(): Unit =
+    if (clazz.isEmpty) {
+      ODatabaseRecordThreadLocal.instance().set(client)
+      try {
+        if (query.nonEmpty) {
+          client.query[java.util.List[T]](new OSQLNonBlockingQuery[T](query.get, new OSQLCallback))
+        } else {
+          client.query[java.util.List[T]](
+            new OSQLNonBlockingQuery[T](
+              s"SELECT * FROM $className SKIP ${skipAndLimit.skip} LIMIT ${skipAndLimit.limit}",
+              new OSQLCallback
+            )
+          )
+        }
+      } catch {
+        case ex: Exception => handleFailure(ex)
+      }
+    } else {
+      client.setDatabaseOwner(oObjectClient)
+      ODatabaseRecordThreadLocal.instance().set(client)
+      oObjectClient.getEntityManager.registerEntityClass(
+        clazz.getOrElse(throw new RuntimeException("Typed stream class is invalid"))
+      )
+
+      try {
+        if (query.nonEmpty) {
+          oObjectClient.query[java.util.List[T]](new OSQLNonBlockingQuery[T](query.get, new OSQLCallback))
+        } else {
+          val oDocs =
+            oObjectClient
+              .query[java.util.List[T]](
+                new OSQLSynchQuery[T](
+                  s"SELECT * FROM $className SKIP ${skipAndLimit.skip} LIMIT ${skipAndLimit.limit}"
+                )
+              )
+              .asScala
+              .toList
+          if (oDocs.nonEmpty) {
+            skipAndLimit.skip = skipAndLimit.skip + skipAndLimit.limit
+          }
+          onSuccess(oDocs)
+        }
+      } catch {
+        case ex: Exception => handleFailure(ex)
+      }
+    }
+
+  def onFailure(exception: Exception) = failureHandler.invoke(exception)
+  def onSuccess(response: List[T]) = responseHandler.invoke(response)
+
+  def handleFailure(ex: Throwable): Unit =
+    failStage(ex)
+
+  def handleResponse(res: List[T]): Unit =
+    reader.convert(res) match {
+      case OSQLResponse(Some(error), _) =>
+        failStage(new IllegalStateException(error))
+      case OSQLResponse(None, Some(result)) if result.records.isEmpty =>
+        completeStage()
+      case OSQLResponse(_, Some(result)) =>
+        emitMultiple(out, result.records.toIterator)
+    }
+
+  setHandler(out, this)
+
+  override def onPull(): Unit = sendOSQLRequest()
+
+  class OSQLCallback extends OCommandResultListener {
+    var oDocs: List[T] = List()
+
+    override def result(iRecord: scala.Any): Boolean = {
+      oDocs :+= iRecord.asInstanceOf[T]
+      true
+    }
+
+    override def getResult: AnyRef = oDocs
+
+    override def end(): Unit = {
+      if (oDocs.nonEmpty) {
+        skipAndLimit.skip = skipAndLimit.skip + skipAndLimit.limit
+      }
+      onSuccess(oDocs)
+    }
+  }
+}
+
+private[orientdb] case class SkipAndLimit(var skip: Int, var limit: Int)

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/OrientDBUpdateSettings.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/OrientDBUpdateSettings.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.orientdb
+
+import com.orientechnologies.orient.core.db.OPartitionedDatabasePool
+
+import scala.concurrent.duration._
+
+//#sink-settings
+final case class OrientDBUpdateSettings(oDatabasePool: OPartitionedDatabasePool,
+                                        maxPartitionSize: Int = Runtime.getRuntime.availableProcessors(),
+                                        maxPoolSize: Int = -1,
+                                        maxRetry: Int = 1,
+                                        retryInterval: FiniteDuration = 5000 millis,
+                                        bufferSize: Int = 10)
+//#sink-settings
+{
+
+  def withMaxPartitionSize(maxPartitionSize: Int): OrientDBUpdateSettings =
+    copy(maxPartitionSize = maxPartitionSize)
+
+  def withMaxPoolSize(maxPoolSize: Int): OrientDBUpdateSettings =
+    copy(maxPoolSize = maxPoolSize)
+
+  def withRetries(maxRetry: Int, retryInterval: Long, timeUnit: TimeUnit): OrientDBUpdateSettings =
+    copy(maxRetry = maxRetry, retryInterval = Duration(retryInterval, timeUnit))
+
+  def withBufferSize(bufferSize: Int): OrientDBUpdateSettings =
+    copy(bufferSize = bufferSize)
+
+  def withOrientDBCredentials(oDatabasePool: OPartitionedDatabasePool): OrientDBUpdateSettings =
+    copy(oDatabasePool = oDatabasePool)
+}
+
+object OrientDBUpdateSettings {
+
+  def create(oDatabasePool: OPartitionedDatabasePool) =
+    OrientDBUpdateSettings(oDatabasePool)
+}

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/javadsl/OrientDBFlow.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/javadsl/OrientDBFlow.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.orientdb.javadsl
+
+import akka.NotUsed
+import akka.stream.alpakka.orientdb._
+import akka.stream.javadsl.Flow
+import com.orientechnologies.orient.core.record.impl.ODocument
+
+import scala.collection.JavaConverters._
+import java.util.{List => JavaList}
+
+object OrientDBFlow {
+
+  /**
+   * Java API: creates a [[OrientDBFlowStage]] that accepts as ODocument
+   */
+  def create(
+      className: String,
+      settings: OrientDBUpdateSettings
+  ): Flow[OIncomingMessage[ODocument, NotUsed], JavaList[OIncomingMessage[ODocument, NotUsed]], NotUsed] =
+    akka.stream.scaladsl.Flow
+      .fromGraph(
+        new OrientDBFlowStage[ODocument, NotUsed, JavaList[OIncomingMessage[ODocument, NotUsed]]](
+          className,
+          settings,
+          _.asJava,
+          None
+        )
+      )
+      .mapAsync(1)(identity)
+      .asJava
+
+  /**
+   * Java API: creates a [[OrientDBFlowStage]] that accepts specific type
+   */
+  def typed[T](
+      className: String,
+      settings: OrientDBUpdateSettings,
+      clazz: Option[Class[T]]
+  ): Flow[OIncomingMessage[T, NotUsed], JavaList[OIncomingMessage[T, NotUsed]], NotUsed] =
+    akka.stream.scaladsl.Flow
+      .fromGraph(
+        new OrientDBFlowStage[T, NotUsed, JavaList[OIncomingMessage[T, NotUsed]]](className, settings, _.asJava, clazz)
+      )
+      .mapAsync(1)(identity)
+      .asJava
+
+  /**
+   * Creates a [[akka.stream.javadsl.Flow]] from [[OIncomingMessage]]
+   * with `passThrough` of type `C`.
+   */
+  def createWithPassThrough[C](
+      className: String,
+      settings: OrientDBUpdateSettings
+  ): Flow[OIncomingMessage[ODocument, C], JavaList[OIncomingMessage[ODocument, C]], NotUsed] =
+    akka.stream.scaladsl.Flow
+      .fromGraph(
+        new OrientDBFlowStage[ODocument, C, JavaList[OIncomingMessage[ODocument, C]]](
+          className,
+          settings,
+          _.asJava,
+          None
+        )
+      )
+      .mapAsync(1)(identity)
+      .asJava
+}

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/javadsl/OrientDBSink.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/javadsl/OrientDBSink.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.orientdb.javadsl
+
+import java.util.concurrent.CompletionStage
+
+import akka.{Done, NotUsed}
+import akka.stream.alpakka.orientdb._
+import akka.stream.javadsl._
+import com.orientechnologies.orient.core.record.impl.ODocument
+
+object OrientDBSink {
+
+  /**
+   * Java API: creates a sink that accepts as ODocument
+   */
+  def create(className: String,
+             settings: OrientDBUpdateSettings): Sink[OIncomingMessage[ODocument, NotUsed], CompletionStage[Done]] =
+    OrientDBFlow
+      .create(className, settings)
+      .toMat(Sink.ignore, Keep.right[NotUsed, CompletionStage[Done]])
+
+  /**
+   * Java API: creates a sink that accepts as specific type
+   */
+  def typed[T](className: String,
+               settings: OrientDBUpdateSettings,
+               clazz: Class[T]): Sink[OIncomingMessage[T, NotUsed], CompletionStage[Done]] =
+    OrientDBFlow
+      .typed[T](className, settings, Some(clazz))
+      .toMat(Sink.ignore, Keep.right[NotUsed, CompletionStage[Done]])
+}

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/javadsl/OrientDBSource.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/javadsl/OrientDBSource.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.orientdb.javadsl
+
+import akka.NotUsed
+import akka.stream.alpakka.orientdb._
+import akka.stream.javadsl.Source
+import com.orientechnologies.orient.core.record.impl.ODocument
+
+object OrientDBSource {
+
+  /**
+   * Java API: creates a [[OrientDBSourceStage]] that producer as ODocument
+   */
+  def create(className: String,
+             settings: OrientDBSourceSettings,
+             query: String): Source[OOutgoingMessage[ODocument], NotUsed] =
+    Source.fromGraph(
+      new OrientDBSourceStage(
+        className,
+        Option(query),
+        settings,
+        new ODocumentMessageReader[ODocument]()
+      )
+    )
+
+  /**
+   * Java API: creates a [[OrientDBSourceStage]] that produces as specific type
+   */
+  def typed[T](className: String,
+               settings: OrientDBSourceSettings,
+               clazz: Class[T],
+               query: String = null): Source[OOutgoingMessage[T], NotUsed] =
+    Source.fromGraph(
+      new OrientDBSourceStage[T](
+        className,
+        Option(query),
+        settings,
+        new ODocumentMessageReader[T](),
+        clazz = Some(clazz)
+      )
+    )
+
+  private class ODocumentMessageReader[T] extends MessageReader[T] {
+
+    override def convert(oDocs: List[T]): OSQLResponse[T] =
+      try {
+        OSQLResponse(None, Some(OSQLResult(oDocs.map(OOutgoingMessage(_)))))
+      } catch {
+        case exception: Exception => OSQLResponse(Some(exception.toString), None)
+      }
+  }
+}

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/scaladsl/OrientDBFlow.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/scaladsl/OrientDBFlow.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.orientdb.scaladsl
+
+import akka.NotUsed
+import akka.stream.alpakka.orientdb._
+import akka.stream.scaladsl.Flow
+import com.orientechnologies.orient.core.record.impl.ODocument
+
+object OrientDBFlow {
+
+  /**
+   * Scala API: creates a [[OrientDBFlowStage]] that accepts as ODocument
+   */
+  def create(
+      className: String,
+      settings: OrientDBUpdateSettings
+  ): Flow[OIncomingMessage[ODocument, NotUsed], Seq[OIncomingMessage[ODocument, NotUsed]], NotUsed] =
+    Flow
+      .fromGraph(
+        new OrientDBFlowStage[ODocument, NotUsed, Seq[OIncomingMessage[ODocument, NotUsed]]](
+          className,
+          settings,
+          identity,
+          None
+        )
+      )
+      .mapAsync(1)(identity)
+
+  /**
+   * Creates a [[akka.stream.scaladsl.Flow]]
+   * with `passThrough` of type `C`.
+   */
+  def createWithPassThrough[C](
+      className: String,
+      settings: OrientDBUpdateSettings
+  ): Flow[OIncomingMessage[ODocument, C], Seq[OIncomingMessage[ODocument, C]], NotUsed] =
+    Flow
+      .fromGraph(
+        new OrientDBFlowStage[ODocument, C, Seq[OIncomingMessage[ODocument, C]]](
+          className,
+          settings,
+          identity,
+          None
+        )
+      )
+      .mapAsync(1)(identity)
+}

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/scaladsl/OrientDBSink.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/scaladsl/OrientDBSink.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.orientdb.scaladsl
+
+import akka.{Done, NotUsed}
+import akka.stream.alpakka.orientdb._
+import akka.stream.scaladsl.{Keep, Sink}
+import com.orientechnologies.orient.core.record.impl.ODocument
+
+import scala.concurrent.Future
+
+object OrientDBSink {
+
+  /**
+   * Scala API: creates a sink that accepts as ODocument
+   */
+  def apply(className: String,
+            settings: OrientDBUpdateSettings): Sink[OIncomingMessage[ODocument, NotUsed], Future[Done]] =
+    OrientDBFlow.create(className, settings).toMat(Sink.ignore)(Keep.right)
+
+}

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/scaladsl/OrientDBSource.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/scaladsl/OrientDBSource.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.orientdb.scaladsl
+
+import akka.NotUsed
+import akka.stream.alpakka.orientdb._
+import akka.stream.scaladsl.Source
+import com.orientechnologies.orient.core.record.impl.ODocument
+
+object OrientDBSource {
+
+  /**
+   * Scala API: creates a [[OrientDBSourceStage]] that produces as ODocument
+   */
+  def apply(className: String,
+            settings: OrientDBSourceSettings,
+            query: Option[String] = None): Source[OOutgoingMessage[ODocument], NotUsed] =
+    Source.fromGraph(
+      new OrientDBSourceStage(
+        className,
+        query,
+        settings,
+        new ODocumentMessageReader[ODocument]()
+      )
+    )
+
+  private class ODocumentMessageReader[T] extends MessageReader[T] {
+
+    override def convert(oDocs: List[T]): OSQLResponse[T] =
+      try {
+        OSQLResponse(None, Some(OSQLResult(oDocs.map(OOutgoingMessage(_)))))
+      } catch {
+        case exception: Exception => OSQLResponse(Some(exception.toString), None)
+      }
+  }
+}

--- a/orientdb/src/test/java/akka/stream/alpakka/orientdb/OrientDBTest.java
+++ b/orientdb/src/test/java/akka/stream/alpakka/orientdb/OrientDBTest.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.orientdb;
+
+import akka.Done;
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.alpakka.orientdb.javadsl.OrientDBFlow;
+import akka.stream.alpakka.orientdb.javadsl.OrientDBSink;
+import akka.stream.alpakka.orientdb.javadsl.OrientDBSource;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.testkit.JavaTestKit;
+import com.orientechnologies.orient.client.remote.OServerAdmin;
+import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
+import com.orientechnologies.orient.core.db.OPartitionedDatabasePool;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class OrientDBTest {
+
+  private static OServerAdmin oServerAdmin;
+  private static OPartitionedDatabasePool oDatabase;
+  private static ODatabaseDocumentTx client;
+  private static ActorSystem system;
+  private static ActorMaterializer materializer;
+
+  //#init-settings
+  private static String url = "remote:127.0.0.1:2424/";
+  private static String dbName = "GratefulDeadConcertsJava";
+  private static String dbUrl = url + dbName;
+  private static String username = "root";
+  private static String password = "root";
+  //#init-settings
+
+  private static String source = "source1";
+  private static String sink1 = "sink1";
+  private static String sink2 = "sink2";
+  private static String sink3 = "sink3";
+  private static String sink6 = "sink6";
+
+  //#define-class
+  public class source1 {
+
+    private String book_title;
+
+    public void setBook_title(String book_title) {
+      this.book_title = book_title;
+    }
+
+    public String getBook_title() {
+      return book_title;
+    }
+  }
+
+  public class sink2 {
+
+    private String book_title;
+
+    public void setBook_title(String book_title) {
+      this.book_title = book_title;
+    }
+
+    public String getBook_title() {
+      return book_title;
+    }
+  }
+  //#define-class
+
+  public class KafkaOffset {
+
+    private int offset;
+
+    public KafkaOffset(int offset) {
+      this.offset = offset;
+    }
+
+    public void setOffset(int offset) {
+      this.offset = offset;
+    }
+
+    public int getOffset() {
+      return offset;
+    }
+  }
+
+  public class messagesFromKafka {
+
+    private String book_title;
+
+    private KafkaOffset kafkaOffset;
+
+    public messagesFromKafka(String book_title, KafkaOffset kafkaOffset) {
+      this.book_title = book_title;
+      this.kafkaOffset = kafkaOffset;
+    }
+
+    public void setBook_title(String book_title) {
+      this.book_title = book_title;
+    }
+
+    public String getBook_title() {
+      return book_title;
+    }
+
+    public void setKafkaOffset(KafkaOffset kafkaOffset) {
+      this.kafkaOffset = kafkaOffset;
+    }
+
+    public KafkaOffset getKafkaOffset() {
+      return kafkaOffset;
+    }
+  }
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    //#init-mat
+    system = ActorSystem.create();
+    materializer = ActorMaterializer.create(system);
+    //#init-mat
+
+    //#init-db
+    oServerAdmin = new OServerAdmin(url).connect(username, password);
+    if (!oServerAdmin.existsDatabase(dbName, "plocal")) {
+      oServerAdmin.createDatabase(dbName, "document", "plocal");
+    }
+    //#init-db
+
+
+    oDatabase =
+      new OPartitionedDatabasePool(dbUrl, username, password,
+        Runtime.getRuntime().availableProcessors(), 10);
+    client = oDatabase.acquire();
+
+    register(source);
+
+    flush(source, "book_title", "Akka in Action");
+    flush(source, "book_title", "Programming in Scala");
+    flush(source, "book_title", "Learning Scala");
+    flush(source, "book_title", "Scala for Spark in Production");
+    flush(source, "book_title", "Scala Puzzlers");
+    flush(source, "book_title", "Effective Akka");
+    flush(source, "book_title", "Akka Concurrency");
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    unregister(source);
+    unregister(sink1);
+    unregister(sink2);
+    unregister(sink3);
+    unregister(sink6);
+
+    if (oServerAdmin.existsDatabase(dbName, "plocal")) {
+      oServerAdmin.dropDatabase(dbName, "plocal");
+    }
+    oServerAdmin.close();
+
+    client.close();
+    oDatabase.close();
+    JavaTestKit.shutdownActorSystem(system);
+  }
+
+  private static void register(String className) {
+    if (!client.getMetadata().getSchema().existsClass(className)) {
+      client.getMetadata().getSchema().createClass(className);
+    }
+  }
+
+  private static void flush(String className, String fieldName, String fieldValue) {
+    ODocument oDocument = new ODocument()
+      .field(fieldName, fieldValue);
+    oDocument.setClassNameIfExists(className);
+    oDocument.save();
+  }
+
+  private static void unregister(String className) {
+    if (client.getMetadata().getSchema().existsClass(className)) {
+      client.getMetadata().getSchema().dropClass(className);
+    }
+  }
+
+  @Test
+  public void oDocObjectStream() throws Exception {
+    // Copy source to sink1 through ODocument stream
+    //#run-odocument
+    CompletionStage<Done> f1 = OrientDBSource.create(
+      source,
+      OrientDBSourceSettings.create(oDatabase),
+      null
+    )
+      .map(m -> OIncomingMessage.create(m.oDocument()))
+      .runWith(
+        OrientDBSink.create(
+          sink1,
+          OrientDBUpdateSettings.create(oDatabase)
+        ),
+        materializer
+      );
+    //#run-odocument
+
+    f1.toCompletableFuture().get(60, TimeUnit.SECONDS);
+
+    CompletionStage<List<String>> f2 = OrientDBSource.create(
+      sink1,
+      OrientDBSourceSettings.create(oDatabase),
+      null
+    )
+      .map(m -> m.oDocument().<String>field("book_title"))
+      .runWith(Sink.seq(), materializer);
+
+    List<String> result = new ArrayList<>(f2.toCompletableFuture().get(60, TimeUnit.SECONDS));
+
+    List<String> expect = Arrays.asList(
+      "Akka Concurrency",
+      "Akka in Action",
+      "Effective Akka",
+      "Learning Scala",
+      "Programming in Scala",
+      "Scala Puzzlers",
+      "Scala for Spark in Production"
+    );
+
+    Collections.sort(result);
+    assertEquals(expect, result);
+  }
+
+  @Test
+  public void typedStream() throws Exception {
+    // Copy source/book to sink2/book through Typed stream
+    //#run-typed
+    CompletionStage<Done> f1 = OrientDBSource.typed(
+      source,
+      OrientDBSourceSettings.create(oDatabase),
+      source1.class,
+      null
+    )
+      .map(m -> {
+        ODatabaseDocumentTx db = oDatabase.acquire();
+        db.setDatabaseOwner(new OObjectDatabaseTx(db));
+        ODatabaseRecordThreadLocal.instance().set(db);
+        sink2 sink = new sink2();
+        sink.setBook_title(m.oDocument().getBook_title());
+        return OIncomingMessage.create(sink);
+      })
+      .runWith(OrientDBSink.typed(
+        sink2,
+        OrientDBUpdateSettings.create(oDatabase),
+        sink2.class
+      ), materializer);
+    //#run-typed
+
+    f1.toCompletableFuture().get(60, TimeUnit.SECONDS);
+
+    CompletionStage<List<String>> f2 = OrientDBSource.typed(
+      sink2,
+      OrientDBSourceSettings.create(oDatabase),
+      sink2.class,
+      null
+    )
+      .map(m -> {
+        ODatabaseDocumentTx db = oDatabase.acquire();
+        db.setDatabaseOwner(new OObjectDatabaseTx(db));
+        ODatabaseRecordThreadLocal.instance().set(db);
+        return m.oDocument().getBook_title();
+      })
+      .runWith(Sink.seq(), materializer);
+
+    List<String> result = new ArrayList<>(f2.toCompletableFuture().get(60, TimeUnit.SECONDS));
+
+    List<String> expect = Arrays.asList(
+      "Akka Concurrency",
+      "Akka in Action",
+      "Effective Akka",
+      "Learning Scala",
+      "Programming in Scala",
+      "Scala Puzzlers",
+      "Scala for Spark in Production"
+    );
+
+    Collections.sort(result);
+    assertEquals(expect, result);
+  }
+
+  @Test
+  public void typedStreamWithPassThrough() throws Exception {
+    //#kafka-example
+    // We're going to pretend we got messages from kafka.
+    // After we've written them to OrientDB, we want
+    // to commit the offset to Kafka
+
+    List<Integer> committedOffsets = new ArrayList<>();
+    List<messagesFromKafka> messagesFromKafkas = Arrays.asList(
+        new messagesFromKafka("Akka Concurrency", new KafkaOffset(0)),
+        new messagesFromKafka("Akka in Action", new KafkaOffset(1)),
+        new messagesFromKafka("Effective Akka", new KafkaOffset(2)));
+
+    Consumer<KafkaOffset> commitToKafka = new Consumer<KafkaOffset>() {
+      @Override
+      public void accept(KafkaOffset kafkaOffset) {
+        committedOffsets.add(kafkaOffset.getOffset());
+      }
+    };
+
+    Source.from(messagesFromKafkas)
+      .map(kafkaMessage -> {
+        String book_title = kafkaMessage.getBook_title();
+        return OIncomingMessage.create(new ODocument().field("book_title", book_title),
+          kafkaMessage.kafkaOffset);
+      })
+      .via(OrientDBFlow.createWithPassThrough(
+        sink6,
+        OrientDBUpdateSettings.create(oDatabase)
+      ))
+      .map(messages -> {
+        ODatabaseDocumentTx db = oDatabase.acquire();
+        db.setDatabaseOwner(new OObjectDatabaseTx(db));
+        ODatabaseRecordThreadLocal.instance().set(db);
+        messages.stream()
+          .forEach(message -> {
+            commitToKafka.accept(((KafkaOffset) message.passThrough()));
+          });
+        return NotUsed.getInstance();
+      })
+      .runWith(Sink.seq(), materializer)
+      .toCompletableFuture().get(60, TimeUnit.SECONDS);
+    //#kafka-example
+
+    assertEquals(Arrays.asList(0, 1, 2), committedOffsets);
+
+    List<Object> result2 = OrientDBSource.create(
+      sink6,
+      OrientDBSourceSettings.create(oDatabase),
+      null
+    ).map(m -> m.oDocument().field("book_title"))
+     .runWith(Sink.seq(), materializer)
+     .toCompletableFuture().get(60, TimeUnit.SECONDS);
+
+    assertEquals(
+      messagesFromKafkas.stream().map(m -> m.getBook_title()).sorted().collect(Collectors.toList()),
+      result2.stream().sorted().collect(Collectors.toList())
+    );
+  }
+
+  @Test
+  public void flow() throws Exception {
+    // Copy source to sink3 through ODocument stream
+    //#run-flow
+    CompletionStage<List<List<OIncomingMessage<ODocument, NotUsed>>>> f1 = OrientDBSource.create(
+      source,
+      OrientDBSourceSettings.create(oDatabase),
+      null
+    )
+      .map(m -> OIncomingMessage.create(m.oDocument()))
+      .via(OrientDBFlow.create(
+        sink3,
+        OrientDBUpdateSettings.create(oDatabase)
+      ))
+      .runWith(Sink.seq(), materializer);
+    //#run-flow
+
+    f1.toCompletableFuture().get();
+
+    // Assert docs in sink3
+    CompletionStage<List<String>> f2 = OrientDBSource.create(
+      sink3,
+      OrientDBSourceSettings.create(oDatabase),
+      null
+    )
+      .map(m -> m.oDocument().<String>field("book_title"))
+      .runWith(Sink.seq(), materializer);
+
+    List<String> result2 = new ArrayList<>(f2.toCompletableFuture().get(60, TimeUnit.SECONDS));
+
+    List<String> expect = Arrays.asList(
+      "Akka Concurrency",
+      "Akka in Action",
+      "Effective Akka",
+      "Learning Scala",
+      "Programming in Scala",
+      "Scala Puzzlers",
+      "Scala for Spark in Production"
+    );
+
+    Collections.sort(result2);
+    assertEquals(expect, result2);
+  }
+}

--- a/orientdb/src/test/scala/akka/stream/alpakka/orientdb/OrientDBSpec.scala
+++ b/orientdb/src/test/scala/akka/stream/alpakka/orientdb/OrientDBSpec.scala
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.orientdb
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.orientdb.scaladsl._
+import akka.stream.scaladsl.{Sink, Source}
+import akka.testkit.TestKit
+import com.orientechnologies.orient.client.remote.OServerAdmin
+import com.orientechnologies.orient.core.db.OPartitionedDatabasePool
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx
+import com.orientechnologies.orient.core.record.impl.ODocument
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class OrientDBSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+
+  //#init-mat
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
+  //#init-mat
+
+  //#init-settings
+  val url = "remote:127.0.0.1:2424/"
+  val dbName = "GratefulDeadConcertsScala"
+  val dbUrl = s"$url$dbName"
+  val username = "root"
+  val password = "root"
+  //#init-settings
+
+  val source = "source2"
+  val sink4 = "sink4"
+  val sink5 = "sink5"
+  val sink7 = "sink7"
+
+  //#define-class
+  case class Book(title: String)
+  //#define-class
+
+  //#define-client
+  var oServerAdmin: OServerAdmin = _
+  var oDatabase: OPartitionedDatabasePool = _
+  var client: ODatabaseDocumentTx = _
+  //#define-client
+
+  override def beforeAll() = {
+    //#init-db
+    oServerAdmin = new OServerAdmin(url).connect(username, password)
+    if (!oServerAdmin.existsDatabase(dbName, "plocal")) {
+      oServerAdmin.createDatabase(dbName, "document", "plocal")
+    }
+
+    oDatabase = new OPartitionedDatabasePool(dbUrl, username, password, Runtime.getRuntime.availableProcessors(), 10)
+    client = oDatabase.acquire()
+
+    register(source)
+
+    flush(source, "book_title", "Akka in Action")
+    flush(source, "book_title", "Programming in Scala")
+    flush(source, "book_title", "Learning Scala")
+    flush(source, "book_title", "Scala for Spark in Production")
+    flush(source, "book_title", "Scala Puzzlers")
+    flush(source, "book_title", "Effective Akka")
+    flush(source, "book_title", "Akka Concurrency")
+  }
+
+  override def afterAll() = {
+    unregister(source)
+    unregister(sink4)
+    unregister(sink5)
+    unregister(sink7)
+
+    if (oServerAdmin.existsDatabase(dbName, "plocal")) {
+      oServerAdmin.dropDatabase(dbName, "plocal")
+    }
+    oServerAdmin.close()
+
+    client.close()
+    oDatabase.close()
+    TestKit.shutdownActorSystem(system)
+  }
+
+  private def register(className: String): Unit =
+    if (!client.getMetadata.getSchema.existsClass(className))
+      client.getMetadata.getSchema.createClass(className)
+
+  private def flush(className: String, fieldName: String, fieldValue: String): Unit = {
+    val oDocument = new ODocument()
+      .field(fieldName, fieldValue)
+    oDocument.setClassNameIfExists(className)
+    oDocument.save()
+  }
+
+  private def unregister(className: String): Unit =
+    if (client.getMetadata.getSchema.existsClass(className))
+      client.getMetadata.getSchema.dropClass(className)
+
+  "OrientDB connector" should {
+    "consume and publish documents as ODocument" in {
+      //Copy source to sink1 through ODocument stream
+      val f1 = OrientDBSource(
+        source,
+        OrientDBSourceSettings(oDatabasePool = oDatabase)
+      ).map { message: OOutgoingMessage[ODocument] =>
+          OIncomingMessage(message.oDocument)
+        }
+        .runWith(
+          OrientDBSink(
+            sink4,
+            OrientDBUpdateSettings(oDatabasePool = oDatabase)
+          )
+        )
+
+      Await.ready(f1, Duration.Inf)
+
+      //#run-odocument
+      val f2 = OrientDBSource(
+        sink4,
+        OrientDBSourceSettings(oDatabasePool = oDatabase)
+      ).map { message =>
+          message.oDocument.field[String]("book_title")
+        }
+        .runWith(Sink.seq)
+      //#run-odocument
+
+      val result = Await.result(f2, Duration.Inf)
+
+      result.sorted shouldEqual Seq(
+        "Akka Concurrency",
+        "Akka in Action",
+        "Effective Akka",
+        "Learning Scala",
+        "Programming in Scala",
+        "Scala Puzzlers",
+        "Scala for Spark in Production"
+      )
+    }
+  }
+
+  "OrientDBFlow" should {
+    "store ODocuments and pass ODocuments" in {
+      // Copy source/book to sink3/book through ODocument stream
+      //#run-flow
+
+      val f1 = OrientDBSource(
+        source,
+        OrientDBSourceSettings(oDatabasePool = oDatabase)
+      ).map { message: OOutgoingMessage[ODocument] =>
+          OIncomingMessage(message.oDocument)
+        }
+        .via(
+          OrientDBFlow.create(
+            sink5,
+            OrientDBUpdateSettings(oDatabasePool = oDatabase)
+          )
+        )
+        .runWith(Sink.seq)
+      //#run-flow
+
+      Await.ready(f1, Duration.Inf)
+
+      val f2 = OrientDBSource(
+        sink5,
+        OrientDBSourceSettings(oDatabasePool = oDatabase)
+      ).map { message =>
+          message.oDocument.field[String]("book_title")
+        }
+        .runWith(Sink.seq)
+
+      val result2 = Await.result(f2, Duration.Inf)
+
+      result2.sorted shouldEqual Seq(
+        "Akka Concurrency",
+        "Akka in Action",
+        "Effective Akka",
+        "Learning Scala",
+        "Programming in Scala",
+        "Scala Puzzlers",
+        "Scala for Spark in Production"
+      )
+    }
+  }
+
+  "OrientDBFlow" should {
+    "kafka-example - store documents and pass Responses with passThrough" in {
+      //#kafka-example
+      // We're going to pretend we got messages from kafka.
+      // After we've written them to oRIENTdb, we want
+      // to commit the offset to Kafka
+
+      case class KafkaOffset(offset: Int)
+      case class KafkaMessage(book: Book, offset: KafkaOffset)
+
+      val messagesFromKafka = List(
+        KafkaMessage(Book("Book 1"), KafkaOffset(0)),
+        KafkaMessage(Book("Book 2"), KafkaOffset(1)),
+        KafkaMessage(Book("Book 3"), KafkaOffset(2))
+      )
+
+      var committedOffsets = List[KafkaOffset]()
+
+      def commitToKakfa(offset: KafkaOffset): Unit =
+        committedOffsets = committedOffsets :+ offset
+
+      val f1 = Source(messagesFromKafka)
+        .map { kafkaMessage: KafkaMessage =>
+          val book = kafkaMessage.book
+          val id = book.title
+          println("title: " + book.title)
+
+          OIncomingMessage(new ODocument().field("book_title", id), kafkaMessage.offset)
+        }
+        .via(
+          OrientDBFlow.createWithPassThrough(
+            sink7,
+            OrientDBUpdateSettings(oDatabase)
+          )
+        )
+        .map { messages: Seq[OIncomingMessage[ODocument, KafkaOffset]] =>
+          messages.foreach { message =>
+            commitToKakfa(message.passThrough)
+          }
+        }
+        .runWith(Sink.seq)
+
+      Await.ready(f1, Duration.Inf)
+      //#kafka-example
+      assert(List(0, 1, 2) == committedOffsets.map(_.offset))
+
+      val f2 = OrientDBSource(
+        sink7,
+        OrientDBSourceSettings(oDatabasePool = oDatabase)
+      ).map { message =>
+          message.oDocument.field[String]("book_title")
+        }
+        .runWith(Sink.seq)
+
+      val result2 = Await.result(f2, Duration.Inf)
+
+      result2.sorted shouldEqual Seq(
+        "Book 1",
+        "Book 2",
+        "Book 3"
+      )
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -175,6 +175,13 @@ object Dependencies {
     )
   )
 
+  val OrientDB = Seq(
+    libraryDependencies ++= Seq(
+      "com.orientechnologies" % "orientdb-graphdb" % "2.2.30", // ApacheV2
+      "com.orientechnologies" % "orientdb-object" % "2.2.30" // ApacheV2
+    )
+  )
+
   val S3 = Seq(
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,


### PR DESCRIPTION
This PR is created to propose the addition of connector for [OrientDB](http://orientdb.com/orientdb/) in alpakka.

Features:
- Provides source & sink for reading & writing to OrientDB Document & Graph databases.
- Supports custom Objects api in javadsl using OrientDB OObjectDatabaseTx.