### PR TITLE
Add DynamoDB TTL support #603

### DIFF
--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoProtocol.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoProtocol.scala
@@ -52,6 +52,7 @@ private[alpakka] trait DynamoProtocol {
   protected val deleteTableM = new DeleteTableRequestProtocolMarshaller(protocol)
   protected val describeLimitsM = new DescribeLimitsRequestProtocolMarshaller(protocol)
   protected val describeTableM = new DescribeTableRequestProtocolMarshaller(protocol)
+  protected val describeTimeToLiveM = new DescribeTimeToLiveRequestProtocolMarshaller(protocol)
   protected val getItemM = new GetItemRequestProtocolMarshaller(protocol)
   protected val listTablesM = new ListTablesRequestProtocolMarshaller(protocol)
   protected val putItemM = new PutItemRequestProtocolMarshaller(protocol)
@@ -59,6 +60,7 @@ private[alpakka] trait DynamoProtocol {
   protected val scanM = new ScanRequestProtocolMarshaller(protocol)
   protected val updateItemM = new UpdateItemRequestProtocolMarshaller(protocol)
   protected val updateTableM = new UpdateTableRequestProtocolMarshaller(protocol)
+  protected val updateTimeToLiveM = new UpdateTimeToLiveRequestProtocolMarshaller(protocol)
 
   protected val batchGetItemU = protocol.createResponseHandler(meta, new BatchGetItemResultJsonUnmarshaller)
   protected val batchWriteItemU = protocol.createResponseHandler(meta, new BatchWriteItemResultJsonUnmarshaller)
@@ -67,6 +69,8 @@ private[alpakka] trait DynamoProtocol {
   protected val deleteTableU = protocol.createResponseHandler(meta, new DeleteTableResultJsonUnmarshaller)
   protected val describeLimitsU = protocol.createResponseHandler(meta, new DescribeLimitsResultJsonUnmarshaller)
   protected val describeTableU = protocol.createResponseHandler(meta, new DescribeTableResultJsonUnmarshaller)
+  protected val describeTimeToLiveU =
+    protocol.createResponseHandler(meta, new DescribeTimeToLiveResultJsonUnmarshaller)
   protected val getItemU = protocol.createResponseHandler(meta, new GetItemResultJsonUnmarshaller)
   protected val listTablesU = protocol.createResponseHandler(meta, new ListTablesResultJsonUnmarshaller)
   protected val putItemU = protocol.createResponseHandler(meta, new PutItemResultJsonUnmarshaller)
@@ -74,5 +78,6 @@ private[alpakka] trait DynamoProtocol {
   protected val scanU = protocol.createResponseHandler(meta, new ScanResultJsonUnmarshaller)
   protected val updateItemU = protocol.createResponseHandler(meta, new UpdateItemResultJsonUnmarshaller)
   protected val updateTableU = protocol.createResponseHandler(meta, new UpdateTableResultJsonUnmarshaller)
+  protected val updateTimeToLiveU = protocol.createResponseHandler(meta, new UpdateTimeToLiveResultJsonUnmarshaller)
 
 }

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/javadsl/DynamoClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/javadsl/DynamoClient.scala
@@ -45,6 +45,8 @@ final class DynamoClient(settings: DynamoSettings)(implicit system: ActorSystem,
 
   def describeTable(request: DescribeTableRequest) = single(DescribeTable(request))
 
+  def describeTimeToLive(request: DescribeTimeToLiveRequest) = single(DescribeTimeToLive(request))
+
   def query(request: QueryRequest) = single(Query(request))
 
   def scan(request: ScanRequest) = single(Scan(request))
@@ -61,4 +63,5 @@ final class DynamoClient(settings: DynamoSettings)(implicit system: ActorSystem,
 
   def listTables(request: ListTablesRequest) = single(ListTables(request))
 
+  def updateTimeToLive(request: UpdateTimeToLiveRequest) = single(UpdateTimeToLive(request))
 }

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoImplicits.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoImplicits.scala
@@ -121,4 +121,20 @@ object DynamoImplicits extends DynamoProtocol {
     override val marshaller = listTablesM
     def toOp: ListTables = this
   }
+
+  implicit class DescribeTimeToLive(val request: DescribeTimeToLiveRequest) extends AwsOp {
+    override type A = DescribeTimeToLiveRequest
+    override type B = DescribeTimeToLiveResult
+    override val handler = describeTimeToLiveU
+    override val marshaller = describeTimeToLiveM
+    def toOp: DescribeTimeToLive = this
+  }
+
+  implicit class UpdateTimeToLive(val request: UpdateTimeToLiveRequest) extends AwsOp {
+    override type A = UpdateTimeToLiveRequest
+    override type B = UpdateTimeToLiveResult
+    override val handler = updateTimeToLiveU
+    override val marshaller = updateTimeToLiveM
+    def toOp: UpdateTimeToLive = this
+  }
 }

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TableSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TableSpec.scala
@@ -51,7 +51,16 @@ class TableSpec extends TestKit(ActorSystem("TableSpec")) with AsyncWordSpecLike
         .map(_.getTableDescription.getProvisionedThroughput.getWriteCapacityUnits shouldEqual newMaxLimit)
     }
 
-    "5) delete table" in {
+    // TODO: Enable this test when DynamoDB Local supports TTLs
+    "5) update time to live" ignore {
+      client
+        .single(describeTimeToLiveRequest)
+        .map(_.getTimeToLiveDescription.getAttributeName shouldEqual null)
+        .flatMap(_ => client.single(updateTimeToLiveRequest))
+        .map(_.getTimeToLiveSpecification.getAttributeName shouldEqual "expires")
+    }
+
+    "6) delete table" in {
       client
         .single(deleteTableRequest)
         .flatMap(_ => client.single(listTablesRequest))

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TestOps.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TestOps.scala
@@ -109,6 +109,13 @@ object TableSpecOps extends TestOps {
       new ProvisionedThroughput().withWriteCapacityUnits(newMaxLimit).withReadCapacityUnits(newMaxLimit)
     )
 
+  val describeTimeToLiveRequest = new DescribeTimeToLiveRequest()
+  val updateTimeToLiveRequest = new UpdateTimeToLiveRequest()
+    .withTableName(tableName)
+    .withTimeToLiveSpecification(
+      new TimeToLiveSpecification().withAttributeName("expires").withEnabled(true)
+    )
+
   val deleteTableRequest = common.deleteTableRequest
 
 }


### PR DESCRIPTION
Add DynamoDB support for operations:

* DescribeTimeToLive
* UpdateTimeToLive

Unfortunately cannot be tested locally as DynamoDB Local does not
support these operations.