### PR TITLE
ElasticsearchFlow now returns info about both success and failed messages - with optional cargo

### DIFF
--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -32,24 +32,12 @@ Java
 
 This is all preparation that we are going to need.
 
-### JsObject message
+### Streaming messages
 
-Now we can stream messages which contains spray-json's `JsObject` (in Scala) or `java.util.Map<String, Object>` (in Java)
-from or to Elasticsearch where we have access to by providing the `RestClient` to the
+Now we can stream messages from or to Elasticsearch by providing the `RestClient` to the
 @scaladoc[ElasticsearchSource](akka.stream.alpakka.elasticsearch.scaladsl.ElasticsearchSource$) or the
 @scaladoc[ElasticsearchSink](akka.stream.alpakka.elasticsearch.scaladsl.ElasticsearchSink$).
 
-Scala
-: @@snip ($alpakka$/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala) { #run-jsobject }
-
-Java
-: @@snip ($alpakka$/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java) { #run-jsobject }
-
-
-### Typed messages
-
-Also, it's possible to stream messages which contains any classes. In Scala, spray-json is used for JSON conversion,
-so defining the mapped class and `JsonFormat` for it is necessary. In Java, Jackson is used, so just define the mapped class.
 
 Scala
 : @@snip ($alpakka$/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala) { #define-class }
@@ -58,7 +46,7 @@ Java
 : @@snip ($alpakka$/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java) { #define-class }
 
 
-Use `ElasticsearchSource.typed` and `ElasticsearchSink.typed` to create source and sink instead.
+Use `ElasticsearchSource.create` and `ElasticsearchSink.create` to create source and sink.
 
 Scala
 : @@snip ($alpakka$/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala) { #run-typed }
@@ -99,6 +87,15 @@ Scala (flow)
 
 Java (flow)
 : @@snip ($alpakka$/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java) { #run-flow }
+
+### Passing data through ElasticsearchFlow
+
+When streaming documents from Kafka, you might want to commit to Kafka **AFTER** the document has been written to Elastic.
+
+Scala (flow)
+: @@snip ($alpakka$/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala) { #kafka-example }
+
+
 
 ### Running the example code
 

--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -95,6 +95,9 @@ When streaming documents from Kafka, you might want to commit to Kafka **AFTER**
 Scala (flow)
 : @@snip ($alpakka$/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala) { #kafka-example }
 
+Java (flow)
+: @@snip ($alpakka$/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java) { #kafka-example }
+
 
 
 ### Running the example code

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
@@ -25,24 +25,32 @@ import org.apache.http.util.EntityUtils
 
 object IncomingMessage {
   // Apply method to use when not using cargo
-  def apply[T](id: Option[String], source: T): IncomingMessage[T, Any] =
-    IncomingMessage(id, source, null)
+  def apply[T](id: Option[String], source: T): IncomingMessage[T, NotUsed] =
+    IncomingMessage(id, source, NotUsed)
 
   // Java-api - without cargo
-  def create[T](id: String, source: T): IncomingMessage[T, Any] =
+  def create[T](id: String, source: T): IncomingMessage[T, NotUsed] =
     IncomingMessage(Option(id), source)
+
+  // Java-api - without cargo
+  def create[T](source: T): IncomingMessage[T, NotUsed] =
+    IncomingMessage(None, source)
 
   // Java-api - with cargo
   def create[T, C](id: String, source: T, cargo: C): IncomingMessage[T, C] =
     IncomingMessage(Option(id), source, cargo)
+
+  // Java-api - with cargo
+  def create[T, C](source: T, cargo: C): IncomingMessage[T, C] =
+    IncomingMessage(None, source, cargo)
 }
 
 final case class IncomingMessage[T, C](id: Option[String], source: T, cargo: C)
 
 object IncomingMessageResult {
   // Apply method to use when not using cargo
-  def apply[T](source: T, success: Boolean): IncomingMessageResult[T, Any] =
-    IncomingMessageResult(source, null, success)
+  def apply[T](source: T, success: Boolean): IncomingMessageResult[T, NotUsed] =
+    IncomingMessageResult(source, NotUsed, success)
 }
 
 final case class IncomingMessageResult[T, C](source: T, cargo: C, success: Boolean)

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
@@ -24,10 +24,10 @@ object ElasticsearchFlow {
       settings: ElasticsearchSinkSettings,
       client: RestClient,
       objectMapper: ObjectMapper
-  ): akka.stream.javadsl.Flow[IncomingMessage[T, Any], JavaList[IncomingMessageResult[T, Any]], NotUsed] =
+  ): akka.stream.javadsl.Flow[IncomingMessage[T, NotUsed], JavaList[IncomingMessageResult[T, NotUsed]], NotUsed] =
     Flow
       .fromGraph(
-        new ElasticsearchFlowStage[T, Any](indexName,
+        new ElasticsearchFlowStage[T, NotUsed](indexName,
                                            typeName,
                                            client,
                                            settings.asScala,

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
@@ -5,86 +5,69 @@
 package akka.stream.alpakka.elasticsearch.javadsl
 
 import akka.NotUsed
-import akka.stream.alpakka.elasticsearch.{ElasticsearchFlowStage, IncomingMessage, MessageWriter}
+import akka.stream.alpakka.elasticsearch._
 import akka.stream.scaladsl.Flow
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.elasticsearch.client.RestClient
 
 import scala.collection.JavaConverters._
-import java.util.{List => JavaList, Map => JavaMap}
+import java.util.{List => JavaList}
 
 object ElasticsearchFlow {
 
   /**
-   * Java API: creates a [[ElasticsearchFlowStage]] that accepts as JsObject
+   * Java API: creates a [[ElasticsearchFlowStage]] using IncomingMessage (without cargo)
    */
-  def create(
-      indexName: String,
-      typeName: String,
-      settings: ElasticsearchSinkSettings,
-      client: RestClient
-  ): akka.stream.javadsl.Flow[IncomingMessage[JavaMap[String, Object]], JavaList[
-    IncomingMessage[JavaMap[String, Object]]
-  ], NotUsed] =
-    create(indexName, typeName, settings, client, new ObjectMapper())
-
-  /**
-   * Java API: creates a [[ElasticsearchFlowStage]] that accepts as JsObject
-   */
-  def create(
+  def create[T](
       indexName: String,
       typeName: String,
       settings: ElasticsearchSinkSettings,
       client: RestClient,
       objectMapper: ObjectMapper
-  ): akka.stream.javadsl.Flow[IncomingMessage[JavaMap[String, Object]], JavaList[
-    IncomingMessage[JavaMap[String, Object]]
-  ], NotUsed] =
+  ): akka.stream.javadsl.Flow[IncomingMessage[T], JavaList[IncomingMessageResult[T]], NotUsed] =
     Flow
       .fromGraph(
-        new ElasticsearchFlowStage[JavaMap[String, Object], JavaList[IncomingMessage[JavaMap[String, Object]]]](
-          indexName,
-          typeName,
-          client,
-          settings.asScala,
-          _.asJava,
-          new JacksonWriter[JavaMap[String, Object]](objectMapper)
-        )
+        new ElasticsearchFlowStage[T, IncomingMessage[T]](indexName,
+                                                          typeName,
+                                                          client,
+                                                          settings.asScala,
+                                                          new JacksonWriter[T](objectMapper))
       )
       .mapAsync(1)(identity)
+      .map(
+        x =>
+          x.map { e =>
+            IncomingMessageResult[T](e.message.source, e.success)
+        }
+      )
+      .map(x => x.asJava)
       .asJava
 
   /**
-   * Java API: creates a [[ElasticsearchFlowStage]] that accepts specific type
+   * Java API: creates a [[ElasticsearchFlowStage]] using IncomingMessageWithCargo
    */
-  def typed[T](
-      indexName: String,
-      typeName: String,
-      settings: ElasticsearchSinkSettings,
-      client: RestClient
-  ): akka.stream.javadsl.Flow[IncomingMessage[T], JavaList[IncomingMessage[T]], NotUsed] =
-    typed(indexName, typeName, settings, client, new ObjectMapper())
-
-  /**
-   * Java API: creates a [[ElasticsearchFlowStage]] that accepts specific type
-   */
-  def typed[T](
+  def createWithCargo[T, C](
       indexName: String,
       typeName: String,
       settings: ElasticsearchSinkSettings,
       client: RestClient,
       objectMapper: ObjectMapper
-  ): akka.stream.javadsl.Flow[IncomingMessage[T], JavaList[IncomingMessage[T]], NotUsed] =
+  ): akka.stream.javadsl.Flow[IncomingMessageWithCargo[T, C], JavaList[IncomingMessageWithCargoResult[T, C]], NotUsed] =
     Flow
       .fromGraph(
-        new ElasticsearchFlowStage[T, JavaList[IncomingMessage[T]]](indexName,
-                                                                    typeName,
-                                                                    client,
-                                                                    settings.asScala,
-                                                                    _.asJava,
-                                                                    new JacksonWriter[T](objectMapper))
+        new ElasticsearchFlowStage[T, IncomingMessageWithCargo[T, C]](indexName,
+                                                                      typeName,
+                                                                      client,
+                                                                      settings.asScala,
+                                                                      new JacksonWriter[T](objectMapper))
       )
       .mapAsync(1)(identity)
+      .map { x =>
+        x.map { e =>
+          IncomingMessageWithCargoResult(e.message.source, e.message.cargo, e.success)
+        }
+      }
+      .map(x => x.asJava)
       .asJava
 
   private class JacksonWriter[T](mapper: ObjectMapper) extends MessageWriter[T] {

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
@@ -28,10 +28,10 @@ object ElasticsearchFlow {
     Flow
       .fromGraph(
         new ElasticsearchFlowStage[T, NotUsed](indexName,
-                                           typeName,
-                                           client,
-                                           settings.asScala,
-                                           new JacksonWriter[T](objectMapper))
+                                               typeName,
+                                               client,
+                                               settings.asScala,
+                                               new JacksonWriter[T](objectMapper))
       )
       .mapAsync(1)(identity)
       .map(x => x.asJava)

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
@@ -16,7 +16,7 @@ import java.util.{List => JavaList}
 object ElasticsearchFlow {
 
   /**
-   * Java API: creates a [[ElasticsearchFlowStage]] without cargo
+   * Java API: creates a [[ElasticsearchFlowStage]] without passThrough
    */
   def create[T](
       indexName: String,
@@ -38,9 +38,9 @@ object ElasticsearchFlow {
       .asJava
 
   /**
-   * Java API: creates a [[ElasticsearchFlowStage]] with cargo
+   * Java API: creates a [[ElasticsearchFlowStage]] with passThrough
    */
-  def createWithCargo[T, C](
+  def createWithPassThrough[T, C](
       indexName: String,
       typeName: String,
       settings: ElasticsearchSinkSettings,

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
@@ -16,7 +16,7 @@ import java.util.{List => JavaList}
 object ElasticsearchFlow {
 
   /**
-   * Java API: creates a [[ElasticsearchFlowStage]] using IncomingMessage (without cargo)
+   * Java API: creates a [[ElasticsearchFlowStage]] without cargo
    */
   def create[T](
       indexName: String,
@@ -24,27 +24,21 @@ object ElasticsearchFlow {
       settings: ElasticsearchSinkSettings,
       client: RestClient,
       objectMapper: ObjectMapper
-  ): akka.stream.javadsl.Flow[IncomingMessage[T], JavaList[IncomingMessageResult[T]], NotUsed] =
+  ): akka.stream.javadsl.Flow[IncomingMessage[T, Any], JavaList[IncomingMessageResult[T, Any]], NotUsed] =
     Flow
       .fromGraph(
-        new ElasticsearchFlowStage[T, IncomingMessage[T]](indexName,
-                                                          typeName,
-                                                          client,
-                                                          settings.asScala,
-                                                          new JacksonWriter[T](objectMapper))
+        new ElasticsearchFlowStage[T, Any](indexName,
+                                           typeName,
+                                           client,
+                                           settings.asScala,
+                                           new JacksonWriter[T](objectMapper))
       )
       .mapAsync(1)(identity)
-      .map(
-        x =>
-          x.map { e =>
-            IncomingMessageResult[T](e.message.source, e.success)
-        }
-      )
       .map(x => x.asJava)
       .asJava
 
   /**
-   * Java API: creates a [[ElasticsearchFlowStage]] using IncomingMessageWithCargo
+   * Java API: creates a [[ElasticsearchFlowStage]] with cargo
    */
   def createWithCargo[T, C](
       indexName: String,
@@ -52,21 +46,16 @@ object ElasticsearchFlow {
       settings: ElasticsearchSinkSettings,
       client: RestClient,
       objectMapper: ObjectMapper
-  ): akka.stream.javadsl.Flow[IncomingMessageWithCargo[T, C], JavaList[IncomingMessageWithCargoResult[T, C]], NotUsed] =
+  ): akka.stream.javadsl.Flow[IncomingMessage[T, C], JavaList[IncomingMessageResult[T, C]], NotUsed] =
     Flow
       .fromGraph(
-        new ElasticsearchFlowStage[T, IncomingMessageWithCargo[T, C]](indexName,
-                                                                      typeName,
-                                                                      client,
-                                                                      settings.asScala,
-                                                                      new JacksonWriter[T](objectMapper))
+        new ElasticsearchFlowStage[T, C](indexName,
+                                         typeName,
+                                         client,
+                                         settings.asScala,
+                                         new JacksonWriter[T](objectMapper))
       )
       .mapAsync(1)(identity)
-      .map { x =>
-        x.map { e =>
-          IncomingMessageWithCargoResult(e.message.source, e.message.cargo, e.success)
-        }
-      }
       .map(x => x.asJava)
       .asJava
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSink.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSink.scala
@@ -21,7 +21,7 @@ object ElasticsearchSink {
                 typeName: String,
                 settings: ElasticsearchSinkSettings,
                 client: RestClient,
-                objectMapper: ObjectMapper): akka.stream.javadsl.Sink[IncomingMessage[T], CompletionStage[Done]] =
+                objectMapper: ObjectMapper): akka.stream.javadsl.Sink[IncomingMessage[T, Any], CompletionStage[Done]] =
     ElasticsearchFlow
       .create(indexName, typeName, settings, client, objectMapper)
       .toMat(Sink.ignore, Keep.right[NotUsed, CompletionStage[Done]])

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSink.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSink.scala
@@ -17,11 +17,13 @@ object ElasticsearchSink {
   /**
    * Java API: creates a sink based on [[ElasticsearchFlowStage]]
    */
-  def create[T](indexName: String,
-                typeName: String,
-                settings: ElasticsearchSinkSettings,
-                client: RestClient,
-                objectMapper: ObjectMapper): akka.stream.javadsl.Sink[IncomingMessage[T, NotUsed], CompletionStage[Done]] =
+  def create[T](
+      indexName: String,
+      typeName: String,
+      settings: ElasticsearchSinkSettings,
+      client: RestClient,
+      objectMapper: ObjectMapper
+  ): akka.stream.javadsl.Sink[IncomingMessage[T, NotUsed], CompletionStage[Done]] =
     ElasticsearchFlow
       .create(indexName, typeName, settings, client, objectMapper)
       .toMat(Sink.ignore, Keep.right[NotUsed, CompletionStage[Done]])

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSink.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSink.scala
@@ -21,7 +21,7 @@ object ElasticsearchSink {
                 typeName: String,
                 settings: ElasticsearchSinkSettings,
                 client: RestClient,
-                objectMapper: ObjectMapper): akka.stream.javadsl.Sink[IncomingMessage[T, Any], CompletionStage[Done]] =
+                objectMapper: ObjectMapper): akka.stream.javadsl.Sink[IncomingMessage[T, NotUsed], CompletionStage[Done]] =
     ElasticsearchFlow
       .create(indexName, typeName, settings, client, objectMapper)
       .toMat(Sink.ignore, Keep.right[NotUsed, CompletionStage[Done]])

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSink.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSink.scala
@@ -15,53 +15,15 @@ import org.elasticsearch.client.RestClient
 object ElasticsearchSink {
 
   /**
-   * Java API: creates a sink based on [[ElasticsearchFlowStage]] that accepts as JsObject
+   * Java API: creates a sink based on [[ElasticsearchFlowStage]]
    */
-  def create(
-      indexName: String,
-      typeName: String,
-      settings: ElasticsearchSinkSettings,
-      client: RestClient
-  ): akka.stream.javadsl.Sink[IncomingMessage[java.util.Map[String, Object]], CompletionStage[Done]] =
-    ElasticsearchFlow
-      .create(indexName, typeName, settings, client)
-      .toMat(Sink.ignore, Keep.right[NotUsed, CompletionStage[Done]])
-
-  /**
-   * Java API: creates a sink based on [[ElasticsearchFlowStage]] that accepts as JsObject
-   */
-  def create(
-      indexName: String,
-      typeName: String,
-      settings: ElasticsearchSinkSettings,
-      client: RestClient,
-      objectMapper: ObjectMapper
-  ): akka.stream.javadsl.Sink[IncomingMessage[java.util.Map[String, Object]], CompletionStage[Done]] =
+  def create[T](indexName: String,
+                typeName: String,
+                settings: ElasticsearchSinkSettings,
+                client: RestClient,
+                objectMapper: ObjectMapper): akka.stream.javadsl.Sink[IncomingMessage[T], CompletionStage[Done]] =
     ElasticsearchFlow
       .create(indexName, typeName, settings, client, objectMapper)
-      .toMat(Sink.ignore, Keep.right[NotUsed, CompletionStage[Done]])
-
-  /**
-   * Java API: creates a sink based on [[ElasticsearchFlowStage]] that accepts as specific type
-   */
-  def typed[T](indexName: String,
-               typeName: String,
-               settings: ElasticsearchSinkSettings,
-               client: RestClient): akka.stream.javadsl.Sink[IncomingMessage[T], CompletionStage[Done]] =
-    ElasticsearchFlow
-      .typed(indexName, typeName, settings, client)
-      .toMat(Sink.ignore, Keep.right[NotUsed, CompletionStage[Done]])
-
-  /**
-   * Java API: creates a sink based on [[ElasticsearchFlowStage]] that accepts as specific type
-   */
-  def typed[T](indexName: String,
-               typeName: String,
-               settings: ElasticsearchSinkSettings,
-               client: RestClient,
-               objectMapper: ObjectMapper): akka.stream.javadsl.Sink[IncomingMessage[T], CompletionStage[Done]] =
-    ElasticsearchFlow
-      .typed(indexName, typeName, settings, client, objectMapper)
       .toMat(Sink.ignore, Keep.right[NotUsed, CompletionStage[Done]])
 
 }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchFlow.scala
@@ -18,10 +18,10 @@ object ElasticsearchFlow {
   def create[T](indexName: String, typeName: String, settings: ElasticsearchSinkSettings)(
       implicit client: RestClient,
       writer: JsonWriter[T]
-  ): Flow[IncomingMessage[T, Any], Seq[IncomingMessageResult[T, Any]], NotUsed] =
+  ): Flow[IncomingMessage[T, NotUsed], Seq[IncomingMessageResult[T, NotUsed]], NotUsed] =
     Flow
       .fromGraph(
-        new ElasticsearchFlowStage[T, Any](
+        new ElasticsearchFlowStage[T, NotUsed](
           indexName,
           typeName,
           client,

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchFlow.scala
@@ -13,7 +13,7 @@ import spray.json._
 object ElasticsearchFlow {
 
   /**
-   * Scala API: creates a [[ElasticsearchFlowStage]] without cargo
+   * Scala API: creates a [[ElasticsearchFlowStage]] without passThrough
    */
   def create[T](indexName: String, typeName: String, settings: ElasticsearchSinkSettings)(
       implicit client: RestClient,
@@ -32,9 +32,9 @@ object ElasticsearchFlow {
       .mapAsync(1)(identity)
 
   /**
-   * Scala API: creates a [[ElasticsearchFlowStage]] with cargo
+   * Scala API: creates a [[ElasticsearchFlowStage]] with passThrough
    */
-  def createWithCargo[T, C](indexName: String, typeName: String, settings: ElasticsearchSinkSettings)(
+  def createWithPassThrough[T, C](indexName: String, typeName: String, settings: ElasticsearchSinkSettings)(
       implicit client: RestClient,
       writer: JsonWriter[T]
   ): Flow[IncomingMessage[T, C], Seq[IncomingMessageResult[T, C]], NotUsed] =

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchFlow.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.elasticsearch.scaladsl
 
 import akka.NotUsed
-import akka.stream.alpakka.elasticsearch.{ElasticsearchFlowStage, IncomingMessage, MessageWriter}
+import akka.stream.alpakka.elasticsearch._
 import akka.stream.scaladsl.Flow
 import org.elasticsearch.client.RestClient
 import spray.json._
@@ -13,41 +13,52 @@ import spray.json._
 object ElasticsearchFlow {
 
   /**
-   * Scala API: creates a [[ElasticsearchFlowStage]] that accepts as JsObject
+   * Scala API: creates a [[ElasticsearchFlowStage]] using IncomingMessage (without cargo)
    */
-  def apply(indexName: String, typeName: String, settings: ElasticsearchSinkSettings)(
-      implicit client: RestClient
-  ): Flow[IncomingMessage[JsObject], Seq[IncomingMessage[JsObject]], NotUsed] =
+  def create[T](indexName: String, typeName: String, settings: ElasticsearchSinkSettings)(
+      implicit client: RestClient,
+      writer: JsonWriter[T]
+  ): Flow[IncomingMessage[T], Seq[IncomingMessageResult[T]], NotUsed] =
     Flow
       .fromGraph(
-        new ElasticsearchFlowStage[JsObject, Seq[IncomingMessage[JsObject]]](
+        new ElasticsearchFlowStage[T, IncomingMessage[T]](
           indexName,
           typeName,
           client,
           settings,
-          identity,
-          new SprayJsonWriter[JsObject]()(DefaultJsonProtocol.RootJsObjectFormat)
+          new SprayJsonWriter[T]()(writer)
         )
       )
       .mapAsync(1)(identity)
+      .map { x =>
+        x.map { e =>
+          IncomingMessageResult(e.message.source, e.success)
+        }
+      }
 
   /**
-   * Scala API: creates a [[ElasticsearchFlowStage]] that accepts specific type
+   * Scala API: creates a [[ElasticsearchFlowStage]] using IncomingMessageWithCargo
    */
-  def typed[T](indexName: String, typeName: String, settings: ElasticsearchSinkSettings)(
+  def createWithCargo[T, C](indexName: String, typeName: String, settings: ElasticsearchSinkSettings)(
       implicit client: RestClient,
       writer: JsonWriter[T]
-  ): Flow[IncomingMessage[T], Seq[IncomingMessage[T]], NotUsed] =
+  ): Flow[IncomingMessageWithCargo[T, C], Seq[IncomingMessageWithCargoResult[T, C]], NotUsed] =
     Flow
       .fromGraph(
-        new ElasticsearchFlowStage[T, Seq[IncomingMessage[T]]](indexName,
-                                                               typeName,
-                                                               client,
-                                                               settings,
-                                                               identity,
-                                                               new SprayJsonWriter[T]()(writer))
+        new ElasticsearchFlowStage[T, IncomingMessageWithCargo[T, C]](
+          indexName,
+          typeName,
+          client,
+          settings,
+          new SprayJsonWriter[T]()(writer)
+        )
       )
       .mapAsync(1)(identity)
+      .map { x =>
+        x.map { e =>
+          IncomingMessageWithCargoResult(e.message.source, e.message.cargo, e.success)
+        }
+      }
 
   private class SprayJsonWriter[T](implicit writer: JsonWriter[T]) extends MessageWriter[T] {
     override def convert(message: T): String = message.toJson.toString()

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSink.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSink.scala
@@ -20,7 +20,7 @@ object ElasticsearchSink {
   def create[T](indexName: String, typeName: String, settings: ElasticsearchSinkSettings)(
       implicit client: RestClient,
       writer: JsonWriter[T]
-  ): Sink[IncomingMessage[T], Future[Done]] =
+  ): Sink[IncomingMessage[T, Any], Future[Done]] =
     ElasticsearchFlow.create[T](indexName, typeName, settings).toMat(Sink.ignore)(Keep.right)
 
 }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSink.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSink.scala
@@ -5,30 +5,22 @@
 package akka.stream.alpakka.elasticsearch.scaladsl
 
 import akka.Done
-import akka.stream.alpakka.elasticsearch.{ElasticsearchFlowStage, IncomingMessage}
+import akka.stream.alpakka.elasticsearch.{IncomingMessage}
 import akka.stream.scaladsl.{Keep, Sink}
 import org.elasticsearch.client.RestClient
-import spray.json.{JsObject, JsonWriter}
+import spray.json.{JsonWriter}
 
 import scala.concurrent.Future
 
 object ElasticsearchSink {
 
   /**
-   * Scala API: creates a sink based on [[ElasticsearchFlowStage]] that accepts as JsObject
+   * Scala API: creates a sink based on [[ElasticsearchFlowStage]]
    */
-  def apply(indexName: String, typeName: String, settings: ElasticsearchSinkSettings)(
-      implicit client: RestClient
-  ): Sink[IncomingMessage[JsObject], Future[Done]] =
-    ElasticsearchFlow.apply(indexName, typeName, settings).toMat(Sink.ignore)(Keep.right)
-
-  /**
-   * Scala API: creates a sink based on [[ElasticsearchFlowStage]] that accepts as specific type
-   */
-  def typed[T](indexName: String, typeName: String, settings: ElasticsearchSinkSettings)(
+  def create[T](indexName: String, typeName: String, settings: ElasticsearchSinkSettings)(
       implicit client: RestClient,
       writer: JsonWriter[T]
   ): Sink[IncomingMessage[T], Future[Done]] =
-    ElasticsearchFlow.typed[T](indexName, typeName, settings).toMat(Sink.ignore)(Keep.right)
+    ElasticsearchFlow.create[T](indexName, typeName, settings).toMat(Sink.ignore)(Keep.right)
 
 }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSink.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSink.scala
@@ -4,11 +4,11 @@
 
 package akka.stream.alpakka.elasticsearch.scaladsl
 
-import akka.Done
-import akka.stream.alpakka.elasticsearch.{IncomingMessage}
+import akka.{Done, NotUsed}
+import akka.stream.alpakka.elasticsearch.IncomingMessage
 import akka.stream.scaladsl.{Keep, Sink}
 import org.elasticsearch.client.RestClient
-import spray.json.{JsonWriter}
+import spray.json.JsonWriter
 
 import scala.concurrent.Future
 
@@ -20,7 +20,7 @@ object ElasticsearchSink {
   def create[T](indexName: String, typeName: String, settings: ElasticsearchSinkSettings)(
       implicit client: RestClient,
       writer: JsonWriter[T]
-  ): Sink[IncomingMessage[T, Any], Future[Done]] =
+  ): Sink[IncomingMessage[T, NotUsed], Future[Done]] =
     ElasticsearchFlow.create[T](indexName, typeName, settings).toMat(Sink.ignore)(Keep.right)
 
 }

--- a/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
+++ b/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
@@ -213,7 +213,7 @@ public class ElasticsearchTest {
   public void flow() throws Exception {
     // Copy source/book to sink3/book through JsObject stream
     //#run-flow
-    CompletionStage<List<List<IncomingMessageResult<Book, Object>>>> f1 = ElasticsearchSource.typed(
+    CompletionStage<List<List<IncomingMessageResult<Book, NotUsed>>>> f1 = ElasticsearchSource.typed(
         "source",
         "book",
         "{\"match_all\": {}}",
@@ -230,7 +230,7 @@ public class ElasticsearchTest {
         .runWith(Sink.seq(), materializer);
     //#run-flow
 
-    List<List<IncomingMessageResult<Book, Object>>> result1 = f1.toCompletableFuture().get();
+    List<List<IncomingMessageResult<Book, NotUsed>>> result1 = f1.toCompletableFuture().get();
     flush("sink3");
 
     for(int i = 0; i < result1.size(); i ++){

--- a/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
+++ b/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
@@ -288,7 +288,7 @@ public class ElasticsearchTest {
               return IncomingMessage.create(id, book, kafkaMessage.offset);
             })
             .via( // write to elastic
-                    ElasticsearchFlow.<Book, KafkaOffset>createWithCargo(
+                    ElasticsearchFlow.<Book, KafkaOffset>createWithPassThrough(
                             "sink6",
                             "book",
                             new ElasticsearchSinkSettings().withBufferSize(5),
@@ -299,7 +299,7 @@ public class ElasticsearchTest {
                       .forEach(result -> {
                         if (!result.success()) throw new RuntimeException("Failed to write message to elastic");
                         // Commit to kafka
-                        kafkaCommitter.commit(result.cargo());
+                        kafkaCommitter.commit(result.passThrough());
                       });
               return NotUsed.getInstance();
 

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
@@ -318,7 +318,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "ElasticsearchFlow" should {
-    "kafka-example - store documents and pass Responses with cargo" in {
+    "kafka-example - store documents and pass Responses with passThrough" in {
 
       //#kafka-example
       // We're going to pretend we got messages from kafka.
@@ -349,7 +349,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
           IncomingMessage(Some(id), book, kafkaMessage.offset)
         }
         .via( // write to elastic
-          ElasticsearchFlow.createWithCargo[Book, KafkaOffset](
+          ElasticsearchFlow.createWithPassThrough[Book, KafkaOffset](
             "sink6",
             "book",
             ElasticsearchSinkSettings(5)
@@ -359,7 +359,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
           messageResults.foreach { result =>
             if (!result.success) throw new Exception("Failed to write message to elastic")
             // Commit to kafka
-            commitToKakfa(result.cargo)
+            commitToKakfa(result.passThrough)
           }
         }
         .runWith(Sink.seq)

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
@@ -14,7 +14,6 @@ import org.apache.http.entity.StringEntity
 import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner
 import org.elasticsearch.client.RestClient
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
-import spray.json.JsString
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -96,56 +95,6 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
                           new StringEntity(s"""{"title": "$title"}"""),
                           new BasicHeader("Content-Type", "application/json"))
 
-  "Elasticsearch connector" should {
-    "consume and publish documents as JsObject" in {
-      // Copy source/book to sink1/book through JsObject stream
-      //#run-jsobject
-      val f1 = ElasticsearchSource(
-        "source",
-        "book",
-        """{"match_all": {}}""",
-        ElasticsearchSourceSettings(5)
-      ).map { message: OutgoingMessage[JsObject] =>
-          IncomingMessage(Some(message.id), message.source)
-        }
-        .runWith(
-          ElasticsearchSink(
-            "sink1",
-            "book",
-            ElasticsearchSinkSettings(5)
-          )
-        )
-      //#run-jsobject
-
-      Await.result(f1, Duration.Inf)
-
-      flush("sink1")
-
-      // Assert docs in sink1/book
-      val f2 = ElasticsearchSource(
-        "sink1",
-        "book",
-        """{"match_all": {}}""",
-        ElasticsearchSourceSettings()
-      ).map { message =>
-          message.source.fields("title").asInstanceOf[JsString].value
-        }
-        .runWith(Sink.seq)
-
-      val result = Await.result(f2, Duration.Inf)
-
-      result.sorted shouldEqual Seq(
-        "Akka Concurrency",
-        "Akka in Action",
-        "Effective Akka",
-        "Learning Scala",
-        "Programming in Scala",
-        "Scala Puzzlers",
-        "Scala for Spark in Production"
-      )
-    }
-  }
-
   "Typed Elasticsearch connector" should {
     "consume and publish documents as specific type" in {
       // Copy source/book to sink2/book through typed stream
@@ -161,7 +110,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
           IncomingMessage(Some(message.id), message.source)
         }
         .runWith(
-          ElasticsearchSink.typed[Book](
+          ElasticsearchSink.create[Book](
             "sink2",
             "book",
             ElasticsearchSinkSettings(5)
@@ -170,6 +119,8 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       //#run-typed
 
       Await.result(f1, Duration.Inf)
+
+
 
       flush("sink2")
 
@@ -215,7 +166,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
           IncomingMessage(Some(message.id), message.source)
         }
         .via(
-          ElasticsearchFlow.typed[Book](
+          ElasticsearchFlow.create[Book](
             "sink3",
             "book",
             ElasticsearchSinkSettings(5)
@@ -228,7 +179,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       flush("sink3")
 
       // Assert no errors
-      assert(result1.forall(_.isEmpty))
+      assert(result1.forall( !_.exists(_.success == false) ))
 
       // Assert docs in sink3/book
       val f2 = ElasticsearchSource
@@ -271,7 +222,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
             IncomingMessage(Some(index.toString), Book(book))
         }
         .via(
-          ElasticsearchFlow.typed[Book](
+          ElasticsearchFlow.create[Book](
             "sink4",
             "book",
             ElasticsearchSinkSettings(5)
@@ -283,7 +234,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       flush("sink4")
 
       // Assert no error
-      assert(result1.forall(_.isEmpty))
+      assert(result1.forall( !_.exists(_.success == false) ))
 
       // Assert docs in sink4/book
       val f2 = ElasticsearchSource
@@ -320,9 +271,10 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       ).map {
           case (book: JsObject, index: Int) =>
             IncomingMessage(Some(index.toString), book)
+          case _ => ??? // Keep the compiler from complaining
         }
         .via(
-          ElasticsearchFlow(
+          ElasticsearchFlow.create(
             "sink5",
             "book",
             ElasticsearchSinkSettings(maxRetry = 5, retryInterval = 100)
@@ -335,7 +287,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       val end = System.currentTimeMillis()
 
       // Assert retired documents
-      assert(result1.flatten == Seq(IncomingMessage(Some("1"), Map("subject" -> "Akka Concurrency").toJson)))
+      assert(result1.flatten.filter(!_.success).toList == Seq(IncomingMessageResult[JsValue](Map("subject" -> "Akka Concurrency").toJson, false)))
 
       // Assert retried 5 times by looking duration
       assert(end - start > 5 * 100)
@@ -362,5 +314,81 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       )
     }
   }
+
+  "ElasticsearchFlow" should {
+    "kafka-example - store documents and pass Responses with cargo" in {
+
+      //#kafka-example
+      // We're going to pretend we got messages from kafka.
+      // After we've written them to Elastic, we want
+      // to commit the offset to Kafka
+
+      case class KafkaOffset(offset:Int)
+      case class KafkaMessage(book: Book, offset:KafkaOffset)
+
+      val messagesFromKafka = List(
+        KafkaMessage(Book("Book 1"), KafkaOffset(0)),
+        KafkaMessage(Book("Book 2"), KafkaOffset(1)),
+        KafkaMessage(Book("Book 3"), KafkaOffset(2))
+      )
+
+      var committedOffsets = List[KafkaOffset]()
+
+      def commitToKakfa(offset:KafkaOffset): Unit = {
+        committedOffsets = committedOffsets :+ offset
+      }
+
+      val f1 = Source(messagesFromKafka) // Asume we get this from Kafka
+        .map { kafkaMessage: KafkaMessage =>
+
+          val book = kafkaMessage.book
+          val id = book.title
+          println("title: " + book.title)
+
+          // Transform message so that we can write to elastic
+          IncomingMessageWithCargo(Some(id), book, kafkaMessage.offset)
+        }
+        .via( // write to elastic
+          ElasticsearchFlow.createWithCargo[Book, KafkaOffset](
+            "sink3",
+            "book",
+            ElasticsearchSinkSettings(5)
+          )
+        ).map {
+          messageResults =>
+            messageResults.foreach {
+              result =>
+                if ( !result.success ) throw new Exception("Failed to write message to elastic")
+                // Commit to kafka
+                commitToKakfa(result.cargo)
+            }
+      }.runWith(Sink.seq)
+
+      Await.ready(f1, Duration.Inf)
+      //#kafka-example
+      flush("sink3")
+
+      // Make sure all messages was committed to kafka
+      assert ( List(0,1,2) == committedOffsets.map(_.offset))
+
+      // Assert that all docs were written to elastic
+      val f2 = ElasticsearchSource
+        .typed[Book](
+        "sink3",
+        "book",
+        """{"match_all": {}}""",
+        ElasticsearchSourceSettings()
+      )
+        .map { message =>
+          message.source.title
+        }
+        .runWith(Sink.seq)
+
+      val result2 = Await.result(f2, Duration.Inf)
+
+      result2.sorted shouldEqual messagesFromKafka.map(_.book.title).sorted
+    }
+  }
+
 
 }


### PR DESCRIPTION
This a replacement-PR for https://github.com/akka/alpakka/pull/586.

This PR changes the original ElasticsearchFlowStage-implementation and adds the "returns info about both success and failed messages"-functionality to it.

The original ElasticsearchFlowStage-implementation only returns info about failed messages.
This makes it impossible to pass "info" through the elastic-flow.
Example of such info might be a Kafka-offset that should be committed AFTER the message has been written to elastic.

The fix in this PR makes this possible.