### PR TITLE
Provides Unix Domain Socket support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ lazy val alpakka = project
     sns,
     sqs,
     sse,
+    unixdomainsocket,
     xml
   )
   .settings(
@@ -125,6 +126,8 @@ lazy val sqs = alpakkaProject("sqs",
                               parallelExecution in Test := false)
 
 lazy val sse = alpakkaProject("sse", Dependencies.Sse)
+
+lazy val unixdomainsocket = alpakkaProject("unix-domain-socket", Dependencies.UnixDomainSocket)
 
 lazy val xml = alpakkaProject("xml", Dependencies.Xml)
 

--- a/docs/src/main/paradox/connectors.md
+++ b/docs/src/main/paradox/connectors.md
@@ -24,6 +24,7 @@
 * [Server-sent Events (SSE)](sse.md)
 * [Slick (JDBC) Connector](slick.md)
 * [Spring Web](spring-web.md)
+* [Unix Domain Sockets](unix-domain-socket.md)
 
 @@@
 

--- a/docs/src/main/paradox/unix-domain-socket.md
+++ b/docs/src/main/paradox/unix-domain-socket.md
@@ -1,0 +1,39 @@
+# Unix Domain Socket Connector
+
+[From Wikipedia](https://en.wikipedia.org/wiki/Unix_domain_socket), _A Unix domain socket or IPC socket (inter-process communication socket) is a data communications endpoint for exchanging data between processes executing on the same host operating system._ Unix Domain Sockets leverage files and so operating system level access control can be utilized. This is a security advantage over using TCP/UDP where IPC is required without a more complex [Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_Layer_Security). Performance also favors Unix Domain Sockets over TCP/UDP given that the Operating System's network stack is bypassed.
+
+This connector provides an implementation of a Unix Domain Socket with interfaces modelled on the conventional `Tcp` Akka Streams class. The connector uses JNI and so there are no native dependencies.
+
+> Note that Unix Domain Sockets, as the name implies, do not apply to Windows.
+
+## Artifacts
+
+@@dependency [sbt,Maven,Gradle] {
+  group=com.lightbend.akka
+  artifact=akka-stream-alpakka-unixdomainsocket_$scalaBinaryVersion$
+  version=$version$
+}
+
+## Usage
+
+The binding and connecting APIs are extremely similar to the `Tcp` Akka Streams class. `UnixDomainSocket` is generally substitutable for `Tcp` except that the `SocketAddress` is different (Unix Domain Sockets requires a `java.net.File` as opposed to a host and port). Please read the following for details:
+
+* [Scala user reference for `Tcp`](https://doc.akka.io/docs/akka/current/stream/stream-io.html?language=scala)
+* [Java user reference for `Tcp`](https://doc.akka.io/docs/akka/current/stream/stream-io.html?language=java)
+
+### Binding to a file
+
+Scala
+: @@snip ($alpakka$/unix-domain-socket/src/test/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocketSpec.scala) { #binding }
+
+Java
+: @@snip ($alpakka$/unix-domain-socket/src/test/java/akka/stream/alpakka/unixdomainsocket/javadsl/UnixDomainSocketTest.java) { #binding }
+
+### Connecting to a file
+
+Scala
+: @@snip ($alpakka$/unix-domain-socket/src/test/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocketSpec.scala) { #outgoingConnection }
+
+Java
+: @@snip ($alpakka$/unix-domain-socket/src/test/java/akka/stream/alpakka/unixdomainsocket/javadsl/UnixDomainSocketTest.java) { #outgoingConnection }
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -219,6 +219,12 @@ object Dependencies {
     )
   )
 
+  val UnixDomainSocket = Seq(
+    libraryDependencies ++= Seq(
+      "com.github.jnr" % "jnr-unixsocket" % "0.18" // BSD/ApacheV2/CPL/MIT as per https://github.com/akka/alpakka/issues/620#issuecomment-348727265
+    )
+  )
+
   val Xml = Seq(
     libraryDependencies ++= Seq(
       "com.fasterxml" % "aalto-xml" % "1.0.0", // ApacheV2,

--- a/unix-domain-socket/src/main/resources/reference.conf
+++ b/unix-domain-socket/src/main/resources/reference.conf
@@ -1,0 +1,13 @@
+akka.stream.alpakka.unix-domain-socket {
+  // Size of the buffer to receive data. The Linux /proc/sys/net/core/wmem_max is around 200k,
+  // so 64k seems reasonable given 8k is normal for TCP. Denominations of the power of 2 are
+  // always good in terms of memory alignment. Limited as a signed Int i.e. 2GiB - undefined
+  // behavior beyond that.
+  receive-buffer-size = 64k
+
+  // Size of the buffer to send data. The Linux /proc/sys/net/core/wmem_max is around 200k,
+  // so 64k seems reasonable given 8k is normal for TCP. Denominations of the power of 2 are
+  // always good in terms of memory alignment. Limited as a signed Int i.e. 2GiB - undefined
+  // behavior beyond that.
+  send-buffer-size    = 64k
+}

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/javadsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/javadsl/UnixDomainSocket.scala
@@ -111,6 +111,8 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends akka.actor.Ext
    * [[akka.stream.scaladsl.RunnableGraph]] the server is not immediately available. Only after the materialized future
    * completes is the server ready to accept client connections.
    *
+   * TODO: Support idleTimeout as per Tcp.
+   *
    * @param file      The file to listen on
    * @param backlog   Controls the size of the connection backlog
    * @param halfClose
@@ -154,6 +156,8 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends akka.actor.Ext
    * to achieve application level chunks you have to introduce explicit framing in your streams,
    * for example using the [[akka.stream.javadsl.Framing]] stages.
    *
+   * TODO: Support idleTimeout as per Tcp.
+   *
    * @param remoteAddress The remote address to connect to
    * @param localAddress  Optional local address for the connection
    * @param halfClose
@@ -179,6 +183,8 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends akka.actor.Ext
   /**
    * Creates an [[UnixDomainSocket.OutgoingConnection]] without specifying options.
    * It represents a prospective UnixDomainSocket client connection to the given endpoint.
+   *
+   * TODO: Support idleTimeout as per Tcp.
    *
    * Note that the ByteString chunk boundaries are not retained across the network,
    * to achieve application level chunks you have to introduce explicit framing in your streams,

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/javadsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/javadsl/UnixDomainSocket.scala
@@ -25,7 +25,7 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
   /**
    * Represents a prospective UnixDomainSocket server binding.
    */
-  class ServerBinding private[akka] (delegate: ScalaUnixDomainSocket.ServerBinding) {
+  final class ServerBinding private[akka] (delegate: ScalaUnixDomainSocket.ServerBinding) {
 
     /**
      * The local address of the endpoint bound by the materialization of the `connections` [[Source]].
@@ -44,7 +44,7 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
   /**
    * Represents an accepted incoming UnixDomainSocket connection.
    */
-  class IncomingConnection private[akka] (delegate: ScalaUnixDomainSocket.IncomingConnection) {
+  final class IncomingConnection private[akka] (delegate: ScalaUnixDomainSocket.IncomingConnection) {
 
     /**
      * The local address this connection is bound to.
@@ -75,7 +75,7 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
   /**
    * Represents a prospective outgoing UnixDomainSocket connection.
    */
-  class OutgoingConnection private[akka] (delegate: ScalaUnixDomainSocket.OutgoingConnection) {
+  final class OutgoingConnection private[akka] (delegate: ScalaUnixDomainSocket.OutgoingConnection) {
 
     /**
      * The remote address this connection is or will be bound to.
@@ -98,7 +98,7 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
     new UnixDomainSocket(system)
 }
 
-class UnixDomainSocket(system: ExtendedActorSystem) extends akka.actor.Extension {
+final class UnixDomainSocket(system: ExtendedActorSystem) extends akka.actor.Extension {
   import UnixDomainSocket._
   import akka.dispatch.ExecutionContexts.{sameThreadExecutionContext ⇒ ec}
 

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/javadsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/javadsl/UnixDomainSocket.scala
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.unixdomainsocket.javadsl
+
+import java.io.File
+import java.util.Optional
+import java.util.concurrent.CompletionStage
+
+import scala.compat.java8.OptionConverters._
+import scala.compat.java8.FutureConverters._
+import akka.NotUsed
+import akka.actor.{ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import akka.stream.alpakka.unixdomainsocket.scaladsl.{UnixDomainSocket => ScalaUnixDomainSocket}
+import akka.stream.javadsl.{Flow, Source}
+import akka.stream.Materializer
+import akka.util.ByteString
+import jnr.unixsocket.UnixSocketAddress
+
+import scala.concurrent.duration.Duration
+
+object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdProvider {
+
+  /**
+   * Represents a prospective UnixDomainSocket server binding.
+   */
+  class ServerBinding private[akka] (delegate: ScalaUnixDomainSocket.ServerBinding) {
+
+    /**
+     * The local address of the endpoint bound by the materialization of the `connections` [[Source]].
+     */
+    def localAddress: UnixSocketAddress = delegate.localAddress
+
+    /**
+     * Asynchronously triggers the unbinding of the port that was bound by the materialization of the `connections`
+     * [[Source]].
+     *
+     * The produced [[java.util.concurrent.CompletionStage]] is fulfilled when the unbinding has been completed.
+     */
+    def unbind(): CompletionStage[Unit] = delegate.unbind().toJava
+  }
+
+  /**
+   * Represents an accepted incoming UnixDomainSocket connection.
+   */
+  class IncomingConnection private[akka] (delegate: ScalaUnixDomainSocket.IncomingConnection) {
+
+    /**
+     * The local address this connection is bound to.
+     */
+    def localAddress: UnixSocketAddress = delegate.localAddress
+
+    /**
+     * The remote address this connection is bound to.
+     */
+    def remoteAddress: UnixSocketAddress = delegate.remoteAddress
+
+    /**
+     * Handles the connection using the given flow, which is materialized exactly once and the respective
+     * materialized value is returned.
+     *
+     * Convenience shortcut for: `flow.join(handler).run()`.
+     */
+    def handleWith[Mat](handler: Flow[ByteString, ByteString, Mat], materializer: Materializer): Mat =
+      delegate.handleWith(handler.asScala)(materializer)
+
+    /**
+     * A flow representing the client on the other side of the connection.
+     * This flow can be materialized only once.
+     */
+    def flow: Flow[ByteString, ByteString, NotUsed] = new Flow(delegate.flow)
+  }
+
+  /**
+   * Represents a prospective outgoing UnixDomainSocket connection.
+   */
+  class OutgoingConnection private[akka] (delegate: ScalaUnixDomainSocket.OutgoingConnection) {
+
+    /**
+     * The remote address this connection is or will be bound to.
+     */
+    def remoteAddress: UnixSocketAddress = delegate.remoteAddress
+
+    /**
+     * The local address of the endpoint bound by the materialization of the connection materialization.
+     */
+    def localAddress: UnixSocketAddress = delegate.localAddress
+  }
+
+  override def get(system: ActorSystem): UnixDomainSocket =
+    super.get(system)
+
+  def lookup(): ExtensionId[_ <: Extension] =
+    UnixDomainSocket
+
+  def createExtension(system: ExtendedActorSystem): UnixDomainSocket =
+    new UnixDomainSocket(system)
+}
+
+class UnixDomainSocket(system: ExtendedActorSystem) extends akka.actor.Extension {
+  import UnixDomainSocket._
+  import akka.dispatch.ExecutionContexts.{sameThreadExecutionContext ⇒ ec}
+
+  private lazy val delegate: ScalaUnixDomainSocket = ScalaUnixDomainSocket(system)
+
+  /**
+   * Creates a [[UnixDomainSocket.ServerBinding]] instance which represents a prospective UnixDomainSocket server binding on the given `endpoint`.
+   *
+   * Please note that the startup of the server is asynchronous, i.e. after materializing the enclosing
+   * [[akka.stream.scaladsl.RunnableGraph]] the server is not immediately available. Only after the materialized future
+   * completes is the server ready to accept client connections.
+   *
+   * @param file      The file to listen on
+   * @param backlog   Controls the size of the connection backlog
+   * @param halfClose
+   *                  Controls whether the connection is kept open even after writing has been completed to the accepted
+   *                  UnixDomainSocket connections.
+   *                  If set to true, the connection will implement the UnixDomainSocket half-close mechanism, allowing the client to
+   *                  write to the connection even after the server has finished writing. The UnixDomainSocket socket is only closed
+   *                  after both the client and server finished writing.
+   *                  If set to false, the connection will immediately closed once the server closes its write side,
+   *                  independently whether the client is still attempting to write. This setting is recommended
+   *                  for servers, and therefore it is the default setting.
+   */
+  def bind(file: File, backlog: Int, halfClose: Boolean): Source[IncomingConnection, CompletionStage[ServerBinding]] =
+    Source.fromGraph(
+      delegate
+        .bind(file, backlog, halfClose)
+        .map(new IncomingConnection(_))
+        .mapMaterializedValue(_.map(new ServerBinding(_))(ec).toJava)
+    )
+
+  /**
+   * Creates a [[UnixDomainSocket.ServerBinding]] without specifying options.
+   * It represents a prospective UnixDomainSocket server binding on the given `endpoint`.
+   *
+   * Please note that the startup of the server is asynchronous, i.e. after materializing the enclosing
+   * [[akka.stream.scaladsl.RunnableGraph]] the server is not immediately available. Only after the materialized future
+   * completes is the server ready to accept client connections.
+   */
+  def bind(file: File): Source[IncomingConnection, CompletionStage[ServerBinding]] =
+    Source.fromGraph(
+      delegate
+        .bind(file)
+        .map(new IncomingConnection(_))
+        .mapMaterializedValue(_.map(new ServerBinding(_))(ec).toJava)
+    )
+
+  /**
+   * Creates an [[UnixDomainSocket.OutgoingConnection]] instance representing a prospective UnixDomainSocket client connection to the given endpoint.
+   *
+   * Note that the ByteString chunk boundaries are not retained across the network,
+   * to achieve application level chunks you have to introduce explicit framing in your streams,
+   * for example using the [[akka.stream.javadsl.Framing]] stages.
+   *
+   * @param remoteAddress The remote address to connect to
+   * @param localAddress  Optional local address for the connection
+   * @param halfClose
+   *                  Controls whether the connection is kept open even after writing has been completed to the accepted
+   *                  UnixDomainSocket connections.
+   *                  If set to true, the connection will implement the UnixDomainSocket half-close mechanism, allowing the server to
+   *                  write to the connection even after the client has finished writing. The UnixDomainSocket socket is only closed
+   *                  after both the client and server finished writing. This setting is recommended for clients and
+   *                  therefore it is the default setting.
+   *                  If set to false, the connection will immediately closed once the client closes its write side,
+   *                  independently whether the server is still attempting to write.
+   */
+  def outgoingConnection(remoteAddress: UnixSocketAddress,
+                         localAddress: Optional[UnixSocketAddress],
+                         halfClose: Boolean,
+                         connectTimeout: Duration): Flow[ByteString, ByteString, CompletionStage[OutgoingConnection]] =
+    Flow.fromGraph(
+      delegate
+        .outgoingConnection(remoteAddress, localAddress.asScala, halfClose, connectTimeout)
+        .mapMaterializedValue(_.map(new OutgoingConnection(_))(ec).toJava)
+    )
+
+  /**
+   * Creates an [[UnixDomainSocket.OutgoingConnection]] without specifying options.
+   * It represents a prospective UnixDomainSocket client connection to the given endpoint.
+   *
+   * Note that the ByteString chunk boundaries are not retained across the network,
+   * to achieve application level chunks you have to introduce explicit framing in your streams,
+   * for example using the [[akka.stream.javadsl.Framing]] stages.
+   */
+  def outgoingConnection(file: File): Flow[ByteString, ByteString, CompletionStage[OutgoingConnection]] =
+    Flow.fromGraph(
+      delegate
+        .outgoingConnection(new UnixSocketAddress(file))
+        .mapMaterializedValue(_.map(new OutgoingConnection(_))(ec).toJava)
+    )
+
+}

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -336,6 +336,8 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends Extension {
    * [[akka.stream.scaladsl.RunnableGraph]] the server is not immediately available. Only after the materialized future
    * completes is the server ready to accept client connections.
    *
+   * TODO: Support idleTimeout as per Tcp.
+   *
    * @param file      The file to listen on
    * @param backlog   Controls the size of the connection backlog
    * @param halfClose
@@ -413,6 +415,8 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends Extension {
    * [[akka.stream.scaladsl.RunnableGraph]] the server is not immediately available. Only after the returned future
    * completes is the server ready to accept client connections.
    *
+   * TODO: Support idleTimeout as per Tcp.
+   *
    * @param handler   A Flow that represents the server logic
    * @param file      The file to listen on
    * @param backlog   Controls the size of the connection backlog
@@ -442,6 +446,8 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends Extension {
    * Note that the ByteString chunk boundaries are not retained across the network,
    * to achieve application level chunks you have to introduce explicit framing in your streams,
    * for example using the [[akka.stream.scaladsl.Framing]] stages.
+   *
+   * TODO: Support idleTimeout as per Tcp.
    *
    * @param remoteAddress The remote address to connect to
    * @param localAddress  Optional local address for the connection

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -65,11 +65,11 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
   }
 
   /**
-   * Represents a prospective outgoing TCP connection.
+   * Represents a prospective outgoing Unix Domain Socket connection.
    */
   final case class OutgoingConnection(remoteAddress: UnixSocketAddress, localAddress: UnixSocketAddress)
 
-  private val ReceiveBufferSize = 8192
+  private val ReceiveBufferSize = 65536 // The Linux /proc/sys/net/core/wmem_max is around 200k, so 64k seems reasonable given 8k is normal for TCP. TODO: Make this configurable.
   private sealed abstract class ReceiveContext(
       val queue: SourceQueueWithComplete[ByteString],
       val buffer: ByteBuffer
@@ -84,7 +84,7 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
       pendingResult: Future[QueueOfferResult]
   ) extends ReceiveContext(queue, buffer)
 
-  private val SendBufferSize = 8192
+  private val SendBufferSize = 65536 // See the comment for ReceiveBufferSize. TODO: Make this configurable.
   private sealed abstract class SendContext(
       val buffer: ByteBuffer
   )

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -313,7 +313,7 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends Extension {
 
   import UnixDomainSocket._
 
-  implicit val materializer: ActorMaterializer = ActorMaterializer()(system)
+  private implicit val materializer: ActorMaterializer = ActorMaterializer()(system)
   import system.dispatcher
 
   private val sel = NativeSelectorProvider.getInstance.openSelector

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -322,10 +322,8 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends Extension {
   ioThread.start()
 
   CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseServiceStop, "stopUnixDomainSocket") { () =>
-    Future.successful {
-      sel.close() // Not much else that we can do
-      Done
-    }
+    sel.close() // Not much else that we can do
+    Future.successful(Done)
   }
 
   private val receiveBufferSize: Int =
@@ -347,9 +345,9 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends Extension {
    * @param backlog   Controls the size of the connection backlog
    * @param halfClose
    *                  Controls whether the connection is kept open even after writing has been completed to the accepted
-   *                  TCP connections.
-   *                  If set to true, the connection will implement the TCP half-close mechanism, allowing the client to
-   *                  write to the connection even after the server has finished writing. The TCP socket is only closed
+   *                  socket connections.
+   *                  If set to true, the connection will implement the socket half-close mechanism, allowing the client to
+   *                  write to the connection even after the server has finished writing. The socket is only closed
    *                  after both the client and server finished writing.
    *                  If set to false, the connection will immediately closed once the server closes its write side,
    *                  independently whether the client is still attempting to write. This setting is recommended
@@ -429,9 +427,9 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends Extension {
    * @param backlog   Controls the size of the connection backlog
    * @param halfClose
    *                  Controls whether the connection is kept open even after writing has been completed to the accepted
-   *                  TCP connections.
-   *                  If set to true, the connection will implement the TCP half-close mechanism, allowing the client to
-   *                  write to the connection even after the server has finished writing. The TCP socket is only closed
+   *                  socket connections.
+   *                  If set to true, the connection will implement the socket half-close mechanism, allowing the client to
+   *                  write to the connection even after the server has finished writing. The socket is only closed
    *                  after both the client and server finished writing.
    *                  If set to false, the connection will immediately closed once the server closes its write side,
    *                  independently whether the client is still attempting to write. This setting is recommended
@@ -460,9 +458,9 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends Extension {
    * @param localAddress  Optional local address for the connection
    * @param halfClose
    *                  Controls whether the connection is kept open even after writing has been completed to the accepted
-   *                  TCP connections.
-   *                  If set to true, the connection will implement the TCP half-close mechanism, allowing the server to
-   *                  write to the connection even after the client has finished writing. The TCP socket is only closed
+   *                  socket connections.
+   *                  If set to true, the connection will implement the socket half-close mechanism, allowing the server to
+   *                  write to the connection even after the client has finished writing. The socket is only closed
    *                  after both the client and server finished writing. This setting is recommended for clients and
    *                  therefore it is the default setting.
    *                  If set to false, the connection will immediately closed once the client closes its write side,

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -309,7 +309,7 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
 /**
  * Provides Unix Domain Socket functionality to Akka Streams with an interface similar to Akka's Tcp class.
  */
-class UnixDomainSocket(system: ExtendedActorSystem) extends Extension {
+final class UnixDomainSocket(system: ExtendedActorSystem) extends Extension {
 
   import UnixDomainSocket._
 

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -1,0 +1,515 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.unixdomainsocket.scaladsl
+
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.channels.{SelectionKey, Selector}
+
+import akka.{Done, NotUsed}
+import akka.actor.{
+  ActorSystem,
+  Cancellable,
+  CoordinatedShutdown,
+  ExtendedActorSystem,
+  Extension,
+  ExtensionId,
+  ExtensionIdProvider
+}
+import akka.stream._
+import akka.stream.scaladsl.{BroadcastHub, Flow, Keep, Sink, Source, SourceQueueWithComplete}
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.util.ByteString
+import jnr.enxio.channels.NativeSelectorProvider
+import jnr.unixsocket.{UnixServerSocketChannel, UnixSocketAddress, UnixSocketChannel}
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
+
+object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdProvider {
+
+  def apply()(implicit system: ActorSystem): UnixDomainSocket = super.apply(system)
+
+  override def createExtension(system: ExtendedActorSystem) =
+    new UnixDomainSocket(system)
+
+  override def lookup(): ExtensionId[_ <: Extension] =
+    UnixDomainSocket
+
+  /**
+   * * Represents a successful server binding.
+   */
+  final case class ServerBinding(localAddress: UnixSocketAddress)(private val unbindAction: () => Future[Unit]) {
+    def unbind(): Future[Unit] = unbindAction()
+  }
+
+  /**
+   * Represents an accepted incoming connection.
+   */
+  final case class IncomingConnection(localAddress: UnixSocketAddress,
+                                      remoteAddress: UnixSocketAddress,
+                                      flow: Flow[ByteString, ByteString, NotUsed]) {
+
+    /**
+     * Handles the connection using the given flow, which is materialized exactly once and the respective
+     * materialized instance is returned.
+     *
+     * Convenience shortcut for: `flow.join(handler).run()`.
+     */
+    def handleWith[Mat](handler: Flow[ByteString, ByteString, Mat])(implicit materializer: Materializer): Mat =
+      flow.joinMat(handler)(Keep.right).run()
+  }
+
+  /**
+   * Represents a prospective outgoing TCP connection.
+   */
+  final case class OutgoingConnection(remoteAddress: UnixSocketAddress, localAddress: UnixSocketAddress)
+
+  private val ReceiveBufferSize = 8192
+  private sealed abstract class ReceiveContext(
+      val queue: SourceQueueWithComplete[ByteString],
+      val buffer: ByteBuffer
+  )
+  private case class ReceiveAvailable(
+      override val queue: SourceQueueWithComplete[ByteString],
+      override val buffer: ByteBuffer
+  ) extends ReceiveContext(queue, buffer)
+  private case class PendingReceiveAck(
+      override val queue: SourceQueueWithComplete[ByteString],
+      override val buffer: ByteBuffer,
+      pendingResult: Future[QueueOfferResult]
+  ) extends ReceiveContext(queue, buffer)
+
+  private val SendBufferSize = 8192
+  private sealed abstract class SendContext(
+      val buffer: ByteBuffer
+  )
+  private case class SendAvailable(
+      override val buffer: ByteBuffer
+  ) extends SendContext(buffer)
+  private case class SendRequested(
+      override val buffer: ByteBuffer,
+      sent: Promise[Done]
+  ) extends SendContext(buffer)
+  private case object CloseRequested extends SendContext(ByteString.empty.asByteBuffer)
+
+  private class SendReceiveContext(
+      @volatile var send: SendContext,
+      @volatile var receive: ReceiveContext
+  )
+
+  /*
+   * All NIO for UnixDomainSocket across an entire actor system is performed on just one thread. Data
+   * is input/output as fast as possible with back-pressure being fully implemented e.g. if there's
+   * no other thread ready to consume a receive buffer, then there is no registration for a read
+   * operation.
+   */
+  private def nioEventLoop(sel: Selector)(implicit ec: ExecutionContext): Unit =
+    while (sel.isOpen) {
+      val nrOfKeysSelected = sel.select()
+      if (sel.isOpen) {
+        val keySelectable = nrOfKeysSelected > 0
+        val keys = if (keySelectable) sel.selectedKeys().iterator() else sel.keys().iterator()
+        while (keys.hasNext) {
+          val key = keys.next()
+          if (key != null) { // Observed as sometimes being null via sel.keys().iterator()
+            if (keySelectable && (key.isAcceptable || key.isConnectable)) {
+              val newConnectionOp = key.attachment().asInstanceOf[(Selector, SelectionKey) => Unit]
+              newConnectionOp(sel, key)
+            }
+            key.attachment match {
+              case sendReceiveContext: SendReceiveContext =>
+                sendReceiveContext.send match {
+                  case SendRequested(buffer, sent) if keySelectable && key.isWritable =>
+                    key.channel().asInstanceOf[UnixSocketChannel].write(buffer)
+                    if (buffer.remaining == 0) {
+                      sendReceiveContext.send = SendAvailable(buffer)
+                      key.interestOps(key.interestOps() & ~SelectionKey.OP_WRITE)
+                      sent.success(Done)
+                    }
+                  case _: SendRequested =>
+                    key.interestOps(key.interestOps() | SelectionKey.OP_WRITE)
+                  case CloseRequested =>
+                    key.cancel()
+                    key.channel.close()
+                  case _: SendAvailable =>
+                }
+                sendReceiveContext.receive match {
+                  case ReceiveAvailable(queue, buffer) if keySelectable && key.isReadable =>
+                    buffer.clear()
+                    val n = key.channel.asInstanceOf[UnixSocketChannel].read(buffer)
+                    if (n >= 0) {
+                      buffer.flip()
+                      val pendingResult = queue.offer(ByteString(buffer))
+                      pendingResult.onComplete(_ => sel.wakeup())
+                      sendReceiveContext.receive = PendingReceiveAck(queue, buffer, pendingResult)
+                      key.interestOps(key.interestOps() & ~SelectionKey.OP_READ)
+                    } else {
+                      queue.complete()
+                      key.cancel()
+                      key.channel.close()
+                    }
+                  case PendingReceiveAck(receiveQueue, receiveBuffer, pendingResult) if pendingResult.isCompleted =>
+                    pendingResult.value.get match {
+                      case Success(QueueOfferResult.Enqueued) =>
+                        sendReceiveContext.receive = ReceiveAvailable(receiveQueue, receiveBuffer)
+                        key.interestOps(key.interestOps() | SelectionKey.OP_READ)
+                      case _ =>
+                        receiveQueue.complete()
+                        key.cancel()
+                        key.channel.close()
+                    }
+                  case _: ReceiveAvailable =>
+                }
+              case _: ((Selector, SelectionKey) => Unit) @unchecked =>
+            }
+          }
+          if (keySelectable) keys.remove()
+        }
+      }
+    }
+
+  private def acceptKey(
+      localAddress: UnixSocketAddress,
+      incomingConnectionQueue: SourceQueueWithComplete[IncomingConnection],
+      halfClose: Boolean
+  )(sel: Selector, key: SelectionKey)(implicit mat: ActorMaterializer, ec: ExecutionContext): Unit = {
+
+    val acceptingChannel = key.channel().asInstanceOf[UnixServerSocketChannel]
+    val acceptedChannel = acceptingChannel.accept()
+    acceptedChannel.configureBlocking(false)
+    val (context, flow) = sendReceiveStructures(sel)
+    acceptedChannel.register(sel, SelectionKey.OP_READ, context)
+    val connectionFlow =
+      if (halfClose)
+        Flow.fromGraph(new HalfCloseFlow).via(flow)
+      else
+        flow
+    incomingConnectionQueue.offer(
+      IncomingConnection(localAddress, acceptingChannel.getRemoteSocketAddress, connectionFlow)
+    )
+  }
+
+  private def connectKey(remoteAddress: UnixSocketAddress,
+                         connectionFinished: Promise[Done],
+                         cancellable: Option[Cancellable],
+                         sendReceiveContext: SendReceiveContext)(sel: Selector, key: SelectionKey): Unit = {
+
+    val connectingChannel = key.channel().asInstanceOf[UnixSocketChannel]
+    cancellable.foreach(_.cancel())
+    try {
+      connectingChannel.register(sel, SelectionKey.OP_READ, sendReceiveContext)
+      val finishExpected = connectingChannel.finishConnect()
+      require(finishExpected, "Internal error - our call to connection finish wasn't expected.")
+      connectionFinished.trySuccess(Done)
+    } catch {
+      case NonFatal(e) =>
+        connectionFinished.tryFailure(e)
+        key.cancel()
+    }
+  }
+
+  private def sendReceiveStructures(sel: Selector)(
+      implicit mat: ActorMaterializer,
+      ec: ExecutionContext
+  ): (SendReceiveContext, Flow[ByteString, ByteString, NotUsed]) = {
+
+    val (receiveQueue, receiveSource) =
+      Source
+        .queue[ByteString](2, OverflowStrategy.backpressure)
+        .prefixAndTail(0)
+        .map(_._2)
+        .toMat(Sink.head)(Keep.both)
+        .run()
+    val sendReceiveContext =
+      new SendReceiveContext(
+        SendAvailable(ByteBuffer.allocate(SendBufferSize)),
+        ReceiveAvailable(receiveQueue, ByteBuffer.allocate(ReceiveBufferSize))
+      ) // FIXME: No need for the costly allocation of direct buffers yet given https://github.com/jnr/jnr-unixsocket/pull/49
+    val sendSink =
+      BroadcastHub
+        .sink[ByteString]
+        .mapMaterializedValue { sendSource =>
+          sendSource
+            .expand { bytes =>
+              if (bytes.size <= SendBufferSize) {
+                List(bytes).toIterator
+              } else {
+                def splitToBufferSize(bytes: ByteString, acc: List[ByteString]): List[ByteString] =
+                  if (bytes.nonEmpty) {
+                    val (left, right) = bytes.splitAt(SendBufferSize)
+                    splitToBufferSize(right, acc :+ left)
+                  } else {
+                    acc
+                  }
+                splitToBufferSize(bytes, List.empty).toIterator
+              }
+            }
+            .mapAsync(1) { bytes =>
+              // Note - it is an error to get here and not have an AvailableSendContext
+              val sent = Promise[Done]
+              val sendBuffer = sendReceiveContext.send.buffer
+              sendBuffer.clear()
+              val copied = bytes.copyToBuffer(sendBuffer)
+              sendBuffer.flip()
+              require(copied == bytes.size) // It is an error to exceed our buffer size given the above expand
+              sendReceiveContext.send = SendRequested(sendBuffer, sent)
+              sel.wakeup()
+              sent.future.map(_ => bytes)
+            }
+            .watchTermination() {
+              case (mat, done) =>
+                done.onComplete { _ =>
+                  sendReceiveContext.send = CloseRequested
+                  sel.wakeup()
+                }
+                (mat, done)
+            }
+            .runWith(Sink.ignore)
+        }
+    (sendReceiveContext, Flow.fromSinkAndSourceCoupled(sendSink, Source.fromFutureSource(receiveSource)))
+  }
+
+  /*
+   * A flow that requires the downstream to complete for it to complete i.e. it will
+   * keep going if the upstream completes.
+   */
+  private class HalfCloseFlow extends GraphStage[FlowShape[ByteString, ByteString]] {
+    private val in = Inlet[ByteString]("HalfCloseFlow.in")
+    private val out = Outlet[ByteString]("HalfCloseFlow.out")
+
+    override val shape: FlowShape[ByteString, ByteString] = FlowShape.of(in, out)
+
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+      new GraphStageLogic(shape) {
+
+        override def preStart(): Unit =
+          setKeepGoing(true) // At a minimum, the downstream completion will stop this stage.
+
+        setHandler(in, new InHandler {
+          override def onPush(): Unit =
+            push(out, grab(in))
+
+          override def onUpstreamFinish(): Unit =
+            ()
+        })
+
+        setHandler(out, new OutHandler {
+          override def onPull(): Unit =
+            if (!isClosed(in) && !hasBeenPulled(in)) pull(in)
+        })
+      }
+  }
+}
+
+/**
+ * Provides Unix Domain Socket functionality to Akka Streams with an interface similar to Akka's Tcp class.
+ */
+class UnixDomainSocket(system: ExtendedActorSystem) extends Extension {
+
+  import UnixDomainSocket._
+
+  implicit val materializer: ActorMaterializer = ActorMaterializer()(system)
+  import system.dispatcher
+
+  private val sel = NativeSelectorProvider.getInstance.openSelector
+
+  private val ioThread = new Thread((() => nioEventLoop(sel)): Runnable, "unix-domain-socket-io")
+  ioThread.start()
+
+  CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseServiceStop, "stopUnixDomainSocket") { () =>
+    Future.successful {
+      sel.close() // Not much else that we can do
+      Done
+    }
+  }
+
+  /**
+   * Creates a [[UnixDomainSocket.ServerBinding]] instance which represents a prospective Unix Domain Socket
+   * server binding on the given `endpoint`.
+   *
+   * Please note that the startup of the server is asynchronous, i.e. after materializing the enclosing
+   * [[akka.stream.scaladsl.RunnableGraph]] the server is not immediately available. Only after the materialized future
+   * completes is the server ready to accept client connections.
+   *
+   * @param file      The file to listen on
+   * @param backlog   Controls the size of the connection backlog
+   * @param halfClose
+   *                  Controls whether the connection is kept open even after writing has been completed to the accepted
+   *                  TCP connections.
+   *                  If set to true, the connection will implement the TCP half-close mechanism, allowing the client to
+   *                  write to the connection even after the server has finished writing. The TCP socket is only closed
+   *                  after both the client and server finished writing.
+   *                  If set to false, the connection will immediately closed once the server closes its write side,
+   *                  independently whether the client is still attempting to write. This setting is recommended
+   *                  for servers, and therefore it is the default setting.
+   */
+  def bind(file: File,
+           backlog: Int = 128,
+           halfClose: Boolean = false): Source[IncomingConnection, Future[ServerBinding]] = {
+
+    val (incomingConnectionQueue, incomingConnectionSource) =
+      Source
+        .queue[IncomingConnection](2, OverflowStrategy.backpressure)
+        .prefixAndTail(0)
+        .map {
+          case (_, source) =>
+            source
+              .watchTermination() { (mat, done) =>
+                done
+                  .andThen {
+                    case _ =>
+                      try {
+                        file.delete()
+                      } catch {
+                        case NonFatal(_) =>
+                      }
+                  }
+                mat
+              }
+        }
+        .toMat(Sink.head)(Keep.both)
+        .run()
+
+    val serverBinding = Promise[ServerBinding]
+
+    val channel = UnixServerSocketChannel.open()
+    channel.configureBlocking(false)
+    val address = new UnixSocketAddress(file)
+    val registeredKey =
+      channel.register(sel, SelectionKey.OP_ACCEPT, acceptKey(address, incomingConnectionQueue, halfClose) _)
+    try {
+      channel.socket().bind(address, backlog)
+      serverBinding.success(
+        ServerBinding(address) { () =>
+          registeredKey.cancel()
+          channel.close()
+          incomingConnectionQueue.complete()
+          incomingConnectionQueue.watchCompletion().map(_ => ())
+        }
+      )
+    } catch {
+      case NonFatal(e) =>
+        registeredKey.cancel()
+        channel.close()
+        incomingConnectionQueue.fail(e)
+        serverBinding.failure(e)
+    }
+
+    Source
+      .fromFutureSource(incomingConnectionSource)
+      .mapMaterializedValue(_ => serverBinding.future)
+  }
+
+  /**
+   * Creates a [[UnixDomainSocket.ServerBinding]] instance which represents a prospective Unix Socket server binding on the given `endpoint`
+   * handling the incoming connections using the provided Flow.
+   *
+   * Please note that the startup of the server is asynchronous, i.e. after materializing the enclosing
+   * [[akka.stream.scaladsl.RunnableGraph]] the server is not immediately available. Only after the returned future
+   * completes is the server ready to accept client connections.
+   *
+   * @param handler   A Flow that represents the server logic
+   * @param file      The file to listen on
+   * @param backlog   Controls the size of the connection backlog
+   * @param halfClose
+   *                  Controls whether the connection is kept open even after writing has been completed to the accepted
+   *                  TCP connections.
+   *                  If set to true, the connection will implement the TCP half-close mechanism, allowing the client to
+   *                  write to the connection even after the server has finished writing. The TCP socket is only closed
+   *                  after both the client and server finished writing.
+   *                  If set to false, the connection will immediately closed once the server closes its write side,
+   *                  independently whether the client is still attempting to write. This setting is recommended
+   *                  for servers, and therefore it is the default setting.
+   */
+  def bindAndHandle(handler: Flow[ByteString, ByteString, _],
+                    file: File,
+                    backlog: Int = 128,
+                    halfClose: Boolean = false): Future[ServerBinding] =
+    bind(file, backlog, halfClose)
+      .to(Sink.foreach { conn: IncomingConnection ⇒
+        conn.flow.join(handler).run()
+      })
+      .run()
+
+  /**
+   * Creates an [[UnixDomainSocket.OutgoingConnection]] instance representing a prospective Unix Domain client connection to the given endpoint.
+   *
+   * Note that the ByteString chunk boundaries are not retained across the network,
+   * to achieve application level chunks you have to introduce explicit framing in your streams,
+   * for example using the [[akka.stream.scaladsl.Framing]] stages.
+   *
+   * @param remoteAddress The remote address to connect to
+   * @param localAddress  Optional local address for the connection
+   * @param halfClose
+   *                  Controls whether the connection is kept open even after writing has been completed to the accepted
+   *                  TCP connections.
+   *                  If set to true, the connection will implement the TCP half-close mechanism, allowing the server to
+   *                  write to the connection even after the client has finished writing. The TCP socket is only closed
+   *                  after both the client and server finished writing. This setting is recommended for clients and
+   *                  therefore it is the default setting.
+   *                  If set to false, the connection will immediately closed once the client closes its write side,
+   *                  independently whether the server is still attempting to write.
+   */
+  def outgoingConnection(
+      remoteAddress: UnixSocketAddress,
+      localAddress: Option[UnixSocketAddress] = None,
+      halfClose: Boolean = true,
+      connectTimeout: Duration = Duration.Inf
+  ): Flow[ByteString, ByteString, Future[OutgoingConnection]] = {
+
+    val channel = UnixSocketChannel.open()
+    channel.configureBlocking(false)
+    val connectionFinished = Promise[Done]
+    val cancellable =
+      connectTimeout match {
+        case d: FiniteDuration =>
+          Some(system.scheduler.scheduleOnce(d, { () =>
+            channel.close()
+          }))
+        case _ =>
+          None
+      }
+    val (context, flow) = sendReceiveStructures(sel)
+    val registeredKey =
+      channel
+        .register(sel, SelectionKey.OP_CONNECT, connectKey(remoteAddress, connectionFinished, cancellable, context) _)
+    val connection = Try(channel.connect(remoteAddress))
+    connection.failed.foreach(e => connectionFinished.failure(e))
+
+    val connectionFlow =
+      if (halfClose)
+        Flow.fromGraph(new HalfCloseFlow).via(flow)
+      else
+        flow
+    connectionFlow
+      .merge(Source.fromFuture(connectionFinished.future.map(_ => ByteString.empty)))
+      .filter(_.nonEmpty) // We merge above so that we can get connection failures - we're not interested in the empty bytes though
+      .mapMaterializedValue { _ =>
+        connection match {
+          case Success(_) =>
+            connectionFinished.future
+              .map(_ => OutgoingConnection(remoteAddress, localAddress.getOrElse(new UnixSocketAddress(""))))
+          case Failure(e) =>
+            registeredKey.cancel()
+            channel.close()
+            Future.failed(e)
+        }
+      }
+  }
+
+  /**
+   * Creates an [[UnixDomainSocket.OutgoingConnection]] without specifying options.
+   * It represents a prospective Unix Domain client connection to the given endpoint.
+   *
+   * Note that the ByteString chunk boundaries are not retained across the network,
+   * to achieve application level chunks you have to introduce explicit framing in your streams,
+   * for example using the [[akka.stream.scaladsl.Framing]] stages.
+   */
+  def outgoingConnection(file: File): Flow[ByteString, ByteString, Future[OutgoingConnection]] =
+    outgoingConnection(new UnixSocketAddress(file))
+}

--- a/unix-domain-socket/src/test/resources/application.conf
+++ b/unix-domain-socket/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  loglevel = "DEBUG"
+}

--- a/unix-domain-socket/src/test/resources/logback-test.xml
+++ b/unix-domain-socket/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/sse.log</file>
+        <append>false</append>
+        <encoder>
+            <pattern>%d{ISO8601} %-5level [%thread] [%logger{36}]  %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="FILE" />
+    </root>
+</configuration>

--- a/unix-domain-socket/src/test/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocketSpec.scala
+++ b/unix-domain-socket/src/test/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocketSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.unixdomainsocket.scaladsl
+
+import java.io.{File, IOException}
+import java.nio.file.Files
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.testkit._
+import akka.util.ByteString
+import org.scalatest._
+
+class UnixDomainSocketSpec
+    extends TestKit(ActorSystem("UnixDomainSocketSpec"))
+    with AsyncWordSpecLike
+    with Matchers
+    with BeforeAndAfterAll {
+
+  override def afterAll: Unit =
+    TestKit.shutdownActorSystem(system)
+
+  implicit val ma: ActorMaterializer = ActorMaterializer()
+
+  "A Unix Domain Socket" should {
+    "receive what is sent" in {
+      val file = Files.createTempFile("UnixDomainSocketSpec1", ".sock").toFile
+      file.delete()
+      file.deleteOnExit()
+
+      //#binding
+      val binding =
+        UnixDomainSocket().bindAndHandle(Flow.fromFunction(identity), file)
+      //#binding
+
+      //#outgoingConnection
+      binding.flatMap { connection =>
+        val sendBytes = ByteString("Hello")
+        val result =
+          Source
+            .single(sendBytes)
+            .via(UnixDomainSocket().outgoingConnection(file))
+            .runWith(Sink.head)
+        //#outgoingConnection
+        result
+          .map(receiveBytes => assert(receiveBytes == sendBytes))
+          .flatMap {
+            case `succeed` => connection.unbind().map(_ => succeed)
+            case failedAssertion => failedAssertion
+          }
+      //#outgoingConnection
+      }
+      //#outgoingConnection
+    }
+
+    "not be able to bind to a non-existant file" in {
+      val binding =
+        UnixDomainSocket().bindAndHandle(Flow.fromFunction(identity), new File("/thisshouldnotexist"))
+
+      binding.failed.map {
+        case _: IOException => succeed
+      }
+    }
+
+    "not be able to connect to a non-existant file" in {
+      val connection =
+        Source
+          .single(ByteString("hi"))
+          .via(UnixDomainSocket().outgoingConnection(new File("/thisshouldnotexist")))
+          .runWith(Sink.head)
+
+      connection.failed.map {
+        case _: IOException => succeed
+      }
+    }
+  }
+}


### PR DESCRIPTION
Provides Java and Scala DSLs along with documentation for both.

The `UnixDomainSocket` class is modelled directly from its `Tcp` counterpart. Note that, for no particular reason, I've not included support for `idleTimeout` on binding and connecting. This should be trivial. I just ran out of time.

*NOTE* The PR will require squashing given that commits pertain to PR feedback.

Fixes #620 