### PR TITLE
JMS: Support message individual timeToLive during send (#441)

### DIFF
--- a/docs/src/main/paradox/jms.md
+++ b/docs/src/main/paradox/jms.md
@@ -61,7 +61,7 @@ Use a case class with the subtype of @scaladoc[JmsMessage](akka.stream.alpakka.j
 the creation of sinks according to the message type (see below for an example).
 
 
-### Sending text messages with properties to a JMS provider
+### Sending text messages to a JMS provider
 
 Create a sink, that accepts and forwards @scaladoc[JmsTextMessage](akka.stream.alpakka.jms.JmsTextMessage$)s to the JMS provider:
 
@@ -145,8 +145,16 @@ Scala
 : @@snip ($alpakka$/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #create-messages-with-properties }
 
 Java
-: @@snip ($alpakka$/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-test-message-list #create-messages-with-properties }
+: @@snip ($alpakka$/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-messages-with-properties }
 
+### Sending messages with header to a JMS provider
+For every @scaladoc[JmsMessage](akka.stream.alpakka.jms.JmsMessage$) you can set also jms headers. 
+
+Scala
+: @@snip ($alpakka$/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #create-messages-with-headers }
+
+Java
+: @@snip ($alpakka$/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-messages-with-headers }
 
 ## Receiving messages from a JMS provider
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsMessages.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsMessages.scala
@@ -6,34 +6,45 @@ package akka.stream.alpakka.jms
 
 import scala.collection.JavaConverters._
 import java.util
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.Duration
 
 sealed trait JmsHeader {
 
   /**
    * Indicates if this header must be set during the send() operation according to the JMS specification or as attribute of the jms message before.
    */
-  def usedDuringSend(): Boolean
+  def usedDuringSend: Boolean
 }
 
 final case class JmsCorrelationId(jmsCorrelationId: String) extends JmsHeader {
-  override def usedDuringSend(): Boolean = false
+  override val usedDuringSend = false
 }
 
 final case class JmsReplyTo(jmsDestination: Destination) extends JmsHeader {
-  override def usedDuringSend(): Boolean = false
+  override val usedDuringSend = false
 }
 final case class JmsType(jmsType: String) extends JmsHeader {
-  override def usedDuringSend(): Boolean = false
+  override val usedDuringSend = false
 }
 
 final case class JmsTimeToLive(timeInMillis: Long) extends JmsHeader {
-  override def usedDuringSend(): Boolean = true
+  override val usedDuringSend = true
 }
+
+/**
+ * Priority of a message can be between 0 (lowest) and 9 (highest). The default priority is 4.
+ */
 final case class JmsPriority(priority: Int) extends JmsHeader {
-  override def usedDuringSend(): Boolean = true
+  override val usedDuringSend = true
 }
+
+/**
+ * Delivery mode can be [[javax.jms.DeliveryMode.NON_PERSISTENT]] or [[javax.jms.DeliveryMode.PERSISTENT]]
+ */
 final case class JmsDeliveryMode(deliveryMode: Int) extends JmsHeader {
-  override def usedDuringSend(): Boolean = true
+  override val usedDuringSend = true
 }
 
 object JmsCorrelationId {
@@ -68,9 +79,14 @@ object JmsType {
 object JmsTimeToLive {
 
   /**
+   * Scala API: create [[JmsTimeToLive]]
+   */
+  def apply(timeToLive: Duration): JmsTimeToLive = JmsTimeToLive(timeToLive.toMillis)
+
+  /**
    * Java API: create  [[JmsTimeToLive]]
    */
-  def create(timeInMillis: Long) = JmsTimeToLive(timeInMillis)
+  def create(timeToLive: Long, unit: TimeUnit) = JmsTimeToLive(unit.toMillis(timeToLive))
 }
 
 object JmsPriority {

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsMessages.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsMessages.scala
@@ -7,10 +7,34 @@ package akka.stream.alpakka.jms
 import scala.collection.JavaConverters._
 import java.util
 
-sealed trait JmsHeader
-final case class JmsCorrelationId(jmsCorrelationId: String) extends JmsHeader
-final case class JmsReplyTo(jmsDestination: Destination) extends JmsHeader
-final case class JmsType(jmsType: String) extends JmsHeader
+sealed trait JmsHeader {
+
+  /**
+   * Indicates if this header must be set during the send() operation according to the JMS specification or as attribute of the jms message before.
+   */
+  def usedDuringSend(): Boolean
+}
+
+final case class JmsCorrelationId(jmsCorrelationId: String) extends JmsHeader {
+  override def usedDuringSend(): Boolean = false
+}
+
+final case class JmsReplyTo(jmsDestination: Destination) extends JmsHeader {
+  override def usedDuringSend(): Boolean = false
+}
+final case class JmsType(jmsType: String) extends JmsHeader {
+  override def usedDuringSend(): Boolean = false
+}
+
+final case class JmsTimeToLive(timeInMillis: Long) extends JmsHeader {
+  override def usedDuringSend(): Boolean = true
+}
+final case class JmsPriority(priority: Int) extends JmsHeader {
+  override def usedDuringSend(): Boolean = true
+}
+final case class JmsDeliveryMode(deliveryMode: Int) extends JmsHeader {
+  override def usedDuringSend(): Boolean = true
+}
 
 object JmsCorrelationId {
 
@@ -39,6 +63,30 @@ object JmsType {
    * Java API: create  [[JmsType]]
    */
   def create(jmsType: String) = JmsType(jmsType)
+}
+
+object JmsTimeToLive {
+
+  /**
+   * Java API: create  [[JmsTimeToLive]]
+   */
+  def create(timeInMillis: Long) = JmsTimeToLive(timeInMillis)
+}
+
+object JmsPriority {
+
+  /**
+   * Java API: create  [[JmsPriority]]
+   */
+  def create(priority: Int) = JmsPriority(priority)
+}
+
+object JmsDeliveryMode {
+
+  /**
+   * Java API: create  [[JmsDeliveryMode]]
+   */
+  def create(deliveryMode: Int) = JmsDeliveryMode(deliveryMode)
 }
 
 sealed trait JmsMessage {

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsSinkStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsSinkStage.scala
@@ -41,15 +41,31 @@ final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[SinkShape
           override def onPush(): Unit = {
 
             val elem: JmsMessage = grab(in)
+
             val message: Message = createMessage(jmsSession, elem)
             populateMessageProperties(message, elem.properties)
-            populateMessageHeader(message, elem.headers)
 
-            jmsProducer.send(message)
+            val (sendHeaders, headersBeforeSend: Set[JmsHeader]) = elem.headers.partition(_.usedDuringSend())
+            populateMessageHeader(message, headersBeforeSend)
+
+            val deliveryModeOption = findHeader(sendHeaders) { case x: JmsDeliveryMode => x.deliveryMode }
+            val priorityOption = findHeader(sendHeaders) { case x: JmsPriority => x.priority }
+            val timeToLiveInMillisOption = findHeader(sendHeaders) { case x: JmsTimeToLive => x.timeInMillis }
+
+            jmsProducer.send(
+              message,
+              deliveryModeOption.getOrElse(jmsProducer.getDeliveryMode),
+              priorityOption.getOrElse(jmsProducer.getPriority),
+              timeToLiveInMillisOption.getOrElse(jmsProducer.getTimeToLive)
+            )
+
             pull(in)
           }
         }
       )
+
+      private def findHeader[T](headersDuringSend: Set[JmsHeader])(f: PartialFunction[JmsHeader, T]): Option[T] =
+        headersDuringSend.collect(f).headOption
 
       private def createMessage(jmsSession: JmsSession, element: JmsMessage): Message =
         element match {
@@ -70,6 +86,20 @@ final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[SinkShape
 
         }
 
+      private def populateMessageProperties(message: javax.jms.Message, properties: Map[String, Any]): Unit =
+        properties.foreach {
+          case (key, v) =>
+            v match {
+              case v: String => message.setStringProperty(key, v)
+              case v: Int => message.setIntProperty(key, v)
+              case v: Boolean => message.setBooleanProperty(key, v)
+              case v: Byte => message.setByteProperty(key, v)
+              case v: Short => message.setShortProperty(key, v)
+              case v: Long => message.setLongProperty(key, v)
+              case v: Double => message.setDoubleProperty(key, v)
+            }
+        }
+
       private def populateMapMessage(message: javax.jms.MapMessage, map: Map[String, Any]): Unit =
         map.foreach {
           case (key, v) =>
@@ -82,20 +112,6 @@ final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[SinkShape
               case v: Long => message.setLong(key, v)
               case v: Double => message.setDouble(key, v)
               case v: Array[Byte] => message.setBytes(key, v)
-            }
-        }
-
-      private def populateMessageProperties(message: javax.jms.Message, properties: Map[String, Any]): Unit =
-        properties.foreach {
-          case (key, v) =>
-            v match {
-              case v: String => message.setStringProperty(key, v)
-              case v: Int => message.setIntProperty(key, v)
-              case v: Boolean => message.setBooleanProperty(key, v)
-              case v: Byte => message.setByteProperty(key, v)
-              case v: Short => message.setShortProperty(key, v)
-              case v: Long => message.setLongProperty(key, v)
-              case v: Double => message.setDoubleProperty(key, v)
             }
         }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsSinkStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsSinkStage.scala
@@ -45,7 +45,7 @@ final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[SinkShape
             val message: Message = createMessage(jmsSession, elem)
             populateMessageProperties(message, elem.properties)
 
-            val (sendHeaders, headersBeforeSend: Set[JmsHeader]) = elem.headers.partition(_.usedDuringSend())
+            val (sendHeaders, headersBeforeSend: Set[JmsHeader]) = elem.headers.partition(_.usedDuringSend)
             populateMessageHeader(message, headersBeforeSend)
 
             val deliveryModeOption = findHeader(sendHeaders) { case x: JmsDeliveryMode => x.deliveryMode }

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
@@ -21,6 +21,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import javax.jms.DeliveryMode;
 import javax.jms.Message;
 import java.nio.charset.Charset;
 import java.util.*;
@@ -30,6 +31,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 
@@ -332,6 +334,9 @@ public class JmsConnectorsTest {
                     .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsType.create("type")))
                     .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsCorrelationId.create("correlationId")))
                     .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsReplyTo.queue("test-reply")))
+                    .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsTimeToLive.create(99999)))
+                    .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsPriority.create(2)))
+                    .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsDeliveryMode.create(DeliveryMode.NON_PERSISTENT)))
                     .collect(Collectors.toList());
             //#create-messages-with-properties
 
@@ -362,6 +367,10 @@ public class JmsConnectorsTest {
                 assertEquals(outMsg.getJMSType(), "type");
                 assertEquals(outMsg.getJMSCorrelationID(), "correlationId");
                 assertEquals(((ActiveMQQueue) outMsg.getJMSReplyTo()).getQueueName(), "test-reply");
+                
+                assertTrue(outMsg.getJMSExpiration()!= 0);
+                assertEquals(2,outMsg.getJMSPriority());
+                assertEquals(DeliveryMode.NON_PERSISTENT,outMsg.getJMSDeliveryMode());
                 msgIdx++;
             }
         });


### PR DESCRIPTION
Add support for attributes timeToLive, priority and deliveryMode per message in JmsSinkStage.

Resolves #441 