### PR TITLE
AMQP keep connection open if there are pending acks

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpRpcFlowStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpRpcFlowStage.scala
@@ -34,14 +34,12 @@ final class AmqpRpcFlowStage(settings: AmqpSinkSettings, bufferSize: Int, respon
     extends GraphStageWithMaterializedValue[FlowShape[OutgoingMessage, CommittableIncomingMessage], Future[String]]
     with AmqpConnector { stage =>
 
-  import AmqpRpcFlowStage._
-
   val in = Inlet[OutgoingMessage]("AmqpRpcFlow.in")
   val out = Outlet[CommittableIncomingMessage]("AmqpRpcFlow.out")
 
   override def shape: FlowShape[OutgoingMessage, CommittableIncomingMessage] = FlowShape.of(in, out)
 
-  override protected def initialAttributes: Attributes = defaultAttributes
+  override protected def initialAttributes: Attributes = AmqpRpcFlowStage.defaultAttributes
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[String]) = {
     val promise = Promise[String]()
@@ -53,7 +51,7 @@ final class AmqpRpcFlowStage(settings: AmqpSinkSettings, bufferSize: Int, respon
       private val queue = mutable.Queue[CommittableIncomingMessage]()
       private var queueName: String = _
       private val unackedMessages = new AtomicInteger()
-      private var outstandingMessages = 0
+      private val outstandingMessages = new AtomicInteger()
 
       override def connectionFactoryFrom(settings: AmqpConnectionSettings) = stage.connectionFactoryFrom(settings)
       override def newConnection(factory: ConnectionFactory, settings: AmqpConnectionSettings): Connection =
@@ -82,25 +80,25 @@ final class AmqpRpcFlowStage(settings: AmqpSinkSettings, bufferSize: Int, respon
         val commitCallback = getAsyncCallback[CommitCallback] {
           case AckArguments(deliveryTag, multiple, promise) => {
             channel.basicAck(deliveryTag, multiple)
-            unackedMessages.decrementAndGet()
-            if (unackedMessages.get() == 0) completeStage()
+            if (unackedMessages
+                  .decrementAndGet() == 0 && (isClosed(out) || (isClosed(in) && queue.isEmpty && outstandingMessages
+                  .get() == 0))) completeStage()
             promise.complete(Try(Done))
           }
           case NackArguments(deliveryTag, multiple, requeue, promise) => {
             channel.basicNack(deliveryTag, multiple, requeue)
-            unackedMessages.decrementAndGet()
-            if (unackedMessages.get() == 0) completeStage()
+            if (unackedMessages
+                  .decrementAndGet() == 0 && (isClosed(out) || (isClosed(in) && queue.isEmpty && outstandingMessages
+                  .get() == 0))) completeStage()
             promise.complete(Try(Done))
           }
         }
 
         val amqpSourceConsumer = new DefaultConsumer(channel) {
-          override def handleDelivery(
-              consumerTag: String,
-              envelope: Envelope,
-              properties: BasicProperties,
-              body: Array[Byte]
-          ): Unit =
+          override def handleDelivery(consumerTag: String,
+                                      envelope: Envelope,
+                                      properties: BasicProperties,
+                                      body: Array[Byte]): Unit =
             consumerCallback.invoke(
               new CommittableIncomingMessage {
                 override val message = IncomingMessage(ByteString(body), envelope, properties)
@@ -149,23 +147,11 @@ final class AmqpRpcFlowStage(settings: AmqpSinkSettings, bufferSize: Int, respon
       def handleDelivery(message: CommittableIncomingMessage): Unit =
         if (isAvailable(out)) {
           pushMessage(message)
+        } else if (queue.size + 1 > bufferSize) {
+          failStage(new RuntimeException(s"Reached maximum buffer size $bufferSize"))
         } else {
-          if (queue.size + 1 > bufferSize) {
-            failStage(new RuntimeException(s"Reached maximum buffer size $bufferSize"))
-          } else {
-            queue.enqueue(message)
-          }
+          queue.enqueue(message)
         }
-
-      def pushMessage(message: CommittableIncomingMessage): Unit = {
-        push(out, message)
-
-        outstandingMessages -= 1
-
-        if (outstandingMessages == 0 && unackedMessages.get() == 0 && isClosed(in)) {
-          completeStage()
-        }
-      }
 
       setHandler(
         out,
@@ -174,8 +160,17 @@ final class AmqpRpcFlowStage(settings: AmqpSinkSettings, bufferSize: Int, respon
             if (queue.nonEmpty) {
               pushMessage(queue.dequeue())
             }
+
+          override def onDownstreamFinish(): Unit =
+            if (unackedMessages.get() == 0) super.onDownstreamFinish()
         }
       )
+
+      def pushMessage(message: CommittableIncomingMessage): Unit = {
+        push(out, message)
+        unackedMessages.incrementAndGet()
+        outstandingMessages.decrementAndGet()
+      }
 
       setHandler(
         in,
@@ -185,7 +180,7 @@ final class AmqpRpcFlowStage(settings: AmqpSinkSettings, bufferSize: Int, respon
           // haven't processed a message yet, we do want to complete
           // so that we don't hang.
           override def onUpstreamFinish(): Unit =
-            if (queue.isEmpty && outstandingMessages == 0 && unackedMessages.get() == 0) super.onUpstreamFinish()
+            if (queue.isEmpty && outstandingMessages.get() == 0 && unackedMessages.get() == 0) super.onUpstreamFinish()
 
           override def onPush(): Unit = {
             val elem = grab(in)
@@ -213,8 +208,7 @@ final class AmqpRpcFlowStage(settings: AmqpSinkSettings, bufferSize: Int, respon
               }
             }
 
-            unackedMessages.addAndGet(expectedResponses)
-            outstandingMessages += expectedResponses
+            outstandingMessages.addAndGet(expectedResponses)
             pull(in)
           }
         }

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
@@ -73,7 +73,7 @@ final class AmqpSourceStage(settings: AmqpSourceSettings, bufferSize: Int)
           case AckArguments(deliveryTag, multiple, promise) => {
             try {
               channel.basicAck(deliveryTag, multiple)
-              if (unackedMessages.decrementAndGet() == 0 && !channel.isOpen) completeStage()
+              if (unackedMessages.decrementAndGet() == 0 &&  isClosed(out)) completeStage()
               promise.complete(Try(Done))
             } catch {
               case e: Throwable => promise.failure(e)
@@ -82,7 +82,7 @@ final class AmqpSourceStage(settings: AmqpSourceSettings, bufferSize: Int)
           case NackArguments(deliveryTag, multiple, requeue, promise) => {
             try {
               channel.basicNack(deliveryTag, multiple, requeue)
-              if (unackedMessages.decrementAndGet() == 0 && !channel.isOpen) completeStage()
+              if (unackedMessages.decrementAndGet() == 0 && isClosed(out)) completeStage()
               promise.complete(Try(Done))
             } catch {
               case e: Throwable => promise.failure(e)

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
@@ -73,7 +73,7 @@ final class AmqpSourceStage(settings: AmqpSourceSettings, bufferSize: Int)
           case AckArguments(deliveryTag, multiple, promise) => {
             try {
               channel.basicAck(deliveryTag, multiple)
-              if (unackedMessages.decrementAndGet() == 0 &&  isClosed(out)) completeStage()
+              if (unackedMessages.decrementAndGet() == 0 && isClosed(out)) completeStage()
               promise.complete(Try(Done))
             } catch {
               case e: Throwable => promise.failure(e)

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import akka.stream.javadsl.Keep;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -248,88 +249,83 @@ public class AmqpConnectorsTest {
     final String queueName = "amqp-conn-it-spec-rpc-queue-" + System.currentTimeMillis();
     final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
 
-    final Flow<OutgoingMessage,IncomingMessage, CompletionStage<String>> ampqRpcFlow = AmqpRpcFlow.atMostOnceFlow(
-            AmqpSinkSettings.create().withRoutingKey(queueName).withDeclarations(queueDeclaration), 10);
-
-    final Integer bufferSize = 10;
-    final Source<CommittableIncomingMessage, NotUsed> amqpSource = AmqpSource.committableSource(
-            NamedQueueSourceSettings.create(
-                    DefaultAmqpConnection.getInstance(),
-                    queueName
-            ).withDeclarations(queueDeclaration),
-            bufferSize
-    );
-
     final List<String> input = Arrays.asList("one", "two", "three", "four", "five");
-    TestSubscriber.Probe<IncomingMessage> probe =
-            Source.from(input)
-                    .map(ByteString::fromString)
-                    .map(bytes -> new OutgoingMessage(bytes, false, false, Optional.empty(), Optional.empty()))
-                    .via(ampqRpcFlow)
-                    .runWith(TestSink.probe(system), materializer);
 
-    Sink<OutgoingMessage, CompletionStage<Done>> amqpSink = AmqpSink.createReplyTo(
-            AmqpReplyToSinkSettings.create(DefaultAmqpConnection.getInstance())
+    final Flow<OutgoingMessage, CommittableIncomingMessage, CompletionStage<String>> ampqRpcFlow = AmqpRpcFlow.committableFlow(
+            AmqpSinkSettings.create()
+                    .withRoutingKey(queueName)
+                    .withDeclarations(queueDeclaration)
+            , 10, 1);
+    Pair<CompletionStage<String>, TestSubscriber.Probe<IncomingMessage>> result =
+      Source.from(input)
+        .map(ByteString::fromString)
+        .map(bytes -> new OutgoingMessage(bytes, false, false, Optional.empty(), Optional.empty()))
+        .viaMat(ampqRpcFlow, Keep.right())
+        .mapAsync(1, cm -> cm.ack(false).thenApply(unused -> cm.message()))
+        .toMat(TestSink.probe(system), Keep.both())
+        .run(materializer);
+
+    result.first().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    Sink<OutgoingMessage, CompletionStage<Done>> amqpSink = AmqpSink.createReplyTo(AmqpReplyToSinkSettings.create(DefaultAmqpConnection.getInstance()));
+
+    final Source<CommittableIncomingMessage, NotUsed> amqpSource = AmqpSource.committableSource(
+      NamedQueueSourceSettings.create(
+              DefaultAmqpConnection.getInstance(),
+              queueName
+      ).withDeclarations(queueDeclaration),
+            10
     );
 
     amqpSource.map(b ->
-            new OutgoingMessage(b.message().bytes(), false, false, Optional.of(b.message().properties()), Optional.empty())
+      new OutgoingMessage(b.message().bytes(), false, false, Optional.of(b.message().properties()), Optional.empty())
     ).runWith(amqpSink, materializer);
 
-    List<IncomingMessage> probeResult = JavaConverters.seqAsJavaListConverter(probe.toStrict(Duration.create(5, TimeUnit.SECONDS))).asJava();
+    amqpSource.map(cm -> cm.message().bytes().utf8String()).take(input.size()).runWith(Sink.seq(), materializer);
 
+    List<IncomingMessage> probeResult = JavaConverters.seqAsJavaListConverter(result.second().toStrict(Duration.create(5, TimeUnit.SECONDS))).asJava();
     assertEquals(probeResult.stream().map(s -> s.bytes().utf8String()).collect(Collectors.toList()), input);
-
-    final CompletionStage<List<String>> result =
-            amqpSource.map(cm -> cm.message().bytes().utf8String()).take(input.size()).runWith(Sink.seq(), materializer);
-
   }
 
 
     @Test
     public void republishMessageWithoutAutoAckIfNacked() throws Exception {
+
+        @SuppressWarnings("unchecked")
+        AmqpConnectionDetails connectionSettings = AmqpConnectionDetails.create("invalid", 5673)
+                .withHostsAndPorts(Pair.create("localhost", 5672));
+
         final String queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis();
         final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
 
-        @SuppressWarnings("unchecked")
-        AmqpConnectionDetails amqpConnectionDetails = AmqpConnectionDetails.create("invalid", 5673)
-                .withHostsAndPorts(Pair.create("localhost", 5672), Pair.create("localhost", 5674));
-
         final Sink<ByteString, CompletionStage<Done>> amqpSink = AmqpSink.createSimple(
-                AmqpSinkSettings.create(amqpConnectionDetails)
-                        .withRoutingKey(queueName)
-                        .withDeclarations(queueDeclaration)
+          AmqpSinkSettings.create(connectionSettings).withRoutingKey(queueName).withDeclarations(queueDeclaration)
         );
-
-        //#create-source-withoutautoack
-        final Integer bufferSize = 10;
-        final Source<CommittableIncomingMessage, NotUsed> amqpSource = AmqpSource.committableSource(
-                NamedQueueSourceSettings.create(
-                        DefaultAmqpConnection.getInstance(),
-                        queueName
-                ).withDeclarations(queueDeclaration),
-                bufferSize
-        );
-        //#create-source-withoutautoack
 
         final List<String> input = Arrays.asList("one", "two", "three", "four", "five");
-        Source.from(input).map(ByteString::fromString).runWith(amqpSink, materializer);
+        Source.from(input).map(ByteString::fromString).runWith(amqpSink, materializer).toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+        final Integer bufferSize = 10;
+        final Source<CommittableIncomingMessage, NotUsed> amqpSource = AmqpSource.committableSource(
+          NamedQueueSourceSettings.create(connectionSettings, queueName).withDeclarations(queueDeclaration),
+          bufferSize
+        );
 
         //#run-source-withoutautoack-and-nack
-        final CompletionStage<List<IncomingMessage>> result =
-                amqpSource
-                        .mapAsync(1, cm -> cm.nack(false, true).thenApply(unused -> cm.message()))
-                        .take(input.size()).runWith(Sink.seq(), materializer);
+        final CompletionStage<List<CommittableIncomingMessage>> result1 = amqpSource
+          .take(input.size())
+          .mapAsync(1, cm -> cm.nack(false, true).thenApply(unused -> cm))
+          .runWith(Sink.seq(), materializer);
         //#run-source-withoutautoack-and-nack
 
-        result.toCompletableFuture().get(3, TimeUnit.SECONDS);
+        result1.toCompletableFuture().get(3, TimeUnit.SECONDS);
 
-        final CompletionStage<List<IncomingMessage>> result2 =
-                amqpSource
-                        .mapAsync(1, cm -> cm.ack(false).thenApply(unused -> cm.message()))
-                        .take(input.size()).runWith(Sink.seq(), materializer);
+        final CompletionStage<List<CommittableIncomingMessage>> result2 = amqpSource
+          .mapAsync(1, cm -> cm.ack(false).thenApply(unused -> cm))
+          .take(input.size())
+          .runWith(Sink.seq(), materializer);
 
-        assertEquals(input, result2.toCompletableFuture().get(3, TimeUnit.SECONDS).stream().map(m -> m.bytes().utf8String()).collect(Collectors.toList()));
+        assertEquals(input, result2.toCompletableFuture().get(3, TimeUnit.SECONDS).stream().map(m -> m.message().bytes().utf8String()).collect(Collectors.toList()));
     }
 
     @Test

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
@@ -363,7 +363,14 @@ public class AmqpConnectorsTest {
                 amqpSource
                         .take(input.size()).runWith(Sink.seq(), materializer);
 
-        result.toCompletableFuture().get(3, TimeUnit.SECONDS).stream().map(cm -> cm.ack(false));
+        result.toCompletableFuture().get(3, TimeUnit.SECONDS).stream().map(cm -> {
+            try {
+                cm.ack(false).toCompletableFuture().get(3, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                assertEquals(e.getMessage(), false, true);
+            }
+            return true;
+        });
     }
 
     @Test

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
@@ -333,6 +333,40 @@ public class AmqpConnectorsTest {
     }
 
     @Test
+    public void keepConnectionPpenIfDownstreamClosesAndThereArePendingAcks() throws Exception {
+        final String queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis();
+        final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
+
+        @SuppressWarnings("unchecked")
+        AmqpConnectionDetails amqpConnectionDetails = AmqpConnectionDetails.create("invalid", 5673)
+                .withHostsAndPorts(Pair.create("localhost", 5672), Pair.create("localhost", 5674));
+
+        final Sink<ByteString, CompletionStage<Done>> amqpSink = AmqpSink.createSimple(
+                AmqpSinkSettings.create(amqpConnectionDetails)
+                        .withRoutingKey(queueName)
+                        .withDeclarations(queueDeclaration)
+        );
+
+        final Integer bufferSize = 10;
+        final Source<CommittableIncomingMessage, NotUsed> amqpSource = AmqpSource.committableSource(
+                NamedQueueSourceSettings.create(
+                        DefaultAmqpConnection.getInstance(),
+                        queueName
+                ).withDeclarations(queueDeclaration),
+                bufferSize
+        );
+
+        final List<String> input = Arrays.asList("one", "two", "three", "four", "five");
+        Source.from(input).map(ByteString::fromString).runWith(amqpSink, materializer);
+
+        final CompletionStage<List<CommittableIncomingMessage>> result =
+                amqpSource
+                        .take(input.size()).runWith(Sink.seq(), materializer);
+
+        result.toCompletableFuture().get(3, TimeUnit.SECONDS).stream().map(cm -> cm.ack(false));
+    }
+
+    @Test
     public void setRoutingKeyPerMessageAndConsumeThemInTheSameJVM() throws Exception {
         final String exchangeName = "amqp.topic." + System.currentTimeMillis();
         final ExchangeDeclaration exchangeDeclaration = ExchangeDeclaration.create(exchangeName, "topic");

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
@@ -333,7 +333,7 @@ public class AmqpConnectorsTest {
     }
 
     @Test
-    public void keepConnectionPpenIfDownstreamClosesAndThereArePendingAcks() throws Exception {
+    public void keepConnectionOpenIfDownstreamClosesAndThereArePendingAcks() throws Exception {
         final String queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis();
         final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
 
@@ -357,7 +357,8 @@ public class AmqpConnectorsTest {
         );
 
         final List<String> input = Arrays.asList("one", "two", "three", "four", "five");
-        Source.from(input).map(ByteString::fromString).runWith(amqpSink, materializer);
+        Source.from(input).map(ByteString::fromString).runWith(amqpSink, materializer)
+                .toCompletableFuture().get(3, TimeUnit.SECONDS);
 
         final CompletionStage<List<CommittableIncomingMessage>> result =
                 amqpSource

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -418,7 +418,6 @@ class AmqpConnectorsSpec extends AmqpSpec {
       val input = Vector("one", "two", "three", "four", "five")
       Source(input).map(s => ByteString(s)).runWith(amqpSink).futureValue shouldEqual Done
 
-
       val amqpSource = AmqpSource.committableSource(
         NamedQueueSourceSettings(connectionSettings, queueName).withDeclarations(queueDeclaration),
         bufferSize = 10


### PR DESCRIPTION
I found some issues with the way the unacknowledged messages are tracked in the AMQP connector.

I also move around a couple things so it's easier to compare the SourceStage and the FlowStage to ensure that both use the same logic. In the future it might make sense to merge them in one stage (as the MQTT connector).