### PR TITLE
Remove mosquette from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,3 @@ target/
 ext-lib-src/
 .ensime
 .ensime_cache/
-moquette_store.mapdb
-moquette_store.mapdb.p
-moquette_store.mapdb.t


### PR DESCRIPTION
Closes #284  

Mosquette was actually removed on long time ago (https://github.com/akka/alpakka/commit/67be7aeddbdb50d4d5858d3466e39a149bb568e4)
So the files can be removed from .gitignore and the issue can be closed.