### PR TITLE
[MQTT] Allow setting QoS & retained per message

### DIFF
--- a/docs/src/main/paradox/mqtt.md
+++ b/docs/src/main/paradox/mqtt.md
@@ -65,6 +65,13 @@ Scala
 Java
 : @@snip ($alpakka$/mqtt/src/test/java/akka/stream/alpakka/mqtt/javadsl/MqttSourceTest.java) { #run-sink }
 
+The QoS and the retained flag can be configured on a per-message basis.
+Scala
+: @@snip ($alpakka$/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala) { #will-message }
+
+Java
+: @@snip ($alpakka$/mqtt/src/test/java/akka/stream/alpakka/mqtt/javadsl/MqttSourceTest.java) { #will-message }
+
 It is also possible to connect to the MQTT server in bidirectional fashion, using a single underlying connection (and client ID). To do that create an MQTT flow that combines the functionalities of an MQTT source and an MQTT sink.
 
 Scala

--- a/mqtt/src/main/scala/akka/stream/alpakka/mqtt/Mqtt.scala
+++ b/mqtt/src/main/scala/akka/stream/alpakka/mqtt/Mqtt.scala
@@ -130,6 +130,24 @@ object MqttMessage {
    */
   def create(topic: String, payload: ByteString) =
     MqttMessage(topic, payload)
+
+  /**
+   * Java API: create  [[MqttMessage]]
+   */
+  def create(topic: String, payload: ByteString, qos: MqttQoS) =
+    MqttMessage(topic, payload, Some(qos))
+
+  /**
+   * Java API: create  [[MqttMessage]]
+   */
+  def create(topic: String, payload: ByteString, retained: Boolean) =
+    MqttMessage(topic, payload, retained = retained)
+
+  /**
+   * Java API: create  [[MqttMessage]]
+   */
+  def create(topic: String, payload: ByteString, qos: MqttQoS, retained: Boolean) =
+    MqttMessage(topic, payload, Some(qos), retained = retained)
 }
 
 /**

--- a/mqtt/src/main/scala/akka/stream/alpakka/mqtt/MqttFlowStage.scala
+++ b/mqtt/src/main/scala/akka/stream/alpakka/mqtt/MqttFlowStage.scala
@@ -76,7 +76,8 @@ final class MqttFlowStage(sourceSettings: MqttSourceSettings,
               case Some(client) =>
                 val msg = grab(in)
                 val pahoMsg = new PahoMqttMessage(msg.payload.toArray)
-                pahoMsg.setQos(qos.byteValue)
+                pahoMsg.setQos(msg.qos.getOrElse(qos).byteValue)
+                pahoMsg.setRetained(msg.retained)
                 client.publish(msg.topic, pahoMsg, msg, onPublished.invoke _)
               case None => failStage(NoClientException)
             }

--- a/mqtt/src/test/java/akka/stream/alpakka/mqtt/javadsl/MqttSourceTest.java
+++ b/mqtt/src/test/java/akka/stream/alpakka/mqtt/javadsl/MqttSourceTest.java
@@ -79,7 +79,7 @@ public class MqttSourceTest {
     unackedResult.first().toCompletableFuture().get(5, TimeUnit.SECONDS);
 
     final Sink<MqttMessage, CompletionStage<Done>> mqttSink = MqttSink.create(sinkSettings, MqttQoS.atLeastOnce());
-    Source.from(input).map(s -> new MqttMessage(topic, ByteString.fromString(s))).runWith(mqttSink, materializer);
+    Source.from(input).map(s -> MqttMessage.create(topic, ByteString.fromString(s))).runWith(mqttSink, materializer);
 
     assertEquals(input, unackedResult.second().toCompletableFuture().get(5, TimeUnit.SECONDS).stream().map(m -> m.message().payload().utf8String()).collect(Collectors.toList()));
 
@@ -120,7 +120,7 @@ public class MqttSourceTest {
 
     unackedResult.first().toCompletableFuture().get(5, TimeUnit.SECONDS);
 
-    Source.from(input).map(s -> new MqttMessage(topic, ByteString.fromString(s)))
+    Source.from(input).map(s -> MqttMessage.create(topic, ByteString.fromString(s)))
           .runWith(mqttSink, materializer)
           .toCompletableFuture()
           .get(3, TimeUnit.SECONDS);

--- a/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSinkSpec.scala
+++ b/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSinkSpec.scala
@@ -104,7 +104,7 @@ class MqttSinkSpec
     }
 
     "received retained message on new client" in {
-      val msg = MqttMessage(topic, ByteString("ohi"), Some(MqttQoS.atLeastOnce), true)
+      val msg = MqttMessage(topic, ByteString("ohi"), Some(MqttQoS.atLeastOnce), retained = true)
 
       val messageSent = Source.single(msg).runWith(MqttSink(sinkSettings, MqttQoS.atLeastOnce))
 

--- a/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSinkSpec.scala
+++ b/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSinkSpec.scala
@@ -114,7 +114,7 @@ class MqttSinkSpec
         .withClientId("source-spec/retained")
 
       val messageFuture =
-        MqttSource(MqttSourceSettings(retainedSinkSettings, Map(topic -> MqttQoS.atLeastOnce)), 8)
+        MqttSource.atMostOnce(MqttSourceSettings(retainedSinkSettings, Map(topic -> MqttQoS.atLeastOnce)), 8)
           .runWith(Sink.head)
 
       val message = messageFuture.futureValue

--- a/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSinkSpec.scala
+++ b/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSinkSpec.scala
@@ -102,5 +102,24 @@ class MqttSinkSpec
 
       termination.futureValue shouldBe Done
     }
+
+    "received retained message on new client" in {
+      val msg = MqttMessage(topic, ByteString("ohi"), Some(MqttQoS.atLeastOnce), true)
+
+      val messageSent = Source.single(msg).runWith(MqttSink(sinkSettings, MqttQoS.atLeastOnce))
+
+      Await.ready(messageSent, 3 seconds)
+
+      val retainedSinkSettings = sourceSettings
+        .withClientId("source-spec/retained")
+
+      val messageFuture =
+        MqttSource(MqttSourceSettings(retainedSinkSettings, Map(topic -> MqttQoS.atLeastOnce)), 8)
+          .runWith(Sink.head)
+
+      val message = messageFuture.futureValue
+      message.topic shouldBe msg.topic
+      message.payload shouldBe msg.payload
+    }
   }
 }

--- a/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSinkSpec.scala
+++ b/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSinkSpec.scala
@@ -114,7 +114,8 @@ class MqttSinkSpec
         .withClientId("source-spec/retained")
 
       val messageFuture =
-        MqttSource.atMostOnce(MqttSourceSettings(retainedSinkSettings, Map(topic -> MqttQoS.atLeastOnce)), 8)
+        MqttSource
+          .atMostOnce(MqttSourceSettings(retainedSinkSettings, Map(topic -> MqttQoS.atLeastOnce)), 8)
           .runWith(Sink.head)
 
       val message = messageFuture.futureValue

--- a/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala
+++ b/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala
@@ -241,7 +241,7 @@ class MqttSourceSpec
       elem2.futureValue shouldBe MqttMessage(topic1, ByteString("ohi"))
     }
 
-    "support will message" in {
+    "support will message" ignore {
       import system.dispatcher
 
       val msg = MqttMessage(topic1, ByteString("ohi"))

--- a/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala
+++ b/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala
@@ -246,6 +246,10 @@ class MqttSourceSpec
 
       val msg = MqttMessage(topic1, ByteString("ohi"))
 
+      //#will-message
+      val lastWill = MqttMessage(willTopic, ByteString("ohi"), Some(MqttQoS.AtLeastOnce), retained = true)
+      //#will-message
+
       // Create a proxy to RabbitMQ so it can be shutdown
       val (proxyBinding, connection) = Tcp().bind("localhost", 1337).toMat(Sink.head)(Keep.both).run()
       val proxyKs = connection.map(
@@ -261,7 +265,7 @@ class MqttSourceSpec
         sourceSettings
           .withClientId("source-spec/testator")
           .withBroker("tcp://localhost:1337")
-          .withWill(MqttMessage(willTopic, ByteString("ohi"), Some(MqttQoS.AtLeastOnce), retained = true)),
+          .withWill(lastWill),
         Map(topic1 -> MqttQoS.AtLeastOnce)
       )
       val source1 = MqttSource.atMostOnce(settings1, 8)

--- a/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala
+++ b/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala
@@ -241,7 +241,7 @@ class MqttSourceSpec
       elem2.futureValue shouldBe MqttMessage(topic1, ByteString("ohi"))
     }
 
-    "support will message" ignore {
+    "support will message" in {
       import system.dispatcher
 
       val msg = MqttMessage(topic1, ByteString("ohi"))

--- a/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala
+++ b/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala
@@ -261,7 +261,7 @@ class MqttSourceSpec
         sourceSettings
           .withClientId("source-spec/testator")
           .withBroker("tcp://localhost:1337")
-          .withWill(Will(MqttMessage(willTopic, ByteString("ohi")), MqttQoS.AtLeastOnce, retained = true)),
+          .withWill(MqttMessage(willTopic, ByteString("ohi"), Some(MqttQoS.AtLeastOnce), retained = true)),
         Map(topic1 -> MqttQoS.AtLeastOnce)
       )
       val source1 = MqttSource.atMostOnce(settings1, 8)


### PR DESCRIPTION
Closes #337

Allow setting QoS and retained flag per message.
Deprecate the old Will message since the new message already contains the necessary data.
Bring back the will test since I can't see why it was ignored.

No breaking changes in the existing APIs.