### PR TITLE
S3: sets default credentials provider to default

### DIFF
--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -48,7 +48,7 @@ akka.stream.alpakka.s3 {
       #   - credentials file
       #   - EC2 credentials service
       #   - IAM / metadata
-      provider = anon
+      provider = default
     }
     default-region = "us-west-2"
   }


### PR DESCRIPTION
Fixes inconsistency mentioned in #580 