### PR TITLE
S3: use default region provider

### DIFF
--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -57,18 +57,15 @@ akka.stream.alpakka.s3 {
       # supported providers:
       # static - static credentials,
       #   required params:
-      #     akka.stream.alpakka.s3.aws.region.default-region
-      #     OR akka.stream.alpakka.s3.aws.default-region
+      #     default-region
       # default: as described in com.amazonaws.regions.AwsRegionProvider.DefaultAwsRegionProviderChain docs,
       # attempts to get the region from either:
       #   - environment variables
       #   - system properties
       #   - progile file
       #   - EC2 metadata
-      provider = "static"
-      # default-region = "us-west-2"
+      provider = default
     }
-    default-region = "us-west-2"
   }
 
   # Enable path style access to s3, i.e. "https://s3-eu-west-1.amazonaws.com/my.bucket/myobject"

--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -50,6 +50,24 @@ akka.stream.alpakka.s3 {
       #   - IAM / metadata
       provider = anon
     }
+
+    # If this section is absent, the fallback behavior is to use the
+    # com.amazonaws.regions.AwsRegionProvider.DefaultAwsRegionProviderChain instance to resolve region
+    region {
+      # supported providers:
+      # static - static credentials,
+      #   required params:
+      #     akka.stream.alpakka.s3.aws.region.default-region
+      #     OR akka.stream.alpakka.s3.aws.default-region
+      # default: as described in com.amazonaws.regions.AwsRegionProvider.DefaultAwsRegionProviderChain docs,
+      # attempts to get the region from either:
+      #   - environment variables
+      #   - system properties
+      #   - progile file
+      #   - EC2 metadata
+      provider = "static"
+      # default-region = "us-west-2"
+    }
     default-region = "us-west-2"
   }
 

--- a/s3/src/main/scala/akka/stream/alpakka/s3/S3Settings.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/S3Settings.scala
@@ -94,13 +94,7 @@ object S3Settings {
       val regionProviderPath = "aws.region.provider"
 
       val staticRegionProvider = new AwsRegionProvider {
-        lazy val getRegion: String = {
-          if (s3Config.hasPath("aws.region.default-region")) {
-            s3Config.getString("aws.region.default-region")
-          } else {
-            s3Config.getString("aws.default-region")
-          }
-        }
+        lazy val getRegion: String = s3Config.getString("aws.region.default-region")
       }
 
       if (s3Config.hasPath(regionProviderPath)) {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -33,7 +33,7 @@ private[alpakka] object HttpRequests {
     )
 
     HttpRequest(HttpMethods.GET)
-      .withHeaders(Host(requestHost(bucket, conf.s3Region)))
+      .withHeaders(Host(requestHost(bucket, conf.s3RegionProvider.getRegion)))
       .withUri(requestUri(bucket, None).withQuery(query))
   }
 
@@ -85,7 +85,7 @@ private[alpakka] object HttpRequests {
                               method: HttpMethod = HttpMethods.GET,
                               uriFn: (Uri => Uri) = identity)(implicit conf: S3Settings): HttpRequest =
     HttpRequest(method)
-      .withHeaders(Host(requestHost(s3Location.bucket, conf.s3Region)))
+      .withHeaders(Host(requestHost(s3Location.bucket, conf.s3RegionProvider.getRegion)))
       .withUri(uriFn(requestUri(s3Location.bucket, Some(s3Location.key))))
 
   @throws(classOf[IllegalUriException])
@@ -131,9 +131,9 @@ private[alpakka] object HttpRequests {
     val path = key.fold(basePath) { someKey =>
       someKey.split("/").foldLeft(basePath)((acc, p) => acc / p)
     }
-    val uri = Uri(path = path, authority = Authority(requestHost(bucket, conf.s3Region)))
+    val uri = Uri(path = path, authority = Authority(requestHost(bucket, conf.s3RegionProvider.getRegion)))
     conf.proxy match {
-      case None => uri.withScheme("https").withHost(requestHost(bucket, conf.s3Region))
+      case None => uri.withScheme("https").withHost(requestHost(bucket, conf.s3RegionProvider.getRegion))
       case Some(proxy) => uri.withPort(proxy.port).withScheme(proxy.scheme).withHost(proxy.host)
     }
   }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -59,7 +59,10 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
   implicit val conf = settings
   val MinChunkSize = 5242880 //in bytes
   // def because tokens can expire
-  def signingKey = SigningKey(settings.credentialsProvider, CredentialScope(LocalDate.now(), settings.s3Region, "s3"))
+  def signingKey = SigningKey(
+    settings.credentialsProvider,
+    CredentialScope(LocalDate.now(), settings.s3RegionProvider.getRegion, "s3")
+  )
 
   def download(s3Location: S3Location, range: Option[ByteRange] = None): Source[ByteString, NotUsed] = {
     import mat.executionContext

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -79,6 +79,10 @@ object S3Client {
 
     new S3Client(settings, system, mat)
   }
+
+  def create(s3Settings: S3Settings)(implicit system: ActorSystem, mat: Materializer): S3Client = {
+    new S3Client(s3Settings, system, mat)
+  }
 }
 
 final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materializer) {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -80,9 +80,8 @@ object S3Client {
     new S3Client(settings, system, mat)
   }
 
-  def create(s3Settings: S3Settings)(implicit system: ActorSystem, mat: Materializer): S3Client = {
+  def create(s3Settings: S3Settings)(implicit system: ActorSystem, mat: Materializer): S3Client =
     new S3Client(s3Settings, system, mat)
-  }
 }
 
 final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materializer) {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -6,22 +6,25 @@ package akka.stream.alpakka.s3.javadsl
 
 import java.time.Instant
 import java.util.concurrent.CompletionStage
+
 import scala.compat.java8.FutureConverters._
+
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.impl.model.JavaUri
 import akka.http.javadsl.model.headers.ByteRange
 import akka.http.javadsl.model.{ContentType, HttpResponse, Uri}
-import akka.http.scaladsl.model.headers.{ByteRange ⇒ ScalaByteRange}
-import akka.http.scaladsl.model.{ContentTypes, ContentType ⇒ ScalaContentType}
+import akka.http.scaladsl.model.headers.{ByteRange => ScalaByteRange}
+import akka.http.scaladsl.model.{ContentTypes, ContentType => ScalaContentType}
 import akka.stream.Materializer
 import akka.stream.alpakka.s3.S3Settings
 import akka.stream.alpakka.s3.acl.CannedAcl
-import akka.stream.alpakka.s3.auth.{AWSCredentials ⇒ OldAWSCredentials}
+import akka.stream.alpakka.s3.auth.{AWSCredentials => OldAWSCredentials}
 import akka.stream.alpakka.s3.impl._
 import akka.stream.javadsl.{Sink, Source}
 import akka.util.ByteString
 import com.amazonaws.auth._
+import com.amazonaws.regions.AwsRegionProvider
 import com.typesafe.config.ConfigFactory
 
 final case class MultipartUploadResult(location: Uri, bucket: String, key: String, etag: String)
@@ -58,13 +61,22 @@ object S3Client {
       region
     )
 
-  def create(credentials: AWSCredentialsProvider, region: String)(implicit system: ActorSystem,
-                                                                  mat: Materializer): S3Client = {
-
-    val settings = S3Settings(ConfigFactory.load()).copy(
-      credentialsProvider = credentials,
-      s3Region = region
+  def create(credentialsProvider: AWSCredentialsProvider, region: String)(implicit system: ActorSystem,
+                                                                          mat: Materializer): S3Client =
+    create(
+      credentialsProvider,
+      new AwsRegionProvider {
+        def getRegion: String = region
+      }
     )
+
+  def create(credentialsProvider: AWSCredentialsProvider,
+             regionProvider: AwsRegionProvider)(implicit system: ActorSystem, mat: Materializer): S3Client = {
+    val settings = S3Settings(ConfigFactory.load()).copy(
+      credentialsProvider = credentialsProvider,
+      s3RegionProvider = regionProvider
+    )
+
     new S3Client(settings, system, mat)
   }
 }

--- a/s3/src/test/java/akka/stream/alpakka/s3/javadsl/DocSnippets.java
+++ b/s3/src/test/java/akka/stream/alpakka/s3/javadsl/DocSnippets.java
@@ -12,6 +12,7 @@ import akka.stream.alpakka.s3.S3Settings;
 import akka.stream.alpakka.s3.scaladsl.S3WireMockBase;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.AwsRegionProvider;
 import scala.Some;
 
 public class DocSnippets extends S3WireMockBase {
@@ -32,6 +33,11 @@ public class DocSnippets extends S3WireMockBase {
                         "mySecretAccessKey"
                 )
         );
+        final AwsRegionProvider regionProvider = new AwsRegionProvider() {
+            public String getRegion() {
+                return "";
+            }
+        };
         final Proxy proxy = new Proxy(host, port, "https");
 
         // Set pathStyleAccess to true and specify proxy, leave region blank
@@ -39,7 +45,7 @@ public class DocSnippets extends S3WireMockBase {
                 MemoryBufferType.getInstance(),
                 Some.apply(proxy),
                 credentials,
-                "",
+                regionProvider,
                 true
         );
         final S3Client s3Client = new S3Client(settings,system(), mat);

--- a/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
+++ b/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
@@ -19,9 +19,11 @@ import akka.stream.alpakka.s3.scaladsl.S3WireMockBase;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.AwsRegionProvider;
 import org.junit.Test;
 import scala.Option;
 import scala.Some;
@@ -38,12 +40,21 @@ public class S3ClientTest extends S3WireMockBase {
             new BasicAWSCredentials("my-AWS-access-key-ID", "my-AWS-password")
     );
 
+    private AwsRegionProvider regionProvider(String region) {
+        return new AwsRegionProvider() {
+            @Override
+            public String getRegion() throws SdkClientException {
+                return region;
+            }
+        };
+    };
+
     private final Proxy proxy = new Proxy("localhost",port(),"http");
     private final S3Settings settings = new S3Settings(
             MemoryBufferType.getInstance(),
             Some.apply(proxy),
             credentials,
-            "us-east-1",
+            regionProvider("us-east-1"),
             false
     );
     private final S3Client client = new S3Client(settings, system(), materializer);

--- a/s3/src/test/scala/akka/stream/alpakka/s3/S3SettingsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/S3SettingsSpec.scala
@@ -116,7 +116,8 @@ class S3SettingsSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     val otherRegion = "testRegion"
 
     val settings: S3Settings = mkConfig(
-      s"""akka.stream.alpakka.s3.aws.region.provider = static
+      s"""
+         |akka.stream.alpakka.s3.aws.region.provider = static
          |akka.stream.alpakka.s3.aws.default-region = $otherRegion
          |""".stripMargin
     )
@@ -128,5 +129,25 @@ class S3SettingsSpec extends S3WireMockBase with S3ClientIntegrationSpec {
       "akka.stream.alpakka.s3.aws.region.provider = default" // no credentials section
     )
     settings.s3RegionProvider shouldBe a[DefaultAwsRegionProviderChain]
+  }
+
+  it should "be able to instantiate using custom config prefix" in {
+    val myS3ConfigPrefix = "my-s3-config"
+    val otherRegion = "testRegion"
+
+    val settings: S3Settings = S3Settings.apply(
+      ConfigFactory.parseString(
+        s"""
+           |$myS3ConfigPrefix.aws.region.provider = static
+           |$myS3ConfigPrefix.aws.default-region = $otherRegion
+           |$myS3ConfigPrefix.buffer = memory
+           |$myS3ConfigPrefix.path-style-access = true
+        """.stripMargin
+      ),
+      myS3ConfigPrefix
+    )
+
+    settings.pathStyleAccess shouldBe true
+    settings.s3RegionProvider.getRegion shouldBe otherRegion
   }
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/S3SettingsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/S3SettingsSpec.scala
@@ -15,7 +15,6 @@ class S3SettingsSpec extends S3WireMockBase with S3ClientIntegrationSpec {
       ConfigFactory.parseString(
         s"""
           |akka.stream.alpakka.s3.buffer = memory
-          |akka.stream.alpakka.s3.aws.default-region = us-east-1
           |akka.stream.alpakka.s3.path-style-access = false
           |$more
         """.stripMargin
@@ -105,20 +104,9 @@ class S3SettingsSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     val otherRegion = "testRegion"
 
     val settings: S3Settings = mkConfig(
-      s"""akka.stream.alpakka.s3.aws.region.provider = static
-         |akka.stream.alpakka.s3.aws.region.default-region = $otherRegion
-         |""".stripMargin
-    )
-    settings.s3RegionProvider.getRegion shouldBe otherRegion
-  }
-
-  it should "use region from old configuration path when using static region provider for BC" in {
-    val otherRegion = "testRegion"
-
-    val settings: S3Settings = mkConfig(
       s"""
          |akka.stream.alpakka.s3.aws.region.provider = static
-         |akka.stream.alpakka.s3.aws.default-region = $otherRegion
+         |akka.stream.alpakka.s3.aws.region.default-region = $otherRegion
          |""".stripMargin
     )
     settings.s3RegionProvider.getRegion shouldBe otherRegion
@@ -139,7 +127,7 @@ class S3SettingsSpec extends S3WireMockBase with S3ClientIntegrationSpec {
       ConfigFactory.parseString(
         s"""
            |$myS3ConfigPrefix.aws.region.provider = static
-           |$myS3ConfigPrefix.aws.default-region = $otherRegion
+           |$myS3ConfigPrefix.aws.region.default-region = $otherRegion
            |$myS3ConfigPrefix.buffer = memory
            |$myS3ConfigPrefix.path-style-access = true
         """.stripMargin

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -11,6 +11,7 @@ import akka.stream.alpakka.s3.acl.CannedAcl
 import akka.stream.alpakka.s3.{BufferType, MemoryBufferType, Proxy, S3Settings}
 import akka.stream.scaladsl.Source
 import com.amazonaws.auth.{AWSCredentialsProvider, AWSStaticCredentialsProvider, AnonymousAWSCredentials}
+import com.amazonaws.regions.AwsRegionProvider
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -23,8 +24,13 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
       awsCredentials: AWSCredentialsProvider = new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()),
       s3Region: String = "us-east-1",
       pathStyleAccess: Boolean = false
-  ) =
-    new S3Settings(bufferType, proxy, awsCredentials, s3Region, pathStyleAccess)
+  ) = {
+    val regionProvider = new AwsRegionProvider {
+      def getRegion = s3Region
+    }
+
+    new S3Settings(bufferType, proxy, awsCredentials, regionProvider, pathStyleAccess)
+  }
 
   val location = S3Location("bucket", "image-1024@2x")
   val contentType = MediaTypes.`image/jpeg`

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/AwsS3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/AwsS3IntegrationSpec.scala
@@ -14,9 +14,10 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Ignore, Matchers}
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
+
+import com.amazonaws.regions.AwsRegionProvider
 
 /*
  * This is an integration test and ignored by default
@@ -43,13 +44,19 @@ class AwsS3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matc
     PatienceConfig(timeout = Span(5, Seconds), interval = Span(30, Millis))
 
   val defaultRegion = "us-east-1"
+  val defaultRegionProvider = new AwsRegionProvider {
+    val getRegion: String = defaultRegion
+  }
   val defaultRegionBucket = "my-test-us-east-1"
 
   val otherRegion = "eu-central-1"
+  val otherRegionProvider = new AwsRegionProvider {
+    val getRegion: String = otherRegion
+  }
   val otherRegionBucket = "my.test.frankfurt" // with dots forcing path style access
 
-  val settings = S3Settings(ConfigFactory.load().getConfig("aws")).copy(s3Region = defaultRegion)
-  val otherRegionSettings = settings.copy(pathStyleAccess = true, s3Region = otherRegion)
+  val settings = S3Settings(ConfigFactory.load().getConfig("aws")).copy(s3RegionProvider = defaultRegionProvider)
+  val otherRegionSettings = settings.copy(pathStyleAccess = true, s3RegionProvider = otherRegionProvider)
 
   val defaultRegionClient = new S3Client(settings)
   val otherRegionClient = new S3Client(otherRegionSettings)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/DocSnippets.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/DocSnippets.scala
@@ -8,6 +8,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.s3.{MemoryBufferType, Proxy, S3Settings}
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.regions.AwsRegionProvider
 
 object DoucmentationSnippets {
 
@@ -19,16 +20,19 @@ object DoucmentationSnippets {
     val host = "s3.eu-geo.objectstorage.softlayer.net"
     val port = 443
 
-    val credentials = new AWSStaticCredentialsProvider(
+    val credentialsProvider = new AWSStaticCredentialsProvider(
       new BasicAWSCredentials(
         "myAccessKeyId",
         "mySecretAccessKey"
       )
     )
+    val regionProvider = new AwsRegionProvider {
+      def getRegion = ""
+    }
     val proxy = Some(Proxy(host, port, "https"))
 
     // Set pathStyleAccess to true and specify proxy, leave region blank
-    val settings = new S3Settings(MemoryBufferType, proxy, credentials, "", true)
+    val settings = new S3Settings(MemoryBufferType, proxy, credentialsProvider, regionProvider, true)
     val s3Client = new S3Client(settings)(system, materializer)
     // #scala-bluemix-example
   }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
@@ -9,15 +9,21 @@ import akka.stream.alpakka.s3.impl.{S3Headers, ServerSideEncryption}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import scala.concurrent.Future
+
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.regions.AwsRegionProvider
 
 class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
 
-  val awsCredentials = new AWSStaticCredentialsProvider(
+  val awsCredentialsProvider = new AWSStaticCredentialsProvider(
     new BasicAWSCredentials("my-AWS-access-key-ID", "my-AWS-password")
   )
+  val regionProvider =
+    new AwsRegionProvider {
+      def getRegion: String = "us-east-1"
+    }
   val proxy = Option(Proxy("localhost", port, "http"))
-  val settings = new S3Settings(MemoryBufferType, proxy, awsCredentials, "us-east-1", false)
+  val settings = new S3Settings(MemoryBufferType, proxy, awsCredentialsProvider, regionProvider, false)
   val s3Client = new S3Client(settings)(system, materializer)
 
   "S3Sink" should "upload a stream of bytes to S3" in {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
@@ -10,16 +10,22 @@ import akka.stream.alpakka.s3.{MemoryBufferType, Proxy, S3Exception, S3Settings}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import scala.concurrent.Future
+
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.regions.AwsRegionProvider
 
 class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
 
   //#client
-  val awsCredentials = new AWSStaticCredentialsProvider(
+  val awsCredentialsProvider = new AWSStaticCredentialsProvider(
     new BasicAWSCredentials("my-AWS-access-key-ID", "my-AWS-password")
   )
+  val regionProvider =
+    new AwsRegionProvider {
+      def getRegion: String = "us-east-1"
+    }
   val proxy = Option(Proxy("localhost", port, "http"))
-  val settings = new S3Settings(MemoryBufferType, proxy, awsCredentials, "us-east-1", false)
+  val settings = new S3Settings(MemoryBufferType, proxy, awsCredentialsProvider, regionProvider, false)
   val s3Client = new S3Client(settings)(system, materializer)
   //#client
 


### PR DESCRIPTION
Suggestion to continue with the approach used in https://github.com/akka/alpakka/pull/440 to use default AWS resolver for `region` as well.

Potentially simplifies configuration of an application when using AWS.