### PR TITLE
HBase example refinement

### DIFF
--- a/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala
+++ b/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala
@@ -22,13 +22,12 @@ import scala.util.{Failure, Success}
 
 class HBaseStageSpec extends WordSpec with Matchers {
 
-  implicit def toBytes(string: String): Array[Byte] = Bytes.toBytes(string)
-
-  case class Person(id: Int, name: String)
-
   val hbaseIT = sys.env.get("HBASE_TEST")
 
   //#create-converter
+  implicit def toBytes(string: String): Array[Byte] = Bytes.toBytes(string)
+  case class Person(id: Int, name: String)
+
   val hBaseConverter: Person => Put = { person =>
     val put = new Put(s"id_${person.id}")
     put.addColumn("info", "name", person.name)


### PR DESCRIPTION
I think that example should look like that because it is self-explanatory. It does not suggest that `Put` has constructor that operates on `String` argument.