### PR TITLE
AWS S3: Support for customer key server side encryption

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Headers.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Headers.scala
@@ -76,7 +76,7 @@ object StorageClass {
 sealed abstract class ServerSideEncryption {
   def headers: immutable.Seq[HttpHeader]
 
-  def headers(request: S3Request): immutable.Seq[HttpHeader]
+  def headersFor(request: S3Request): immutable.Seq[HttpHeader]
 }
 
 object ServerSideEncryption {
@@ -84,7 +84,7 @@ object ServerSideEncryption {
   case object AES256 extends ServerSideEncryption {
     override def headers: immutable.Seq[HttpHeader] = RawHeader("x-amz-server-side-encryption", "AES256") :: Nil
 
-    override def headers(request: S3Request): immutable.Seq[HttpHeader] = request match {
+    override def headersFor(request: S3Request): immutable.Seq[HttpHeader] = request match {
       case PutObject | InitiateMultipartUpload => headers
       case _ => Nil
     }
@@ -107,7 +107,7 @@ object ServerSideEncryption {
       headers
     }
 
-    override def headers(request: S3Request): immutable.Seq[HttpHeader] = request match {
+    override def headersFor(request: S3Request): immutable.Seq[HttpHeader] = request match {
       case PutObject | InitiateMultipartUpload => headers
       case _ => Nil
     }
@@ -129,7 +129,7 @@ object ServerSideEncryption {
         md5
       })) :: Nil
 
-    override def headers(request: S3Request): immutable.Seq[HttpHeader] = request match {
+    override def headersFor(request: S3Request): immutable.Seq[HttpHeader] = request match {
       case GetObject | HeadObject | PutObject | InitiateMultipartUpload | UploadPart =>
         headers
       case _ => Nil

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Request.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Request.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.s3.impl
+
+trait S3Request
+
+case object GetObject extends S3Request
+
+case object HeadObject extends S3Request
+
+case object PutObject extends S3Request
+
+case object InitiateMultipartUpload extends S3Request
+
+case object UploadPart extends S3Request

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -189,9 +189,9 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
       s3Location: S3Location,
       contentType: ContentType = ContentTypes.`application/octet-stream`,
       s3Headers: S3Headers,
+      sse: Option[ServerSideEncryption] = None,
       chunkSize: Int = MinChunkSize,
-      chunkingParallelism: Int = 4,
-      sse: Option[ServerSideEncryption] = None
+      chunkingParallelism: Int = 4
   ): Sink[ByteString, Future[CompleteMultipartUploadResult]] =
     chunkAndRequest(s3Location, contentType, s3Headers, chunkSize, sse)(chunkingParallelism)
       .toMat(completionSink(s3Location))(Keep.right)

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -195,7 +195,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    */
   def getObjectMetadata(bucket: String, key: String): CompletionStage[Optional[ObjectMetadata]] =
     impl
-      .getObjectMetadata(bucket, key)
+      .getObjectMetadata(bucket, key, None)
       .map { opt =>
         Optional.ofNullable(opt.map(metaDataToJava).orNull)
       }(mat.executionContext)
@@ -250,7 +250,8 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
                  contentType.asInstanceOf[ScalaContentType],
                  data.asScala,
                  contentLength,
-                 s3Headers)
+                 s3Headers,
+                 None)
       .map(metaDataToJava)(mat.executionContext)
       .toJava
 
@@ -416,7 +417,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    */
   def download(bucket: String, key: String): Source[ByteString, CompletionStage[ObjectMetadata]] =
     impl
-      .download(S3Location(bucket, key))
+      .download(S3Location(bucket, key), None, None)
       .mapMaterializedValue(_.map(metaDataToJava)(mat.executionContext).toJava)
       .asJava
 
@@ -447,7 +448,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
   def download(bucket: String, key: String, range: ByteRange): Source[ByteString, CompletionStage[ObjectMetadata]] = {
     val scalaRange = range.asInstanceOf[ScalaByteRange]
     impl
-      .download(S3Location(bucket, key), Some(scalaRange))
+      .download(S3Location(bucket, key), Some(scalaRange), None)
       .mapMaterializedValue(_.map(metaDataToJava)(mat.executionContext).toJava)
       .asJava
   }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
@@ -6,8 +6,6 @@ package akka.stream.alpakka.s3.scaladsl
 
 import java.time.Instant
 
-import scala.concurrent.Future
-import akka.{Done, NotUsed}
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{`Content-Length`, `Last-Modified`, ByteRange, ETag}
@@ -18,9 +16,11 @@ import akka.stream.alpakka.s3.auth.{AWSCredentials => OldAWSCredentials}
 import akka.stream.alpakka.s3.impl._
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
+import akka.{Done, NotUsed}
 import com.amazonaws.auth._
 
 import scala.collection.immutable.Seq
+import scala.concurrent.Future
 
 final case class MultipartUploadResult(location: Uri, bucket: String, key: String, etag: String)
 
@@ -182,21 +182,27 @@ final class S3Client(val s3Settings: S3Settings)(implicit system: ActorSystem, m
    * @param bucket the s3 bucket name
    * @param key the s3 object key
    * @param method the [[HttpMethod]] to use when making the request
-   * @param sse the server side encryption to use
+   * @param s3Headers any headers you want to add
    * @return a [[Future]] containing the raw [[HttpResponse]]
    */
-  def request(bucket: String, key: String, method: HttpMethod = HttpMethods.GET, sse: Option[ServerSideEncryption] = None): Future[HttpResponse] =
-    impl.request(S3Location(bucket, key), method, sse = sse)
+  def request(bucket: String,
+              key: String,
+              method: HttpMethod = HttpMethods.GET,
+              s3Headers: S3Headers = S3Headers.empty): Future[HttpResponse] =
+    impl.request(S3Location(bucket, key), method, s3Headers = s3Headers)
 
   /**
    * Gets the metadata for a S3 Object
    *
    * @param bucket the s3 bucket name
    * @param key the s3 object key
+   * @param sse the server side encryption to use
    * @return A [[Future]] containing an [[Option]] that will be [[None]] in case the object does not exist
    */
-  def getObjectMetadata(bucket: String, key: String): Future[Option[ObjectMetadata]] =
-    impl.getObjectMetadata(bucket, key)
+  def getObjectMetadata(bucket: String,
+                        key: String,
+                        sse: Option[ServerSideEncryption] = None): Future[Option[ObjectMetadata]] =
+    impl.getObjectMetadata(bucket, key, sse)
 
   /**
    * Deletes a S3 Object
@@ -217,6 +223,7 @@ final class S3Client(val s3Settings: S3Settings)(implicit system: ActorSystem, m
    * @param contentLength the number of bytes that will be uploaded (required!)
    * @param contentType an optional [[ContentType]]
    * @param s3Headers any headers you want to add
+   * @param sse the server side encryption to use
    * @return a [[Future]] containing the [[ObjectMetadata]] of the uploaded S3 Object
    */
   def putObject(bucket: String,
@@ -224,44 +231,24 @@ final class S3Client(val s3Settings: S3Settings)(implicit system: ActorSystem, m
                 data: Source[ByteString, _],
                 contentLength: Long,
                 contentType: ContentType = ContentTypes.`application/octet-stream`,
-                s3Headers: S3Headers): Future[ObjectMetadata] =
-    impl.putObject(S3Location(bucket, key), contentType, data, contentLength, s3Headers)
+                s3Headers: S3Headers,
+                sse: Option[ServerSideEncryption] = None): Future[ObjectMetadata] =
+    impl.putObject(S3Location(bucket, key), contentType, data, contentLength, s3Headers, sse)
 
   /**
    * Downloads a S3 Object
    *
    * @param bucket the s3 bucket name
    * @param key the s3 object key
-   * @return A [[Source]] of [[ByteString]] that materializes into a [[Future]] containing the [[ObjectMetadata]]
-   */
-  def download(bucket: String, key: String): Source[ByteString, Future[ObjectMetadata]] =
-    impl.download(S3Location(bucket, key))
-
-  /**
-   * Downloads a S3 Object
-   *
-   * @param bucket the s3 bucket name
-   * @param key the s3 object key
-   * @param sse the server side encryption used on upload
-   * @return A [[Source]] of [[ByteString]] that materializes into a [[Future]] containing the [[ObjectMetadata]]
-   */
-  def download(bucket: String, key: String, sse: ServerSideEncryption): Source[ByteString, Future[ObjectMetadata]] =
-    impl.download(S3Location(bucket, key), sse = Some(sse))
-
-  /**
-   * Downloads a specific byte range of a S3 Object
-   *
-   * @param bucket the s3 bucket name
-   * @param key the s3 object key
-   * @param range the [[ByteRange]] you want to download
+   * @param range [optional] the [[ByteRange]] you want to download
    * @param sse [optional] the server side encryption used on upload
    * @return A [[Source]] of [[ByteString]] that materializes into a [[Future]] containing the [[ObjectMetadata]]
    */
   def download(bucket: String,
                key: String,
-               range: ByteRange,
+               range: Option[ByteRange] = None,
                sse: Option[ServerSideEncryption] = None): Source[ByteString, Future[ObjectMetadata]] =
-    impl.download(S3Location(bucket, key), Some(range), sse)
+    impl.download(S3Location(bucket, key), range, sse)
 
   /**
    * Will return a source of object metadata for a given bucket with optional prefix.

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
@@ -299,9 +299,9 @@ final class S3Client(val s3Settings: S3Settings)(implicit system: ActorSystem, m
         S3Location(bucket, key),
         contentType,
         S3Headers(cannedAcl, metaHeaders),
+        sse,
         chunkSize,
-        chunkingParallelism,
-        sse
+        chunkingParallelism
       )
       .mapMaterializedValue(_.map(MultipartUploadResult.apply)(system.dispatcher))
 
@@ -330,9 +330,9 @@ final class S3Client(val s3Settings: S3Settings)(implicit system: ActorSystem, m
         S3Location(bucket, key),
         contentType,
         s3Headers.getOrElse(S3Headers.empty),
+        sse,
         chunkSize,
-        chunkingParallelism,
-        sse
+        chunkingParallelism
       )
       .mapMaterializedValue(_.map(MultipartUploadResult.apply)(system.dispatcher))
 }

--- a/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
+++ b/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
@@ -112,9 +112,24 @@ public class S3ClientTest extends S3WireMockBase {
 
         Optional<ObjectMetadata> result = source.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
+        Optional<String> s3eTag = result.get().getETag();
+
+        assertEquals(s3eTag, Optional.of(etag()));
+    }
+
+    @Test
+    public void headServerSideEncryption() throws Exception {
+        mockHeadSSEC();
+
+        //#objectMetadata
+        final CompletionStage<Optional<ObjectMetadata>> source = client.getObjectMetadata(bucket(), bucketKey(), sseCustomerKeys());
+        //#objectMetadata
+
+        Optional<ObjectMetadata> result = source.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
         Optional<String> etag = result.get().getETag();
 
-        assertEquals(etag, Optional.of("5b27a21a97fcf8a7004dd1d906e7a5ba"));
+        assertEquals(etag, Optional.of(etagSSE()));
     }
 
     @Test

--- a/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
+++ b/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
@@ -17,6 +17,7 @@ import akka.stream.Materializer;
 import akka.stream.alpakka.s3.MemoryBufferType;
 import akka.stream.alpakka.s3.Proxy;
 import akka.stream.alpakka.s3.S3Settings;
+import akka.stream.alpakka.s3.impl.ServerSideEncryption;
 import akka.stream.alpakka.s3.scaladsl.S3WireMockBase;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
@@ -69,6 +70,23 @@ public class S3ClientTest extends S3WireMockBase {
     }
 
     @Test
+    public void multipartUploadSSE() throws Exception {
+
+        mockUploadSSE();
+
+        //#upload
+        final Sink<ByteString, CompletionStage<MultipartUploadResult>> sink = client.multipartUpload(bucket(), bucketKey(), sseCustomerKeys());
+        //#upload
+
+        final CompletionStage<MultipartUploadResult> resultCompletionStage =
+                Source.single(ByteString.fromString(body())).runWith(sink, materializer);
+
+        MultipartUploadResult result = resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+        assertEquals(new MultipartUploadResult(Uri.create(url()), bucket(), bucketKey(), etag()), result);
+    }
+
+    @Test
     public void download() throws Exception {
 
         mockDownload();
@@ -100,6 +118,22 @@ public class S3ClientTest extends S3WireMockBase {
     }
 
     @Test
+    public void downloadServerSideEncryption() throws Exception {
+        mockDownloadSSEC();
+
+        //#download
+        final Source<ByteString, CompletionStage<ObjectMetadata>> source = client.download(bucket(), bucketKey(), sseCustomerKeys());
+        //#download
+
+        final CompletionStage<String> resultCompletionStage =
+                source.map(ByteString::utf8String).runWith(Sink.head(), materializer);
+
+        String result = resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+        assertEquals(bodySSE(), result);
+    }
+
+    @Test
     public void rangedDownload() throws Exception {
 
         mockRangedDownload();
@@ -115,6 +149,24 @@ public class S3ClientTest extends S3WireMockBase {
         byte[] result = resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
         assertTrue(Arrays.equals(rangeOfBody(), result));
+    }
+
+    @Test
+    public void rangedDownloadServerSideEncryption() throws Exception {
+
+        mockRangedDownloadSSE();
+
+        //#rangedDownload
+        final Source<ByteString, CompletionStage<ObjectMetadata>> source = client.download(bucket(), bucketKey(),
+                ByteRange.createSlice(bytesRangeStart(), bytesRangeEnd()), sseCustomerKeys());
+        //#rangedDownload
+
+        final CompletionStage<byte[]> resultCompletionStage =
+                source.map(ByteString::toArray).runWith(Sink.head(), materializer);
+
+        byte[] result = resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+        assertTrue(Arrays.equals(rangeOfBodySSE(), result));
     }
 
     @Test

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3HeadersSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3HeadersSpec.scala
@@ -24,6 +24,22 @@ class S3HeadersSpec extends FlatSpec with Matchers {
     kms.headers should contain(RawHeader("x-amz-server-side-encryption-context", "base-64-encoded-context"))
   }
 
+  it should "create well formed headers for customer keys encryption" in {
+    val key = "rOJ7HxUze312HtqOL+55ahqbokC+nc614oRlrYdjGhE="
+    val md5Key = "nU0sHdKlctQdn+Up4POVJw=="
+
+    var ssec = ServerSideEncryption.CustomerKeys(key, Some(md5Key))
+    ssec.headers should contain(RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256"))
+    ssec.headers should contain(RawHeader("x-amz-server-side-encryption-customer-key", key))
+    ssec.headers should contain(RawHeader("x-amz-server-side-encryption-customer-key-MD5", md5Key))
+
+    //Non md5
+    ssec = ServerSideEncryption.CustomerKeys(key)
+    ssec.headers should contain(RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256"))
+    ssec.headers should contain(RawHeader("x-amz-server-side-encryption-customer-key", key))
+    ssec.headers should contain(RawHeader("x-amz-server-side-encryption-customer-key-MD5", md5Key))
+  }
+
   "StorageClass" should "create well formed headers for 'infrequent access'" in {
     StorageClass.InfrequentAccess.header shouldEqual RawHeader("x-amz-storage-class", "STANDARD_IA")
   }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3HeadersSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3HeadersSpec.scala
@@ -15,19 +15,19 @@ class S3HeadersSpec extends FlatSpec with Matchers {
   }
 
   it should "create well formed headers for AES-256 encryption by requests" in {
-    var headers = ServerSideEncryption.AES256.headers(HeadObject)
+    var headers = ServerSideEncryption.AES256.headersFor(HeadObject)
     headers.size shouldBe 0
 
-    headers = ServerSideEncryption.AES256.headers(GetObject)
+    headers = ServerSideEncryption.AES256.headersFor(GetObject)
     headers.size shouldBe 0
 
-    headers = ServerSideEncryption.AES256.headers(PutObject)
+    headers = ServerSideEncryption.AES256.headersFor(PutObject)
     headers should contain(RawHeader("x-amz-server-side-encryption", "AES256"))
 
-    headers = ServerSideEncryption.AES256.headers(InitiateMultipartUpload)
+    headers = ServerSideEncryption.AES256.headersFor(InitiateMultipartUpload)
     headers should contain(RawHeader("x-amz-server-side-encryption", "AES256"))
 
-    headers = ServerSideEncryption.AES256.headers(UploadPart)
+    headers = ServerSideEncryption.AES256.headersFor(UploadPart)
     headers.size shouldBe 0
   }
 
@@ -45,27 +45,27 @@ class S3HeadersSpec extends FlatSpec with Matchers {
     val kms =
       ServerSideEncryption.KMS("arn:aws:kms:my-region:my-account-id:key/my-key-id", Some("base-64-encoded-context"))
 
-    var headers = kms.headers(HeadObject)
+    var headers = kms.headersFor(HeadObject)
     headers.size shouldBe 0
 
-    headers = kms.headers(GetObject)
+    headers = kms.headersFor(GetObject)
     headers.size shouldBe 0
 
-    headers = kms.headers(PutObject)
+    headers = kms.headersFor(PutObject)
     headers should contain(RawHeader("x-amz-server-side-encryption", "aws:kms"))
     headers should contain(
       RawHeader("x-amz-server-side-encryption-aws-kms-key-id", "arn:aws:kms:my-region:my-account-id:key/my-key-id")
     )
     headers should contain(RawHeader("x-amz-server-side-encryption-context", "base-64-encoded-context"))
 
-    headers = kms.headers(InitiateMultipartUpload)
+    headers = kms.headersFor(InitiateMultipartUpload)
     headers should contain(RawHeader("x-amz-server-side-encryption", "aws:kms"))
     headers should contain(
       RawHeader("x-amz-server-side-encryption-aws-kms-key-id", "arn:aws:kms:my-region:my-account-id:key/my-key-id")
     )
     headers should contain(RawHeader("x-amz-server-side-encryption-context", "base-64-encoded-context"))
 
-    headers = kms.headers(UploadPart)
+    headers = kms.headersFor(UploadPart)
     headers.size shouldBe 0
   }
 
@@ -91,31 +91,31 @@ class S3HeadersSpec extends FlatSpec with Matchers {
 
     val ssec = ServerSideEncryption.CustomerKeys(key, Some(md5Key))
 
-    var headers = ssec.headers(HeadObject)
+    var headers = ssec.headersFor(HeadObject)
     headers.size shouldBe 3
     headers should contain(RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256"))
     headers should contain(RawHeader("x-amz-server-side-encryption-customer-key", key))
     headers should contain(RawHeader("x-amz-server-side-encryption-customer-key-MD5", md5Key))
 
-    headers = ssec.headers(GetObject)
+    headers = ssec.headersFor(GetObject)
     headers.size shouldBe 3
     headers should contain(RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256"))
     headers should contain(RawHeader("x-amz-server-side-encryption-customer-key", key))
     headers should contain(RawHeader("x-amz-server-side-encryption-customer-key-MD5", md5Key))
 
-    headers = ssec.headers(PutObject)
+    headers = ssec.headersFor(PutObject)
     headers.size shouldBe 3
     headers should contain(RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256"))
     headers should contain(RawHeader("x-amz-server-side-encryption-customer-key", key))
     headers should contain(RawHeader("x-amz-server-side-encryption-customer-key-MD5", md5Key))
 
-    headers = ssec.headers(InitiateMultipartUpload)
+    headers = ssec.headersFor(InitiateMultipartUpload)
     headers.size shouldBe 3
     headers should contain(RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256"))
     headers should contain(RawHeader("x-amz-server-side-encryption-customer-key", key))
     headers should contain(RawHeader("x-amz-server-side-encryption-customer-key-MD5", md5Key))
 
-    headers = ssec.headers(UploadPart)
+    headers = ssec.headersFor(UploadPart)
     headers.size shouldBe 3
     headers should contain(RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256"))
     headers should contain(RawHeader("x-amz-server-side-encryption-customer-key", key))

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3HeadersSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3HeadersSpec.scala
@@ -14,6 +14,23 @@ class S3HeadersSpec extends FlatSpec with Matchers {
     ServerSideEncryption.AES256.headers should contain(RawHeader("x-amz-server-side-encryption", "AES256"))
   }
 
+  it should "create well formed headers for AES-256 encryption by requests" in {
+    var headers = ServerSideEncryption.AES256.headers(HeadObject)
+    headers.size shouldBe 0
+
+    headers = ServerSideEncryption.AES256.headers(GetObject)
+    headers.size shouldBe 0
+
+    headers = ServerSideEncryption.AES256.headers(PutObject)
+    headers should contain(RawHeader("x-amz-server-side-encryption", "AES256"))
+
+    headers = ServerSideEncryption.AES256.headers(InitiateMultipartUpload)
+    headers should contain(RawHeader("x-amz-server-side-encryption", "AES256"))
+
+    headers = ServerSideEncryption.AES256.headers(UploadPart)
+    headers.size shouldBe 0
+  }
+
   it should "create well formed headers for aws:kms encryption" in {
     val kms =
       ServerSideEncryption.KMS("arn:aws:kms:my-region:my-account-id:key/my-key-id", Some("base-64-encoded-context"))
@@ -22,6 +39,34 @@ class S3HeadersSpec extends FlatSpec with Matchers {
       RawHeader("x-amz-server-side-encryption-aws-kms-key-id", "arn:aws:kms:my-region:my-account-id:key/my-key-id")
     )
     kms.headers should contain(RawHeader("x-amz-server-side-encryption-context", "base-64-encoded-context"))
+  }
+
+  it should "create well formed headers for aws:kms encryption by requests" in {
+    val kms =
+      ServerSideEncryption.KMS("arn:aws:kms:my-region:my-account-id:key/my-key-id", Some("base-64-encoded-context"))
+
+    var headers = kms.headers(HeadObject)
+    headers.size shouldBe 0
+
+    headers = kms.headers(GetObject)
+    headers.size shouldBe 0
+
+    headers = kms.headers(PutObject)
+    headers should contain(RawHeader("x-amz-server-side-encryption", "aws:kms"))
+    headers should contain(
+      RawHeader("x-amz-server-side-encryption-aws-kms-key-id", "arn:aws:kms:my-region:my-account-id:key/my-key-id")
+    )
+    headers should contain(RawHeader("x-amz-server-side-encryption-context", "base-64-encoded-context"))
+
+    headers = kms.headers(InitiateMultipartUpload)
+    headers should contain(RawHeader("x-amz-server-side-encryption", "aws:kms"))
+    headers should contain(
+      RawHeader("x-amz-server-side-encryption-aws-kms-key-id", "arn:aws:kms:my-region:my-account-id:key/my-key-id")
+    )
+    headers should contain(RawHeader("x-amz-server-side-encryption-context", "base-64-encoded-context"))
+
+    headers = kms.headers(UploadPart)
+    headers.size shouldBe 0
   }
 
   it should "create well formed headers for customer keys encryption" in {
@@ -38,6 +83,43 @@ class S3HeadersSpec extends FlatSpec with Matchers {
     ssec.headers should contain(RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256"))
     ssec.headers should contain(RawHeader("x-amz-server-side-encryption-customer-key", key))
     ssec.headers should contain(RawHeader("x-amz-server-side-encryption-customer-key-MD5", md5Key))
+  }
+
+  it should "create well formed headers for customer keys encryption by requests" in {
+    val key = "rOJ7HxUze312HtqOL+55ahqbokC+nc614oRlrYdjGhE="
+    val md5Key = "nU0sHdKlctQdn+Up4POVJw=="
+
+    val ssec = ServerSideEncryption.CustomerKeys(key, Some(md5Key))
+
+    var headers = ssec.headers(HeadObject)
+    headers.size shouldBe 3
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256"))
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-key", key))
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-key-MD5", md5Key))
+
+    headers = ssec.headers(GetObject)
+    headers.size shouldBe 3
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256"))
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-key", key))
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-key-MD5", md5Key))
+
+    headers = ssec.headers(PutObject)
+    headers.size shouldBe 3
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256"))
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-key", key))
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-key-MD5", md5Key))
+
+    headers = ssec.headers(InitiateMultipartUpload)
+    headers.size shouldBe 3
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256"))
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-key", key))
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-key-MD5", md5Key))
+
+    headers = ssec.headers(UploadPart)
+    headers.size shouldBe 3
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256"))
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-key", key))
+    headers should contain(RawHeader("x-amz-server-side-encryption-customer-key-MD5", md5Key))
   }
 
   "StorageClass" should "create well formed headers for 'infrequent access'" in {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.s3.impl
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.model.headers.{ByteRange, RawHeader}
+import akka.http.scaladsl.model.headers.ByteRange
 import akka.stream.alpakka.s3.{MemoryBufferType, S3Settings}
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.TestKit
@@ -23,76 +23,6 @@ class S3StreamSpec(_system: ActorSystem)
 
   def this() = this(ActorSystem("S3StreamSpec"))
   implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system).withDebugLogging(true))
-
-  "S3Stream" should "have an empty headers when call downloadOrUpdatePart without server side encryption" in {
-    val credentials =
-      new AWSStaticCredentialsProvider(
-        new BasicAWSCredentials(
-          "test-Id",
-          "test-key"
-        )
-      )
-    implicit val settings = new S3Settings(MemoryBufferType, None, credentials, "us-east-1", false)
-
-    val s3Stream = new S3Stream(settings)
-    val result = s3Stream.downloadOrUpdatePartHeaders(None)
-
-    result.headers.size shouldBe 0
-  }
-
-  it should "have empty header when call downloadOrUpdatePart with AE256 server side encryption" in {
-    val credentials =
-      new AWSStaticCredentialsProvider(
-        new BasicAWSCredentials(
-          "test-Id",
-          "test-key"
-        )
-      )
-    implicit val settings = new S3Settings(MemoryBufferType, None, credentials, "us-east-1", false)
-
-    val s3Stream = new S3Stream(settings)
-    val sse = Some(ServerSideEncryption.AES256)
-    val result = s3Stream.downloadOrUpdatePartHeaders(sse)
-
-    result.headers.size shouldBe 0
-  }
-
-  it should "have empty header when call downloadOrUpdatePart with KMS server side encryption" in {
-    val credentials =
-      new AWSStaticCredentialsProvider(
-        new BasicAWSCredentials(
-          "test-Id",
-          "test-key"
-        )
-      )
-    implicit val settings = new S3Settings(MemoryBufferType, None, credentials, "us-east-1", false)
-
-    val s3Stream = new S3Stream(settings)
-    val sse = Some(ServerSideEncryption.KMS("my-key"))
-    val result = s3Stream.downloadOrUpdatePartHeaders(sse)
-
-    result.headers.size shouldBe 0
-  }
-
-  it should "have 3 headers when call downloadOrUpdatePart with Customer key server side encryption" in {
-    val credentials =
-      new AWSStaticCredentialsProvider(
-        new BasicAWSCredentials(
-          "test-Id",
-          "test-key"
-        )
-      )
-    implicit val settings = new S3Settings(MemoryBufferType, None, credentials, "us-east-1", false)
-
-    val s3Stream = new S3Stream(settings)
-    val sse = Some(ServerSideEncryption.CustomerKeys("my-key", Some("md5")))
-    val result = s3Stream.downloadOrUpdatePartHeaders(sse)
-
-    result.headers.size shouldBe 3
-    result.headers should contain(RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256"))
-    result.headers should contain(RawHeader("x-amz-server-side-encryption-customer-key", "my-key"))
-    result.headers should contain(RawHeader("x-amz-server-side-encryption-customer-key-MD5", "md5"))
-  }
 
   "Non-ranged downloads" should "have one (host) header" in {
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
@@ -72,7 +72,7 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
 
     val result = s3Source.map(_.utf8String).runWith(Sink.head)
 
-    result.futureValue shouldBe body
+    result.futureValue shouldBe bodySSE
   }
 
   it should "fail if request returns 404" in {


### PR DESCRIPTION
fix #654 S3 support server side encryption - customer keys (SSE-C)