### PR TITLE
Update AMQP client version to the latest

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
 
   val Amqp = Seq(
     libraryDependencies ++= Seq(
-      "com.rabbitmq" % "amqp-client" % "3.6.1" // APLv2
+      "com.rabbitmq" % "amqp-client" % "5.0.0" // APLv2
     )
   )
 


### PR DESCRIPTION
Just a bit of housekeeping.

Bugs have been fixed and performance improved.
Only breaking change is that auto-recovery was disabled by default and now it's enable by default. I can make it disable by default but I think that makes sense to go along with the underlying library (thoughts??)

Also, since version 4.0, allows using Java IO which should reduce the number of threads. I've tried it and all the test pass just fine (and seem faster but I can't say without proper measurements). so my question is:
a) Should it be enabled it by default?
b) Should we expose all the settings for NIO as rabbitmq client library does?
I haven't include the NIO change because it would conflict with #506 and I'd rather to get that done first and then introduce NIO.


As I side note, I think that it would be good to systematically review the dependencies before every release and update all of them to the latest possible version (without breaking changes, of course).