### PR TITLE
Consolidate documentation about docker images required for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ script:
   - find . -name "*.log" -exec ./scripts/cat-log.sh {} \;
 
 after_failure:
-  - docker-compose logs mqtt
-  - docker-compose logs cassandra
+  - docker-compose logs
 
 before_cache:
   - find $HOME/.ivy2 -name "ivydata-*.properties" -print -delete

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,24 +4,14 @@
 
 version: '2'
 services:
+  amqp:
+    image: rabbitmq:3
+    ports:
+      - "5672:5672"
   cassandra:
     image: cassandra:3.0.15
     ports:
       - "9042:9042"
-  rabbitmq:
-    image: rabbitmq:3
-    ports:
-      - "5672:5672"
-  mongo:
-    image: mongo
-    ports:
-      - "27017:27017"
-  mqtt:
-    image: toke/mosquitto
-    ports:
-      - "1883:1883"
-    volumes:
-      - ./mqtt/src/test/travis:/mqtt/config/conf.d
   dynamodb:
     image: deangiberson/aws-dynamodb-local
     ports:
@@ -58,4 +48,13 @@ services:
       - "AUTH_HOST=http://ironauth:8090"
     ports:
       - "8080:8080"
-
+  mongo:
+    image: mongo
+    ports:
+      - "27017:27017"
+  mqtt:
+    image: toke/mosquitto
+    ports:
+      - "1883:1883"
+    volumes:
+      - ./mqtt/src/test/travis:/mqtt/config/conf.d

--- a/docs/src/main/paradox/amqp.md
+++ b/docs/src/main/paradox/amqp.md
@@ -146,7 +146,7 @@ The code in this guide is part of runnable tests of this project. You are welcom
 
 > Test code requires AMQP server running in the background. You can start one quickly using docker:
 >
-> `docker run --rm -p 5672:5672 rabbitmq:3`
+> `docker-compose up amqp`
 
 Scala
 :   ```

--- a/docs/src/main/paradox/cassandra.md
+++ b/docs/src/main/paradox/cassandra.md
@@ -80,9 +80,9 @@ Java
 
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
 
-> Test code requires Cassandra server running in the background. You can start one quickly using docker:
+> Test code requires Cassandra running in the background. You can start it quickly using docker:
 >
-> `docker run --rm -p 9042:9042 cassandra:3`
+> `docker-compose up cassandra`
 
 Scala
 :   ```

--- a/docs/src/main/paradox/dynamodb.md
+++ b/docs/src/main/paradox/dynamodb.md
@@ -50,9 +50,9 @@ Java
 
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
 
-> Test code requires DynamoDB server running in the background. You can start one quickly using docker:
+> Test code requires DynamoDB running in the background. You can start one quickly using docker:
 >
-> `docker run --rm -p 8001:8000 deangiberson/aws-dynamodb-local`
+> `docker-compose up dynamodb`
 
 Scala
 :   ```

--- a/docs/src/main/paradox/geode.md
+++ b/docs/src/main/paradox/geode.md
@@ -145,15 +145,18 @@ create region --name=persons --type=PARTITION_REDUNDANT --redundant-copies=2
 
 Integration test are run against localhost geode, but IT_GEODE_HOSTNAME environment variable can change this:
 
-```bash
-export IT_GEODE_HOSTNAME=geode-host-locator
+> Test code requires Geode running in the background. You can start it quickly using docker:
+>
+> `docker-compose up geode`
 
-sbt
-```
+Scala
+:   ```
+    sbt
+    > geode/testOnly *Spec
+    ```
 
-From sbt shell
-
-```sbtshell
-project geode
-test
-```
+Java
+:   ```
+    sbt
+    > geode/testOnly *Test
+    ```

--- a/docs/src/main/paradox/ironmq.md
+++ b/docs/src/main/paradox/ironmq.md
@@ -53,3 +53,19 @@ if the producer will implement a batch mechanism in the future.
 
 The producer also provides a Committable aware Flow/Sink as `Flow[(PushMessage, ToCommit), (Message.Id, CommitResult), CommitMat]`.
 It can be used to consume a Flow from an IronMq consumer or any other source that provides a commit mechanism.
+
+> Test code requires IronMQ running in the background. You can start it quickly using docker:
+>
+> `docker-compose up ironauth ironmq`
+
+Scala
+:   ```
+    sbt
+    > ironmq/testOnly *Spec
+    ```
+
+Java
+:   ```
+    sbt
+    > ironmq/testOnly *Test
+    ```

--- a/docs/src/main/paradox/mongodb.md
+++ b/docs/src/main/paradox/mongodb.md
@@ -77,9 +77,9 @@ Scala
 
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
 
-> Test code requires MongoDB server running in the background. You can start one quickly using docker:
+> Test code requires a MongoDB server running in the background. You can start one quickly using docker:
 >
-> `docker run --rm mongo`
+> `docker-compose up mongo`
 
 Scala
 :   ```

--- a/docs/src/main/paradox/mqtt.md
+++ b/docs/src/main/paradox/mqtt.md
@@ -92,6 +92,10 @@ Java
 
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
 
+> Test code requires a MQTT server running in the background. You can start one quickly using docker:
+>
+> `docker-compose up mqtt`
+
 Scala
 :   ```
     sbt


### PR DESCRIPTION
Closes #75
 
* Add the same info to all docs.
* Replac the raw call to docker to a call to docker-compose, since the containers are already configured there.
* Fix the travis config to show all the docker logs instead of only some of the containers.