### PR TITLE
Update Signer.scala

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/auth/Signer.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/auth/Signer.scala
@@ -15,7 +15,7 @@ import com.amazonaws.auth
 import com.amazonaws.auth._
 
 private[alpakka] object Signer {
-  private val dateFormatter = DateTimeFormatter.ofPattern("YYYYMMdd'T'HHmmssX")
+  private val dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssX")
 
   def signedRequest(request: HttpRequest, key: SigningKey, date: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC))(
       implicit mat: Materializer


### PR DESCRIPTION
Changed dateFormatter from week-year to year to fix RequestTimeTooSkewed at the end of the year.
For example:
Making a request at the 12/31/2017 returns the following error:
<Error><Code>RequestTimeTooSkewed</Code><Message>The difference between the request time and the current time is too large.</Message><RequestTime>20181231T143952Z</RequestTime><ServerTime>2017-12-31T14:39:53Z</ServerTime>
As you can see the RequestTime year is 2018, while the ServerTime is 2017.
This is caused by using YYYY (week year) in the DateFormatter.ofPattern - [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html)