### PR TITLE
Make JmsSink materialize to Future[Done]

### DIFF
--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsSinkStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsSinkStage.scala
@@ -6,10 +6,14 @@ package akka.stream.alpakka.jms
 
 import javax.jms.{Message, MessageProducer}
 
-import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler}
-import akka.stream.{ActorAttributes, Attributes, Inlet, SinkShape}
+import akka.Done
+import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, InHandler}
+import akka.stream._
 
-final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[SinkShape[JmsMessage]] {
+import scala.concurrent.{Future, Promise}
+
+final class JmsSinkStage(settings: JmsSinkSettings)
+    extends GraphStageWithMaterializedValue[SinkShape[JmsMessage], Future[Done]] {
 
   private val in = Inlet[JmsMessage]("JmsSink.in")
 
@@ -18,8 +22,9 @@ final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[SinkShape
   override protected def initialAttributes: Attributes =
     ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher")
 
-  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
-    new GraphStageLogic(shape) with JmsConnector {
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Done]) = {
+    val completionPromise = Promise[Done]()
+    val logic = new GraphStageLogic(shape) with JmsConnector {
 
       private var jmsProducer: MessageProducer = _
 
@@ -37,6 +42,16 @@ final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[SinkShape
       setHandler(
         in,
         new InHandler {
+
+          override def onUpstreamFinish(): Unit = {
+            super.onUpstreamFinish()
+            completionPromise.trySuccess(Done)
+          }
+
+          override def onUpstreamFailure(ex: Throwable): Unit = {
+            super.onUpstreamFailure(ex)
+            completionPromise.tryFailure(ex)
+          }
 
           override def onPush(): Unit = {
 
@@ -129,7 +144,14 @@ final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[SinkShape
         }
       }
 
-      override def postStop(): Unit = Option(jmsSession).foreach(_.closeSession())
+      override def postStop(): Unit = {
+        if (!completionPromise.isCompleted) completionPromise.tryFailure(new AbruptStageTerminationException(this))
+        Option(jmsSession).foreach(_.closeSession())
+      }
     }
+
+    (logic, completionPromise.future)
+
+  }
 
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
@@ -4,48 +4,67 @@
 
 package akka.stream.alpakka.jms.javadsl
 
-import akka.NotUsed
+import java.util.concurrent.CompletionStage
 
 import akka.stream.alpakka.jms.{JmsMessage, JmsSinkSettings, JmsSinkStage}
-import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.{Flow, Keep}
+import akka.{Done, NotUsed}
 
 import scala.collection.JavaConversions
+import scala.compat.java8.FutureConverters
 
 object JmsSink {
 
   /**
    * Java API: Creates an [[JmsSink]] for [[JmsMessage]]s
    */
-  def create[R <: JmsMessage](jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[R, NotUsed] =
-    akka.stream.javadsl.Sink.fromGraph(new JmsSinkStage(jmsSinkSettings))
+  def create[R <: JmsMessage](jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[R, CompletionStage[Done]] =
+    akka.stream.scaladsl.Sink
+      .fromGraph(new JmsSinkStage(jmsSinkSettings))
+      .mapMaterializedValue(FutureConverters.toJava)
+      .asJava
 
   /**
    * Java API: Creates an [[JmsSink]] for strings
    */
-  def textSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[String, NotUsed] =
-    akka.stream.alpakka.jms.scaladsl.JmsSink.textSink(jmsSinkSettings).asJava
+  def textSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[String, CompletionStage[Done]] =
+    akka.stream.alpakka.jms.scaladsl.JmsSink
+      .textSink(jmsSinkSettings)
+      .mapMaterializedValue(FutureConverters.toJava)
+      .asJava
 
   /**
    * Java API: Creates an [[JmsSink]] for bytes
    */
-  def bytesSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[Array[Byte], NotUsed] =
-    akka.stream.alpakka.jms.scaladsl.JmsSink.bytesSink(jmsSinkSettings).asJava
+  def bytesSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[Array[Byte], CompletionStage[Done]] =
+    akka.stream.alpakka.jms.scaladsl.JmsSink
+      .bytesSink(jmsSinkSettings)
+      .mapMaterializedValue(FutureConverters.toJava)
+      .asJava
 
   /**
    * Java API: Creates an [[JmsSink]] for maps with primitive datatypes as value
    */
-  def mapSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[java.util.Map[String, Any], NotUsed] = {
+  def mapSink(
+      jmsSinkSettings: JmsSinkSettings
+  ): akka.stream.javadsl.Sink[java.util.Map[String, Any], CompletionStage[Done]] = {
 
-    val scalaSink = akka.stream.alpakka.jms.scaladsl.JmsSink.mapSink(jmsSinkSettings)
+    val scalaSink =
+      akka.stream.alpakka.jms.scaladsl.JmsSink.mapSink(jmsSinkSettings).mapMaterializedValue(FutureConverters.toJava)
     val javaToScalaConversion =
       Flow.fromFunction((javaMap: java.util.Map[String, Any]) => JavaConversions.mapAsScalaMap(javaMap).toMap)
-    javaToScalaConversion.to(scalaSink).asJava
+    javaToScalaConversion.toMat(scalaSink)(Keep.right).asJava
   }
 
   /**
    * Java API: Creates an [[JmsSink]] for serializable objects
    */
-  def objectSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[java.io.Serializable, NotUsed] =
-    akka.stream.alpakka.jms.scaladsl.JmsSink.objectSink(jmsSinkSettings).asJava
+  def objectSink(
+      jmsSinkSettings: JmsSinkSettings
+  ): akka.stream.javadsl.Sink[java.io.Serializable, CompletionStage[Done]] =
+    akka.stream.alpakka.jms.scaladsl.JmsSink
+      .objectSink(jmsSinkSettings)
+      .mapMaterializedValue(FutureConverters.toJava)
+      .asJava
 
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSink.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSink.scala
@@ -4,48 +4,50 @@
 
 package akka.stream.alpakka.jms.scaladsl
 
-import akka.NotUsed
+import akka.{Done, NotUsed}
 import akka.stream.alpakka.jms._
-import akka.stream.scaladsl.{Flow, Sink}
+import akka.stream.scaladsl.{Flow, Keep, Sink}
+
+import scala.concurrent.Future
 
 object JmsSink {
 
   /**
    * Scala API: Creates an [[JmsSink]] for [[JmsMessage]]s
    */
-  def apply(jmsSettings: JmsSinkSettings): Sink[JmsMessage, NotUsed] =
+  def apply(jmsSettings: JmsSinkSettings): Sink[JmsMessage, Future[Done]] =
     Sink.fromGraph(new JmsSinkStage(jmsSettings))
 
   /**
    * Scala API: Creates an [[JmsSink]] for strings
    */
-  def textSink(jmsSettings: JmsSinkSettings): Sink[String, NotUsed] = {
+  def textSink(jmsSettings: JmsSinkSettings): Sink[String, Future[Done]] = {
     val jmsMsgSink = Sink.fromGraph(new JmsSinkStage(jmsSettings))
-    Flow.fromFunction((s: String) => JmsTextMessage(s)).to(jmsMsgSink)
+    Flow.fromFunction((s: String) => JmsTextMessage(s)).toMat(jmsMsgSink)(Keep.right)
   }
 
   /**
    * Scala API: Creates an [[JmsSink]] for bytes
    */
-  def bytesSink(jmsSettings: JmsSinkSettings): Sink[Array[Byte], NotUsed] = {
+  def bytesSink(jmsSettings: JmsSinkSettings): Sink[Array[Byte], Future[Done]] = {
     val jmsMsgSink = Sink.fromGraph(new JmsSinkStage(jmsSettings))
-    Flow.fromFunction((s: Array[Byte]) => JmsByteMessage(s)).to(jmsMsgSink)
+    Flow.fromFunction((s: Array[Byte]) => JmsByteMessage(s)).toMat(jmsMsgSink)(Keep.right)
   }
 
   /**
    * Scala API: Creates an [[JmsSink]] for maps with primitive data types
    */
-  def mapSink(jmsSettings: JmsSinkSettings): Sink[Map[String, Any], NotUsed] = {
+  def mapSink(jmsSettings: JmsSinkSettings): Sink[Map[String, Any], Future[Done]] = {
     val jmsMsgSink = Sink.fromGraph(new JmsSinkStage(jmsSettings))
-    Flow.fromFunction((s: Map[String, Any]) => JmsMapMessage(s)).to(jmsMsgSink)
+    Flow.fromFunction((s: Map[String, Any]) => JmsMapMessage(s)).toMat(jmsMsgSink)(Keep.right)
   }
 
   /**
    * Scala API: Creates an [[JmsSink]] for serializable objects
    */
-  def objectSink(jmsSettings: JmsSinkSettings): Sink[java.io.Serializable, NotUsed] = {
+  def objectSink(jmsSettings: JmsSinkSettings): Sink[java.io.Serializable, Future[Done]] = {
     val jmsMsgSink = Sink.fromGraph(new JmsSinkStage(jmsSettings))
-    Flow.fromFunction((s: java.io.Serializable) => JmsObjectMessage(s)).to(jmsMsgSink)
+    Flow.fromFunction((s: java.io.Serializable) => JmsObjectMessage(s)).toMat(jmsMsgSink)(Keep.right)
   }
 
 }


### PR DESCRIPTION
Sometimes it's useful to know when the stream has completed. Materializing `JmsSink` to a `Future` makes this easier.