### PR TITLE
Close MQTT client and release all resources on postStop

### DIFF
--- a/mqtt/src/main/scala/akka/stream/alpakka/mqtt/MqttFlowStage.scala
+++ b/mqtt/src/main/scala/akka/stream/alpakka/mqtt/MqttFlowStage.scala
@@ -220,6 +220,7 @@ final class MqttFlowStage(sourceSettings: MqttSourceSettings,
               new IllegalStateException("Cannot complete subscription because the stage is about to stop or fail")
             )
         try mqttClient.disconnect()
+        catch { case _: Throwable => () } finally try mqttClient.close()
         catch { case _: Throwable => () }
       }
     }, subscriptionPromise.future)


### PR DESCRIPTION
Closes #695 

The reason for the two catches is that disconnect could throw and exception but we still want to close the client.