### PR TITLE
AMQP: add support for native ConnectionFactory as a configuration option

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnector.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnector.scala
@@ -54,12 +54,11 @@ private[amqp] trait AmqpConnector {
         factory
     }
 
-  private def asAddresses(hostAndPorts: Seq[(String, Int)]): Seq[Address] = {
+  private def asAddresses(hostAndPorts: Seq[(String, Int)]): Seq[Address] =
     if (hostAndPorts.nonEmpty)
       hostAndPorts.map(hp => new Address(hp._1, hp._2))
     else
       throw new IllegalArgumentException("You need to supply at least one host/port pair.")
-  }
 
   import scala.collection.JavaConverters._
   def newConnection(factory: ConnectionFactory, settings: AmqpConnectionSettings): Connection = settings match {

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnector.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnector.scala
@@ -55,13 +55,18 @@ private[amqp] trait AmqpConnector {
     }
 
   def newConnection(factory: ConnectionFactory, settings: AmqpConnectionSettings): Connection = settings match {
-    case a: AmqpConnectionDetails => {
+    case a: AmqpConnectionDetails =>
       import scala.collection.JavaConverters._
       if (a.hostAndPortList.nonEmpty)
         factory.newConnection(a.hostAndPortList.map(hp => new Address(hp._1, hp._2)).asJava)
       else
         throw new IllegalArgumentException("You need to supply at least one host/port pair.")
-    }
+    case a: AmqpConnectionFactory =>
+      import scala.collection.JavaConverters._
+      if (a.hostAndPortList.nonEmpty)
+        factory.newConnection(a.hostAndPortList.map(hp => new Address(hp._1, hp._2)).asJava)
+      else
+        throw new IllegalArgumentException("You need to supply at least one host/port pair.")
     case _ => factory.newConnection()
   }
 }

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnector.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnector.scala
@@ -54,19 +54,19 @@ private[amqp] trait AmqpConnector {
         factory
     }
 
+  private def asAddresses(hostAndPorts: Seq[(String, Int)]): Seq[Address] = {
+    if (hostAndPorts.nonEmpty)
+      hostAndPorts.map(hp => new Address(hp._1, hp._2))
+    else
+      throw new IllegalArgumentException("You need to supply at least one host/port pair.")
+  }
+
+  import scala.collection.JavaConverters._
   def newConnection(factory: ConnectionFactory, settings: AmqpConnectionSettings): Connection = settings match {
     case a: AmqpConnectionDetails =>
-      import scala.collection.JavaConverters._
-      if (a.hostAndPortList.nonEmpty)
-        factory.newConnection(a.hostAndPortList.map(hp => new Address(hp._1, hp._2)).asJava)
-      else
-        throw new IllegalArgumentException("You need to supply at least one host/port pair.")
+      factory.newConnection(asAddresses(a.hostAndPortList).asJava)
     case a: AmqpConnectionFactory =>
-      import scala.collection.JavaConverters._
-      if (a.hostAndPortList.nonEmpty)
-        factory.newConnection(a.hostAndPortList.map(hp => new Address(hp._1, hp._2)).asJava)
-      else
-        throw new IllegalArgumentException("You need to supply at least one host/port pair.")
+      factory.newConnection(asAddresses(a.hostAndPortList).asJava)
     case _ => factory.newConnection()
   }
 }

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnector.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnector.scala
@@ -14,10 +14,12 @@ import scala.util.control.NonFatal
  */
 private[amqp] trait AmqpConnector {
 
-  def connectionFactoryFrom(settings: AmqpConnectionSettings): ConnectionFactory = {
-    val factory = new ConnectionFactory
+  def connectionFactoryFrom(settings: AmqpConnectionSettings): ConnectionFactory =
     settings match {
-      case AmqpConnectionUri(uri) => factory.setUri(uri)
+      case AmqpConnectionUri(uri) =>
+        val factory = new ConnectionFactory
+        factory.setUri(uri)
+        factory
       case AmqpConnectionDetails(_,
                                  maybeCredentials,
                                  maybeVirtualHost,
@@ -30,6 +32,7 @@ private[amqp] trait AmqpConnector {
                                  automaticRecoveryEnabled,
                                  topologyRecoveryEnabled,
                                  exceptionHandler) =>
+        val factory = new ConnectionFactory
         maybeCredentials.foreach { credentials =>
           factory.setUsername(credentials.username)
           factory.setPassword(credentials.password)
@@ -44,10 +47,12 @@ private[amqp] trait AmqpConnector {
         automaticRecoveryEnabled.foreach(factory.setAutomaticRecoveryEnabled)
         topologyRecoveryEnabled.foreach(factory.setTopologyRecoveryEnabled)
         exceptionHandler.foreach(factory.setExceptionHandler)
-      case DefaultAmqpConnection => // leave it be as is
+        factory
+      case DefaultAmqpConnection =>
+        new ConnectionFactory
+      case AmqpConnectionFactory(factory) =>
+        factory
     }
-    factory
-  }
 
   def newConnection(factory: ConnectionFactory, settings: AmqpConnectionSettings): Connection = settings match {
     case a: AmqpConnectionDetails => {

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.amqp
 
-import com.rabbitmq.client.ExceptionHandler
+import com.rabbitmq.client.{ConnectionFactory, ExceptionHandler}
 
 /**
  * Internal API
@@ -147,6 +147,16 @@ object AmqpConnectionUri {
    * Java API:
    */
   def create(uri: String): AmqpConnectionUri = AmqpConnectionUri(uri)
+}
+
+final case class AmqpConnectionFactory(underlying: ConnectionFactory) extends AmqpConnectionSettings
+
+object AmqpConnectionFactory {
+
+  /**
+   * Java API
+   */
+  def create(connectionFactory: ConnectionFactory): AmqpConnectionFactory = AmqpConnectionFactory(connectionFactory)
 }
 
 final case class AmqpConnectionDetails(

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
@@ -149,7 +149,26 @@ object AmqpConnectionUri {
   def create(uri: String): AmqpConnectionUri = AmqpConnectionUri(uri)
 }
 
-final case class AmqpConnectionFactory(underlying: ConnectionFactory) extends AmqpConnectionSettings
+/**
+ * Uses a native [[com.rabbitmq.client.ConnectionFactory]] to configure an AMQP connection.
+ *
+ * @param underlying   The instance of the ConnectionFactory to build the connection from.
+ * @param hostAndPorts An optional list of host and ports.
+ *                     If empty, it defaults to the host and port in the underlying factory.
+ */
+final case class AmqpConnectionFactory(underlying: ConnectionFactory, private val hostAndPorts: (String, Int)*)
+    extends AmqpConnectionSettings {
+
+  /**
+   * @return A list of hosts and ports for this AMQP connection.
+   *         Uses host and port from the underlying factory if hostAndPorts was left out on construction.
+   */
+  def hostAndPortList: Seq[(String, Int)] =
+    if (hostAndPorts.isEmpty)
+      Seq((underlying.getHost, underlying.getPort))
+    else
+      hostAndPorts.toList
+}
 
 object AmqpConnectionFactory {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
 
   val Amqp = Seq(
     libraryDependencies ++= Seq(
-      "com.rabbitmq" % "amqp-client" % "5.0.0" // APLv2
+      "com.rabbitmq" % "amqp-client" % "5.1.1" // APLv2
     )
   )
 


### PR DESCRIPTION
This PR adds a new AmqpConnectionSettings type that accepts a native `ConnectionFactory` from the underlying RabbitMQ client.

The motivation is that I needed to give an SSL truststore with an imported mutual certificate. This required me to inject a `SocketFactory` with that truststore directly into the AMQP `ConnectionFactory`. This isn't supported by the `AmqpConnectionDetails` class. I thought it might be useful in some more complex use cases (like this one) to give the underlying `ConnectionFactory` directly to the Alpakka AMQP graphstage, so you can use the more advanced features of the Java RabbitMQ client.

The new settings type (`AmqpConnectionFactory`) can be constructed with a single `ConnectionFactory`. I maintained support for multiple host/port combinations with an extra `hostAndPorts` parameter. If `hostAndPorts` is empty, the host/port from the `ConnectionFactory` is used.

Please let me know your feedback.