### PR TITLE
jms: fix NPE when connection failed to initialize

### DIFF
--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -21,7 +21,7 @@ private[jms] trait JmsConnector { this: GraphStageLogic =>
 
   implicit private[jms] var ec: ExecutionContext = _
 
-  private[jms] var jmsConnection: Connection = _
+  private[jms] var jmsConnection: Option[Connection] = None
 
   private[jms] var jmsSessions = Seq.empty[JmsSession]
 
@@ -32,7 +32,7 @@ private[jms] trait JmsConnector { this: GraphStageLogic =>
   private[jms] def fail = getAsyncCallback[Throwable](e => failStage(e))
 
   private def onConnection = getAsyncCallback[Connection] { c =>
-    jmsConnection = c
+    jmsConnection = Some(c)
   }
 
   private def onSession =

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsSourceStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsSourceStage.scala
@@ -257,7 +257,7 @@ abstract class SourceStageLogic[T](shape: SourceShape[T],
     if (stopping.compareAndSet(false, true))
       Future {
         try {
-          jmsConnection.stop()
+          jmsConnection.foreach(_.stop())
         } catch {
           case NonFatal(e) => log.error(e, "Error stopping JMS connection {}", jmsConnection)
         }
@@ -271,7 +271,7 @@ abstract class SourceStageLogic[T](shape: SourceShape[T],
         }
         .onComplete { _ =>
           try {
-            jmsConnection.close()
+            jmsConnection.foreach(_.close())
           } catch {
             case NonFatal(e) => log.error(e, "Error closing JMS connection {}", jmsConnection)
           } finally {
@@ -287,7 +287,7 @@ abstract class SourceStageLogic[T](shape: SourceShape[T],
     if (stopping.compareAndSet(false, true)) {
       Future {
         try {
-          jmsConnection.close()
+          jmsConnection.foreach(_.close())
           log.info("JMS connection {} closed", jmsConnection)
           markAborted.invoke(ex)
         } catch {


### PR DESCRIPTION
When `javax.jms.ConnectionFactory#createConnection()` throws an exception (e.g. failed to connect), we are left with a null connection and throw a NPE when closing the stage.