### PR TITLE
jms: add queue browser

### DIFF
--- a/docs/src/main/paradox/jms.md
+++ b/docs/src/main/paradox/jms.md
@@ -373,6 +373,34 @@ Java
 *  Buffering is not supported in transaction mode. The `bufferSize` is ignored.
 *  The default `AcknowledgeMode` is `SessionTransacted` but can be overridden to custom `AcknowledgeMode`s, even implementation-specific ones by setting the `AcknowledgeMode` in the `JmsSourceSettings` when creating the stream. 
  
+### Browsing messages from a JMS provider
+
+The browse source will stream the messages in a queue without consuming them.
+
+Create a source:
+
+Scala
+: @@snip ($alpakka$/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #create-browse-source }
+
+Java
+: @@snip ($alpakka$/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-browse-source }
+
+The `messageSelector` parameter can be used to filter the messages. Otherwise it will browse the entire content of the queue.
+
+Unlike the other sources, the browse source will complete after browsing all the messages:
+
+Scala
+: @@snip ($alpakka$/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #run-browse-source }
+
+Java
+: @@snip ($alpakka$/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #run-browse-source }
+
+**Notes:**
+
+*  Messages may be arriving and expiring while the scan is done.
+*  The JMS API does not require the content of an enumeration to be a static snapshot of queue content. Whether these changes are visible or not depends on the JMS provider.
+*  A message must not be returned by a QueueBrowser before its delivery time has been reached.
+
 
 ### Using Topic with an JMS provider
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -90,3 +90,22 @@ final case class JmsSinkSettings(connectionFactory: ConnectionFactory,
 }
 
 final case class Credentials(username: String, password: String)
+
+object JmsBrowseSettings {
+
+  def create(connectionFactory: ConnectionFactory) = JmsBrowseSettings(connectionFactory)
+
+}
+
+final case class JmsBrowseSettings(connectionFactory: ConnectionFactory,
+                                   destination: Option[Queue] = None,
+                                   credentials: Option[Credentials] = None,
+                                   selector: Option[String] = None,
+                                   acknowledgeMode: Option[AcknowledgeMode] = None)
+    extends JmsSettings {
+  def withCredential(credentials: Credentials): JmsBrowseSettings = copy(credentials = Some(credentials))
+  def withQueue(name: String): JmsBrowseSettings = copy(destination = Some(Queue(name)))
+  def withSelector(selector: String): JmsBrowseSettings = copy(selector = Some(selector))
+  def withAcknowledgeMode(acknowledgeMode: AcknowledgeMode): JmsBrowseSettings =
+    copy(acknowledgeMode = Option(acknowledgeMode))
+}

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsBrowseStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsBrowseStage.scala
@@ -11,6 +11,7 @@ import akka.stream.stage.{GraphStage, GraphStageLogic, OutHandler}
 import java.util.{Enumeration => JEnumeration}
 
 private[stream] final class JmsBrowseStage(settings: JmsBrowseSettings) extends GraphStage[SourceShape[Message]] {
+  private val queue = settings.destination.getOrElse { throw new IllegalArgumentException("Destination is missing") }
 
   private val out = Outlet[Message]("JmsBrowseStage.out")
   val shape = SourceShape(out)
@@ -28,7 +29,6 @@ private[stream] final class JmsBrowseStage(settings: JmsBrowseSettings) extends 
       var messages: JEnumeration[Message] = _
 
       override def preStart(): Unit = {
-        val queue = settings.destination.getOrElse { throw new IllegalArgumentException("Destination is missing") }
         val ackMode = settings.acknowledgeMode.getOrElse(AcknowledgeMode.AutoAcknowledge).mode
         connection = settings.connectionFactory.createConnection()
         connection.start()

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsBrowseStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsBrowseStage.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.jms
+
+import javax.jms._
+
+import akka.stream.{ActorAttributes, Attributes, Outlet, SourceShape}
+import akka.stream.stage.{GraphStage, GraphStageLogic, OutHandler}
+import java.util.{Enumeration => JEnumeration}
+
+private[stream] final class JmsBrowseStage(settings: JmsBrowseSettings) extends GraphStage[SourceShape[Message]] {
+
+  private val out = Outlet[Message]("JmsBrowseStage.out")
+  val shape = SourceShape(out)
+
+  override protected def initialAttributes: Attributes =
+    ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher")
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with OutHandler {
+      setHandler(out, this)
+
+      var connection: Connection = _
+      var session: Session = _
+      var browser: QueueBrowser = _
+      var messages: JEnumeration[Message] = _
+
+      override def preStart(): Unit = {
+        val queue = settings.destination.getOrElse { throw new IllegalArgumentException("Destination is missing") }
+        val ackMode = settings.acknowledgeMode.getOrElse(AcknowledgeMode.AutoAcknowledge).mode
+        connection = settings.connectionFactory.createConnection()
+        connection.start()
+
+        session = connection.createSession(false, ackMode)
+        browser = session.createBrowser(session.createQueue(queue.name), settings.selector.orNull)
+        messages = browser.getEnumeration.asInstanceOf[JEnumeration[Message]]
+      }
+
+      override def postStop(): Unit = {
+        messages = null
+        if (browser ne null) {
+          browser.close()
+          browser = null
+        }
+        if (session ne null) {
+          session.close()
+          session = null
+        }
+        if (connection ne null) {
+          connection.close()
+          connection = null
+        }
+      }
+
+      def onPull(): Unit =
+        if (messages.hasMoreElements) {
+          push(out, messages.nextElement())
+        } else {
+          complete(out)
+        }
+    }
+}

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSource.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSource.scala
@@ -6,6 +6,7 @@ package akka.stream.alpakka.jms.javadsl
 
 import javax.jms.Message
 
+import akka.NotUsed
 import akka.stream.KillSwitch
 import akka.stream.alpakka.jms._
 
@@ -67,4 +68,10 @@ object JmsSource {
    */
   def txSource(jmsSettings: JmsSourceSettings): akka.stream.javadsl.Source[TxEnvelope, KillSwitch] =
     akka.stream.javadsl.Source.fromGraph(new JmsTxSourceStage(jmsSettings))
+
+  /**
+   * Java API: Creates a [[JmsSource]] for browsing messages non-destructively
+   */
+  def browse(jmsSettings: JmsBrowseSettings): akka.stream.javadsl.Source[Message, NotUsed] =
+    akka.stream.javadsl.Source.fromGraph(new JmsBrowseStage(jmsSettings))
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSource.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSource.scala
@@ -6,6 +6,7 @@ package akka.stream.alpakka.jms.scaladsl
 
 import javax.jms._
 
+import akka.NotUsed
 import akka.stream.KillSwitch
 import akka.stream.alpakka.jms._
 import akka.stream.scaladsl.Source
@@ -75,4 +76,9 @@ object JmsSource {
   def txSource(jmsSettings: JmsSourceSettings): Source[TxEnvelope, KillSwitch] =
     Source.fromGraph(new JmsTxSourceStage(jmsSettings))
 
+  /**
+   * Scala API: Creates a [[JmsSource]] for browsing messages non-destructively
+   */
+  def browse(jmsSettings: JmsBrowseSettings): Source[Message, NotUsed] =
+    Source.fromGraph(new JmsBrowseStage(jmsSettings))
 }


### PR DESCRIPTION
Exposes the JMS queue browser API which iterates messages on the queue without consuming them.