### PR TITLE
Fix amqp docs

### DIFF
--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectionProvidersTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectionProvidersTest.java
@@ -12,7 +12,7 @@ import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import org.junit.Test;
 
-public class AmqpConnectionSettingsTest {
+public class AmqpConnectionProvidersTest {
   @Test
   public void LocalAmqpConnectionCreatesNewConnection() throws Exception {
     AmqpConnectionProvider connectionProvider = AmqpLocalConnectionProvider.getInstance();

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -42,7 +42,9 @@ class AmqpConnectorsSpec extends AmqpSpec {
 
       //#create-sink
       val amqpSink = AmqpSink.simple(
-        AmqpSinkSettings(connectionProvider).withRoutingKey(queueName).withDeclarations(queueDeclaration)
+        AmqpSinkSettings(connectionProvider)
+          .withRoutingKey(queueName)
+          .withDeclarations(queueDeclaration)
       )
       //#create-sink
 
@@ -83,8 +85,11 @@ class AmqpConnectorsSpec extends AmqpSpec {
 
       val input = Vector("one", "two", "three", "four", "five")
       //#run-rpc-flow
-      val (rpcQueueF, probe) =
-        Source(input).map(s => ByteString(s)).viaMat(amqpRpcFlow)(Keep.right).toMat(TestSink.probe)(Keep.both).run
+      val (rpcQueueF, probe) = Source(input)
+        .map(s => ByteString(s))
+        .viaMat(amqpRpcFlow)(Keep.right)
+        .toMat(TestSink.probe)(Keep.both)
+        .run
       //#run-rpc-flow
       rpcQueueF.futureValue
 
@@ -175,7 +180,9 @@ class AmqpConnectorsSpec extends AmqpSpec {
       val queueName = "amqp-conn-it-spec-work-queues-" + System.currentTimeMillis()
       val queueDeclaration = QueueDeclaration(queueName)
       val amqpSink = AmqpSink.simple(
-        AmqpSinkSettings(connectionProvider).withRoutingKey(queueName).withDeclarations(queueDeclaration)
+        AmqpSinkSettings(connectionProvider)
+          .withRoutingKey(queueName)
+          .withDeclarations(queueDeclaration)
       )
 
       val input = Vector("one", "two", "three", "four", "five")
@@ -188,7 +195,8 @@ class AmqpConnectorsSpec extends AmqpSpec {
         for (n <- 0 until count) {
           val source = b.add(
             AmqpSource.atMostOnceSource(
-              NamedQueueSourceSettings(connectionProvider, queueName).withDeclarations(queueDeclaration),
+              NamedQueueSourceSettings(connectionProvider, queueName)
+                .withDeclarations(queueDeclaration),
               bufferSize = 1
             )
           )
@@ -212,7 +220,9 @@ class AmqpConnectorsSpec extends AmqpSpec {
       )
 
       val amqpSink = AmqpSink.simple(
-        AmqpSinkSettings(connectionProvider).withRoutingKey(queueName).withDeclarations(queueDeclaration)
+        AmqpSinkSettings(connectionProvider)
+          .withRoutingKey(queueName)
+          .withDeclarations(queueDeclaration)
       )
 
       val publisher = TestPublisher.probe[ByteString]()
@@ -265,7 +275,9 @@ class AmqpConnectorsSpec extends AmqpSpec {
 
       //#create-exchange-sink
       val amqpSink = AmqpSink.simple(
-        AmqpSinkSettings(connectionProvider).withExchange(exchangeName).withDeclarations(exchangeDeclaration)
+        AmqpSinkSettings(connectionProvider)
+          .withExchange(exchangeName)
+          .withDeclarations(exchangeDeclaration)
       )
       //#create-exchange-sink
 
@@ -309,7 +321,9 @@ class AmqpConnectorsSpec extends AmqpSpec {
       val queueDeclaration = QueueDeclaration(queueName)
 
       val amqpSink = AmqpSink.simple(
-        AmqpSinkSettings(connectionProvider).withRoutingKey(queueName).withDeclarations(queueDeclaration)
+        AmqpSinkSettings(connectionProvider)
+          .withRoutingKey(queueName)
+          .withDeclarations(queueDeclaration)
       )
 
       //#create-source-withoutautoack
@@ -338,7 +352,9 @@ class AmqpConnectorsSpec extends AmqpSpec {
       val queueDeclaration = QueueDeclaration(queueName)
 
       val amqpSink = AmqpSink.simple(
-        AmqpSinkSettings(connectionProvider).withRoutingKey(queueName).withDeclarations(queueDeclaration)
+        AmqpSinkSettings(connectionProvider)
+          .withRoutingKey(queueName)
+          .withDeclarations(queueDeclaration)
       )
 
       val input = Vector("one", "two", "three", "four", "five")
@@ -351,8 +367,8 @@ class AmqpConnectorsSpec extends AmqpSpec {
 
       //#run-source-withoutautoack-and-nack
       val result1 = amqpSource
-        .mapAsync(1)(cm => cm.nack().map(_ => cm))
         .take(input.size)
+        .mapAsync(1)(cm => cm.nack().map(_ => cm))
         .runWith(Sink.seq)
       //#run-source-withoutautoack-and-nack
 
@@ -373,7 +389,9 @@ class AmqpConnectorsSpec extends AmqpSpec {
       val queueDeclaration = QueueDeclaration(queueName)
 
       val amqpSink = AmqpSink.simple(
-        AmqpSinkSettings(connectionSettings).withRoutingKey(queueName).withDeclarations(queueDeclaration)
+        AmqpSinkSettings(connectionSettings)
+          .withRoutingKey(queueName)
+          .withDeclarations(queueDeclaration)
       )
 
       val amqpSource = AmqpSource.committableSource(
@@ -398,7 +416,9 @@ class AmqpConnectorsSpec extends AmqpSpec {
       val queueDeclaration = QueueDeclaration(queueName)
 
       val amqpSink = AmqpSink.simple(
-        AmqpSinkSettings(connectionProvider).withRoutingKey(queueName).withDeclarations(queueDeclaration)
+        AmqpSinkSettings(connectionProvider)
+          .withRoutingKey(queueName)
+          .withDeclarations(queueDeclaration)
       )
       val input = Vector("one", "two", "three", "four", "five")
       Source(input).map(s => ByteString(s)).runWith(amqpSink).futureValue shouldEqual Done

--- a/docs/src/main/paradox/amqp.md
+++ b/docs/src/main/paradox/amqp.md
@@ -22,10 +22,11 @@ The AMQP connector provides Akka Stream sources and sinks to connect to AMQP ser
 All the AMQP connectors are configured using a @scaladoc[AmqpConnectionProvider](akka.stream.alpakka.amqp.AmqpConnectionProvider) and a list of @scaladoc[Declaration](akka.stream.alpakka.amqp.Declaration)
 
 There are several types of @scaladoc[AmqpConnectionProvider](akka.stream.alpakka.amqp.AmqpConnectionProvider):
+
 * @scaladoc[AmqpLocalConnectionProvider](akka.stream.alpakka.amqp.AmqpLocalConnectionProvider) which connects to the default localhost. It creates a new connection for each stage.
 * @scaladoc[AmqpUriConnectionProvider](akka.stream.alpakka.amqp.AmqpUriConnectionProvider) which connects to the given AMQP URI. It creates a new connection for each stage.
 * @scaladoc[AmqpDetailsConnectionProvider](akka.stream.alpakka.amqp.AmqpDetailsConnectionProvider) which supports more fine-grained configuration. It creates a new connection for each stage.
-* @scaladoc[AmqpConnectionFactoryConnectionProvider](akka.stream.alpakka.amqp.AmqpConnectionFactoryConnectionProvider) which takes a raw @scaladoc[ConnectionFactory](com.rabbitmq.client.ConnectionFactory). It creates a new connection for each stage.
+* @scaladoc[AmqpConnectionFactoryConnectionProvider](akka.stream.alpakka.amqp.AmqpConnectionFactoryConnectionProvider) which takes a raw [ConnectionFactory](https://www.rabbitmq.com/releases/rabbitmq-java-client/current-javadoc/com/rabbitmq/client/ConnectionFactory.html). It creates a new connection for each stage.
 * @scaladoc[AmqpCachedConnectionProvider](akka.stream.alpakka.amqp.AmqpCachedConnectionProvider) which receive any other provider as parameter and caches the connection it provides to be used in all stages. By default it closes the connection whenever the last stage using the provider stops. Optionally, it takes `automaticRelease` boolean parameter so the connection is not automatically release and the user have to release it explicitly.
 
 ### Sending messages to AMQP server


### PR DESCRIPTION
Fix a couple issues that I found on the amqp docs:
* List of providers not showing as a list
* Link to Amqp ConnectionFactory is broken

Also refactor a bit the example so they look as similar as possible between java and scala.

Unfortunately I can't test that since running `sbt docs/local:paradox` on master always result on:
```
[error] java.net.URISyntaxException: Illegal character in path at index 36: /.../alpakka/docs/src/main/paradox
[error] 	at java.net.URI$Parser.fail(URI.java:2848)
[error] 	at java.net.URI$Parser.checkChars(URI.java:3021)
[error] 	at java.net.URI$Parser.parseHierarchical(URI.java:3105)
[error] 	at java.net.URI$Parser.parse(URI.java:3063)
[error] 	at java.net.URI.<init>(URI.java:588)
[error] 	at com.lightbend.paradox.markdown.Path$.relativeLocalPath(Page.scala:221)
[error] 	at com.lightbend.paradox.ParadoxProcessor.mapping$1(ParadoxProcessor.scala:197)
[error] 	at com.lightbend.paradox.ParadoxProcessor.$anonfun$rootPageMappings$1(ParadoxProcessor.scala:202)
[error] 	at scala.collection.immutable.List.flatMap(List.scala:335)
[error] 	at com.lightbend.paradox.ParadoxProcessor.rootPageMappings(ParadoxProcessor.scala:202)
[error] 	at com.lightbend.paradox.ParadoxProcessor.process(ParadoxProcessor.scala:52)
[error] 	at com.lightbend.paradox.sbt.ParadoxPlugin$.$anonfun$paradoxSettings$37(ParadoxPlugin.scala:144)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:42)
[error] 	at sbt.std.Transform$$anon$4.work(System.scala:64)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:257)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error] 	at sbt.Execute.work(Execute.scala:266)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:257)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:167)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:32)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
[error] 	at java.lang.Thread.run(Thread.java:745)
[error] (docs/local:paradoxMarkdownToHtml) java.net.URISyntaxException: Illegal character in path at index 36: /.../alpakka/docs/src/main/paradox
```
Any idea of what's wrong?
How can I build the docs locally?