### PR TITLE
Examples: make use of materialized value in JMS

### DIFF
--- a/doc-examples/src/main/scala/jms/JmsSampleBase.scala
+++ b/doc-examples/src/main/scala/jms/JmsSampleBase.scala
@@ -6,15 +6,18 @@ package jms
 
 import javax.jms.ConnectionFactory
 
+import akka.Done
 import akka.stream.alpakka.jms.JmsSinkSettings
 import akka.stream.alpakka.jms.scaladsl.JmsSink
 import akka.stream.scaladsl.{Sink, Source}
 import playground.ActorSystemAvailable
 
+import scala.concurrent.Future
+
 class JmsSampleBase extends ActorSystemAvailable {
 
   def enqueue(connectionFactory: ConnectionFactory)(msgs: String*): Unit = {
-    val jmsSink: Sink[String, _] =
+    val jmsSink: Sink[String, Future[Done]] =
       JmsSink.textSink(
         JmsSinkSettings(connectionFactory).withQueue("test")
       )


### PR DESCRIPTION
As JMS sources now have a proper materialized value I changed the examples to shut down the flows properly.