### PR TITLE
Add support for s3 list buckets v1

### DIFF
--- a/docs/src/main/paradox/s3.md
+++ b/docs/src/main/paradox/s3.md
@@ -82,8 +82,14 @@ complete( eventualMeta.map ( meta ⇒
 Scala
 : @@snip ($alpakka$/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala) { #list-bucket }
 
+Scala API Version 1
+: @@snip ($alpakka$/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala) { #list-bucket-v1 }
+
 Java
 : @@snip ($alpakka$/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java) { #list-bucket }
+
+Java API Version 1
+: @@snip ($alpakka$/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java) { #list-bucket-v1 }
 
 
 ### Running the example code

--- a/docs/src/main/paradox/s3.md
+++ b/docs/src/main/paradox/s3.md
@@ -82,15 +82,8 @@ complete( eventualMeta.map ( meta ⇒
 Scala
 : @@snip ($alpakka$/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala) { #list-bucket }
 
-Scala API Version 1
-: @@snip ($alpakka$/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala) { #list-bucket-v1 }
-
 Java
 : @@snip ($alpakka$/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java) { #list-bucket }
-
-Java API Version 1
-: @@snip ($alpakka$/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java) { #list-bucket-v1 }
-
 
 ### Running the example code
 

--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -76,4 +76,8 @@ akka.stream.alpakka.s3 {
 
   # Custom endpoint url, used for alternate s3 implementations
   # endpoint-url = null
+
+  # Which version of the list bucket api to use. Set to 1 to use the old style version 1 API.
+  # By default the newer version 2 api is used.
+  list-bucket-api-version = 2
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -21,11 +21,10 @@ private[alpakka] object HttpRequests {
   def listBucket(
       bucket: String,
       prefix: Option[String] = None,
-      continuationToken: Option[String] = None,
-      apiVersion: ApiVersion = ListBucketVersion2
+      continuationToken: Option[String] = None
   )(implicit conf: S3Settings): HttpRequest = {
 
-    val (listType, continuationTokenName) = apiVersion match {
+    val (listType, continuationTokenName) = conf.listBucketApiVersion match {
       case ListBucketVersion1 => (None, "marker")
       case ListBucketVersion2 => (Some("2"), "continuation-token")
     }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -21,14 +21,16 @@ private[alpakka] object HttpRequests {
   def listBucket(
       bucket: String,
       prefix: Option[String] = None,
-      continuationToken: Option[String] = None
+      continuationToken: Option[String] = None,
+      useApiVersion2: Boolean = true
   )(implicit conf: S3Settings): HttpRequest = {
 
+    val (listType, continuationTokenName) = if (useApiVersion2) (Some("2"), "continuation-token") else (None, "marker")
     val query = Query(
       Seq(
-        "list-type" -> Some("2"),
+        "list-type" -> listType,
         "prefix" -> prefix,
-        "continuation-token" -> continuationToken
+        continuationTokenName -> continuationToken
       ).collect { case (k, Some(v)) => k -> v }.toMap
     )
 

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -22,10 +22,14 @@ private[alpakka] object HttpRequests {
       bucket: String,
       prefix: Option[String] = None,
       continuationToken: Option[String] = None,
-      useApiVersion2: Boolean = true
+      apiVersion: ApiVersion = ListBucketVersion2
   )(implicit conf: S3Settings): HttpRequest = {
 
-    val (listType, continuationTokenName) = if (useApiVersion2) (Some("2"), "continuation-token") else (None, "marker")
+    val (listType, continuationTokenName) = apiVersion match {
+      case ListBucketVersion1 => (None, "marker")
+      case ListBucketVersion2 => (Some("2"), "continuation-token")
+    }
+
     val query = Query(
       Seq(
         "list-type" -> listType,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -80,7 +80,9 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
     (source, meta)
   }
 
-  def listBucket(bucket: String, prefix: Option[String] = None): Source[ListBucketResultContents, NotUsed] = {
+  def listBucket(bucket: String,
+                 prefix: Option[String] = None,
+                 useApiVersion2: Boolean): Source[ListBucketResultContents, NotUsed] = {
     sealed trait ListBucketState
     case object Starting extends ListBucketState
     case class Running(continuationToken: String) extends ListBucketState
@@ -89,7 +91,7 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
     import system.dispatcher
 
     def listBucketCall(token: Option[String]): Future[Option[(ListBucketState, Seq[ListBucketResultContents])]] =
-      signAndGetAs[ListBucketResult](HttpRequests.listBucket(bucket, prefix, token))
+      signAndGetAs[ListBucketResult](HttpRequests.listBucket(bucket, prefix, token, useApiVersion2))
         .map { (res: ListBucketResult) =>
           Some(
             res.continuationToken

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -486,15 +486,36 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
   }
 
   /**
-   * Will return a source of object metadata for a given bucket with optional prefix.
+   * Will return a source of object metadata for a given bucket with optional prefix using version 2 of the LIst Bucket API.
    * This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html
+   *
    * @param bucket Which bucket that you list object metadata for
    * @param prefix Prefix of the keys you want to list under passed bucket
    * @return Source of object metadata
    */
   def listBucket(bucket: String, prefix: Option[String]): Source[ListBucketResultContents, NotUsed] =
     impl
-      .listBucket(bucket, prefix)
+      .listBucket(bucket, prefix, useApiVersion2 = false)
+      .map { scalaContents =>
+        listingToJava(scalaContents)
+      }
+      .asJava
+
+  /**
+   * Will return a source of object metadata for a given bucket with optional prefix using version 1 of the List Bucket API.
+   * This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
+   *
+   * @param bucket Which bucket that you list object metadata for
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @return Source of object metadata
+   */
+  def listBucketV1(bucket: String, prefix: Option[String]): Source[ListBucketResultContents, NotUsed] =
+    impl
+      .listBucket(bucket, prefix, useApiVersion2 = true)
       .map { scalaContents =>
         listingToJava(scalaContents)
       }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -486,10 +486,13 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
   }
 
   /**
-   * Will return a source of object metadata for a given bucket with optional prefix using version 2 of the LIst Bucket API.
+   * Will return a source of object metadata for a given bucket with optional prefix using version 2 of the List Bucket API.
    * This will automatically page through all keys with the given parameters.
    *
-   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html
+   * The <code>akka.stream.alpakka.s3.list-bucket-api-version</code> can be set to 1 to use the older API version 1
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html  (version 1 API)
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html (version 1 API)
    *
    * @param bucket Which bucket that you list object metadata for
    * @param prefix Prefix of the keys you want to list under passed bucket

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -497,7 +497,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    */
   def listBucket(bucket: String, prefix: Option[String]): Source[ListBucketResultContents, NotUsed] =
     impl
-      .listBucket(bucket, prefix, useApiVersion2 = true)
+      .listBucket(bucket, prefix, apiVersion = ListBucketVersion2)
       .map { scalaContents =>
         listingToJava(scalaContents)
       }
@@ -515,7 +515,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    */
   def listBucketV1(bucket: String, prefix: Option[String]): Source[ListBucketResultContents, NotUsed] =
     impl
-      .listBucket(bucket, prefix, useApiVersion2 = false)
+      .listBucket(bucket, prefix, apiVersion = ListBucketVersion1)
       .map { scalaContents =>
         listingToJava(scalaContents)
       }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -497,7 +497,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    */
   def listBucket(bucket: String, prefix: Option[String]): Source[ListBucketResultContents, NotUsed] =
     impl
-      .listBucket(bucket, prefix, useApiVersion2 = false)
+      .listBucket(bucket, prefix, useApiVersion2 = true)
       .map { scalaContents =>
         listingToJava(scalaContents)
       }
@@ -515,7 +515,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    */
   def listBucketV1(bucket: String, prefix: Option[String]): Source[ListBucketResultContents, NotUsed] =
     impl
-      .listBucket(bucket, prefix, useApiVersion2 = true)
+      .listBucket(bucket, prefix, useApiVersion2 = false)
       .map { scalaContents =>
         listingToJava(scalaContents)
       }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -497,25 +497,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    */
   def listBucket(bucket: String, prefix: Option[String]): Source[ListBucketResultContents, NotUsed] =
     impl
-      .listBucket(bucket, prefix, apiVersion = ListBucketVersion2)
-      .map { scalaContents =>
-        listingToJava(scalaContents)
-      }
-      .asJava
-
-  /**
-   * Will return a source of object metadata for a given bucket with optional prefix using version 1 of the List Bucket API.
-   * This will automatically page through all keys with the given parameters.
-   *
-   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
-   *
-   * @param bucket Which bucket that you list object metadata for
-   * @param prefix Prefix of the keys you want to list under passed bucket
-   * @return Source of object metadata
-   */
-  def listBucketV1(bucket: String, prefix: Option[String]): Source[ListBucketResultContents, NotUsed] =
-    impl
-      .listBucket(bucket, prefix, apiVersion = ListBucketVersion1)
+      .listBucket(bucket, prefix)
       .map { scalaContents =>
         listingToJava(scalaContents)
       }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
@@ -266,13 +266,10 @@ final class S3Client(val s3Settings: S3Settings)(implicit system: ActorSystem, m
    *
    * @param bucket Which bucket that you list object metadata for
    * @param prefix Prefix of the keys you want to list under passed bucket
-   * @param useApiVersion2 If true (the default) use the List Buckets API version 2, otherwise use version 1
    * @return [[Source]] of [[ListBucketResultContents]]
    */
-  def listBucket(bucket: String,
-                 prefix: Option[String],
-                 apiVersion: ApiVersion = ListBucketVersion2): Source[ListBucketResultContents, NotUsed] =
-    impl.listBucket(bucket, prefix, apiVersion)
+  def listBucket(bucket: String, prefix: Option[String]): Source[ListBucketResultContents, NotUsed] =
+    impl.listBucket(bucket, prefix)
 
   /**
    * Uploads a S3 Object by making multiple requests

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
@@ -266,10 +266,13 @@ final class S3Client(val s3Settings: S3Settings)(implicit system: ActorSystem, m
    *
    * @param bucket Which bucket that you list object metadata for
    * @param prefix Prefix of the keys you want to list under passed bucket
+   * @param useApiVersion2 If true (the default) use the List Buckets API version 2, otherwise use version 1
    * @return [[Source]] of [[ListBucketResultContents]]
    */
-  def listBucket(bucket: String, prefix: Option[String]): Source[ListBucketResultContents, NotUsed] =
-    impl.listBucket(bucket, prefix)
+  def listBucket(bucket: String,
+                 prefix: Option[String],
+                 useApiVersion2: Boolean = true): Source[ListBucketResultContents, NotUsed] =
+    impl.listBucket(bucket, prefix, useApiVersion2)
 
   /**
    * Uploads a S3 Object by making multiple requests

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
@@ -261,8 +261,13 @@ final class S3Client(val s3Settings: S3Settings)(implicit system: ActorSystem, m
     impl.download(S3Location(bucket, key), range, sse)
 
   /**
-   * Will return a source of object metadata for a given bucket with optional prefix.
+   * Will return a source of object metadata for a given bucket with optional prefix using version 2 of the List Bucket API.
    * This will automatically page through all keys with the given parameters.
+   *
+   * The `akka.stream.alpakka.s3.list-bucket-api-version` can be set to 1 to use the older API version 1
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html  (version 1 API)
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html (version 1 API)
    *
    * @param bucket Which bucket that you list object metadata for
    * @param prefix Prefix of the keys you want to list under passed bucket

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
@@ -271,8 +271,8 @@ final class S3Client(val s3Settings: S3Settings)(implicit system: ActorSystem, m
    */
   def listBucket(bucket: String,
                  prefix: Option[String],
-                 useApiVersion2: Boolean = true): Source[ListBucketResultContents, NotUsed] =
-    impl.listBucket(bucket, prefix, useApiVersion2)
+                 apiVersion: ApiVersion = ListBucketVersion2): Source[ListBucketResultContents, NotUsed] =
+    impl.listBucket(bucket, prefix, apiVersion)
 
   /**
    * Uploads a S3 Object by making multiple requests

--- a/s3/src/test/java/akka/stream/alpakka/s3/javadsl/DocSnippets.java
+++ b/s3/src/test/java/akka/stream/alpakka/s3/javadsl/DocSnippets.java
@@ -10,6 +10,7 @@ import akka.stream.Materializer;
 import akka.stream.alpakka.s3.MemoryBufferType;
 import akka.stream.alpakka.s3.Proxy;
 import akka.stream.alpakka.s3.S3Settings;
+import akka.stream.alpakka.s3.impl.ListBucketVersion2;
 import akka.stream.alpakka.s3.scaladsl.S3WireMockBase;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -48,7 +49,8 @@ public class DocSnippets extends S3WireMockBase {
                 credentials,
                 regionProvider,
                 true,
-                scala.Option.empty()
+                scala.Option.empty(),
+                ListBucketVersion2.getInstance()
         );
         final S3Client s3Client = new S3Client(settings,system(), mat);
         // #java-bluemix-example

--- a/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
+++ b/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
@@ -222,7 +222,7 @@ public class S3ClientTest extends S3WireMockBase {
     @Test
     public void listBucketV1() throws Exception {
 
-        mockListBucket();
+        mockListBucketVersion1();
 
         //#list-bucket-v1
         final Source<ListBucketResultContents, NotUsed> keySource = client.listBucketV1(bucket(), Option.apply(listPrefix()));

--- a/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
+++ b/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
@@ -17,6 +17,7 @@ import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.s3.MemoryBufferType;
 import akka.stream.alpakka.s3.Proxy;
+import akka.stream.alpakka.s3.impl.ListBucketVersion2;
 import akka.stream.alpakka.s3.S3Settings;
 import akka.stream.alpakka.s3.impl.ServerSideEncryption;
 import akka.stream.alpakka.s3.scaladsl.S3WireMockBase;
@@ -61,7 +62,8 @@ public class S3ClientTest extends S3WireMockBase {
             credentials,
             regionProvider("us-east-1"),
             false,
-            scala.Option.empty()
+            scala.Option.empty(),
+            ListBucketVersion2.getInstance()
     );
     private final S3Client client = new S3Client(settings, system(), materializer);
     //#client
@@ -210,23 +212,6 @@ public class S3ClientTest extends S3WireMockBase {
         //#list-bucket
         final Source<ListBucketResultContents, NotUsed> keySource = client.listBucket(bucket(), Option.apply(listPrefix()));
         //#list-bucket
-
-        final CompletionStage<ListBucketResultContents> resultCompletionStage = keySource.runWith(Sink.head(), materializer);
-
-        ListBucketResultContents result = resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
-
-        assertEquals(result.key(), listKey());
-
-    }
-
-    @Test
-    public void listBucketV1() throws Exception {
-
-        mockListBucketVersion1();
-
-        //#list-bucket-v1
-        final Source<ListBucketResultContents, NotUsed> keySource = client.listBucketV1(bucket(), Option.apply(listPrefix()));
-        //#list-bucket-v1
 
         final CompletionStage<ListBucketResultContents> resultCompletionStage = keySource.runWith(Sink.head(), materializer);
 

--- a/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
+++ b/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
@@ -218,4 +218,21 @@ public class S3ClientTest extends S3WireMockBase {
         assertEquals(result.key(), listKey());
 
     }
+
+    @Test
+    public void listBucketV1() throws Exception {
+
+        mockListBucket();
+
+        //#list-bucket-v1
+        final Source<ListBucketResultContents, NotUsed> keySource = client.listBucketV1(bucket(), Option.apply(listPrefix()));
+        //#list-bucket-v1
+
+        final CompletionStage<ListBucketResultContents> resultCompletionStage = keySource.runWith(Sink.head(), materializer);
+
+        ListBucketResultContents result = resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+        assertEquals(result.key(), listKey());
+
+    }
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/S3SettingsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/S3SettingsSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.stream.alpakka.s3
 
+import akka.stream.alpakka.s3.impl.{ListBucketVersion1, ListBucketVersion2}
 import akka.stream.alpakka.s3.scaladsl.{S3ClientIntegrationSpec, S3WireMockBase}
 import com.amazonaws.auth._
 import com.amazonaws.regions.DefaultAwsRegionProviderChain
@@ -169,4 +170,23 @@ class S3SettingsSpec extends S3WireMockBase with S3ClientIntegrationSpec with Op
     settings.endpointUrl.value shouldEqual endpointUrl
   }
 
+  it should "instantiate with the list bucket api version 2 by default" in {
+    val settings: S3Settings = mkConfig("")
+    settings.listBucketApiVersion shouldEqual ListBucketVersion2
+  }
+
+  it should "instantiate with the list bucket api version 1 if list-bucket-api-version is set to 1" in {
+    val settings: S3Settings = mkConfig("akka.stream.alpakka.s3.list-bucket-api-version = 1")
+    settings.listBucketApiVersion shouldEqual ListBucketVersion1
+  }
+
+  it should "instantiate with the list bucket api version 2 if list-bucket-api-version is set to a number that is neither 1 or 2" in {
+    val settings: S3Settings = mkConfig("akka.stream.alpakka.s3.list-bucket-api-version = 0")
+    settings.listBucketApiVersion shouldEqual ListBucketVersion2
+  }
+
+  it should "instantiate with the list bucket api version 2 if list-bucket-api-version is set to a value that is not a nymber" in {
+    val settings: S3Settings = mkConfig("akka.stream.alpakka.s3.list-bucket-api-version = 'version 1'")
+    settings.listBucketApiVersion shouldEqual ListBucketVersion2
+  }
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -274,6 +274,24 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
                                       "continuation-token" -> "randomToken")
   }
 
+  it should "properly construct the list bucket request when using api version 1" in {
+    implicit val settings = getSettings(s3Region = "region", pathStyleAccess = true)
+
+    val req =
+      HttpRequests.listBucket(location.bucket, useApiVersion2 = false)
+
+    req.uri.query() shouldEqual Query()
+  }
+
+  it should "properly construct the list bucket request when using api version set to 1 and a continuation token" in {
+    implicit val settings = getSettings(s3Region = "region", pathStyleAccess = true)
+
+    val req =
+      HttpRequests.listBucket(location.bucket, continuationToken = Some("randomToken"), useApiVersion2 = false)
+
+    req.uri.query() shouldEqual Query("marker" -> "randomToken")
+  }
+
   it should "support custom endpoint configured by `endpointUrl`" in {
     implicit val system: ActorSystem = ActorSystem("HttpRequestsSpec")
     import system.dispatcher

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -11,11 +11,9 @@ import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{HttpEntity, HttpRequest, IllegalUriException, MediaTypes}
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.s3.acl.CannedAcl
-import akka.stream.alpakka.s3.scaladsl.S3Client
 import akka.stream.alpakka.s3.{BufferType, MemoryBufferType, Proxy, S3Settings}
 import akka.stream.scaladsl.Source
 import akka.testkit.{SocketUtil, TestProbe}
-import akka.util.ByteString
 import com.amazonaws.auth.{AWSCredentialsProvider, AWSStaticCredentialsProvider, AnonymousAWSCredentials}
 import com.amazonaws.regions.AwsRegionProvider
 import org.scalatest.concurrent.ScalaFutures
@@ -278,7 +276,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
     implicit val settings = getSettings(s3Region = "region", pathStyleAccess = true)
 
     val req =
-      HttpRequests.listBucket(location.bucket, useApiVersion2 = false)
+      HttpRequests.listBucket(location.bucket, apiVersion = ListBucketVersion1)
 
     req.uri.query() shouldEqual Query()
   }
@@ -287,7 +285,9 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
     implicit val settings = getSettings(s3Region = "region", pathStyleAccess = true)
 
     val req =
-      HttpRequests.listBucket(location.bucket, continuationToken = Some("randomToken"), useApiVersion2 = false)
+      HttpRequests.listBucket(location.bucket,
+                              continuationToken = Some("randomToken"),
+                              apiVersion = ListBucketVersion1)
 
     req.uri.query() shouldEqual Query("marker" -> "randomToken")
   }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -28,13 +28,20 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
       awsCredentials: AWSCredentialsProvider = new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()),
       s3Region: String = "us-east-1",
       pathStyleAccess: Boolean = false,
-      endpointUrl: Option[String] = None
+      endpointUrl: Option[String] = None,
+      listBucketApiVersion: ApiVersion = ListBucketVersion2
   ) = {
     val regionProvider = new AwsRegionProvider {
       def getRegion = s3Region
     }
 
-    new S3Settings(bufferType, proxy, awsCredentials, regionProvider, pathStyleAccess, endpointUrl)
+    new S3Settings(bufferType,
+                   proxy,
+                   awsCredentials,
+                   regionProvider,
+                   pathStyleAccess,
+                   endpointUrl,
+                   listBucketApiVersion)
   }
 
   val location = S3Location("bucket", "image-1024@2x")
@@ -273,21 +280,21 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "properly construct the list bucket request when using api version 1" in {
-    implicit val settings = getSettings(s3Region = "region", pathStyleAccess = true)
+    implicit val settings =
+      getSettings(s3Region = "region", pathStyleAccess = true, listBucketApiVersion = ListBucketVersion1)
 
     val req =
-      HttpRequests.listBucket(location.bucket, apiVersion = ListBucketVersion1)
+      HttpRequests.listBucket(location.bucket)
 
     req.uri.query() shouldEqual Query()
   }
 
   it should "properly construct the list bucket request when using api version set to 1 and a continuation token" in {
-    implicit val settings = getSettings(s3Region = "region", pathStyleAccess = true)
+    implicit val settings =
+      getSettings(s3Region = "region", pathStyleAccess = true, listBucketApiVersion = ListBucketVersion1)
 
     val req =
-      HttpRequests.listBucket(location.bucket,
-                              continuationToken = Some("randomToken"),
-                              apiVersion = ListBucketVersion1)
+      HttpRequests.listBucket(location.bucket, continuationToken = Some("randomToken"))
 
     req.uri.query() shouldEqual Query("marker" -> "randomToken")
   }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/MarshallingSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/MarshallingSpec.scala
@@ -75,4 +75,100 @@ class MarshallingSpec(_system: ActorSystem)
     )
   }
 
+  val listBucketV2TruncatedResponse = """<?xml version="1.0" encoding="UTF-8"?>
+                                        |<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                                        |    <Name>bucket</Name>
+                                        |    <Prefix/>
+                                        |    <KeyCount>205</KeyCount>
+                                        |    <MaxKeys>1000</MaxKeys>
+                                        |    <NextContinuationToken>dummy/continuation/token</NextContinuationToken>
+                                        |    <IsTruncated>true</IsTruncated>
+                                        |    <Contents>
+                                        |        <Key>my-image.jpg</Key>
+                                        |        <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                                        |        <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+                                        |        <Size>434234</Size>
+                                        |        <StorageClass>STANDARD</StorageClass>
+                                        |    </Contents>
+                                        |    <Contents>
+                                        |        <Key>my-image2.jpg</Key>
+                                        |        <LastModified>2009-10-12T17:50:31.000Z</LastModified>
+                                        |        <ETag>&quot;599bab3ed2c697f1d26842727561fd94&quot;</ETag>
+                                        |        <Size>1234</Size>
+                                        |        <StorageClass>REDUCED_REDUNDANCY</StorageClass>
+                                        |    </Contents>
+                                        |</ListBucketResult>""".stripMargin
+  it should "Use the value of the `NextContinuationToken` element as the continuation token of a truncated API V1 response" in {
+    val entity =
+      HttpEntity(MediaTypes.`application/xml` withCharset HttpCharsets.`UTF-8`, listBucketV2TruncatedResponse)
+
+    val result = Marshalling.listBucketResultUnmarshaller(entity)
+
+    result.futureValue shouldEqual ListBucketResult(
+      true,
+      Some("dummy/continuation/token"),
+      Seq(
+        ListBucketResultContents("bucket",
+                                 "my-image.jpg",
+                                 "fba9dede5f27731c9771645a39863328",
+                                 434234,
+                                 Instant.parse("2009-10-12T17:50:30Z"),
+                                 "STANDARD"),
+        ListBucketResultContents("bucket",
+                                 "my-image2.jpg",
+                                 "599bab3ed2c697f1d26842727561fd94",
+                                 1234,
+                                 Instant.parse("2009-10-12T17:50:31Z"),
+                                 "REDUCED_REDUNDANCY")
+      )
+    )
+  }
+
+  val listBucketV1TruncatedResponse = """<?xml version="1.0" encoding="UTF-8"?>
+                                        |<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                                        |    <Name>bucket</Name>
+                                        |    <Prefix/>
+                                        |    <KeyCount>205</KeyCount>
+                                        |    <MaxKeys>1000</MaxKeys>
+                                        |    <IsTruncated>true</IsTruncated>
+                                        |    <Contents>
+                                        |        <Key>my-image.jpg</Key>
+                                        |        <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                                        |        <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+                                        |        <Size>434234</Size>
+                                        |        <StorageClass>STANDARD</StorageClass>
+                                        |    </Contents>
+                                        |    <Contents>
+                                        |        <Key>my-image2.jpg</Key>
+                                        |        <LastModified>2009-10-12T17:50:31.000Z</LastModified>
+                                        |        <ETag>&quot;599bab3ed2c697f1d26842727561fd94&quot;</ETag>
+                                        |        <Size>1234</Size>
+                                        |        <StorageClass>REDUCED_REDUNDANCY</StorageClass>
+                                        |    </Contents>
+                                        |</ListBucketResult>""".stripMargin
+  it should "Use the value of the last `Key` element as the continuation token of a truncated API V1 response" in {
+    val entity =
+      HttpEntity(MediaTypes.`application/xml` withCharset HttpCharsets.`UTF-8`, listBucketV1TruncatedResponse)
+
+    val result = Marshalling.listBucketResultUnmarshaller(entity)
+
+    result.futureValue shouldEqual ListBucketResult(
+      true,
+      Some("my-image2.jpg"),
+      Seq(
+        ListBucketResultContents("bucket",
+                                 "my-image.jpg",
+                                 "fba9dede5f27731c9771645a39863328",
+                                 434234,
+                                 Instant.parse("2009-10-12T17:50:30Z"),
+                                 "STANDARD"),
+        ListBucketResultContents("bucket",
+                                 "my-image2.jpg",
+                                 "599bab3ed2c697f1d26842727561fd94",
+                                 1234,
+                                 Instant.parse("2009-10-12T17:50:31Z"),
+                                 "REDUCED_REDUNDANCY")
+      )
+    )
+  }
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
@@ -39,7 +39,7 @@ class S3StreamSpec(_system: ActorSystem)
     }
     val location = S3Location("test-bucket", "test-key")
 
-    implicit val settings = new S3Settings(MemoryBufferType, None, credentialsProvider, regionProvider, false, None)
+    implicit val settings = new S3Settings(MemoryBufferType, None, credentialsProvider, regionProvider, false, None, ListBucketVersion2)
 
     val s3stream = new S3Stream(settings)
     val result: HttpRequest = s3stream invokePrivate requestHeaders(getDownloadRequest(location), None)
@@ -64,7 +64,8 @@ class S3StreamSpec(_system: ActorSystem)
     val location = S3Location("test-bucket", "test-key")
     val range = ByteRange(1, 4)
 
-    implicit val settings = new S3Settings(MemoryBufferType, None, credentialsProvider, regionProvider, false, None)
+    implicit val settings =
+      new S3Settings(MemoryBufferType, None, credentialsProvider, regionProvider, false, None, ListBucketVersion2)
 
     val s3stream = new S3Stream(settings)
     val result: HttpRequest = s3stream invokePrivate requestHeaders(getDownloadRequest(location), Some(range))

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
@@ -39,7 +39,8 @@ class S3StreamSpec(_system: ActorSystem)
     }
     val location = S3Location("test-bucket", "test-key")
 
-    implicit val settings = new S3Settings(MemoryBufferType, None, credentialsProvider, regionProvider, false, None, ListBucketVersion2)
+    implicit val settings =
+      new S3Settings(MemoryBufferType, None, credentialsProvider, regionProvider, false, None, ListBucketVersion2)
 
     val s3stream = new S3Stream(settings)
     val result: HttpRequest = s3stream invokePrivate requestHeaders(getDownloadRequest(location), None)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/DocSnippets.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/DocSnippets.scala
@@ -6,6 +6,7 @@ package akka.stream.alpakka.s3.scaladsl
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.stream.alpakka.s3.impl.ListBucketVersion2
 import akka.stream.alpakka.s3.{MemoryBufferType, Proxy, S3Settings}
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.regions.AwsRegionProvider
@@ -32,7 +33,8 @@ object DoucmentationSnippets {
     val proxy = Some(Proxy(host, port, "https"))
 
     // Set pathStyleAccess to true and specify proxy, leave region blank
-    val settings = new S3Settings(MemoryBufferType, proxy, credentialsProvider, regionProvider, true, None)
+    val settings =
+      new S3Settings(MemoryBufferType, proxy, credentialsProvider, regionProvider, true, None, ListBucketVersion2)
     val s3Client = new S3Client(settings)(system, materializer)
     // #scala-bluemix-example
   }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.s3.scaladsl
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.s3.S3Settings
-import akka.stream.alpakka.s3.impl.{MetaHeaders, S3Headers}
+import akka.stream.alpakka.s3.impl.{ListBucketVersion1, MetaHeaders, S3Headers}
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.util.ByteString
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
@@ -51,15 +51,25 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
       .copy(s3RegionProvider = defaultRegionProvider)
   def otherRegionSettings =
     settings.copy(pathStyleAccess = true, s3RegionProvider = otherRegionProvider)
+  def listBucketVersion1Settings =
+    settings.copy(listBucketApiVersion = ListBucketVersion1)
 
   def defaultRegionContentCount = 4
   def otherRegionContentCount = 5
 
   lazy val defaultRegionClient = new S3Client(settings)
   lazy val otherRegionClient = new S3Client(otherRegionSettings)
+  lazy val version1DefaultRegionClient = new S3Client(listBucketVersion1Settings)
 
   it should "list with real credentials" in {
     val result = defaultRegionClient.listBucket(defaultRegionBucket, None).runWith(Sink.seq)
+
+    val listingResult = result.futureValue
+    listingResult.size shouldBe defaultRegionContentCount
+  }
+
+  it should "list with real credentials using the Version 1 API" in {
+    val result = version1DefaultRegionClient.listBucket(defaultRegionBucket, None).runWith(Sink.seq)
 
     val listingResult = result.futureValue
     listingResult.size shouldBe defaultRegionContentCount
@@ -263,7 +273,7 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
  * (tests that do listing counts might need some tweaking)
  *
  */
-@Ignore
+//@Ignore
 class AWSS3IntegrationSpec extends S3IntegrationSpec
 
 /*

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -273,7 +273,7 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
  * (tests that do listing counts might need some tweaking)
  *
  */
-//@Ignore
+@Ignore
 class AWSS3IntegrationSpec extends S3IntegrationSpec
 
 /*

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
@@ -5,11 +5,11 @@
 package akka.stream.alpakka.s3.scaladsl
 
 import akka.stream.alpakka.s3.{MemoryBufferType, Proxy, S3Settings}
-import akka.stream.alpakka.s3.impl.{S3Headers, ServerSideEncryption}
+import akka.stream.alpakka.s3.impl.{ListBucketVersion2, S3Headers, ServerSideEncryption}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
-import scala.concurrent.Future
 
+import scala.concurrent.Future
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.regions.AwsRegionProvider
 
@@ -23,7 +23,8 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
       def getRegion: String = "us-east-1"
     }
   val proxy = Option(Proxy("localhost", port, "http"))
-  val settings = new S3Settings(MemoryBufferType, proxy, awsCredentialsProvider, regionProvider, false, None)
+  val settings =
+    new S3Settings(MemoryBufferType, proxy, awsCredentialsProvider, regionProvider, false, None, ListBucketVersion2)
   val s3Client = new S3Client(settings)(system, materializer)
 
   "S3Sink" should "upload a stream of bytes to S3" in {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
@@ -140,7 +140,7 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
   }
 
   it should "list keys for a given bucket with a prefix using the version 1 api" in {
-    mockListBucket()
+    mockListBucketVersion1()
 
     //#list-bucket-v1
     val keySource: Source[ListBucketResultContents, NotUsed] =

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
@@ -139,6 +139,18 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     result.futureValue.key shouldBe listKey
   }
 
+  it should "list keys for a given bucket with a prefix using the version 1 api" in {
+    mockListBucket()
+
+    //#list-bucket-v1
+    val keySource: Source[ListBucketResultContents, NotUsed] = s3Client.listBucket(bucket, Some(listPrefix), useApiVersion2 = false)
+    //#list-bucket-v1
+
+    val result = keySource.runWith(Sink.head)
+
+    result.futureValue.key shouldBe listKey
+  }
+
   override protected def afterAll(): Unit = {
     super.afterAll()
     stopWireMockServer()

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
@@ -143,7 +143,8 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     mockListBucket()
 
     //#list-bucket-v1
-    val keySource: Source[ListBucketResultContents, NotUsed] = s3Client.listBucket(bucket, Some(listPrefix), useApiVersion2 = false)
+    val keySource: Source[ListBucketResultContents, NotUsed] =
+      s3Client.listBucket(bucket, Some(listPrefix), useApiVersion2 = false)
     //#list-bucket-v1
 
     val result = keySource.runWith(Sink.head)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
@@ -6,12 +6,12 @@ package akka.stream.alpakka.s3.scaladsl
 
 import akka.NotUsed
 import akka.http.scaladsl.model.headers.ByteRange
-import akka.stream.alpakka.s3.impl.ServerSideEncryption
+import akka.stream.alpakka.s3.impl.{ListBucketVersion1, ServerSideEncryption}
 import akka.stream.alpakka.s3.{MemoryBufferType, Proxy, S3Exception, S3Settings}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
-import scala.concurrent.Future
 
+import scala.concurrent.Future
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.regions.AwsRegionProvider
 
@@ -144,7 +144,7 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
 
     //#list-bucket-v1
     val keySource: Source[ListBucketResultContents, NotUsed] =
-      s3Client.listBucket(bucket, Some(listPrefix), useApiVersion2 = false)
+      s3Client.listBucket(bucket, Some(listPrefix), apiVersion = ListBucketVersion1)
     //#list-bucket-v1
 
     val result = keySource.runWith(Sink.head)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.s3.scaladsl
 
 import akka.NotUsed
 import akka.http.scaladsl.model.headers.ByteRange
-import akka.stream.alpakka.s3.impl.{ListBucketVersion1, ServerSideEncryption}
+import akka.stream.alpakka.s3.impl.{ListBucketVersion2, ServerSideEncryption}
 import akka.stream.alpakka.s3.{MemoryBufferType, Proxy, S3Exception, S3Settings}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
@@ -26,7 +26,8 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
       def getRegion: String = "us-east-1"
     }
   val proxy = Option(Proxy("localhost", port, "http"))
-  val settings = new S3Settings(MemoryBufferType, proxy, awsCredentialsProvider, regionProvider, false, None)
+  val settings =
+    new S3Settings(MemoryBufferType, proxy, awsCredentialsProvider, regionProvider, false, None, ListBucketVersion2)
   val s3Client = new S3Client(settings)(system, materializer)
   //#client
 
@@ -142,10 +143,8 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
   it should "list keys for a given bucket with a prefix using the version 1 api" in {
     mockListBucketVersion1()
 
-    //#list-bucket-v1
     val keySource: Source[ListBucketResultContents, NotUsed] =
-      s3Client.listBucket(bucket, Some(listPrefix), apiVersion = ListBucketVersion1)
-    //#list-bucket-v1
+      s3Client.listBucket(bucket, Some(listPrefix))
 
     val result = keySource.runWith(Sink.head)
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -165,6 +165,31 @@ abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockSer
         )
       )
 
+  def mockListBucketVersion1(): Unit =
+    mock
+      .register(
+        get(urlEqualTo(s"/?prefix=$listPrefix")).willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/xml")
+            .withBody(s"""<?xml version="1.0" encoding="UTF-8"?>
+                        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                            <Name>bucket</Name>
+                            <Prefix>$listPrefix</Prefix>
+                            <Marker/>
+                            <MaxKeys>1000</MaxKeys>
+                            <IsTruncated>false</IsTruncated>
+                            <Contents>
+                                <Key>$listKey</Key>
+                                <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                                <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+                                <Size>434234</Size>
+                                <StorageClass>STANDARD</StorageClass>
+                            </Contents>
+                        </ListBucketResult>""".stripMargin)
+        )
+      )
+
   def mockUpload(): Unit = {
     mock
       .register(

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -147,21 +147,21 @@ abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockSer
           aResponse()
             .withStatus(200)
             .withHeader("Content-Type", "application/xml")
-            .withBody(s"""<?xml version="1.0" encoding="UTF-8"?>
-                        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                            <Name>bucket</Name>
-                            <Prefix>$listPrefix</Prefix>
-                            <KeyCount>1</KeyCount>
-                            <MaxKeys>1000</MaxKeys>
-                            <IsTruncated>false</IsTruncated>
-                            <Contents>
-                                <Key>$listKey</Key>
-                                <LastModified>2009-10-12T17:50:30.000Z</LastModified>
-                                <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
-                                <Size>434234</Size>
-                                <StorageClass>STANDARD</StorageClass>
-                            </Contents>
-                        </ListBucketResult>""".stripMargin)
+            .withBody(s"""|<?xml version="1.0" encoding="UTF-8"?>
+                        |<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        |    <Name>bucket</Name>
+                        |    <Prefix>$listPrefix</Prefix>
+                        |    <KeyCount>1</KeyCount>
+                        |    <MaxKeys>1000</MaxKeys>
+                        |    <IsTruncated>false</IsTruncated>
+                        |    <Contents>
+                        |        <Key>$listKey</Key>
+                        |        <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                        |        <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+                        |        <Size>434234</Size>
+                        |        <StorageClass>STANDARD</StorageClass>
+                        |    </Contents>
+                        |</ListBucketResult>""".stripMargin)
         )
       )
 
@@ -172,21 +172,21 @@ abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockSer
           aResponse()
             .withStatus(200)
             .withHeader("Content-Type", "application/xml")
-            .withBody(s"""<?xml version="1.0" encoding="UTF-8"?>
-                        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                            <Name>bucket</Name>
-                            <Prefix>$listPrefix</Prefix>
-                            <Marker/>
-                            <MaxKeys>1000</MaxKeys>
-                            <IsTruncated>false</IsTruncated>
-                            <Contents>
-                                <Key>$listKey</Key>
-                                <LastModified>2009-10-12T17:50:30.000Z</LastModified>
-                                <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
-                                <Size>434234</Size>
-                                <StorageClass>STANDARD</StorageClass>
-                            </Contents>
-                        </ListBucketResult>""".stripMargin)
+            .withBody(s"""|<?xml version="1.0" encoding="UTF-8"?>
+                        |<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        |    <Name>bucket</Name>
+                        |    <Prefix>$listPrefix</Prefix>
+                        |    <Marker/>
+                        |    <MaxKeys>1000</MaxKeys>
+                        |    <IsTruncated>false</IsTruncated>
+                        |    <Contents>
+                        |        <Key>$listKey</Key>
+                        |        <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                        |        <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+                        |        <Size>434234</Size>
+                        |        <StorageClass>STANDARD</StorageClass>
+                        |    </Contents>
+                        |</ListBucketResult>""".stripMargin)
         )
       )
 


### PR DESCRIPTION
This PR adds the option to `listBucket` using the legacy version 1 api or the current version 2 api. The main driver for this is to support legacy requirements (e.g. third party clients that use version 1, or testing using mock S3 implementations that do not yet support the version 2 api).

The default behaviour is unchanged, using version 2. The Scala implementation makes use of default parameter values to trigger the different versions, whereas the Java implementation adds a new `listBucketV1` method which keep the v1 usage explicit and does not break any existing code that uses the version 2 api.

Looking through the response processing code the `ListBucketResult` only uses response elements that are the same in both version 1 and 2 so I have made no changes there.

Fixes akka/alpakka#468