### PR TITLE
Elasticsearch: enable optimistic locking/concurrency controll (and more)

### DIFF
--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
@@ -29,7 +29,7 @@ object IncomingMessage {
     IncomingMessage(id, source, NotUsed)
 
   // Apply method to use when not using passThrough
-  def apply[T](id: Option[String], source: T, version:Long): IncomingMessage[T, NotUsed] =
+  def apply[T](id: Option[String], source: T, version: Long): IncomingMessage[T, NotUsed] =
     IncomingMessage(id, source, NotUsed, Option(version))
 
   // Java-api - without passThrough
@@ -37,7 +37,7 @@ object IncomingMessage {
     IncomingMessage(Option(id), source)
 
   // Java-api - without passThrough
-  def create[T](id: String, source: T, version:Long): IncomingMessage[T, NotUsed] =
+  def create[T](id: String, source: T, version: Long): IncomingMessage[T, NotUsed] =
     IncomingMessage(Option(id), source, version)
 
   // Java-api - without passThrough
@@ -49,7 +49,7 @@ object IncomingMessage {
     IncomingMessage(Option(id), source, passThrough)
 
   // Java-api - with passThrough
-  def create[T, C](id: String, source: T, passThrough: C, version:Long): IncomingMessage[T, C] =
+  def create[T, C](id: String, source: T, passThrough: C, version: Long): IncomingMessage[T, C] =
     IncomingMessage(Option(id), source, passThrough, Option(version))
 
   // Java-api - with passThrough
@@ -57,15 +57,15 @@ object IncomingMessage {
     IncomingMessage(None, source, passThrough)
 }
 
-final case class IncomingMessage[T, C](id: Option[String], source: T, passThrough: C, version:Option[Long] = None)
+final case class IncomingMessage[T, C](id: Option[String], source: T, passThrough: C, version: Option[Long] = None)
 
 object IncomingMessageResult {
   // Apply method to use when not using passThrough
-  def apply[T](source: T, success: Boolean, errorMsg:Option[String]): IncomingMessageResult[T, NotUsed] =
+  def apply[T](source: T, success: Boolean, errorMsg: Option[String]): IncomingMessageResult[T, NotUsed] =
     IncomingMessageResult(source, NotUsed, success, errorMsg)
 }
 
-final case class IncomingMessageResult[T, C](source: T, passThrough: C, success: Boolean, errorMsg:Option[String])
+final case class IncomingMessageResult[T, C](source: T, passThrough: C, success: Boolean, errorMsg: Option[String])
 
 trait MessageWriter[T] {
   def convert(message: T): String
@@ -125,15 +125,15 @@ class ElasticsearchFlowStage[T, C](
         val (messages, response) = args
         val responseJson = EntityUtils.toString(response.getEntity).parseJson
 
-        case class MessageResultAndIncomingMessage[T2, C2](r:IncomingMessageResult[T2, C2], m:IncomingMessage[T2, C2])
+        case class MessageResultAndIncomingMessage[T2, C2](r: IncomingMessageResult[T2, C2],
+                                                           m: IncomingMessage[T2, C2])
 
         // If some commands in bulk request failed, pass failed messages to follows.
         val items = responseJson.asJsObject.fields("items").asInstanceOf[JsArray]
-        val messageResults:Seq[MessageResultAndIncomingMessage[T, C]] = items.elements.zip(messages).map {
+        val messageResults: Seq[MessageResultAndIncomingMessage[T, C]] = items.elements.zip(messages).map {
           case (item, message) =>
-
             val res = item.asJsObject.fields(insertKeyword).asJsObject
-            val error:Option[String] = res.fields.get("error").map(_.toString())
+            val error: Option[String] = res.fields.get("error").map(_.toString())
             MessageResultAndIncomingMessage(
               IncomingMessageResult(message.source, message.passThrough, error.isEmpty, error),
               message
@@ -147,7 +147,7 @@ class ElasticsearchFlowStage[T, C](
           // NOTE: When we partially return message like this, message will arrive out of order downstream
           // and it can break commit-logic when using Kafka
           retryCount = retryCount + 1
-          failedMessages = failedMsgs.map( _.m) // These are the messages we're going to retry
+          failedMessages = failedMsgs.map(_.m) // These are the messages we're going to retry
           scheduleOnce(NotUsed, settings.retryInterval.millis)
 
           val successMsgs = messageResults.filter(_.r.success)

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
@@ -57,7 +57,11 @@ object IncomingMessage {
     IncomingMessage(None, source, passThrough)
 }
 
-final case class IncomingMessage[T, C](id: Option[String], source: T, passThrough: C, version: Option[Long] = None)
+final case class IncomingMessage[T, C](id: Option[String], source: T, passThrough: C, version: Option[Long] = None) {
+
+  def withVersion(version: Long): IncomingMessage[T, C] =
+    this.copy(version = Option(version))
+}
 
 object IncomingMessageResult {
   // Apply method to use when not using passThrough

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
@@ -28,9 +28,17 @@ object IncomingMessage {
   def apply[T](id: Option[String], source: T): IncomingMessage[T, NotUsed] =
     IncomingMessage(id, source, NotUsed)
 
+  // Apply method to use when not using passThrough
+  def apply[T](id: Option[String], source: T, version:Long): IncomingMessage[T, NotUsed] =
+    IncomingMessage(id, source, NotUsed, Option(version))
+
   // Java-api - without passThrough
   def create[T](id: String, source: T): IncomingMessage[T, NotUsed] =
     IncomingMessage(Option(id), source)
+
+  // Java-api - without passThrough
+  def create[T](id: String, source: T, version:Long): IncomingMessage[T, NotUsed] =
+    IncomingMessage(Option(id), source, version)
 
   // Java-api - without passThrough
   def create[T](source: T): IncomingMessage[T, NotUsed] =
@@ -41,11 +49,15 @@ object IncomingMessage {
     IncomingMessage(Option(id), source, passThrough)
 
   // Java-api - with passThrough
+  def create[T, C](id: String, source: T, passThrough: C, version:Long): IncomingMessage[T, C] =
+    IncomingMessage(Option(id), source, passThrough, Option(version))
+
+  // Java-api - with passThrough
   def create[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
     IncomingMessage(None, source, passThrough)
 }
 
-final case class IncomingMessage[T, C](id: Option[String], source: T, passThrough: C)
+final case class IncomingMessage[T, C](id: Option[String], source: T, passThrough: C, version:Option[Long] = None)
 
 object IncomingMessageResult {
   // Apply method to use when not using passThrough
@@ -180,6 +192,9 @@ class ElasticsearchFlowStage[T, C](
                 Seq(
                   Option("_index" -> JsString(indexName)),
                   Option("_type" -> JsString(typeName)),
+                  message.version.map { version =>
+                    "_version" -> JsNumber(version)
+                  },
                   message.id.map { id =>
                     "_id" -> JsString(id)
                   }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSourceStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSourceStage.scala
@@ -17,7 +17,7 @@ import org.apache.http.message.BasicHeader
 
 import scala.collection.JavaConverters._
 
-final case class OutgoingMessage[T](id: String, source: T, version:Option[Long])
+final case class OutgoingMessage[T](id: String, source: T, version: Option[Long])
 
 case class ScrollResponse[T](error: Option[String], result: Option[ScrollResult[T]])
 case class ScrollResult[T](scrollId: String, messages: Seq[OutgoingMessage[T]])
@@ -62,7 +62,7 @@ sealed class ElasticsearchSourceLogic[T](indexName: String,
     try {
       if (scrollId == null) {
 
-        val includeDocumentVersionJson:String = if (settings.includeDocumentVersion) {
+        val includeDocumentVersionJson: String = if (settings.includeDocumentVersion) {
           // Tell elastic to return the documents '_version'-property with the search-results
           // http://nocf-www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html
           // https://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSourceStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSourceStage.scala
@@ -17,7 +17,7 @@ import org.apache.http.message.BasicHeader
 
 import scala.collection.JavaConverters._
 
-final case class OutgoingMessage[T](id: String, source: T)
+final case class OutgoingMessage[T](id: String, source: T, version:Option[Long])
 
 case class ScrollResponse[T](error: Option[String], result: Option[ScrollResult[T]])
 case class ScrollResult[T](scrollId: String, messages: Seq[OutgoingMessage[T]])
@@ -61,11 +61,21 @@ sealed class ElasticsearchSourceLogic[T](indexName: String,
   def sendScrollScanRequest(): Unit =
     try {
       if (scrollId == null) {
+
+        val includeDocumentVersionJson:String = if (settings.includeDocumentVersion) {
+          // Tell elastic to return the documents '_version'-property with the search-results
+          // http://nocf-www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html
+          // https://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html
+          """ "version": true,"""
+        } else {
+          ""
+        }
+
         client.performRequestAsync(
           "POST",
           s"/$indexName/$typeName/_search",
           Map("scroll" -> "5m", "sort" -> "_doc").asJava,
-          new StringEntity(s"""{"size": ${settings.bufferSize}, "query": ${query}}"""),
+          new StringEntity(s"""{"size": ${settings.bufferSize},$includeDocumentVersionJson "query": ${query}}"""),
           this,
           new BasicHeader("Content-Type", "application/json")
         )

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSinkSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSinkSettings.scala
@@ -9,11 +9,11 @@ import scaladsl.{ElasticsearchSinkSettings => ScalaElasticsearchSinkSettings}
 
 /**
  * Java API to configure Elasticsearch sinks.
-  *
-  * Note: If using retryPartialFailure == true, you will receive
-  * messages out of order downstream in cases where
-  * elastic returns error one some of the documents in a
-  * bulk request.
+ *
+ * Note: If using retryPartialFailure == true, you will receive
+ * messages out of order downstream in cases where
+ * elastic returns error one some of the documents in a
+ * bulk request.
  */
 final class ElasticsearchSinkSettings(val bufferSize: Int,
                                       val retryInterval: Int,

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSinkSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSinkSettings.scala
@@ -9,6 +9,11 @@ import scaladsl.{ElasticsearchSinkSettings => ScalaElasticsearchSinkSettings}
 
 /**
  * Java API to configure Elasticsearch sinks.
+  *
+  * Note: If using retryPartialFailure == true, you will receive
+  * messages out of order downstream in cases where
+  * elastic returns error one some of the documents in a
+  * bulk request.
  */
 final class ElasticsearchSinkSettings(val bufferSize: Int,
                                       val retryInterval: Int,
@@ -16,7 +21,7 @@ final class ElasticsearchSinkSettings(val bufferSize: Int,
                                       val retryPartialFailure: Boolean,
                                       val docAsUpsert: Boolean) {
 
-  def this() = this(10, 5000, 100, true, false)
+  def this() = this(10, 5000, 100, false, false)
 
   def withBufferSize(bufferSize: Int): ElasticsearchSinkSettings =
     new ElasticsearchSinkSettings(bufferSize,

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSource.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSource.scala
@@ -90,7 +90,6 @@ object ElasticsearchSource {
 
       val jsonTree = mapper.readTree(json)
 
-      //val map = mapper.readValue(json, classOf[java.util.Map[String, Object]])
       if (jsonTree.has("error")) {
         ScrollResponse(Some(jsonTree.get("error").asText()), None)
       } else {

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSource.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSource.scala
@@ -96,16 +96,15 @@ object ElasticsearchSource {
       } else {
         val scrollId = jsonTree.get("_scroll_id").asText()
         val hits = jsonTree.get("hits").get("hits").asInstanceOf[ArrayNode]
-        val messages = hits.elements().asScala.toList.map {
-          element =>
-            val id = element.get("_id").asText()
-            val source = element.get("_source")
-            val version:Option[Long] = element.get("_version") match {
-              case n:NumericNode => Some(n.asLong())
-              case _ => None
-            }
+        val messages = hits.elements().asScala.toList.map { element =>
+          val id = element.get("_id").asText()
+          val source = element.get("_source")
+          val version: Option[Long] = element.get("_version") match {
+            case n: NumericNode => Some(n.asLong())
+            case _ => None
+          }
 
-            OutgoingMessage[T](id, mapper.treeToValue(source, clazz), version)
+          OutgoingMessage[T](id, mapper.treeToValue(source, clazz), version)
         }
         ScrollResponse(None, Some(ScrollResult(scrollId, messages)))
       }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSourceSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSourceSettings.scala
@@ -9,16 +9,28 @@ import scaladsl.{ElasticsearchSourceSettings => ScalaElasticsearchSourceSettings
 
 /**
  * Java API to configure Elastiscsearch sources.
+ *
+ * If includeDocumentVersion is true, '_version' is returned with the search-results
+ * http://nocf-www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html
+ * https://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html
  */
-final class ElasticsearchSourceSettings(val bufferSize: Int) {
+final class ElasticsearchSourceSettings
+(
+  val bufferSize: Int,
+  val includeDocumentVersion:Boolean
+) {
 
-  def this() = this(10)
+  def this() = this(10, false)
 
   def withBufferSize(bufferSize: Int): ElasticsearchSourceSettings =
-    new ElasticsearchSourceSettings(bufferSize)
+    new ElasticsearchSourceSettings(bufferSize, includeDocumentVersion)
+
+  def withIncludeDocumentVersion(includeDocumentVersion: Boolean): ElasticsearchSourceSettings =
+    new ElasticsearchSourceSettings(bufferSize, includeDocumentVersion)
 
   private[javadsl] def asScala: ScalaElasticsearchSourceSettings =
     ScalaElasticsearchSourceSettings(
-      bufferSize = this.bufferSize
+      this.bufferSize,
+      this.includeDocumentVersion
     )
 }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSourceSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSourceSettings.scala
@@ -14,10 +14,9 @@ import scaladsl.{ElasticsearchSourceSettings => ScalaElasticsearchSourceSettings
  * http://nocf-www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html
  * https://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html
  */
-final class ElasticsearchSourceSettings
-(
-  val bufferSize: Int,
-  val includeDocumentVersion:Boolean
+final class ElasticsearchSourceSettings(
+    val bufferSize: Int,
+    val includeDocumentVersion: Boolean
 ) {
 
   def this() = this(10, false)

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSinkSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSinkSettings.scala
@@ -6,11 +6,16 @@ package akka.stream.alpakka.elasticsearch.scaladsl
 
 /**
  * Scala API to configure Elasticsearch sinks.
+  *
+  * Note: If using retryPartialFailure == true, you will receive
+  * messages out of order downstream in cases where
+  * elastic returns error one some of the documents in a
+  * bulk request.
  */
 //#sink-settings
 final case class ElasticsearchSinkSettings(bufferSize: Int = 10,
                                            retryInterval: Int = 5000,
                                            maxRetry: Int = 100,
-                                           retryPartialFailure: Boolean = true,
+                                           retryPartialFailure: Boolean = false,
                                            docAsUpsert: Boolean = false)
 //#sink-settings

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSinkSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSinkSettings.scala
@@ -6,11 +6,11 @@ package akka.stream.alpakka.elasticsearch.scaladsl
 
 /**
  * Scala API to configure Elasticsearch sinks.
-  *
-  * Note: If using retryPartialFailure == true, you will receive
-  * messages out of order downstream in cases where
-  * elastic returns error one some of the documents in a
-  * bulk request.
+ *
+ * Note: If using retryPartialFailure == true, you will receive
+ * messages out of order downstream in cases where
+ * elastic returns error one some of the documents in a
+ * bulk request.
  */
 //#sink-settings
 final case class ElasticsearchSinkSettings(bufferSize: Int = 10,

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSource.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSource.scala
@@ -79,7 +79,7 @@ object ElasticsearchSource {
             val id = doc.fields("_id").asInstanceOf[JsString].value
             val source = doc.fields("_source").asJsObject
             // Maybe we got the _version-property
-            val version:Option[Long] = doc.fields.get("_version").map(_.asInstanceOf[JsNumber].value.toLong)
+            val version: Option[Long] = doc.fields.get("_version").map(_.asInstanceOf[JsNumber].value.toLong)
             OutgoingMessage(id, source.convertTo[T], version)
           }
           ScrollResponse(None, Some(ScrollResult(scrollId, messages)))

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSource.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSource.scala
@@ -78,7 +78,9 @@ object ElasticsearchSource {
             val doc = element.asJsObject
             val id = doc.fields("_id").asInstanceOf[JsString].value
             val source = doc.fields("_source").asJsObject
-            OutgoingMessage(id, source.convertTo[T])
+            // Maybe we got the _version-property
+            val version:Option[Long] = doc.fields.get("_version").map(_.asInstanceOf[JsNumber].value.toLong)
+            OutgoingMessage(id, source.convertTo[T], version)
           }
           ScrollResponse(None, Some(ScrollResult(scrollId, messages)))
         }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSourceSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSourceSettings.scala
@@ -6,15 +6,14 @@ package akka.stream.alpakka.elasticsearch.scaladsl
 
 /**
  * Scala API to configure Elastiscsearch sources.
-  *
-  * If includeDocumentVersion is true, '_version' is returned with the search-results
-  * http://nocf-www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html
-  * https://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html
+ *
+ * If includeDocumentVersion is true, '_version' is returned with the search-results
+ * http://nocf-www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html
+ * https://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html
  */
 //#source-settings
-final case class ElasticsearchSourceSettings
-(
-  bufferSize: Int = 10,
-  includeDocumentVersion:Boolean = false
+final case class ElasticsearchSourceSettings(
+    bufferSize: Int = 10,
+    includeDocumentVersion: Boolean = false
 )
 //#source-settings

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSourceSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSourceSettings.scala
@@ -6,7 +6,15 @@ package akka.stream.alpakka.elasticsearch.scaladsl
 
 /**
  * Scala API to configure Elastiscsearch sources.
+  *
+  * If includeDocumentVersion is true, '_version' is returned with the search-results
+  * http://nocf-www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html
+  * https://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html
  */
 //#source-settings
-final case class ElasticsearchSourceSettings(bufferSize: Int = 10)
+final case class ElasticsearchSourceSettings
+(
+  bufferSize: Int = 10,
+  includeDocumentVersion:Boolean = false
+)
 //#source-settings

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
@@ -335,7 +335,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
           ElasticsearchFlow.create(
             "sink5",
             "book",
-            ElasticsearchSinkSettings(maxRetry = 5, retryInterval = 100)
+            ElasticsearchSinkSettings(maxRetry = 5, retryInterval = 100, retryPartialFailure = true)
           )
         )
         .runWith(Sink.seq)
@@ -347,7 +347,8 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       // Assert retired documents
       assert(
         result1.flatten.filter(!_.success).toList == Seq(
-          IncomingMessageResult[JsValue](Map("subject" -> "Akka Concurrency").toJson, false)
+          IncomingMessageResult[JsValue](Map("subject" -> "Akka Concurrency").toJson, false,
+            Some("""{"type":"strict_dynamic_mapping_exception","reason":"mapping set to strict, dynamic introduction of [subject] within [book] is not allowed"}"""))
         )
       )
 
@@ -639,7 +640,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
           ElasticsearchFlow.create[VersionTestDoc](
             indexName,
             typeName,
-            ElasticsearchSinkSettings(bufferSize = 5, maxRetry = 0)
+            ElasticsearchSinkSettings(bufferSize = 5)
           )
         )
         .runWith(Sink.seq)


### PR DESCRIPTION
This PR contains multiple improvements to the elasticsearch-connector:

- Added support for **optimistic locking/concurrency control** (https://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html)
- The flow now **guaranties** that message-results are returned in the **same order** as input.
- Changed the **default** value of the setting **retryPartialFailure to false**. (If retryPartialFailure is true, failed messages will retry, but succeeded messages will be emitted downstream. This breaks the order of messages. Also: I cannot see a situation where single failed documents in a bulk update  can start succeeding when retrying)
- source now supports **custom ObjectMapper**
- **Improved Jackson json code** in java source.

(Please see individual commits)