### PR TITLE
Docs: Fix link to other-docs

### DIFF
--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -7,7 +7,7 @@ part of this project as well as links to components that are maintained by other
 If you'd like to know what integrations with Alpakka look like, have a look at our 
 [self-contained examples](examples/index.html) section.
 
-There are a few blog posts and presentations about Alpakka out there, we've [collected some](other-docs.md).
+There are a few blog posts and presentations about Alpakka out there, we've [collected some](other-docs.html).
 
 The code in this documentation is compiled against
 


### PR DESCRIPTION
# Issues
The link is currently to pointing to https://developer.lightbend.com/docs/alpakka/current/other-docs.md

# Fix
`.html` extension: https://developer.lightbend.com/docs/alpakka/current/other-docs.html