### PR TITLE
Make s3 object metadata available on downloads

### DIFF
--- a/docs/src/main/paradox/s3.md
+++ b/docs/src/main/paradox/s3.md
@@ -59,6 +59,24 @@ Scala
 Java
 : @@snip ($alpakka$/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java) { #rangedDownload }
 
+#### Accessing object metadata
+
+When downloading an object you also get the object's metadata with it. 
+Here's an example of using this metadata to stream an object back to a client in akka http
+
+```scala
+val (data, eventualMeta) = s3Client.download(bucket, objectKey)
+complete( eventualMeta.map ( meta ⇒
+  HttpResponse(
+    entity = HttpEntity(
+      meta.contentType.flatMap(ContentType.parse(_).toOption).getOrElse(`application/octet-stream`),
+      meta.contentLength,
+      data
+    )
+  )
+))
+```
+
 ### List bucket contents
 
 Scala

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -68,19 +68,17 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
 
   def download(s3Location: S3Location,
                range: Option[ByteRange],
-               sse: Option[ServerSideEncryption]): Source[ByteString, Future[ObjectMetadata]] = {
+               sse: Option[ServerSideEncryption]): (Source[ByteString, NotUsed], Future[ObjectMetadata]) = {
     import mat.executionContext
     val s3Headers = S3Headers(sse.fold[Seq[HttpHeader]](Seq.empty) { _.headersFor(GetObject) })
     val future = request(s3Location, rangeOption = range, s3Headers = s3Headers)
-    Source
-      .fromFuture(future.flatMap(entityForSuccess))
-      .map(_.dataBytes)
-      .flatMapConcat(identity)
-      .mapMaterializedValue { _ =>
-        future.map { resp =>
-          ObjectMetadata(resp.headers)
-        }
-      }
+    (
+      Source
+        .fromFuture(future.flatMap(entityForSuccess))
+        .map(_.dataBytes)
+        .flatMapConcat(identity),
+      future.map(resp ⇒ ObjectMetadata(resp.headers))
+    )
   }
 
   def listBucket(bucket: String, prefix: Option[String] = None): Source[ListBucketResultContents, NotUsed] = {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -435,7 +435,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    *
    * @param bucket the s3 bucket name
    * @param key the s3 object key
-   * @return A [[Pair]] with a [[Source]] of [[ByteString]], and a [[CompletionStage]] containing the [[ObjectMetadata]]
+   * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source]] of [[ByteString]], and a [[CompletionStage]] containing the [[ObjectMetadata]]
    */
   def download(bucket: String, key: String): JPair[Source[ByteString, NotUsed], CompletionStage[ObjectMetadata]] =
     toJava(impl.download(S3Location(bucket, key), None, None))
@@ -446,7 +446,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param bucket the s3 bucket name
    * @param key the s3 object key
    * @param sse the server side encryption to use
-   * @return A [[Pair]] with a [[Source]] of [[ByteString]], and a [[CompletionStage]] containing the [[ObjectMetadata]]
+   * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source]] of [[ByteString]], and a [[CompletionStage]] containing the [[ObjectMetadata]]
    */
   def download(bucket: String,
                key: String,
@@ -459,7 +459,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param bucket the s3 bucket name
    * @param key the s3 object key
    * @param range the [[ByteRange]] you want to download
-   * @return A [[Pair]] with a [[Source]] of [[ByteString]], and a [[CompletionStage]] containing the [[ObjectMetadata]]
+   * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source]] of [[ByteString]], and a [[CompletionStage]] containing the [[ObjectMetadata]]
    */
   def download(bucket: String,
                key: String,
@@ -475,7 +475,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param key the s3 object key
    * @param range the [[ByteRange]] you want to download
    * @param sse the server side encryption to use
-   * @return A [[Pair]] with a [[Source]] of [[ByteString]], and a [[CompletionStage]] containing the [[ObjectMetadata]]
+   * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source]] of [[ByteString]], and a [[CompletionStage]] containing the [[ObjectMetadata]]
    */
   def download(bucket: String,
                key: String,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -190,7 +190,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param key the s3 object key
    * @param method the [[HttpMethod]] to use when making the request
    * @param s3Headers any headers you want to add
-   * @return a [[CompletionStage]] containing the raw [[HttpResponse]]
+   * @return a [[java.util.concurrent.CompletionStage]] containing the raw [[HttpResponse]]
    */
   def request(bucket: String,
               key: String,
@@ -206,7 +206,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    *
    * @param bucket the s3 bucket name
    * @param key the s3 object key
-   * @return A [[CompletionStage]] containing an [[Optional]] that will be empty in case the object does not exist
+   * @return A [[java.util.concurrent.CompletionStage]] containing an [[Optional]] that will be empty in case the object does not exist
    */
   def getObjectMetadata(bucket: String, key: String): CompletionStage[Optional[ObjectMetadata]] =
     impl
@@ -222,7 +222,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param bucket the s3 bucket name
    * @param key the s3 object key
    * @param sse the server side encryption to use
-   * @return A [[CompletionStage]] containing an [[Optional]] that will be empty in case the object does not exist
+   * @return A [[java.util.concurrent.CompletionStage]] containing an [[Optional]] that will be empty in case the object does not exist
    */
   def getObjectMetadata(bucket: String,
                         key: String,
@@ -239,7 +239,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    *
    * @param bucket the s3 bucket name
    * @param key the s3 object key
-   * @return A [[CompletionStage]] of [[Void]]
+   * @return A [[java.util.concurrent.CompletionStage]] of [[Void]]
    */
   def deleteObject(bucket: String, key: String): CompletionStage[Done] =
     impl.deleteObject(S3Location(bucket, key)).map(_ => Done.getInstance())(mat.executionContext).toJava
@@ -252,7 +252,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param data a [[Stream]] of [[ByteString]]
    * @param contentLength the number of bytes that will be uploaded (required!)
    * @param contentType an optional [[ContentType]]
-   * @return a [[CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
+   * @return a [[java.util.concurrent.CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
    */
   def putObject(bucket: String,
                 key: String,
@@ -279,7 +279,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param contentLength the number of bytes that will be uploaded (required!)
    * @param contentType an optional [[ContentType]]
    * @param sse the server side encryption to use
-   * @return a [[CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
+   * @return a [[java.util.concurrent.CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
    */
   def putObject(bucket: String,
                 key: String,
@@ -308,7 +308,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param contentType an optional [[ContentType]]
    * @param cannedAcl the Acl
    * @param metaHeaders the metadata headers
-   * @return ta [[CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
+   * @return ta [[java.util.concurrent.CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
    */
   def putObject(bucket: String,
                 key: String,
@@ -330,7 +330,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param cannedAcl the Acl
    * @param metaHeaders the metadata headers
    * @param sse the server side encryption to use
-   * @return a [[CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
+   * @return a [[java.util.concurrent.CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
    */
   def putObject(bucket: String,
                 key: String,
@@ -350,7 +350,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param data a [[Stream]] of [[ByteString]]
    * @param contentLength the number of bytes that will be uploaded (required!)
    * @param contentType an optional [[ContentType]]
-   * @return a [[CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
+   * @return a [[java.util.concurrent.CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
    */
   def putObject(bucket: String,
                 key: String,
@@ -368,7 +368,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param contentLength the number of bytes that will be uploaded (required!)
    * @param contentType an optional [[ContentType]]
    * @param sse the server side encryption to use
-   * @return a [[CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
+   * @return a [[java.util.concurrent.CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
    */
   def putObject(bucket: String,
                 key: String,
@@ -385,7 +385,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param key the s3 object key
    * @param data a [[Stream]] of [[ByteString]]
    * @param contentLength the number of bytes that will be uploaded (required!)
-   * @return a [[CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
+   * @return a [[java.util.concurrent.CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
    */
   def putObject(bucket: String,
                 key: String,
@@ -407,7 +407,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param data a [[Stream]] of [[ByteString]]
    * @param contentLength the number of bytes that will be uploaded (required!)
    * @param sse the server side encryption to use
-   * @return a [[CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
+   * @return a [[java.util.concurrent.CompletionStage]] containing the [[ObjectMetadata]] of the uploaded S3 Object
    */
   def putObject(bucket: String,
                 key: String,
@@ -435,7 +435,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    *
    * @param bucket the s3 bucket name
    * @param key the s3 object key
-   * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source]] of [[ByteString]], and a [[CompletionStage]] containing the [[ObjectMetadata]]
+   * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source]] of [[ByteString]], and a [[java.util.concurrent.CompletionStage]] containing the [[ObjectMetadata]]
    */
   def download(bucket: String, key: String): JPair[Source[ByteString, NotUsed], CompletionStage[ObjectMetadata]] =
     toJava(impl.download(S3Location(bucket, key), None, None))
@@ -446,7 +446,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param bucket the s3 bucket name
    * @param key the s3 object key
    * @param sse the server side encryption to use
-   * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source]] of [[ByteString]], and a [[CompletionStage]] containing the [[ObjectMetadata]]
+   * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source]] of [[ByteString]], and a [[java.util.concurrent.CompletionStage]] containing the [[ObjectMetadata]]
    */
   def download(bucket: String,
                key: String,
@@ -459,7 +459,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param bucket the s3 bucket name
    * @param key the s3 object key
    * @param range the [[ByteRange]] you want to download
-   * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source]] of [[ByteString]], and a [[CompletionStage]] containing the [[ObjectMetadata]]
+   * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source]] of [[ByteString]], and a [[java.util.concurrent.CompletionStage]] containing the [[ObjectMetadata]]
    */
   def download(bucket: String,
                key: String,
@@ -475,7 +475,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param key the s3 object key
    * @param range the [[ByteRange]] you want to download
    * @param sse the server side encryption to use
-   * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source]] of [[ByteString]], and a [[CompletionStage]] containing the [[ObjectMetadata]]
+   * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source]] of [[ByteString]], and a [[java.util.concurrent.CompletionStage]] containing the [[ObjectMetadata]]
    */
   def download(bucket: String,
                key: String,
@@ -507,7 +507,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param key the s3 object key
    * @param contentType an optional [[ContentType]]
    * @param s3Headers any headers you want to add
-   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[java.util.concurrent.CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUpload(bucket: String,
                       key: String,
@@ -526,7 +526,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param contentType an optional [[ContentType]]
    * @param s3Headers any headers you want to add
    * @param sse the server side encryption to use
-   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[java.util.concurrent.CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUpload(bucket: String,
                       key: String,
@@ -546,7 +546,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param contentType an optional [[ContentType]]
    * @param metaHeaders any meta-headers you want to add
    * @param cannedAcl a [[CannedAcl]], defauts to [[CannedAcl.Private]]
-   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[java.util.concurrent.CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUpload(bucket: String,
                       key: String,
@@ -564,7 +564,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param metaHeaders any meta-headers you want to add
    * @param cannedAcl a [[CannedAcl]], defauts to [[CannedAcl.Private]]
    * @param sse sse the server side encryption to use
-   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[java.util.concurrent.CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUpload(bucket: String,
                       key: String,
@@ -581,7 +581,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param key the s3 object key
    * @param contentType an optional [[ContentType]]
    * @param cannedAcl a [[CannedAcl]], defauts to [[CannedAcl.Private]]
-   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[java.util.concurrent.CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUpload(bucket: String,
                       key: String,
@@ -597,7 +597,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param contentType an optional [[ContentType]]
    * @param cannedAcl a [[CannedAcl]], defauts to [[CannedAcl.Private]]
    * @param sse the server side encryption to use
-   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[java.util.concurrent.CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUpload(bucket: String,
                       key: String,
@@ -612,7 +612,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param bucket the s3 bucket name
    * @param key the s3 object key
    * @param contentType an optional [[ContentType]]
-   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[java.util.concurrent.CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUpload(bucket: String,
                       key: String,
@@ -626,7 +626,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param key the s3 object key
    * @param contentType an optional [[ContentType]]
    * @param sse the server side encryption to use
-   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[java.util.concurrent.CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUpload(bucket: String,
                       key: String,
@@ -639,7 +639,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    *
    * @param bucket the s3 bucket name
    * @param key the s3 object key
-   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[java.util.concurrent.CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUpload(bucket: String, key: String): Sink[ByteString, CompletionStage[MultipartUploadResult]] =
     multipartUpload(bucket, key, ContentTypes.APPLICATION_OCTET_STREAM, CannedAcl.Private, MetaHeaders(Map()))
@@ -650,7 +650,7 @@ final class S3Client(s3Settings: S3Settings, system: ActorSystem, mat: Materiali
    * @param bucket the s3 bucket name
    * @param key the s3 object key
    * @param sse the server side encryption to use
-   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[Sink]] that accepts [[ByteString]]'s and materializes to a [[java.util.concurrent.CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUpload(bucket: String,
                       key: String,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
@@ -252,12 +252,12 @@ final class S3Client(val s3Settings: S3Settings)(implicit system: ActorSystem, m
    * @param key the s3 object key
    * @param range [optional] the [[ByteRange]] you want to download
    * @param sse [optional] the server side encryption used on upload
-   * @return A [[Source]] of [[ByteString]] that materializes into a [[Future]] containing the [[ObjectMetadata]]
+   * @return A [[Source]] of [[ByteString]], and a [[Future]] containing the [[ObjectMetadata]]
    */
   def download(bucket: String,
                key: String,
                range: Option[ByteRange] = None,
-               sse: Option[ServerSideEncryption] = None): Source[ByteString, Future[ObjectMetadata]] =
+               sse: Option[ServerSideEncryption] = None): (Source[ByteString, NotUsed], Future[ObjectMetadata]) =
     impl.download(S3Location(bucket, key), range, sse)
 
   /**

--- a/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
+++ b/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import akka.NotUsed;
 import akka.http.javadsl.model.Uri;
 import akka.http.javadsl.model.headers.ByteRange;
+import akka.japi.Pair;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.s3.MemoryBufferType;
@@ -105,7 +106,8 @@ public class S3ClientTest extends S3WireMockBase {
         mockDownload();
 
         //#download
-        final Source<ByteString, CompletionStage<ObjectMetadata>> source = client.download(bucket(), bucketKey());
+        final Pair<Source<ByteString, NotUsed>, CompletionStage<ObjectMetadata>> sourceAndMeta = client.download(bucket(), bucketKey());
+        final Source<ByteString, NotUsed> source = sourceAndMeta.first();
         //#download
 
         final CompletionStage<String> resultCompletionStage =
@@ -150,7 +152,8 @@ public class S3ClientTest extends S3WireMockBase {
         mockDownloadSSEC();
 
         //#download
-        final Source<ByteString, CompletionStage<ObjectMetadata>> source = client.download(bucket(), bucketKey(), sseCustomerKeys());
+        final Pair<Source<ByteString, NotUsed>, CompletionStage<ObjectMetadata>> sourceAndMeta = client.download(bucket(), bucketKey(), sseCustomerKeys());
+        final Source<ByteString, NotUsed> source = sourceAndMeta.first();
         //#download
 
         final CompletionStage<String> resultCompletionStage =
@@ -167,8 +170,9 @@ public class S3ClientTest extends S3WireMockBase {
         mockRangedDownload();
 
         //#rangedDownload
-        final Source<ByteString, CompletionStage<ObjectMetadata>> source = client.download(bucket(), bucketKey(),
+        final Pair<Source<ByteString, NotUsed>, CompletionStage<ObjectMetadata>> sourceAndMeta = client.download(bucket(), bucketKey(),
                 ByteRange.createSlice(bytesRangeStart(), bytesRangeEnd()));
+        final Source<ByteString, NotUsed> source = sourceAndMeta.first();
         //#rangedDownload
 
         final CompletionStage<byte[]> resultCompletionStage =
@@ -185,8 +189,9 @@ public class S3ClientTest extends S3WireMockBase {
         mockRangedDownloadSSE();
 
         //#rangedDownload
-        final Source<ByteString, CompletionStage<ObjectMetadata>> source = client.download(bucket(), bucketKey(),
+        final Pair<Source<ByteString, NotUsed>, CompletionStage<ObjectMetadata>> sourceAndMeta = client.download(bucket(), bucketKey(),
                 ByteRange.createSlice(bytesRangeStart(), bytesRangeEnd()), sseCustomerKeys());
+        final Source<ByteString, NotUsed> source = sourceAndMeta.first();
         //#rangedDownload
 
         final CompletionStage<byte[]> resultCompletionStage =

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -129,11 +129,11 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
 
   it should "download with real credentials" in {
 
-    val download = defaultRegionClient.download(defaultRegionBucket, objectKey)
+    val (source, metaFuture) = defaultRegionClient.download(defaultRegionBucket, objectKey)
 
-    val (metaFuture, bodyFuture) = download
+    val bodyFuture = source
       .map(_.decodeString("utf8"))
-      .toMat(Sink.head)(Keep.both)
+      .toMat(Sink.head)(Keep.right)
       .run()
 
     val result = for {
@@ -161,6 +161,7 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
       )
       download <- defaultRegionClient
         .download(defaultRegionBucket, objectKey)
+        ._1
         .map(_.decodeString("utf8"))
         .runWith(Sink.head)
     } yield (upload, download)
@@ -184,6 +185,7 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
       )
       download <- defaultRegionClient
         .download(defaultRegionBucket, objectKey)
+        ._1
         .map(_.decodeString("utf8"))
         .runWith(Sink.head)
     } yield (upload, download)
@@ -207,6 +209,7 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
       )
       download <- otherRegionClient
         .download(otherRegionBucket, objectKey)
+        ._1
         .map(_.decodeString("utf8"))
         .runWith(Sink.head)
     } yield (upload, download)
@@ -231,6 +234,7 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
       )
       download <- otherRegionClient
         .download(otherRegionBucket, objectKey)
+        ._1
         .map(_.decodeString("utf8"))
         .runWith(Sink.head)
     } yield (upload, download)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3NoMock.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3NoMock.scala
@@ -183,7 +183,7 @@ class S3NoMock extends FlatSpecLike with BeforeAndAfterAll with Matchers with Sc
 
       val download = settings.defaultRegionClient.download(settings.defaultRegionBucket, settings.objectKey)
 
-      val result = download.map(_.decodeString("utf8")).runWith(Sink.head)
+      val result = download._1.map(_.decodeString("utf8")).runWith(Sink.head)
 
       Await.ready(result, 5.seconds).futureValue shouldBe settings.objectValue
     }
@@ -199,6 +199,7 @@ class S3NoMock extends FlatSpecLike with BeforeAndAfterAll with Matchers with Sc
         )
         download <- settings.defaultRegionClient
           .download(settings.defaultRegionBucket, settings.objectKey)
+          ._1
           .map(_.decodeString("utf8"))
           .runWith(Sink.head)
       } yield (upload, download)
@@ -221,6 +222,7 @@ class S3NoMock extends FlatSpecLike with BeforeAndAfterAll with Matchers with Sc
         )
         download <- settings.defaultRegionClient
           .download(settings.defaultRegionBucket, settings.objectKey)
+          ._1
           .map(_.decodeString("utf8"))
           .runWith(Sink.head)
       } yield (upload, download)
@@ -243,6 +245,7 @@ class S3NoMock extends FlatSpecLike with BeforeAndAfterAll with Matchers with Sc
         )
         download <- settings.otherRegionClient
           .download(settings.otherRegionBucket, settings.objectKey)
+          ._1
           .map(_.decodeString("utf8"))
           .runWith(Sink.head)
       } yield (upload, download)
@@ -265,6 +268,7 @@ class S3NoMock extends FlatSpecLike with BeforeAndAfterAll with Matchers with Sc
         )
         download <- settings.otherRegionClient
           .download(settings.otherRegionBucket, settings.objectKey)
+          ._1
           .map(_.decodeString("utf8"))
           .runWith(Sink.head)
       } yield (upload, download)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
@@ -35,7 +35,7 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     mockDownload()
 
     //#download
-    val s3Source: Source[ByteString, _] = s3Client.download(bucket, bucketKey)
+    val (s3Source: Source[ByteString, _], _) = s3Client.download(bucket, bucketKey)
     //#download
 
     val result: Future[String] = s3Source.map(_.utf8String).runWith(Sink.head)
@@ -72,7 +72,7 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     mockRangedDownload()
 
     //#rangedDownload
-    val s3Source: Source[ByteString, _] =
+    val (s3Source: Source[ByteString, _], _) =
       s3Client.download(bucket, bucketKey, Some(ByteRange(bytesRangeStart, bytesRangeEnd)))
     //#rangedDownload
 
@@ -86,7 +86,7 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     mockDownloadSSEC()
 
     //#download
-    val s3Source = s3Client.download(bucket, bucketKey, sse = Some(sseCustomerKeys))
+    val (s3Source, _) = s3Client.download(bucket, bucketKey, sse = Some(sseCustomerKeys))
     //#download
 
     val result = s3Source.map(_.utf8String).runWith(Sink.head)
@@ -100,6 +100,7 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
 
     val result = s3Client
       .download("nonexisting_bucket", "nonexisting_file.xml")
+      ._1
       .map(_.utf8String)
       .runWith(Sink.head)
 
@@ -116,6 +117,7 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     val sse = ServerSideEncryption.CustomerKeys("encoded-key", Some("md5-encoded-key"))
     val result = s3Client
       .download(bucket, bucketKey, sse = Some(sse))
+      ._1
       .map(_.utf8String)
       .runWith(Sink.head)
 


### PR DESCRIPTION
 independent from stream materialization ( #740)

* download method in s3 client now returns a tuple with stream and metadata
* stream from download now materializes into NotUsed