### PR TITLE
Make Slick Flow variable in return type

### DIFF
--- a/docs/src/main/paradox/slick.md
+++ b/docs/src/main/paradox/slick.md
@@ -124,12 +124,22 @@ Scala
 Java
 : @@snip ($alpakka$/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetSink.java) { #sink-example }
 
-For completeness, the Slick connector also exposes a `Flow` that has the exact same functionality as the `Sink` but it allows you to continue the stream for further processing. The return value of every executed statement, e.g. the element values is an `Int` denoting the number of updated/inserted/deleted rows.
+For completeness, the Slick connector also exposes a `Flow` that has the exact same functionality as the `Sink` but it allows you to continue the stream for further processing. The return value of every executed statement, e.g. the element values is the fixed type `Int` denoting the number of updated/inserted/deleted rows.
 
 Scala
 : @@snip ($alpakka$/slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/DocSnippets.scala) { #flow-example }
 
 Java
 : @@snip ($alpakka$/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetFlow.java) { #flow-example }
+
+To have a different return type, use the `flowWithPassThrough` function.
+E.g. when consuming Kafka messages, this allows you to maintain the kafka committable offset so the message can be committed in a next stage in the flow.
+
+Scala
+: @@snip ($alpakka$/slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/DocSnippets.scala) { #flowWithPassThrough-example }
+
+Java
+: @@snip ($alpakka$/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetFlowWithPassThrough.java) { #flowWithPassThrough-example }
+
 
  [jdbcbackend-api]: http://slick.lightbend.com/doc/3.2.1/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader):Database

--- a/slick/src/main/scala/akka/stream/alpakka/slick/javadsl/Slick.scala
+++ b/slick/src/main/scala/akka/stream/alpakka/slick/javadsl/Slick.scala
@@ -90,18 +90,18 @@ object Slick {
       .asJava
 
   /**
-    * Java API: creates a Flow that takes a stream of elements of
-    *           type T, transforms each element to a SQL statement
-    *           using the specified function, then executes
-    *           those statements against the specified Slick database
-    *           and allows to combine the statement result and element into a result type R.
-    *
-    * @param session The database session to use.
-    * @param toStatement A function that creeates the SQL statement to
-    *                    execute from the current element. Any DML or
-    *                    DDL statement is acceptable.
-    * @param mapper A function to create a result from the incoming element T
-    *               and the database statement result.
+   * Java API: creates a Flow that takes a stream of elements of
+   *           type T, transforms each element to a SQL statement
+   *           using the specified function, then executes
+   *           those statements against the specified Slick database
+   *           and allows to combine the statement result and element into a result type R.
+   *
+   * @param session The database session to use.
+   * @param toStatement A function that creeates the SQL statement to
+   *                    execute from the current element. Any DML or
+   *                    DDL statement is acceptable.
+   * @param mapper A function to create a result from the incoming element T
+   *               and the database statement result.
    */
   def flowWithPassThrough[T, R](
       session: SlickSession,
@@ -111,21 +111,21 @@ object Slick {
     flowWithPassThrough(session, 1, toStatement, mapper)
 
   /**
-    * Java API: creates a Flow that takes a stream of elements of
-    *           type T, transforms each element to a SQL statement
-    *           using the specified function, then executes
-    *           those statements against the specified Slick database
-    *           and allows to combine the statement result and element into a result type R.
-    *
-    * @param session The database session to use.
-    * @param parallelism How many parallel asynchronous streams should be
-    *                    used to send statements to the database. Use a
-    *                    value of 1 for sequential execution.
-    * @param toStatement A function that creeates the SQL statement to
-    *                    execute from the current element. Any DML or
-    *                    DDL statement is acceptable.
-    * @param mapper A function to create a result from the incoming element T
-    *               and the database statement result.
+   * Java API: creates a Flow that takes a stream of elements of
+   *           type T, transforms each element to a SQL statement
+   *           using the specified function, then executes
+   *           those statements against the specified Slick database
+   *           and allows to combine the statement result and element into a result type R.
+   *
+   * @param session The database session to use.
+   * @param parallelism How many parallel asynchronous streams should be
+   *                    used to send statements to the database. Use a
+   *                    value of 1 for sequential execution.
+   * @param toStatement A function that creeates the SQL statement to
+   *                    execute from the current element. Any DML or
+   *                    DDL statement is acceptable.
+   * @param mapper A function to create a result from the incoming element T
+   *               and the database statement result.
    */
   def flowWithPassThrough[T, R](
       session: SlickSession,

--- a/slick/src/main/scala/akka/stream/alpakka/slick/javadsl/Slick.scala
+++ b/slick/src/main/scala/akka/stream/alpakka/slick/javadsl/Slick.scala
@@ -221,8 +221,4 @@ object Slick {
   private def toDBIO[T](javaDml: JFunction[T, String]): T => DBIO[Int] = { t =>
     SQLActionBuilder(javaDml.asScala(t), SetParameter.SetUnit).asUpdate
   }
-
-  class JDBIO[T] {
-    def map[B](f: T => B): JDBIO[B] = ???
-  }
 }

--- a/slick/src/main/scala/akka/stream/alpakka/slick/scaladsl/Slick.scala
+++ b/slick/src/main/scala/akka/stream/alpakka/slick/scaladsl/Slick.scala
@@ -71,10 +71,7 @@ object Slick {
       parallelism: Int,
       toStatement: T => DBIO[Int]
   )(implicit session: SlickSession): Flow[T, Int, NotUsed] =
-    Flow[T]
-      .mapAsync(parallelism) { t =>
-        session.db.run(toStatement(t))
-      }
+    flowWithPassThrough(parallelism, toStatement)
 
   /**
    * Scala API: creates a Flow that takes a stream of elements of

--- a/slick/src/main/scala/akka/stream/alpakka/slick/scaladsl/Slick.scala
+++ b/slick/src/main/scala/akka/stream/alpakka/slick/scaladsl/Slick.scala
@@ -77,6 +77,44 @@ object Slick {
       }
 
   /**
+   * Scala API: creates a Flow that takes a stream of elements of
+   *            type T, transforms each element to a SQL statement
+   *            using the specified function, then executes
+   *            those statements against the specified Slick database
+   *            and returns the statement result type R.
+   *
+   * @param toStatement A function to produce the SQL statement to
+   *                    execute based on the current element.
+   * @param session The database session to use.
+   */
+  def flowWithPassThrough[T, R](
+      toStatement: T => DBIO[R]
+  )(implicit session: SlickSession): Flow[T, R, NotUsed] = flowWithPassThrough(1, toStatement)
+
+  /**
+   * Scala API: creates a Flow that takes a stream of elements of
+   *            type T, transforms each element to a SQL statement
+   *            using the specified function, then executes
+   *            those statements against the specified Slick database
+   *            and returns the statement result type R.
+   *
+   * @param toStatement A function to produce the SQL statement to
+   *                    execute based on the current element.
+   * @param parallelism How many parallel asynchronous streams should be
+   *                    used to send statements to the database. Use a
+   *                    value of 1 for sequential execution.
+   * @param session The database session to use.
+   */
+  def flowWithPassThrough[T, R](
+      parallelism: Int,
+      toStatement: T => DBIO[R]
+  )(implicit session: SlickSession): Flow[T, R, NotUsed] =
+    Flow[T]
+      .mapAsync(parallelism) { t =>
+        session.db.run(toStatement(t))
+      }
+
+  /**
    * Scala API: creates a Sink that takes a stream of elements of
    *            type T, transforms each element to a SQL statement
    *            using the specified function, and then executes

--- a/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetFlowWithPassThrough.java
+++ b/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetFlowWithPassThrough.java
@@ -17,8 +17,6 @@ import akka.stream.javadsl.Source;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -57,7 +55,6 @@ public class DocSnippetFlowWithPassThrough {
 
 
   public static void main(String[] args) throws Exception {
-    final ExecutorService executorService = Executors.newSingleThreadExecutor();
     final ActorSystem system = ActorSystem.create();
     final Materializer materializer = ActorMaterializer.create(system);
 
@@ -75,7 +72,7 @@ public class DocSnippetFlowWithPassThrough {
         .via(
           Slick.flowWithPassThrough(
             session,
-            executorService,
+            system.dispatcher(),
             // add an optional second argument to specify the parallism factor (int)
             (kafkaMessage) -> "INSERT INTO ALPAKKA_SLICK_JAVADSL_TEST_USERS VALUES (" + kafkaMessage.msg.id + ", '" + kafkaMessage.msg.name + "')",
             (kafkaMessage, insertCount) -> kafkaMessage.map(user -> new Pair(user, insertCount)) // allows to keep the kafka message offset so it can be committed in a next stage

--- a/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetFlowWithPassThrough.java
+++ b/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetFlowWithPassThrough.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.slick.javadsl;
+
+//#flowWithPassThrough-example
+
+import akka.Done;
+import akka.actor.ActorSystem;
+import akka.japi.Pair;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+// We're going to pretend we got messages from kafka.
+// After we've written them to a db with Slick, we want
+// to commit the offset to Kafka
+public class DocSnippetFlowWithPassThrough {
+
+  // mimics a Kafka 'Committable' type
+  static class CommittableOffset {
+    private Integer offset;
+
+    public CommittableOffset(Integer offset) {
+      this.offset = offset;
+    }
+
+    public CompletableFuture<Done> commit() {
+      return CompletableFuture.completedFuture(Done.getInstance());
+    }
+  }
+
+  static class KafkaMessage<A> {
+    final A msg;
+    final CommittableOffset offset;
+
+    public KafkaMessage(A msg, CommittableOffset offset) {
+      this.msg = msg;
+      this.offset = offset;
+    }
+
+    public <B> KafkaMessage<B> map(Function<A, B> f) {
+      return new KafkaMessage(f.apply(msg), offset);
+    }
+  }
+
+
+  public static void main(String[] args) throws Exception {
+    final ActorSystem system = ActorSystem.create();
+    final Materializer materializer = ActorMaterializer.create(system);
+
+    final SlickSession session = SlickSession.forConfig("slick-h2");
+
+    final List<User> users = IntStream.range(0, 42).boxed().map((i) -> new User(i, "Name"+i)).collect(Collectors.toList());
+
+    List<KafkaMessage<User>> messagesFromKafka = users.stream()
+            .map(user -> new KafkaMessage<>(user, new CommittableOffset(users.indexOf(user))))
+            .collect(Collectors.toList());
+
+    final CompletionStage<Done> done =
+      Source
+        .from(messagesFromKafka)
+        .via(
+          Slick.flowWithPassThrough(
+            session,
+            // add an optional second argument to specify the parallism factor (int)
+            (kafkaMessage) -> "INSERT INTO ALPAKKA_SLICK_JAVADSL_TEST_USERS VALUES (" + kafkaMessage.msg.id + ", '" + kafkaMessage.msg.name + "')",
+            (kafkaMessage, insertCount) -> kafkaMessage.map(user -> new Pair(user, insertCount)) // allows to keep the kafka message offset so it can be committed in a next stage
+          )
+        )
+        .log("nr-of-updated-rows")
+        .mapAsync(1, kafkaMessage -> kafkaMessage.offset.commit()) // in correct order, commit Kafka message
+        .runWith(Sink.ignore(), materializer);
+
+    done.whenComplete((value, exception) -> {
+      session.close();
+      system.terminate();
+    });
+  }
+}
+//#flowWithPassThrough-example

--- a/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetFlowWithPassThrough.java
+++ b/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetFlowWithPassThrough.java
@@ -17,6 +17,8 @@ import akka.stream.javadsl.Source;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -55,6 +57,7 @@ public class DocSnippetFlowWithPassThrough {
 
 
   public static void main(String[] args) throws Exception {
+    final ExecutorService executorService = Executors.newSingleThreadExecutor();
     final ActorSystem system = ActorSystem.create();
     final Materializer materializer = ActorMaterializer.create(system);
 
@@ -72,6 +75,7 @@ public class DocSnippetFlowWithPassThrough {
         .via(
           Slick.flowWithPassThrough(
             session,
+            executorService,
             // add an optional second argument to specify the parallism factor (int)
             (kafkaMessage) -> "INSERT INTO ALPAKKA_SLICK_JAVADSL_TEST_USERS VALUES (" + kafkaMessage.msg.id + ", '" + kafkaMessage.msg.name + "')",
             (kafkaMessage, insertCount) -> kafkaMessage.map(user -> new Pair(user, insertCount)) // allows to keep the kafka message offset so it can be committed in a next stage

--- a/slick/src/test/java/akka/stream/alpakka/slick/javadsl/SlickTest.java
+++ b/slick/src/test/java/akka/stream/alpakka/slick/javadsl/SlickTest.java
@@ -18,9 +18,11 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -153,6 +155,86 @@ public class SlickTest {
     assertEquals(foundUsers, users);
   }
 
+  @Test
+  public void testFlowWithPassThroughWithoutParallelismAndReadBackWithSource() throws Exception {
+    final Flow<User, User, NotUsed> slickFlow = Slick.flowWithPassThrough(session, insertUser, (user, i) -> user);
+    final CompletionStage<List<User>> insertionResultFuture = usersSource.via(slickFlow).runWith(Sink.seq(), materializer);
+    final List<User> insertedUsers = insertionResultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertEquals(SlickTest.users, new HashSet<>(insertedUsers));
+
+    final Source<User, NotUsed> slickSource = Slick.source(
+            session,
+            selectAllUsers,
+            (SlickRow row) -> new User(row.nextInt(), row.nextString())
+    );
+
+    final CompletionStage<List<User>> foundUsersFuture = slickSource.runWith(Sink.seq(), materializer);
+    final Set<User> foundUsers = new HashSet<>(foundUsersFuture.toCompletableFuture().get(3, TimeUnit.SECONDS));
+
+    assertEquals(foundUsers, SlickTest.users);
+  }
+
+  @Test
+  public void testFlowWithPassThroughWithParallelismOf4AndReadBackWithSource() throws Exception {
+    final Flow<User, User, NotUsed> slickFlow = Slick.flowWithPassThrough(session, 4, insertUser, (user, i) -> user);
+    final CompletionStage<List<User>> insertionResultFuture = usersSource.via(slickFlow).runWith(Sink.seq(), materializer);
+    final List<User> insertedUsers = insertionResultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertEquals(users, new HashSet<>(insertedUsers));
+
+    final Source<User, NotUsed> slickSource = Slick.source(
+            session,
+            selectAllUsers,
+            (SlickRow row) -> new User(row.nextInt(), row.nextString())
+    );
+
+    final CompletionStage<List<User>> foundUsersFuture = slickSource.runWith(Sink.seq(), materializer);
+    final Set<User> foundUsers = new HashSet<>(foundUsersFuture.toCompletableFuture().get(3, TimeUnit.SECONDS));
+
+    assertEquals(foundUsers, users);
+  }
+
+  @Test
+  public void testFlowWithPassThroughKafkaExample() throws Exception {
+    final List<User> usersList = new ArrayList<>(SlickTest.users);
+
+    final List<KafkaMessage<User>> messagesFromKafka = usersList.stream()
+            .map(user -> new KafkaMessage<>(user, new KafkaOffset(usersList.indexOf(user))))
+            .collect(Collectors.toList());
+
+    final Function<KafkaMessage<User>, String> insertUserInKafkaMessage = insertUser.compose((KafkaMessage<User> kafkaMessage) -> kafkaMessage.msg);
+
+    List<KafkaOffset> committedOffsets = new ArrayList<>();
+
+    final Function<KafkaOffset, CompletableFuture<Done>> commitToKafka = offset -> {
+      committedOffsets.add(offset);
+      return CompletableFuture.completedFuture(Done.getInstance());
+    };
+
+    final CompletionStage<Done> resultFuture = Source.from(messagesFromKafka)
+            .via(Slick.flowWithPassThrough(session, insertUserInKafkaMessage, (kafkaMessage, insertCount) -> kafkaMessage.map(user -> insertCount)))
+            .mapAsync(1, kafkaMessage -> {
+              if (kafkaMessage.msg == 0) throw new Exception("Failed to write message to db");
+              return commitToKafka.apply(kafkaMessage.offset);
+            })
+            .runWith(Sink.ignore(), materializer);
+    resultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertEquals(users.size(), committedOffsets.size());
+
+    final Source<User, NotUsed> slickSource = Slick.source(
+            session,
+            selectAllUsers,
+            (SlickRow row) -> new User(row.nextInt(), row.nextString())
+    );
+
+    final CompletionStage<List<User>> foundUsersFuture = slickSource.runWith(Sink.seq(), materializer);
+    final Set<User> foundUsers = new HashSet<>(foundUsersFuture.toCompletableFuture().get(3, TimeUnit.SECONDS));
+
+    assertEquals(foundUsers, users);
+  }
+
   private static void executeStatement(String statement, SlickSession session, Materializer materializer) {
     try {
       Source
@@ -164,4 +246,28 @@ public class SlickTest {
         throw new RuntimeException(e);
       }
   }
+
+  // For kafka example test case
+  static class KafkaOffset {
+    private Integer offset;
+
+    public KafkaOffset(Integer offset) {
+      this.offset = offset;
+    }
+  }
+
+  static class KafkaMessage<A> {
+    final A msg;
+    final KafkaOffset offset;
+
+    public KafkaMessage(A msg, KafkaOffset offset) {
+      this.msg = msg;
+      this.offset = offset;
+    }
+
+    public <B> KafkaMessage<B> map(Function<A, B> f) {
+      return new KafkaMessage(f.apply(msg), offset);
+    }
+  }
+
 }

--- a/slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/DocSnippets.scala
+++ b/slick/src/test/scala/akka/stream/alpakka/slick/scaladsl/DocSnippets.scala
@@ -184,3 +184,72 @@ object SlickFlowExample extends App {
   }
 }
 //#flow-example
+
+//#flowWithPassThrough-example
+import scala.concurrent.Future
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+
+import akka.stream.scaladsl._
+import akka.stream.alpakka.slick.scaladsl._
+
+// We're going to pretend we got messages from kafka.
+// After we've written them to a db with Slick, we want
+// to commit the offset to Kafka
+object SlickFlowWithPassThroughExample extends App {
+
+  // mimics a Kafka 'Committable' type
+  case class CommittableOffset(offset: Int) {
+    def commit: Future[Done] = Future.successful(Done)
+  }
+  case class KafkaMessage[A](msg: A, offset: CommittableOffset) {
+    // map the msg and keep the offset
+    def map[B](f: A => B): KafkaMessage[B] = KafkaMessage(f(msg), offset)
+  }
+
+  implicit val system = ActorSystem()
+  implicit val mat = ActorMaterializer()
+  implicit val ec = system.dispatcher
+
+  implicit val session = SlickSession.forConfig("slick-h2")
+
+  // The example domain
+  case class User(id: Int, name: String)
+  val users = (1 to 42).map(i => User(i, s"Name$i"))
+  val messagesFromKafka = users.zipWithIndex.map { case (user, index) => KafkaMessage(user, CommittableOffset(index)) }
+
+  // This import enables the use of the Slick sql"...",
+  // sqlu"...", and sqlt"..." String interpolators.
+  // See "http://slick.lightbend.com/doc/3.2.1/sql.html#string-interpolation"
+  import session.profile.api._
+
+  // Stream the users into the database as insert statements
+  val done: Future[Done] =
+    Source(messagesFromKafka)
+      .via(
+        // add an optional first argument to specify the parallism factor (Int)
+        Slick.flowWithPassThrough { kafkaMessage =>
+          val user = kafkaMessage.msg
+          (sqlu"INSERT INTO ALPAKKA_SLICK_SCALADSL_TEST_USERS VALUES(${user.id}, ${user.name})")
+            .map { insertCount => // map db result to something else
+              // allows to keep the kafka message offset so it can be committed in a next stage
+              kafkaMessage.map(user => (user, insertCount))
+            }
+        }
+      )
+      .log("nr-of-updated-rows")
+      .mapAsync(1) { // in correct order
+        kafkaMessage =>
+          kafkaMessage.offset.commit // commit kafka messages
+      }
+      .runWith(Sink.ignore)
+
+  done.onComplete {
+    case _ =>
+      session.close()
+      system.terminate()
+  }
+}
+//#flowWithPassThrough-example


### PR DESCRIPTION
Proposal for additional 'Slick.flow' function to be flexible in the return type as suggested in [Make Slick Flow variable in return type](https://github.com/akka/alpakka/issues/726) issue.

Based on @ennru's suggestion called the new functions 'flowWithPassThrough', similar to ElasticsearchFlow.
The Scala implementation was quite forward. 
The Java implementation was a bit tricky. Added an additional 'mapper' argument to the method signature to map the DBIO result into something else.

Added test cases including an example with Kafka (also copied from Elasticsearch test case).
Updated documentation including 'with kafka' example.

Let me know what you think of this solution.