### PR TITLE
Fix runtime warning in Elasticsearch test

### DIFF
--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
@@ -87,7 +87,8 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
            |    }
            |  }
            |}
-         """.stripMargin)
+         """.stripMargin),
+      new BasicHeader("Content-Type", "application/json")
     )
 
   private def register(indexName: String, title: String): Unit =


### PR DESCRIPTION
Elasticsearch warns if request hasn't Content-Type header. I forgot adding it to a create mapping request in the test case for Elasticsearch connector.