### PR TITLE
Amqp: remove non-existing port from credentials test in Java

### DIFF
--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
@@ -108,7 +108,7 @@ public class AmqpConnectorsTest {
 
     @SuppressWarnings("unchecked")
     AmqpDetailsConnectionProvider connectionProvider = AmqpDetailsConnectionProvider.create("invalid", 5673)
-            .withHostsAndPorts(Pair.create("localhost", 5672), Pair.create("localhost", 5674))
+            .withHostsAndPorts(Pair.create("localhost", 5672))
             .withCredentials(AmqpCredentials.create("guest", "guest1"));
 
     final Sink<ByteString, CompletionStage<Done>> amqpSink = AmqpSink.createSimple(

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -68,7 +68,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       result.futureValue.map(_.bytes.utf8String) shouldEqual input
     }
 
-    "connection should fail with wrong crecentials" in {
+    "connection should fail with wrong credentials" in {
       val connectionProvider =
         AmqpDetailsConnectionProvider(List(("invalid", 5673)))
           .withHostsAndPorts(("localhost", 5672))


### PR DESCRIPTION
The Java test added to validate #748 used an extra server address which is not available. That's why it failed with the wrong exception type.