### PR TITLE
elasticsearch: ElasticsearchFlowStage now supports custom indexName pr document

### DIFF
--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -125,6 +125,15 @@ Scala
 Java
 : @@snip ($alpakka$/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java) { #kafka-example }
 
+### Specifying custom index-name for every document
+
+When working with index-patterns using wildcards, you might need to specify a custom
+index-name for each document:
+
+Scala
+: @@snip ($alpakka$/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala) { #custom-index-name-example }
+ 
+
 
 
 ### Running the example code

--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -133,7 +133,16 @@ index-name for each document:
 Scala
 : @@snip ($alpakka$/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala) { #custom-index-name-example }
  
+### More custom searching
 
+The easiest way of using ElasticSearch-source, is to just specify the query-param. Sometimes you need more control,
+like specifying which fields to return and so on. In such cases you can instead use 'searchParams' instead:
+
+Scala
+: @@snip ($alpakka$/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala) { #custom-search-params }
+
+Java
+: @@snip ($alpakka$/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java) { #custom-search-params }
 
 
 ### Running the example code

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
@@ -668,6 +668,8 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
     "Should use indexName supplied in message if present" in {
       // Copy source/book to sink2/book through typed stream
 
+
+      //#custom-index-name-example
       val customIndexName = "custom-index"
 
       val f1 = ElasticsearchSource
@@ -677,7 +679,8 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
           query = """{"match_all": {}}"""
         )
         .map { message: OutgoingMessage[Book] =>
-          IncomingMessage(Some(message.id), message.source).withIndexName(customIndexName)
+          IncomingMessage(Some(message.id), message.source)
+            .withIndexName(customIndexName) // Setting the index-name to use for this document
         }
         .runWith(
           ElasticsearchSink.create[Book](
@@ -685,6 +688,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
             typeName = "book"
           )
         )
+      //#custom-index-name-example
 
       Await.result(f1, Duration.Inf)
 

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
@@ -716,4 +716,30 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
     }
   }
 
+  "ElasticsearchSource" should {
+    "should prefetch next scroll" in {
+      val f1 = ElasticsearchSource
+        .typed[Book](
+          indexName = "source",
+          typeName = "book",
+          query = """{"match_all": {}}""",
+          settings = ElasticsearchSourceSettings(bufferSize = 5)
+        )
+        .map(_.source.title)
+        .runWith(Sink.seq)
+
+      val result = Await.result(f1, Duration.Inf).toList
+
+      result.sorted shouldEqual Seq(
+        "Akka Concurrency",
+        "Akka in Action",
+        "Effective Akka",
+        "Learning Scala",
+        "Programming in Scala",
+        "Scala Puzzlers",
+        "Scala for Spark in Production"
+      )
+    }
+  }
+
 }

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
@@ -668,7 +668,6 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
     "Should use indexName supplied in message if present" in {
       // Copy source/book to sink2/book through typed stream
 
-
       //#custom-index-name-example
       val customIndexName = "custom-index"
 
@@ -743,6 +742,68 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
         "Scala Puzzlers",
         "Scala for Spark in Production"
       )
+    }
+  }
+
+  "ElasticsearchSource" should {
+    "be able to use custom searchParams" in {
+
+      //#custom-search-params
+      case class TestDoc(id: String, a: String, b: Option[String], c: String)
+      //#custom-search-params
+
+      implicit val formatVersionTestDoc: JsonFormat[TestDoc] = jsonFormat4(TestDoc)
+
+      val indexName = "custom-search-params-test-scala"
+      val typeName = "TestDoc"
+
+      val docs = List(
+        TestDoc("1", "a1", Some("b1"), "c1"),
+        TestDoc("2", "a2", Some("b2"), "c2"),
+        TestDoc("3", "a3", Some("b3"), "c3")
+      )
+
+      // insert new documents
+      val f1 = Source(docs)
+        .map { doc =>
+          IncomingMessage(Some(doc.id), doc)
+        }
+        .via(
+          ElasticsearchFlow.create[TestDoc](
+            indexName,
+            typeName,
+            ElasticsearchSinkSettings(bufferSize = 5)
+          )
+        )
+        .runWith(Sink.seq)
+
+      val result1 = Await.result(f1, Duration.Inf)
+      flush(indexName)
+
+      // Assert no errors
+      assert(result1.forall(!_.exists(_.success == false)))
+
+      //#custom-search-params
+      // Search for docs and ask elastic to only return some fields
+
+      val f3 = ElasticsearchSource
+        .typed[TestDoc](indexName,
+                        typeName,
+                        searchParams = Map(
+                          "query" -> """ {"match_all": {}} """,
+                          "_source" -> """ ["id", "a", "c"] """
+                        ),
+                        ElasticsearchSourceSettings())
+        .map { message =>
+          message.source
+        }
+        .runWith(Sink.seq)
+
+      //#custom-search-params
+
+      val result3 = Await.result(f3, Duration.Inf)
+      assert(result3.toList.sortBy(_.id) == docs.map(_.copy(b = None)))
+
     }
   }
 


### PR DESCRIPTION
This is needed when streaming to an "index-pattern". 

Example:

posting documents to "my-index-2018-01-31" and "my-index-2018-02-01" while search in kibana for "my-index-*"