### PR TITLE
google-fcm

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val modules: Seq[ProjectReference] = Seq(
   ftp,
   geode,
   googleCloudPubSub,
+  googleFcm,
   hbase,
   ironmq,
   jms,
@@ -94,12 +95,19 @@ lazy val geode =
 
 lazy val googleCloudPubSub = alpakkaProject(
   "google-cloud-pub-sub",
-  "googlecloud.pubsub",
+  "google.cloud.pubsub",
   Dependencies.GooglePubSub,
   fork in Test := true,
   envVars in Test := Map("PUBSUB_EMULATOR_HOST" -> "localhost:8538"),
   // For mockito https://github.com/akka/alpakka/issues/390
   parallelExecution in Test := false
+)
+
+lazy val googleFcm = alpakkaProject(
+  "google-fcm",
+  "google.firebase.fcm",
+  Dependencies.GoogleFcm,
+  fork in Test := true
 )
 
 lazy val hbase = alpakkaProject("hbase", "hbase", Dependencies.HBase, fork in Test := true)

--- a/docs/src/main/paradox/connectors.md
+++ b/docs/src/main/paradox/connectors.md
@@ -17,6 +17,7 @@
 * [File Connectors](file.md)
 * [FTP Connector](ftp.md)
 * [Google Cloud Pub/Sub Connector](google-cloud-pub-sub.md)
+* [Google Firebase Cloud Messaging](google-fcm.md)
 * [HBase Connectors](hbase.md)
 * [IronMq Connectors](ironmq.md)
 * [JMS Connectors](jms.md)

--- a/docs/src/main/paradox/google-fcm.md
+++ b/docs/src/main/paradox/google-fcm.md
@@ -1,0 +1,108 @@
+# Google Firebase Cloud Messaging
+
+The google firebase cloud messaging connector provides a way to send notifications https://firebase.google.com/docs/cloud-messaging/ .
+
+@@@ warning { title='Early state' }
+The whole FCM server implementation doc is a bit unclear. 
+This connector is build from scratch following the documentation.
+So the error parsing, the condition builder, the apns object and some other object/case class
+could (and possibly will) be improved.
+@@@
+
+
+### Reported issues
+
+[Tagged issues at Github](https://github.com/akka/alpakka/labels/p%3Agoogle-fcm)
+
+
+## Artifacts
+
+@@dependency [sbt,Maven,Gradle] {
+  group=com.lightbend.akka
+  artifact=akka-stream-alpakka-google-fcm_$scalaBinaryVersion$
+  version=$version$
+}
+
+## Usage
+
+Possibly needed imports for the following codes.
+
+Scala
+: @@snip ($alpakka$/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/scaladsl/Examples.scala) { #imports }
+
+Java
+: @@snip ($alpakka$/google-fcm/src/test/java/akka/stream/alpakka/google/firebase/fcm/javadsl/Examples.java) { #imports }
+
+
+Prepare the actor system and materializer.
+
+Scala
+: @@snip ($alpakka$/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/scaladsl/Examples.scala) { #init-mat }
+
+Java
+: @@snip ($alpakka$/google-fcm/src/test/java/akka/stream/alpakka/google/firebase/fcm/javadsl/Examples.java) { #init-mat }
+
+
+Prepare your credentials for access to FCM.
+
+Scala
+: @@snip ($alpakka$/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/scaladsl/Examples.scala) { #init-credentials }
+
+Java
+: @@snip ($alpakka$/google-fcm/src/test/java/akka/stream/alpakka/google/firebase/fcm/javadsl/Examples.java) { #init-credentials }
+
+The last two parameters in the above example are the predefined values. 
+You can send test notifications [(so called validate only).](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages/send)
+And you can set the number of maximum concurrent connections.
+There is a limitation in the docs; from one IP you can have maximum 1k pending connections, 
+and you may need to configure `akka.http.host-connection-pool.max-open-requests` in your application.conf.
+
+To send a notification message create your notification object, and send it!
+
+Scala
+: @@snip ($alpakka$/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/scaladsl/Examples.scala) { #simple-send }
+
+Java
+: @@snip ($alpakka$/google-fcm/src/test/java/akka/stream/alpakka/google/firebase/fcm/javadsl/Examples.java) { #simple-send }
+
+With fire and forget you will just send messages and ignore all the errors.
+This is not so healthy in general so you can use the send instead.
+
+Scala
+: @@snip ($alpakka$/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/scaladsl/Examples.scala) { #asFlow-send }
+
+Java
+: @@snip ($alpakka$/google-fcm/src/test/java/akka/stream/alpakka/google/firebase/fcm/javadsl/Examples.java) { #asFlow-send }
+
+With this type of send you can get responses from the server.
+These responses can be @scaladoc[positive](akka.stream.alpakka.google.firebase.fcm.FcmFlowModels.FcmSuccessResponse) or @scaladoc[negative](akka.stream.alpakka.google.firebase.fcm.FcmFlowModels.FcmErrorResponse). 
+You can choose what you want to do with this information, but keep in mind
+if you try to resend the failed messages you will need to implement exponential backoff too!
+
+To help the integration and error handling or logging, there is a variation of the flow where you can send data beside your notification.
+
+Scala
+: @@snip ($alpakka$/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/scaladsl/Examples.scala) { #withData-send }
+
+Java
+: @@snip ($alpakka$/google-fcm/src/test/java/akka/stream/alpakka/google/firebase/fcm/javadsl/Examples.java) { #withData-send }
+
+Here I send a simple string, but you could use any type.
+
+## Scala only
+
+You can build any notification described in the original documentation.
+It can be done by hand, or using some builder method.
+If you build your notification from scratch with options (and not with the provided builders), worth to check isSendable before sending.
+
+Scala
+: @@snip ($alpakka$/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/scaladsl/Examples.scala) { #noti-create }
+
+There is a condition builder too.
+
+Scala
+: @@snip ($alpakka$/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/scaladsl/Examples.scala) { #condition-builder }
+
+## Running the examples
+
+To run the example code you will need to configure a project and notifications in google firebase and provide your own credentials.

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/FcmFlowModels.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/FcmFlowModels.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm
+
+import akka.NotUsed
+import akka.http.scaladsl.HttpExt
+import akka.stream.Materializer
+import akka.stream.alpakka.google.firebase.fcm.impl.{FcmSender, GoogleSession, GoogleTokenApi}
+import akka.stream.scaladsl.Flow
+
+import scala.concurrent.Future
+
+object FcmFlowModels {
+
+  case class FcmFlowConfig(clientEmail: String,
+                           privateKey: String,
+                           projectid: String,
+                           isTest: Boolean = false,
+                           maxConcurentConnections: Int = 100)
+
+  sealed trait FcmResponse
+  case class FcmSuccessResponse(name: String) extends FcmResponse
+  case class FcmErrorResponse(rawError: String) extends FcmResponse
+  case class FcmSend(validate_only: Boolean, message: FcmNotification)
+
+  protected[fcm] def fcmWithData[T](conf: FcmFlowConfig, http: => HttpExt, sender: FcmSender)(
+      implicit materializer: Materializer
+  ): Flow[(FcmNotification, T), (FcmResponse, T), NotUsed] = {
+    import materializer.executionContext
+    val session: GoogleSession = new GoogleSession(conf.clientEmail, conf.privateKey, new GoogleTokenApi(http))
+    Flow[(FcmNotification, T)]
+      .mapAsync(conf.maxConcurentConnections)(
+        in =>
+          session.getToken().flatMap { token =>
+            sender.send(conf.projectid, token, http, FcmSend(conf.isTest, in._1)).zip(Future.successful(in._2))
+        }
+      )
+  }
+
+  protected[fcm] def fcm(conf: FcmFlowConfig, http: => HttpExt, sender: FcmSender)(
+      implicit materializer: Materializer
+  ): Flow[FcmNotification, FcmResponse, NotUsed] = {
+    import materializer.executionContext
+    val session: GoogleSession = new GoogleSession(conf.clientEmail, conf.privateKey, new GoogleTokenApi(http))
+    val sender: FcmSender = new FcmSender()
+    Flow[FcmNotification]
+      .mapAsync(conf.maxConcurentConnections)(
+        in =>
+          session.getToken().flatMap { token =>
+            sender.send(conf.projectid, token, http, FcmSend(conf.isTest, in))
+        }
+      )
+  }
+}

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/FcmNotificationModels.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/FcmNotificationModels.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm
+
+import akka.stream.alpakka.google.firebase.fcm.FcmNotificationModels._
+
+object FcmNotificationModels {
+
+  case class BasicNotification(title: String, body: String)
+
+  case class AndroidNotification(
+      title: String,
+      body: String,
+      icon: String,
+      color: String,
+      sound: String,
+      tag: String,
+      click_action: String,
+      body_loc_key: String,
+      body_loc_args: Seq[String],
+      title_loc_key: String,
+      title_loc_args: Seq[String]
+  )
+
+  case class AndroidConfig(
+      collapse_key: String,
+      priority: AndroidMessagePriority,
+      ttl: String,
+      restricted_package_name: String,
+      data: Map[String, String],
+      notification: AndroidNotification
+  )
+
+  sealed trait AndroidMessagePriority
+  case object Normal extends AndroidMessagePriority
+  case object High extends AndroidMessagePriority
+
+  case class WebPushNotification(title: String, body: String, icon: String)
+  case class WebPushConfig(headers: Map[String, String], data: Map[String, String], notification: WebPushNotification)
+
+  case class ApnsConfig(headers: Map[String, String], rawPayload: String)
+
+  sealed trait NotificationTarget
+  case class Token(token: String) extends NotificationTarget
+  case class Topic(topic: String) extends NotificationTarget
+  case class Condition(conditionText: String) extends NotificationTarget
+
+  object Condition {
+    sealed trait ConditionBuilder {
+      def &&(condition: ConditionBuilder) = And(this, condition)
+      def ||(condition: ConditionBuilder) = Or(this, condition)
+      def unary_! = Not(this)
+      def toConditionText: String
+    }
+    case class Topic(topic: String) extends ConditionBuilder {
+      def toConditionText: String = s"'$topic' in topics"
+    }
+    case class And(condition1: ConditionBuilder, condition2: ConditionBuilder) extends ConditionBuilder {
+      def toConditionText: String = s"(${condition1.toConditionText} && ${condition2.toConditionText})"
+    }
+    case class Or(condition1: ConditionBuilder, condition2: ConditionBuilder) extends ConditionBuilder {
+      def toConditionText: String = s"(${condition1.toConditionText} || ${condition2.toConditionText})"
+    }
+    case class Not(condition: ConditionBuilder) extends ConditionBuilder {
+      def toConditionText: String = s"!(${condition.toConditionText})"
+    }
+
+    def apply(builder: ConditionBuilder): Condition =
+      Condition(builder.toConditionText)
+  }
+
+}
+
+case class FcmNotification(
+    data: Option[Map[String, String]] = None,
+    notification: Option[BasicNotification] = None,
+    android: Option[AndroidConfig] = None,
+    webPush: Option[WebPushConfig] = None,
+    apns: Option[ApnsConfig] = None,
+    token: Option[String] = None,
+    topic: Option[String] = None,
+    condition: Option[String] = None
+) {
+  def withData(data: Map[String, String]): FcmNotification = this.copy(data = Option(data))
+  def withBasicNotification(notification: BasicNotification): FcmNotification =
+    this.copy(notification = Option(notification))
+  def withBasicNotification(title: String, body: String): FcmNotification =
+    this.copy(notification = Option(BasicNotification(title, body)))
+  def withAndroidConfig(android: AndroidConfig): FcmNotification = this.copy(android = Option(android))
+  def withWebPushConfig(webPush: WebPushConfig): FcmNotification = this.copy(webPush = Option(webPush))
+  def withApnsConfig(apns: ApnsConfig): FcmNotification = this.copy(apns = Option(apns))
+  def withTarget(target: NotificationTarget): FcmNotification = target match {
+    case Token(t) => this.copy(token = Option(t), topic = None, condition = None)
+    case Topic(t) => this.copy(token = None, topic = Option(t), condition = None)
+    case Condition(t) => this.copy(token = None, topic = None, condition = Option(t))
+  }
+  def isSendable = (token.isDefined ^ topic.isDefined ^ condition.isDefined) && !(token.isDefined && topic.isDefined)
+}
+
+object FcmNotification {
+  val empty: FcmNotification = FcmNotification()
+  def fromJava(): FcmNotification = empty
+  def apply(notification: BasicNotification, target: NotificationTarget): FcmNotification =
+    empty.withBasicNotification(notification).withTarget(target)
+  def apply(title: String, body: String, target: NotificationTarget): FcmNotification =
+    empty.withBasicNotification(title, body).withTarget(target)
+  def basic(title: String, body: String, target: NotificationTarget) = FcmNotification(title, body, target)
+}

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmJsonSupport.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmJsonSupport.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm.impl
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.stream.alpakka.google.firebase.fcm.FcmFlowModels.{
+  FcmErrorResponse,
+  FcmResponse,
+  FcmSend,
+  FcmSuccessResponse
+}
+import akka.stream.alpakka.google.firebase.fcm.FcmNotification
+import akka.stream.alpakka.google.firebase.fcm.FcmNotificationModels._
+import akka.stream.alpakka.google.firebase.fcm.impl.GoogleTokenApi.OAuthResponse
+import spray.json._
+
+private[fcm] trait FcmJsonSupport extends DefaultJsonProtocol with SprayJsonSupport {
+
+  //custom formatters
+  implicit val fcmSuccessResponseJsonFormat: RootJsonFormat[FcmSuccessResponse] = jsonFormat1(FcmSuccessResponse)
+  implicit object FcmErrorResponseJsonFormat extends RootJsonFormat[FcmErrorResponse] {
+    def write(c: FcmErrorResponse) =
+      c.rawError.parseJson
+
+    def read(value: JsValue) = FcmErrorResponse(value.toString)
+  }
+
+  implicit object FcmResponseFormat extends RootJsonReader[FcmResponse] {
+    def read(value: JsValue) = value match {
+      case JsObject(fields) if fields.keys.exists(_ == "name") => value.convertTo[FcmSuccessResponse]
+      case JsObject(fields) if fields.keys.exists(_ == "error_code") => value.convertTo[FcmErrorResponse]
+      case other => throw DeserializationException(s"FcmResponse expected, but we get $other")
+    }
+  }
+
+  implicit object AndroidMessagePriorityFormat extends RootJsonFormat[AndroidMessagePriority] {
+    def write(c: AndroidMessagePriority) =
+      c match {
+        case Normal => JsString("NORMAL")
+        case High => JsString("HIGH")
+      }
+
+    def read(value: JsValue) = value match {
+      case JsString("NORMAL") => Normal
+      case JsString("HIGH") => High
+      case other => throw DeserializationException(s"AndroidMessagePriority expected, but we get $other")
+    }
+  }
+
+  implicit object ApnsConfigResponseJsonFormat extends RootJsonFormat[ApnsConfig] {
+    def write(c: ApnsConfig) =
+      JsObject(
+        "headers" -> c.headers.toJson,
+        "payload" -> c.rawPayload.parseJson
+      )
+
+    def read(value: JsValue) = {
+      val map = value.asJsObject
+      ApnsConfig(map.fields("headers").convertTo[Map[String, String]], map.fields("payload").toString)
+    }
+  }
+
+  // google -> app
+  implicit val oAuthResponseJsonFormat: RootJsonFormat[OAuthResponse] = jsonFormat3(OAuthResponse)
+  //app -> google
+  implicit val webPushNotificationJsonFormat: RootJsonFormat[WebPushNotification] = jsonFormat3(WebPushNotification)
+  implicit val webPushConfigJsonFormat: RootJsonFormat[WebPushConfig] = jsonFormat3(WebPushConfig.apply _)
+  implicit val androidNotificationJsonFormat: RootJsonFormat[AndroidNotification] = jsonFormat11(AndroidNotification)
+  implicit val androidConfigJsonFormat: RootJsonFormat[AndroidConfig] = jsonFormat6(AndroidConfig.apply _)
+  implicit val basicNotificationJsonFormat: RootJsonFormat[BasicNotification] = jsonFormat2(BasicNotification)
+  implicit val sendableFcmNotificationJsonFormat: RootJsonFormat[FcmNotification] = jsonFormat8(
+    FcmNotification.apply _
+  )
+  implicit val fcmSendJsonFormat: RootJsonFormat[FcmSend] = jsonFormat2(FcmSend)
+}

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmSender.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmSender.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm.impl
+
+import akka.http.scaladsl.HttpExt
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.Materializer
+import akka.stream.alpakka.google.firebase.fcm.FcmFlowModels.{
+  FcmErrorResponse,
+  FcmResponse,
+  FcmSend,
+  FcmSuccessResponse
+}
+import spray.json._
+
+import scala.collection.immutable
+import scala.concurrent.{ExecutionContext, Future}
+
+private[fcm] class FcmSender extends FcmJsonSupport {
+
+  def send(projectId: String, token: String, http: HttpExt, fcmSend: FcmSend)(
+      implicit materializer: Materializer
+  ): Future[FcmResponse] = {
+    val url = s"https://fcm.googleapis.com/v1/projects/$projectId/messages:send"
+
+    val response = http.singleRequest(
+      HttpRequest(
+        HttpMethods.POST,
+        url,
+        immutable.Seq(Authorization(OAuth2BearerToken(token))),
+        HttpEntity(ContentTypes.`application/json`, fcmSend.toJson.compactPrint)
+      )
+    )
+    parse(response)
+  }
+
+  private def parse(response: Future[HttpResponse])(implicit materializer: Materializer): Future[FcmResponse] = {
+    implicit val executionContext: ExecutionContext = materializer.executionContext
+    response.flatMap { rsp =>
+      if (rsp.status.isSuccess) {
+        Unmarshal(rsp.entity).to[FcmSuccessResponse]
+      } else {
+        Unmarshal(rsp.entity).to[FcmErrorResponse]
+      }
+    }
+  }
+}

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleSession.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleSession.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm.impl
+
+import akka.stream.Materializer
+import akka.stream.alpakka.google.firebase.fcm.impl.GoogleTokenApi.AccessTokenExpiry
+
+import scala.concurrent.Future
+
+private[google] class GoogleSession(clientEmail: String, privateKey: String, tokenApi: GoogleTokenApi) {
+  protected var maybeAccessToken: Option[Future[AccessTokenExpiry]] = None
+
+  private def getNewToken()(implicit materializer: Materializer): Future[AccessTokenExpiry] = {
+    val accessToken = tokenApi.getAccessToken(clientEmail = clientEmail, privateKey = privateKey)
+    maybeAccessToken = Some(accessToken)
+    accessToken
+  }
+
+  private def expiresSoon(g: AccessTokenExpiry): Boolean =
+    g.expiresAt < (tokenApi.now + 60)
+
+  def getToken()(implicit materializer: Materializer): Future[String] = {
+    import materializer.executionContext
+    maybeAccessToken
+      .getOrElse(getNewToken())
+      .flatMap { result =>
+        if (expiresSoon(result)) {
+          getNewToken()
+        } else {
+          Future.successful(result)
+        }
+      }
+      .map(_.accessToken)
+  }
+}

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleTokenApi.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleTokenApi.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm.impl
+
+import akka.http.scaladsl.HttpExt
+import akka.http.scaladsl.model.{FormData, HttpMethods, HttpRequest}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.Materializer
+import akka.stream.alpakka.google.firebase.fcm.impl.GoogleTokenApi.{AccessTokenExpiry, OAuthResponse}
+import pdi.jwt.{Jwt, JwtAlgorithm, JwtClaim, JwtTime}
+
+import scala.concurrent.Future
+
+private[google] class GoogleTokenApi(http: => HttpExt) extends FcmJsonSupport {
+  protected val encodingAlgorithm: JwtAlgorithm.RS256.type = JwtAlgorithm.RS256
+
+  private val googleTokenUrl = "https://www.googleapis.com/oauth2/v4/token"
+  private val scope = "https://www.googleapis.com/auth/firebase.messaging"
+
+  def now: Long = JwtTime.nowSeconds
+
+  private def generateJwt(clientEmail: String, privateKey: String): String = {
+    val claim = JwtClaim(content = s"""{"scope":"$scope","aud":"$googleTokenUrl"}""", issuer = Option(clientEmail))
+      .expiresIn(3600)
+      .issuedNow
+    Jwt.encode(claim, privateKey, encodingAlgorithm)
+  }
+
+  def getAccessToken(clientEmail: String, privateKey: String)(
+      implicit materializer: Materializer
+  ): Future[AccessTokenExpiry] = {
+    import materializer.executionContext
+    val expiresAt = now + 3600
+    val jwt = generateJwt(clientEmail, privateKey)
+
+    val requestEntity = FormData(
+      "grant_type" -> "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      "assertion" -> jwt
+    ).toEntity
+
+    for {
+      response <- http.singleRequest(HttpRequest(HttpMethods.POST, googleTokenUrl, entity = requestEntity))
+      result <- Unmarshal(response.entity).to[OAuthResponse]
+    } yield {
+      AccessTokenExpiry(
+        accessToken = result.access_token,
+        expiresAt = expiresAt
+      )
+    }
+  }
+}
+
+object GoogleTokenApi {
+  case class AccessTokenExpiry(accessToken: String, expiresAt: Long)
+  case class OAuthResponse(access_token: String, token_type: String, expires_in: Int)
+}

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/javadsl/GoogleFcmFlow.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/javadsl/GoogleFcmFlow.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm.javadsl
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.japi.Pair
+import akka.stream.alpakka.google.firebase.fcm.FcmFlowModels.{FcmFlowConfig, FcmResponse}
+import akka.stream.alpakka.google.firebase.fcm.impl.FcmSender
+import akka.stream.alpakka.google.firebase.fcm.{FcmFlowModels, FcmNotification}
+import akka.stream.scaladsl.Flow
+import akka.stream.{javadsl, Materializer}
+
+object GoogleFcmFlow {
+  def sendWithPassThrough[T](
+      conf: FcmFlowConfig,
+      actorSystem: ActorSystem,
+      materializer: Materializer
+  ): javadsl.Flow[Pair[FcmNotification, T], Pair[FcmResponse, T], NotUsed] =
+    Flow[Pair[FcmNotification, T]]
+      .map(_.toScala)
+      .via(FcmFlowModels.fcmWithData[T](conf, Http()(actorSystem), new FcmSender)(materializer))
+      .map(t => Pair(t._1, t._2))
+      .asJava
+
+  def send(conf: FcmFlowConfig,
+           actorSystem: ActorSystem,
+           materializer: Materializer): javadsl.Flow[FcmNotification, FcmResponse, NotUsed] =
+    FcmFlowModels.fcm(conf, Http()(actorSystem), new FcmSender)(materializer).asJava
+}

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/javadsl/GoogleFcmSink.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/javadsl/GoogleFcmSink.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm.javadsl
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.stream.alpakka.google.firebase.fcm.FcmFlowModels.FcmFlowConfig
+import akka.stream.alpakka.google.firebase.fcm.{FcmFlowModels, FcmNotification}
+import akka.stream.alpakka.google.firebase.fcm.impl.FcmSender
+import akka.stream.{javadsl, Materializer}
+import akka.stream.scaladsl.Sink
+
+object GoogleFcmSink {
+
+  def fireAndForget(conf: FcmFlowConfig,
+                    actorSystem: ActorSystem,
+                    materializer: Materializer): javadsl.Sink[FcmNotification, NotUsed] =
+    FcmFlowModels.fcm(conf, Http()(actorSystem), new FcmSender)(materializer).to(Sink.ignore).asJava
+
+}

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/scaladsl/GoogleFcmFlow.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/scaladsl/GoogleFcmFlow.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm.scaladsl
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.stream.Materializer
+import akka.stream.alpakka.google.firebase.fcm.FcmFlowModels.{FcmFlowConfig, FcmResponse}
+import akka.stream.alpakka.google.firebase.fcm.impl.FcmSender
+import akka.stream.alpakka.google.firebase.fcm.{FcmFlowModels, FcmNotification}
+import akka.stream.scaladsl.Flow
+
+object GoogleFcmFlow {
+
+  def sendWithPassThrough[T](
+      conf: FcmFlowConfig
+  )(implicit materializer: Materializer,
+    actorSystem: ActorSystem): Flow[(FcmNotification, T), (FcmResponse, T), NotUsed] =
+    FcmFlowModels.fcmWithData[T](conf, Http(), new FcmSender)
+
+  def send(conf: FcmFlowConfig)(implicit materializer: Materializer,
+                                actorSystem: ActorSystem): Flow[FcmNotification, FcmResponse, NotUsed] =
+    FcmFlowModels.fcm(conf, Http(), new FcmSender)
+
+}

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/scaladsl/GoogleFcmSink.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/scaladsl/GoogleFcmSink.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm.scaladsl
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.stream.Materializer
+import akka.stream.alpakka.google.firebase.fcm.FcmFlowModels.FcmFlowConfig
+import akka.stream.alpakka.google.firebase.fcm.{FcmFlowModels, FcmNotification}
+import akka.stream.alpakka.google.firebase.fcm.impl.FcmSender
+import akka.stream.scaladsl.Sink
+
+object GoogleFcmSink {
+
+  def fireAndForget(conf: FcmFlowConfig)(implicit materializer: Materializer,
+                                         actorSystem: ActorSystem): Sink[FcmNotification, NotUsed] =
+    FcmFlowModels.fcm(conf, Http(), new FcmSender).to(Sink.ignore)
+
+}

--- a/google-fcm/src/test/java/akka/stream/alpakka/google/firebase/fcm/javadsl/Examples.java
+++ b/google-fcm/src/test/java/akka/stream/alpakka/google/firebase/fcm/javadsl/Examples.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm.javadsl;
+
+//#imports
+import akka.actor.ActorSystem;
+import akka.japi.Pair;
+import akka.stream.ActorMaterializer;
+import akka.stream.alpakka.google.firebase.fcm.FcmFlowModels;
+import akka.stream.alpakka.google.firebase.fcm.FcmNotification;
+import akka.stream.alpakka.google.firebase.fcm.FcmNotificationModels;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+//#imports
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+public class Examples {
+
+    private static void example() {
+        //#init-mat
+        ActorSystem system = ActorSystem.create();
+        ActorMaterializer materializer = ActorMaterializer.create(system);
+        //#init-mat
+
+        //#init-credentials
+        String privateKey =
+                        "-----BEGIN RSA PRIVATE KEY-----\n" +
+                        "MIIBOgIBAAJBAJHPYfmEpShPxAGP12oyPg0CiL1zmd2V84K5dgzhR9TFpkAp2kl2\n" +
+                        "9BTc8jbAY0dQW4Zux+hyKxd6uANBKHOWacUCAwEAAQJAQVyXbMS7TGDFWnXieKZh\n" +
+                        "Dm/uYA6sEJqheB4u/wMVshjcQdHbi6Rr0kv7dCLbJz2v9bVmFu5i8aFnJy1MJOpA\n" +
+                        "2QIhAPyEAaVfDqJGjVfryZDCaxrsREmdKDlmIppFy78/d8DHAiEAk9JyTHcapckD\n" +
+                        "uSyaE6EaqKKfyRwSfUGO1VJXmPjPDRMCIF9N900SDnTiye/4FxBiwIfdynw6K3dW\n" +
+                        "fBLb6uVYr/r7AiBUu/p26IMm6y4uNGnxvJSqe+X6AxR6Jl043OWHs4AEbwIhANuz\n" +
+                        "Ay3MKOeoVbx0L+ruVRY5fkW+oLHbMGtQ9dZq7Dp9\n" +
+                        "-----END RSA PRIVATE KEY-----";
+        String clientEmail = "test-XXX@test-XXXXX.iam.gserviceaccount.com";
+        String projectId = "test-XXXXX";
+        FcmFlowModels.FcmFlowConfig fcmConfig = new FcmFlowModels.FcmFlowConfig(clientEmail, privateKey, projectId, false, 100);
+        //#init-credentials
+
+        //#simple-send
+        FcmNotification notification = FcmNotification.basic("Test", "This is a test notification!", new FcmNotificationModels.Token("token"));
+        Source.single(notification).runWith(GoogleFcmSink.fireAndForget(fcmConfig, system, materializer), materializer);
+        //#simple-send
+
+        //#asFlow-send
+        CompletionStage<List<FcmFlowModels.FcmResponse>> result1 = Source.single(notification).via(GoogleFcmFlow.send(fcmConfig, system, materializer)).runWith(Sink.seq(), materializer);
+        //#asFlow-send
+
+        //#withData-send
+        CompletionStage<List<Pair<FcmFlowModels.FcmResponse, String>>> result2 =
+                Source.single(new Pair<FcmNotification, String>(notification, "superData"))
+                        .via(GoogleFcmFlow.sendWithPassThrough(fcmConfig, system, materializer))
+                        .runWith(Sink.seq(), materializer);
+        //#withData-send
+
+
+    }
+}

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/ConditionBuilderSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/ConditionBuilderSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm
+
+import akka.stream.alpakka.google.firebase.fcm.FcmNotificationModels.Condition._
+import org.scalatest.{Matchers, WordSpecLike}
+
+class ConditionBuilderSpec extends WordSpecLike with Matchers {
+
+  "ConditionBuilder" must {
+
+    "serialize Topic as expected" in {
+      Topic("TopicA").toConditionText shouldBe """'TopicA' in topics"""
+    }
+
+    "serialize And as expected" in {
+      And(Topic("TopicA"), Topic("TopicB")).toConditionText shouldBe """('TopicA' in topics && 'TopicB' in topics)"""
+    }
+
+    "serialize Or as expected" in {
+      Or(Topic("TopicA"), Topic("TopicB")).toConditionText shouldBe """('TopicA' in topics || 'TopicB' in topics)"""
+    }
+
+    "serialize Not as expected" in {
+      Not(Topic("TopicA")).toConditionText shouldBe """!('TopicA' in topics)"""
+    }
+
+    "serialize recursively and stay correct" in {
+      And(Or(Topic("TopicA"), Topic("TopicB")), Or(Topic("TopicC"), Not(Topic("TopicD")))).toConditionText shouldBe
+      """(('TopicA' in topics || 'TopicB' in topics) && ('TopicC' in topics || !('TopicD' in topics)))"""
+    }
+
+    "can use cool operators" in {
+      (Topic("TopicA") && (Topic("TopicB") || (Topic("TopicC") && !Topic("TopicD")))).toConditionText shouldBe
+      """('TopicA' in topics && ('TopicB' in topics || ('TopicC' in topics && !('TopicD' in topics))))"""
+    }
+  }
+
+}

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/FcmNotificationSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/FcmNotificationSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm
+
+import akka.stream.alpakka.google.firebase.fcm.FcmNotificationModels.{Condition, Token, Topic}
+import org.scalatest.{Matchers, WordSpecLike}
+
+class FcmNotificationSpec extends WordSpecLike with Matchers {
+
+  "SendableNotification" should {
+
+    "target is mandatory" must {
+      "not fail if only one target added" in {
+        FcmNotification(token = Option("")).isSendable shouldBe true
+        FcmNotification(topic = Option("")).isSendable shouldBe true
+        FcmNotification(condition = Option("")).isSendable shouldBe true
+      }
+
+      "must fail if two target added" in {
+        FcmNotification(token = Option(""), topic = Option("")).isSendable shouldBe false
+        FcmNotification(token = Option(""), condition = Option("")).isSendable shouldBe false
+        FcmNotification(topic = Option(""), condition = Option("")).isSendable shouldBe false
+      }
+
+      "must fail if all target added" in {
+        FcmNotification(token = Option(""), topic = Option(""), condition = Option("")).isSendable shouldBe false
+      }
+    }
+
+    "withTarget don't build invalid objects" in {
+      val original = FcmNotification(token = Option(""))
+      val first = original.withTarget(Topic(""))
+      val second = first.withTarget(Condition(Condition.Topic("")))
+      val third = second.withTarget(Token(""))
+      original.isSendable shouldBe true
+      first.isSendable shouldBe true
+      second.isSendable shouldBe true
+      third.isSendable shouldBe true
+    }
+
+  }
+}

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmSenderSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmSenderSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm.impl
+
+import akka.actor.ActorSystem
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.settings.ConnectionPoolSettings
+import akka.http.scaladsl.{HttpExt, HttpsConnectionContext}
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.google.firebase.fcm.FcmFlowModels.{FcmErrorResponse, FcmSend, FcmSuccessResponse}
+import akka.stream.alpakka.google.firebase.fcm.FcmNotification
+import akka.testkit.TestKit
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{verify, when}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+class FcmSenderSpec
+    extends TestKit(ActorSystem())
+    with WordSpecLike
+    with Matchers
+    with ScalaFutures
+    with MockitoSugar
+    with BeforeAndAfterAll {
+
+  override def afterAll: Unit =
+    TestKit.shutdownActorSystem(system)
+
+  implicit val defaultPatience =
+    PatienceConfig(timeout = 2.seconds, interval = 50.millis)
+
+  implicit val executionContext: ExecutionContext = system.dispatcher
+
+  implicit val materializer = ActorMaterializer()
+
+  "FcmSender" should {
+
+    "call the api as the docs want to" in {
+      val sender = new FcmSender
+      val http = mock[HttpExt]
+      when(
+        http.singleRequest(any[HttpRequest](),
+                           any[HttpsConnectionContext](),
+                           any[ConnectionPoolSettings](),
+                           any[LoggingAdapter]())
+      ).thenReturn(
+        Future.successful(HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, """{"name": ""}""")))
+      )
+
+      Await.result(sender.send("projectId", "token", http, FcmSend(false, FcmNotification.empty)),
+                   defaultPatience.timeout)
+
+      val captor: ArgumentCaptor[HttpRequest] = ArgumentCaptor.forClass(classOf[HttpRequest])
+      verify(http).singleRequest(captor.capture(),
+                                 any[HttpsConnectionContext](),
+                                 any[ConnectionPoolSettings](),
+                                 any[LoggingAdapter]())
+      val request: HttpRequest = captor.getValue
+      request.entity shouldBe HttpEntity(ContentTypes.`application/json`, """{"validate_only":false,"message":{}}""")
+      request.uri.toString shouldBe "https://fcm.googleapis.com/v1/projects/projectId/messages:send"
+      request.headers.size shouldBe 1
+      request.headers.head should matchPattern { case HttpHeader("authorization", "Bearer token") => }
+    }
+
+    "parse the success response correctly" in {
+      val sender = new FcmSender
+      val http = mock[HttpExt]
+      when(
+        http.singleRequest(any[HttpRequest](),
+                           any[HttpsConnectionContext](),
+                           any[ConnectionPoolSettings](),
+                           any[LoggingAdapter]())
+      ).thenReturn(
+        Future.successful(HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, """{"name": "test"}""")))
+      )
+
+      sender
+        .send("projectId", "token", http, FcmSend(false, FcmNotification.empty))
+        .futureValue shouldBe FcmSuccessResponse("test")
+    }
+
+    "parse the error response correctly" in {
+      val sender = new FcmSender
+      val http = mock[HttpExt]
+      when(
+        http.singleRequest(any[HttpRequest](),
+                           any[HttpsConnectionContext](),
+                           any[ConnectionPoolSettings](),
+                           any[LoggingAdapter]())
+      ).thenReturn(
+        Future.successful(
+          HttpResponse(status = StatusCodes.BadRequest,
+                       entity = HttpEntity(ContentTypes.`application/json`, """{"name":"test"}"""))
+        )
+      )
+
+      sender
+        .send("projectId", "token", http, FcmSend(false, FcmNotification.empty))
+        .futureValue shouldBe FcmErrorResponse(
+        """{"name":"test"}"""
+      )
+    }
+
+  }
+}

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleTokenApiSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleTokenApiSpec.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm.impl
+
+import akka.actor.ActorSystem
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.settings.ConnectionPoolSettings
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.http.scaladsl.{HttpExt, HttpsConnectionContext}
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.google.firebase.fcm.impl.GoogleTokenApi.AccessTokenExpiry
+import akka.testkit.TestKit
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{verify, when}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import pdi.jwt.{Jwt, JwtAlgorithm}
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+class GoogleTokenApiSpec
+    extends TestKit(ActorSystem())
+    with WordSpecLike
+    with Matchers
+    with ScalaFutures
+    with MockitoSugar
+    with BeforeAndAfterAll {
+
+  override def afterAll: Unit =
+    TestKit.shutdownActorSystem(system)
+  implicit val defaultPatience =
+    PatienceConfig(timeout = 2.seconds, interval = 50.millis)
+
+  implicit val executionContext: ExecutionContext = system.dispatcher
+
+  implicit val materializer = ActorMaterializer()
+
+  //http://travistidwell.com/jsencrypt/demo/
+  val privateKey =
+    """-----BEGIN RSA PRIVATE KEY-----
+      |MIIBOgIBAAJBAJHPYfmEpShPxAGP12oyPg0CiL1zmd2V84K5dgzhR9TFpkAp2kl2
+      |9BTc8jbAY0dQW4Zux+hyKxd6uANBKHOWacUCAwEAAQJAQVyXbMS7TGDFWnXieKZh
+      |Dm/uYA6sEJqheB4u/wMVshjcQdHbi6Rr0kv7dCLbJz2v9bVmFu5i8aFnJy1MJOpA
+      |2QIhAPyEAaVfDqJGjVfryZDCaxrsREmdKDlmIppFy78/d8DHAiEAk9JyTHcapckD
+      |uSyaE6EaqKKfyRwSfUGO1VJXmPjPDRMCIF9N900SDnTiye/4FxBiwIfdynw6K3dW
+      |fBLb6uVYr/r7AiBUu/p26IMm6y4uNGnxvJSqe+X6AxR6Jl043OWHs4AEbwIhANuz
+      |Ay3MKOeoVbx0L+ruVRY5fkW+oLHbMGtQ9dZq7Dp9
+      |-----END RSA PRIVATE KEY-----""".stripMargin
+
+  val publicKey =
+    """-----BEGIN PUBLIC KEY-----
+        |MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAJHPYfmEpShPxAGP12oyPg0CiL1zmd2V
+        |84K5dgzhR9TFpkAp2kl29BTc8jbAY0dQW4Zux+hyKxd6uANBKHOWacUCAwEAAQ==
+        |-----END PUBLIC KEY-----""".stripMargin
+
+  "GoogleTokenApi" should {
+
+    "call the api as the docs want to" in {
+      val http = mock[HttpExt]
+      when(
+        http.singleRequest(any[HttpRequest](),
+                           any[HttpsConnectionContext](),
+                           any[ConnectionPoolSettings](),
+                           any[LoggingAdapter]())
+      ).thenReturn(
+        Future.successful(
+          HttpResponse(
+            entity = HttpEntity(ContentTypes.`application/json`,
+                                """{"access_token": "token", "token_type": "String", "expires_in": 3600}""")
+          )
+        )
+      )
+
+      val api = new GoogleTokenApi(http)
+      Await.result(api.getAccessToken("email", privateKey), defaultPatience.timeout)
+
+      val captor: ArgumentCaptor[HttpRequest] = ArgumentCaptor.forClass(classOf[HttpRequest])
+      verify(http).singleRequest(captor.capture(),
+                                 any[HttpsConnectionContext](),
+                                 any[ConnectionPoolSettings](),
+                                 any[LoggingAdapter]())
+      val request: HttpRequest = captor.getValue
+      request.uri.toString shouldBe "https://www.googleapis.com/oauth2/v4/token"
+      val data = Unmarshal(request.entity).to[String].futureValue
+      data should startWith("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=")
+      val jwt = data.replace("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=", "")
+      val decoded = Jwt.decode(jwt, publicKey, Seq(JwtAlgorithm.RS256))
+      decoded.isSuccess shouldBe true
+      decoded.get should include(""""aud":"https://www.googleapis.com/oauth2/v4/token"""")
+      decoded.get should include(""""scope":"https://www.googleapis.com/auth/firebase.messaging"""")
+      decoded.get should include(""""iss":"email"""")
+
+    }
+
+    "return the token" in {
+      val http = mock[HttpExt]
+      when(
+        http.singleRequest(any[HttpRequest](),
+                           any[HttpsConnectionContext](),
+                           any[ConnectionPoolSettings](),
+                           any[LoggingAdapter]())
+      ).thenReturn(
+        Future.successful(
+          HttpResponse(
+            entity = HttpEntity(ContentTypes.`application/json`,
+                                """{"access_token": "token", "token_type": "String", "expires_in": 3600}""")
+          )
+        )
+      )
+
+      val api = new GoogleTokenApi(http)
+      api.getAccessToken("email", privateKey).futureValue should matchPattern {
+        case AccessTokenExpiry("token", exp) if exp > (System.currentTimeMillis / 1000L + 3000L) =>
+      }
+    }
+  }
+
+}

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/scaladsl/Examples.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/scaladsl/Examples.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm.scaladsl
+
+//#imports
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.google.firebase.fcm.FcmFlowModels.FcmFlowConfig
+import akka.stream.alpakka.google.firebase.fcm.{FcmFlowModels, FcmNotification}
+import akka.stream.alpakka.google.firebase.fcm.FcmNotificationModels._
+import akka.stream.scaladsl.{Sink, Source}
+
+import scala.collection.immutable
+import scala.concurrent.Future
+//#imports
+
+class Examples {
+
+  //#init-mat
+  implicit val system = ActorSystem()
+  implicit val mat = ActorMaterializer()
+  //#init-mat
+
+  //#init-credentials
+  val privateKey =
+    """-----BEGIN RSA PRIVATE KEY-----
+      |MIIBOgIBAAJBAJHPYfmEpShPxAGP12oyPg0CiL1zmd2V84K5dgzhR9TFpkAp2kl2
+      |9BTc8jbAY0dQW4Zux+hyKxd6uANBKHOWacUCAwEAAQJAQVyXbMS7TGDFWnXieKZh
+      |Dm/uYA6sEJqheB4u/wMVshjcQdHbi6Rr0kv7dCLbJz2v9bVmFu5i8aFnJy1MJOpA
+      |2QIhAPyEAaVfDqJGjVfryZDCaxrsREmdKDlmIppFy78/d8DHAiEAk9JyTHcapckD
+      |uSyaE6EaqKKfyRwSfUGO1VJXmPjPDRMCIF9N900SDnTiye/4FxBiwIfdynw6K3dW
+      |fBLb6uVYr/r7AiBUu/p26IMm6y4uNGnxvJSqe+X6AxR6Jl043OWHs4AEbwIhANuz
+      |Ay3MKOeoVbx0L+ruVRY5fkW+oLHbMGtQ9dZq7Dp9
+      |-----END RSA PRIVATE KEY-----""".stripMargin
+  val clientEmail = "test-XXX@test-XXXXX.iam.gserviceaccount.com"
+  val projectId = "test-XXXXX"
+  val fcmConfig = FcmFlowConfig(clientEmail, privateKey, projectId, isTest = false, maxConcurentConnections = 100)
+  //#init-credentials
+
+  //#simple-send
+  val notification = FcmNotification("Test", "This is a test notification!", Token("token"))
+  Source.single(notification).runWith(GoogleFcmSink.fireAndForget(fcmConfig))
+  //#simple-send
+
+  //#asFlow-send
+  val result1: Future[immutable.Seq[FcmFlowModels.FcmResponse]] =
+    Source.single(notification).via(GoogleFcmFlow.send(fcmConfig)).runWith(Sink.seq)
+  //#asFlow-send
+
+  //#withData-send
+  val result2: Future[immutable.Seq[(FcmFlowModels.FcmResponse, String)]] =
+    Source.single((notification, "superData")).via(GoogleFcmFlow.sendWithPassThrough(fcmConfig)).runWith(Sink.seq)
+  //#withData-send
+
+  //#noti-create
+  val buildedNotification = FcmNotification.empty
+    .withTarget(Topic("testers"))
+    .withBasicNotification("title", "body")
+    //.withAndroidConfig(AndroidConfig(...))
+    //.withApnsConfig(ApnsConfig(...))
+    .withWebPushConfig(
+      WebPushConfig(
+        headers = Map.empty,
+        data = Map.empty,
+        WebPushNotification("web-title", "web-body", "http://example.com/icon.png")
+      )
+    )
+  val sendable = buildedNotification.isSendable
+  //#noti-create
+
+  //#condition-builder
+  import akka.stream.alpakka.google.firebase.fcm.FcmNotificationModels.Condition.{Topic => CTopic}
+  val condition = Condition(CTopic("TopicA") && (CTopic("TopicB") || (CTopic("TopicC") && !CTopic("TopicD"))))
+  val conditioneddNotification = FcmNotification("Test", "This is a test notification!", condition)
+  //#condition-builder
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -131,6 +131,15 @@ object Dependencies {
     )
   )
 
+  val GoogleFcm = Seq(
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+      "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+      "com.pauldijou" %% "jwt-core" % "0.14.1", //ApacheV2
+      "org.mockito" % "mockito-core" % "2.7.22" % Test //ApacheV2
+    )
+  )
+
   val HBase = {
     val hbaseVersion = "1.2.4"
     val hadoopVersion = "2.5.1"


### PR DESCRIPTION
fixes #750 

Things I did:
 - inited a new module
 - wrote the necessary models + jsconverters
 - wrote the communication
 - can authenticate and communicate with google
 - wrote test for things
 - can send notifications \o/

Things missing but I will working on after get some responses:
 - write some docs 
 - write the missing tests (after the api freezes)
 - write the java api
 - solve the leftover todos in the code

Questions:
 1. The google-pubsub connector do the jwt encoding by hand, I used the jwt-core. By hand coding, or use a lib?
 2. The google-pubsub use alpakka.googlecloud.pubsub, I used alpakka.google.firebase.fcm. More intermed package or not?
 3. I have "common" codes with the google-pubsub. If you want I can modify both projects to use the same classes, or we could merge these two modul (not so much dependency, not large codebase). (We will have an other google connector (bigquery)  soon, basically the same auth process, same deps the answer to this point can depends on this new info :D If I get close to merge with this, I will port our bigquery code to alpakka ready and PR it too.)
 4. Do I really need to check the configs (get a token) at prestart?
 5. In the FcmNotification class I have an isSendable def which can check if exactly one of the mandatory fields is present. Is it ok to let the users be responsible if they try to send a not sendable message or not? (There are other things I can't check and can cause problems so calling this function is not saving you just help you.)
 6. Is it better to try to parse the error to caseclasses or let it in a jsValue format and let the users decide if they parse it (and handle it) or not? (or try to parse, and if we fail give back the JsValue?)
 7. How can I integration test this? Any idea?
 8. As I asked before how bad using shared HttpExts?
