### PR TITLE
S3: Fix request signing for path and query

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/auth/CanonicalRequest.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/auth/CanonicalRequest.scala
@@ -4,54 +4,85 @@
 
 package akka.stream.alpakka.s3.auth
 
-import java.net.URLEncoder
-
 import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
 
 // Documentation: http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
-private[alpakka] case class CanonicalRequest(method: String,
-                                             uri: String,
-                                             queryString: String,
-                                             headerString: String,
-                                             signedHeaders: String,
-                                             hashedPayload: String) {
-  def canonicalString: String = s"$method\n$uri\n$queryString\n$headerString\n\n$signedHeaders\n$hashedPayload"
+private[alpakka] final case class CanonicalRequest(
+    method: String,
+    uri: String,
+    queryString: String,
+    headerString: String,
+    signedHeaders: String,
+    hashedPayload: String
+) {
+  def canonicalString: String =
+    s"$method\n$uri\n$queryString\n$headerString\n\n$signedHeaders\n$hashedPayload"
 }
 
 private[alpakka] object CanonicalRequest {
-  def from(req: HttpRequest): CanonicalRequest = {
-    val hashedBody = req.headers.find(_.name == "x-amz-content-sha256").map(_.value).getOrElse("")
+  def from(request: HttpRequest): CanonicalRequest = {
+    val hashedBody =
+      request.headers
+        .collectFirst { case header if header.is("x-amz-content-sha256") => header.value }
+        .getOrElse("")
+
     CanonicalRequest(
-      req.method.value,
-      pathEncode(req.uri.path),
-      canonicalQueryString(req.uri.query()),
-      canonicalHeaderString(req.headers),
-      signedHeadersString(req.headers),
+      request.method.value,
+      pathEncode(request.uri.path),
+      canonicalQueryString(request.uri.query()),
+      canonicalHeaderString(request.headers),
+      signedHeadersString(request.headers),
       hashedBody
     )
   }
 
-  def canonicalQueryString(query: Query): String =
-    query.sortBy(_._1).map { case (a, b) => s"${uriEncode(a)}=${uriEncode(b)}" }.mkString("&")
+  // https://tools.ietf.org/html/rfc3986#section-2.3
+  def isUnreservedCharacter(c: Char): Boolean =
+    c.isLetterOrDigit || c == '-' || c == '.' || c == '_' || c == '~'
 
-  private def uriEncode(str: String) = URLEncoder.encode(str, "utf-8")
+  // https://tools.ietf.org/html/rfc3986#section-2.2
+  // Excludes "/" as it is an exception according to spec.
+  val reservedCharacters: String = ":?#[]@!$&'()*+,;="
 
-  def canonicalHeaderString(headers: Seq[HttpHeader]): String = {
-    val grouped = headers.groupBy(_.lowercaseName())
-    val combined = grouped.mapValues(_.map(_.value.replaceAll("\\s+", " ").trim).mkString(","))
-    combined.toList.sortBy(_._1).map { case (k, v) => s"$k:$v" }.mkString("\n")
+  def isReservedCharacter(c: Char): Boolean =
+    reservedCharacters.contains(c)
+
+  def canonicalQueryString(query: Query): String = {
+    def uriEncode(s: String): String = s.flatMap {
+      case c if isUnreservedCharacter(c) => c.toString
+      case c => "%" + c.toHexString.toUpperCase
+    }
+
+    query
+      .sortBy { case (name, _) => name }
+      .map { case (name, value) => s"${uriEncode(name)}=${uriEncode(value)}" }
+      .mkString("&")
   }
 
-  def signedHeadersString(headers: Seq[HttpHeader]): String =
-    headers.map(_.lowercaseName()).distinct.sorted.mkString(";")
-
-  private def pathEncode(path: Path): String =
-    if (path.isEmpty) "/"
-    else
-      path.toString().flatMap {
-        case ch if "!$&'()*+,;:=".contains(ch) => "%" + Integer.toHexString(ch.toInt).toUpperCase
-        case other => other.toString
+  def canonicalHeaderString(headers: Seq[HttpHeader]): String =
+    headers
+      .groupBy(_.lowercaseName)
+      .map {
+        case (name, headers) =>
+          name -> headers
+            .map(header => header.value.replaceAll("\\s+", " ").trim)
+            .mkString(",")
       }
+      .toList
+      .sortBy { case (name, _) => name }
+      .map { case (name, value) => s"$name:$value" }
+      .mkString("\n")
 
+  def signedHeadersString(headers: Seq[HttpHeader]): String =
+    headers.map(_.lowercaseName).distinct.sorted.mkString(";")
+
+  def pathEncode(path: Path): String =
+    if (path.isEmpty) "/"
+    else {
+      path.toString.flatMap {
+        case c if isReservedCharacter(c) => "%" + c.toHexString.toUpperCase
+        case c => c.toString
+      }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/akka/alpakka/issues/719.

- The path encoding in `CanonicalRequest` was not encoding some reserved characters (in [RFC 3986](https://tools.ietf.org/html/rfc3986#section-2.2)), like `#`, `@`, and `&`.
- The query string encoding in `CanonicalRequest` used `java.net.URLEncoder` rather than just encoding the "non unreserved" characters (in [RFC 3986](https://tools.ietf.org/html/rfc3986#section-2.3)).