### PR TITLE
Provide facility to complete an SQS stream after an empty receive

### DIFF
--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -62,7 +62,15 @@ Options:
  - `maxBatchSize` - the maximum number of messages to return (see `MaxNumberOfMessages` in AWS docs). Default: 10
  - `maxBufferSize` - internal buffer size used by the `Source`. Default: 100 messages
  - `waitTimeSeconds` - the duration for which the call waits for a message to arrive in the queue before
-    returning (see `WaitTimeSeconds` in AWS docs). Default: 20 seconds
+    returning (see `WaitTimeSeconds` in AWS docs). Default: 20 seconds  
+ - `closeOnEmptyReceive` - the shutdown behavior of the `Source`. Default: false
+ 
+An `SqsSource` can either provide n infinite stream of messages (the default), or can
+drain its source queue until no further messages are available. The latter
+behaviour is enabled by setting the `closeOnEmptyReceive` flag on creation. If set, the
+`Source` will receive messages until it encounters an empty reply from the server. It 
+then continues to emit any remaining messages in its local buffer. The stage will complete
+once the last message has been send downstream.
 
 Be aware that the `SqsSource` runs multiple requests to Amazon SQS in parallel. The maximum number of concurrent
 requests is limited by `parallelism = maxBufferSize / maxBatchSize`. E.g.: By default `maxBatchSize` is set to 10 and

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -65,7 +65,7 @@ Options:
     returning (see `WaitTimeSeconds` in AWS docs). Default: 20 seconds  
  - `closeOnEmptyReceive` - the shutdown behavior of the `Source`. Default: false
  
-An `SqsSource` can either provide n infinite stream of messages (the default), or can
+An `SqsSource` can either provide an infinite stream of messages (the default), or can
 drain its source queue until no further messages are available. The latter
 behaviour is enabled by setting the `closeOnEmptyReceive` flag on creation. If set, the
 `Source` will receive messages until it encounters an empty reply from the server. It 

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -72,6 +72,10 @@ behaviour is enabled by setting the `closeOnEmptyReceive` flag on creation. If s
 then continues to emit any remaining messages in its local buffer. The stage will complete
 once the last message has been send downstream.
 
+Note that for short-polling (`waitTimeSeconds` of 0), SQS may respond with an empty 
+reply even if there are still messages in the queue. This behavior can be prevented by 
+switching to long-polling (by setting `waitTimeSeconds` to a nonzero value).
+
 Be aware that the `SqsSource` runs multiple requests to Amazon SQS in parallel. The maximum number of concurrent
 requests is limited by `parallelism = maxBufferSize / maxBatchSize`. E.g.: By default `maxBatchSize` is set to 10 and
 `maxBufferSize` is set to 100 so at the maximum, `SqsSource` will run 10 concurrent requests to Amazon SQS. `AmazonSQSAsyncClient`

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
@@ -25,6 +25,19 @@ object SqsSourceSettings {
                       attributeNames.asScala,
                       messageAttributeNames.asScala)
 
+  def create(waitTimeSeconds: Int,
+             maxBufferSize: Int,
+             maxBatchSize: Int,
+             attributeNames: util.List[AttributeName],
+             messageAttributeNames: util.List[MessageAttributeName],
+             closeOnEmptyReceive: Boolean): SqsSourceSettings =
+    SqsSourceSettings(waitTimeSeconds,
+                      maxBufferSize,
+                      maxBatchSize,
+                      attributeNames.asScala,
+                      messageAttributeNames.asScala,
+                      closeOnEmptyReceive)
+
 }
 
 //#SqsSourceSettings
@@ -33,7 +46,8 @@ final case class SqsSourceSettings(
     maxBufferSize: Int,
     maxBatchSize: Int,
     attributeNames: Seq[AttributeName] = Seq(),
-    messageAttributeNames: Seq[MessageAttributeName] = Seq()
+    messageAttributeNames: Seq[MessageAttributeName] = Seq(),
+    closeOnEmptyReceive: Boolean = false
 ) {
   require(maxBatchSize <= maxBufferSize, "maxBatchSize must be lower or equal than maxBufferSize")
   // SQS requirements

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceSpec.scala
@@ -80,6 +80,15 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
       f.map(_ should have size 1)
     }
 
+    "terminate on an empty response if requested" taggedAs Integration in {
+      val queue = randomQueueUrl()
+
+      sqsClient.sendMessage(queue, "alpakka")
+      val f = SqsSource(queue, SqsSourceSettings(0, 100, 10, closeOnEmptyReceive = true)).runWith(Sink.seq)
+
+      f.map(_ should have size 1)
+    }
+
     "finish immediately if the queue does not exist" taggedAs Integration in {
 
       val queue = s"$sqsEndpoint/queue/not-existing"


### PR DESCRIPTION
This addresses issue #776

* Adds a flag to SqsSourceSettings that will cause the source to complete after an empty receive
* Sources will stop polling for new messages after an empty receive is encountered
* Once the last current request completes and the buffer drains, the source completes