### PR TITLE
OrientDB: add to connectors listing

### DIFF
--- a/docs/src/main/paradox/connectors.md
+++ b/docs/src/main/paradox/connectors.md
@@ -22,6 +22,7 @@
 * [JMS Connectors](jms.md)
 * [MongoDB Connector](mongodb.md)
 * [MQTT Connector](mqtt.md)
+* [OrientDB](orientdb.md)
 * [Server-sent Events (SSE)](sse.md)
 * [Slick (JDBC) Connector](slick.md)
 * [Spring Web](spring-web.md)


### PR DESCRIPTION
Just noticed the new connector was missing in the list.