### PR TITLE
jms: add flow producer

### DIFF
--- a/doc-examples/src/main/scala/jms/JmsSampleBase.scala
+++ b/doc-examples/src/main/scala/jms/JmsSampleBase.scala
@@ -4,12 +4,11 @@
 
 package jms
 
-import javax.jms.ConnectionFactory
-
 import akka.Done
-import akka.stream.alpakka.jms.JmsSinkSettings
-import akka.stream.alpakka.jms.scaladsl.JmsSink
+import akka.stream.alpakka.jms.JmsProducerSettings
+import akka.stream.alpakka.jms.scaladsl.JmsProducer
 import akka.stream.scaladsl.{Sink, Source}
+import javax.jms.ConnectionFactory
 import playground.ActorSystemAvailable
 
 import scala.concurrent.Future
@@ -18,8 +17,8 @@ class JmsSampleBase extends ActorSystemAvailable {
 
   def enqueue(connectionFactory: ConnectionFactory)(msgs: String*): Unit = {
     val jmsSink: Sink[String, Future[Done]] =
-      JmsSink.textSink(
-        JmsSinkSettings(connectionFactory).withQueue("test")
+      JmsProducer.textSink(
+        JmsProducerSettings(connectionFactory).withQueue("test")
       )
     Source(msgs.toList).runWith(jmsSink)
   }

--- a/doc-examples/src/main/scala/jms/JmsToFile.scala
+++ b/doc-examples/src/main/scala/jms/JmsToFile.scala
@@ -7,10 +7,10 @@ package jms
 // #sample
 import java.nio.file.Paths
 
-import akka.stream.{IOResult, KillSwitch}
-import akka.stream.alpakka.jms.JmsSourceSettings
-import akka.stream.alpakka.jms.scaladsl.JmsSource
+import akka.stream.alpakka.jms.JmsConsumerSettings
+import akka.stream.alpakka.jms.scaladsl.JmsConsumer
 import akka.stream.scaladsl.{FileIO, Keep, Sink, Source}
+import akka.stream.{IOResult, KillSwitch}
 import akka.util.ByteString
 
 import scala.concurrent.Future
@@ -29,8 +29,8 @@ object JmsToFile extends JmsSampleBase with App {
   // #sample
 
   val jmsSource: Source[String, KillSwitch] =        // (1)
-    JmsSource.textSource(
-      JmsSourceSettings(connectionFactory).withBufferSize(10).withQueue("test")
+    JmsConsumer.textSource(
+      JmsConsumerSettings(connectionFactory).withBufferSize(10).withQueue("test")
     )
 
   val fileSink: Sink[ByteString, Future[IOResult]] = // (2)

--- a/doc-examples/src/main/scala/jms/JmsToHttpGet.scala
+++ b/doc-examples/src/main/scala/jms/JmsToHttpGet.scala
@@ -5,14 +5,14 @@
 package jms
 
 // #sample
+import akka.Done
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.stream.KillSwitch
-import akka.stream.alpakka.jms.JmsSourceSettings
-import akka.stream.alpakka.jms.scaladsl.JmsSource
+import akka.stream.alpakka.jms.JmsConsumerSettings
+import akka.stream.alpakka.jms.scaladsl.JmsConsumer
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.util.ByteString
-import akka.Done
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
@@ -31,8 +31,8 @@ object JmsToHttpGet extends JmsSampleBase with App {
   // format: off
   // #sample
   val jmsSource: Source[String, KillSwitch] =                                 // (1)
-    JmsSource.textSource(
-      JmsSourceSettings(connectionFactory).withBufferSize(10).withQueue("test")
+    JmsConsumer.textSource(
+      JmsConsumerSettings(connectionFactory).withBufferSize(10).withQueue("test")
     )
 
   val (runningSource, finished): (KillSwitch, Future[Done]) =

--- a/doc-examples/src/main/scala/jms/JmsToOneFilePerMessage.scala
+++ b/doc-examples/src/main/scala/jms/JmsToOneFilePerMessage.scala
@@ -8,8 +8,8 @@ package jms
 import java.nio.file.Paths
 
 import akka.stream.KillSwitch
-import akka.stream.alpakka.jms.JmsSourceSettings
-import akka.stream.alpakka.jms.scaladsl.JmsSource
+import akka.stream.alpakka.jms.JmsConsumerSettings
+import akka.stream.alpakka.jms.scaladsl.JmsConsumer
 import akka.stream.scaladsl.{FileIO, Keep, Sink, Source}
 import akka.util.ByteString
 
@@ -28,8 +28,8 @@ object JmsToOneFilePerMessage extends JmsSampleBase with App {
   // #sample
 
   val jmsSource: Source[String, KillSwitch] =                                  // (1)
-    JmsSource.textSource(
-      JmsSourceSettings(connectionFactory).withBufferSize(10).withQueue("test")
+    JmsConsumer.textSource(
+      JmsConsumerSettings(connectionFactory).withBufferSize(10).withQueue("test")
     )
                                                             // stream element type
   val runningSource = jmsSource                             //: String

--- a/doc-examples/src/main/scala/jms/JmsToWebSocket.scala
+++ b/doc-examples/src/main/scala/jms/JmsToWebSocket.scala
@@ -9,8 +9,8 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.ws.{WebSocketRequest, WebSocketUpgradeResponse}
 import akka.stream.KillSwitch
-import akka.stream.alpakka.jms.JmsSourceSettings
-import akka.stream.alpakka.jms.scaladsl.JmsSource
+import akka.stream.alpakka.jms.JmsConsumerSettings
+import akka.stream.alpakka.jms.scaladsl.JmsConsumer
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 
 import scala.collection.immutable.Seq
@@ -43,8 +43,8 @@ object JmsToWebSocket extends JmsSampleBase with App {
   // #sample
 
   val jmsSource: Source[String, KillSwitch] =
-    JmsSource.textSource(                                                             // (1)
-      JmsSourceSettings(connectionFactory).withBufferSize(10).withQueue("test")
+    JmsConsumer.textSource(                                                           // (1)
+      JmsConsumerSettings(connectionFactory).withBufferSize(10).withQueue("test")
     )
 
   val webSocketFlow: Flow[ws.Message, ws.Message, Future[WebSocketUpgradeResponse]] = // (2)

--- a/docs/src/main/paradox/jms.md
+++ b/docs/src/main/paradox/jms.md
@@ -63,7 +63,7 @@ The created @javadoc[ConnectionFactory](javax.jms.ConnectionFactory) is then use
 ## Sending messages to a JMS provider
 
 Use a case class with the subtype of @scaladoc[JmsMessage](akka.stream.alpakka.jms.JmsMessage$) to wrap the messages you want to send and optionally set their properties.
-@java[@scaladoc[JmsSink](akka.stream.alpakka.jms.javadsl.JmsSink$)]@scala[@scaladoc[JmsSink](akka.stream.alpakka.jms.scaladsl.JmsSink$)] contains factory methods to facilitate
+@java[@scaladoc[JmsProducer](akka.stream.alpakka.jms.javadsl.JmsProducer$)]@scala[@scaladoc[JmsProducer](akka.stream.alpakka.jms.scaladsl.JmsProducer$)] contains factory methods to facilitate
 the creation of sinks according to the message type (see below for an example).
 
 
@@ -197,7 +197,7 @@ Java
 
 ## Receiving messages from a JMS provider
 
-@java[@scaladoc[JmsSource](akka.stream.alpakka.jms.javadsl.JmsSource$)]@scala[@scaladoc[JmsSource](akka.stream.alpakka.jms.scaladsl.JmsSource$)] contains factory methods to facilitate
+@java[@scaladoc[JmsConsumer](akka.stream.alpakka.jms.javadsl.JmsConsumer$)]@scala[@scaladoc[JmsConsumer](akka.stream.alpakka.jms.scaladsl.JmsConsumer$)] contains factory methods to facilitate
 the creation of sinks according to the message type (see below for an example).
 
 
@@ -317,7 +317,7 @@ Java
 
 **Notes:**
 
-*  The default `AcknowledgeMode` is `AutoAcknowledge` but can be overridden to custom `AcknowledgeMode`s, even implementation-specific ones by setting the `AcknowledgeMode` in the `JmsSourceSettings` when creating the stream.
+*  The default `AcknowledgeMode` is `AutoAcknowledge` but can be overridden to custom `AcknowledgeMode`s, even implementation-specific ones by setting the `AcknowledgeMode` in the `JmsConsumerSettings` when creating the stream.
 
 ### Receiving @javadoc[javax.jms.Message](javax.jms.Message)s messages from a JMS provider with Client Acknowledgement
 
@@ -385,7 +385,7 @@ Java
 *  Using multiple sessions increases throughput, especially if a acknowledging message by message is desired.
 *  Messages may arrive out of order if `sessionCount` is larger than 1.
 *  Message-by-message acknowledgement can be achieved by setting `bufferSize` to 0, thus disabling buffering. The outstanding messages before backpressure will be the `sessionCount`.
-*  The default `AcknowledgeMode` is `ClientAcknowledge` but can be overridden to custom `AcknowledgeMode`s, even implementation-specific ones by setting the `AcknowledgeMode` in the `JmsSourceSettings` when creating the stream. 
+*  The default `AcknowledgeMode` is `ClientAcknowledge` but can be overridden to custom `AcknowledgeMode`s, even implementation-specific ones by setting the `AcknowledgeMode` in the `JmsConsumerSettings` when creating the stream. 
 
 ### Transactionally receiving @javadoc[javax.jms.Message](javax.jms.Message)s from a JMS provider
 
@@ -414,7 +414,7 @@ Java
 *  Higher throughput is achieved by increasing the `sessionCount`.
 *  Messages will arrive out of order if `sessionCount` is larger than 1.
 *  Buffering is not supported in transaction mode. The `bufferSize` is ignored.
-*  The default `AcknowledgeMode` is `SessionTransacted` but can be overridden to custom `AcknowledgeMode`s, even implementation-specific ones by setting the `AcknowledgeMode` in the `JmsSourceSettings` when creating the stream. 
+*  The default `AcknowledgeMode` is `SessionTransacted` but can be overridden to custom `AcknowledgeMode`s, even implementation-specific ones by setting the `AcknowledgeMode` in the `JmsConsumerSettings` when creating the stream. 
  
 ### Browsing messages from a JMS provider
 
@@ -497,7 +497,7 @@ To stop consumption safely, call `shutdown()` on the `KillSwitch` that is the ma
 ## Using IBM MQ
 
 You can use IBM MQ like any other JMS Provider by creating a `QueueConnectionFactory` or a `TopicConnectionFactory`
-and creating a `JmsSourceSettings` or `JmsSinkSettings` from it.
+and creating a `JmsConsumerSettings` or `JmsProducerSettings` from it.
 The below snippets have been tested with a default IBM MQ docker image which contains queues and topics for testing.
 The following command starts MQ 9 using docker:
 
@@ -505,7 +505,7 @@ The following command starts MQ 9 using docker:
 
 MQ settings for this image are shown here: https://github.com/ibm-messaging/mq-docker#mq-developer-defaults
 
-### Create a JmsSource to an IBM MQ Queue
+### Create a JmsConsumer to an IBM MQ Queue
 
 The `MQQueueConnectionFactory` needs a queue manager name and a channel name, the docker command used in the previous section sets up a `QM1` queue manager and a `DEV.APP.SVRCONN` channel. The IBM MQ client makes it possible to
 connect to the MQ server over TCP/IP or natively through JNI (when the client and server run on the same machine). In the examples below we have chosen to use TCP/IP, which is done by setting the transport type to `CommonConstants.WMQ_CM_CLIENT`.
@@ -523,8 +523,8 @@ Scala
     // Connect to IBM MQ over TCP/IP
     queueConnectionFactory.setTransportType(CommonConstants.WMQ_CM_CLIENT)
     val TestQueueName = "DEV.QUEUE.1"
-    val jmsSource: Source[String, NotUsed] = JmsSource.textSource(
-      JmsSourceSettings(queueConnectionFactory).withQueue(TestQueueName)
+    val jmsSource: Source[String, NotUsed] = JmsConsumer.textSource(
+      JmsConsumerSettings(queueConnectionFactory).withQueue(TestQueueName)
     )
     ```
 
@@ -541,14 +541,14 @@ Java
     // Connect to IBM MQ over TCP/IP
     queueConnectionFactory.setTransportType(CommonConstants.WMQ_CM_CLIENT);
     String testQueueName = "DEV.QUEUE.1";
-    Source<String, NotUsed> jmsSource = JmsSource.textSource(
-      JmsSourceSettings
+    Source<String, NotUsed> jmsSource = JmsConsumer.textSource(
+      JmsConsumerSettings
         .create(queueConnectionFactory)
         .withQueue(testQueueName)
     );
     ```
 
-### Create a JmsSink to an IBM MQ Topic
+### Create a JmsProducer to an IBM MQ Topic
 The IBM MQ docker container sets up a `dev/` topic, which is used in the example below.
 
 Scala
@@ -564,8 +564,8 @@ Scala
     // Connect to IBM MQ over TCP/IP
     topicConnectionFactory.setTransportType(CommonConstants.WMQ_CM_CLIENT)
     val TestTopicName = "dev/"
-    val jmsTopicSink: Sink[String, NotUsed] = JmsSink(
-      JmsSinkSettings(topicConnectionFactory).withTopic(TestTopicName)
+    val jmsTopicSink: Sink[String, NotUsed] = JmsProducer(
+      JmsProducerSettings(topicConnectionFactory).withTopic(TestTopicName)
     )
     ```
 
@@ -582,8 +582,8 @@ Java
     // Connect to IBM MQ over TCP/IP
     topicConnectionFactory.setTransportType(CommonConstants.WMQ_CM_CLIENT);
     String testTopicName = "dev/";
-    Sink<String, NotUsed> jmsTopicSink = JmsSink.textSink(
-      JmsSinkSettings
+    Sink<String, NotUsed> jmsTopicSink = JmsProducer.textSink(
+      JmsProducerSettings
         .create(topicConnectionFactory)
         .withTopic(testTopicName)
     );

--- a/docs/src/main/paradox/jms.md
+++ b/docs/src/main/paradox/jms.md
@@ -172,6 +172,29 @@ Scala
 Java
 : @@snip ($alpakka$/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-messages-with-headers }
 
+
+### Sending messages as a Flow
+
+The producer can also act as a flow, in order to publish messages in the middle of stream processing.
+For example, you can ensure that a message is persisted to the queue before subsequent processing.
+
+Create a flow:
+
+Scala
+: @@snip ($alpakka$/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #create-flow-producer }
+
+Java
+: @@snip ($alpakka$/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-flow-producer }
+
+Run the flow:
+
+Scala
+: @@snip ($alpakka$/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #run-flow-producer }
+
+Java
+: @@snip ($alpakka$/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #run-flow-producer }
+
+
 ## Receiving messages from a JMS provider
 
 @java[@scaladoc[JmsSource](akka.stream.alpakka.jms.javadsl.JmsSource$)]@scala[@scaladoc[JmsSource](akka.stream.alpakka.jms.scaladsl.JmsSource$)] contains factory methods to facilitate

--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -45,47 +45,47 @@ object AcknowledgeMode {
   val SessionTransacted: AcknowledgeMode = new AcknowledgeMode(jms.Session.SESSION_TRANSACTED)
 }
 
-object JmsSourceSettings {
+object JmsConsumerSettings {
 
-  def create(connectionFactory: ConnectionFactory) = JmsSourceSettings(connectionFactory)
+  def create(connectionFactory: ConnectionFactory) = JmsConsumerSettings(connectionFactory)
 
 }
 
-final case class JmsSourceSettings(connectionFactory: ConnectionFactory,
-                                   destination: Option[Destination] = None,
-                                   credentials: Option[Credentials] = None,
-                                   sessionCount: Int = 1,
-                                   bufferSize: Int = 100,
-                                   selector: Option[String] = None,
-                                   acknowledgeMode: Option[AcknowledgeMode] = None)
+final case class JmsConsumerSettings(connectionFactory: ConnectionFactory,
+                                     destination: Option[Destination] = None,
+                                     credentials: Option[Credentials] = None,
+                                     sessionCount: Int = 1,
+                                     bufferSize: Int = 100,
+                                     selector: Option[String] = None,
+                                     acknowledgeMode: Option[AcknowledgeMode] = None)
     extends JmsSettings {
-  def withCredential(credentials: Credentials): JmsSourceSettings = copy(credentials = Some(credentials))
-  def withSessionCount(count: Int): JmsSourceSettings = copy(sessionCount = count)
-  def withBufferSize(size: Int): JmsSourceSettings = copy(bufferSize = size)
-  def withQueue(name: String): JmsSourceSettings = copy(destination = Some(Queue(name)))
-  def withTopic(name: String): JmsSourceSettings = copy(destination = Some(Topic(name)))
-  def withSelector(selector: String): JmsSourceSettings = copy(selector = Some(selector))
-  def withAcknowledgeMode(acknowledgeMode: AcknowledgeMode): JmsSourceSettings =
+  def withCredential(credentials: Credentials): JmsConsumerSettings = copy(credentials = Some(credentials))
+  def withSessionCount(count: Int): JmsConsumerSettings = copy(sessionCount = count)
+  def withBufferSize(size: Int): JmsConsumerSettings = copy(bufferSize = size)
+  def withQueue(name: String): JmsConsumerSettings = copy(destination = Some(Queue(name)))
+  def withTopic(name: String): JmsConsumerSettings = copy(destination = Some(Topic(name)))
+  def withSelector(selector: String): JmsConsumerSettings = copy(selector = Some(selector))
+  def withAcknowledgeMode(acknowledgeMode: AcknowledgeMode): JmsConsumerSettings =
     copy(acknowledgeMode = Option(acknowledgeMode))
 }
 
-object JmsSinkSettings {
+object JmsProducerSettings {
 
-  def create(connectionFactory: ConnectionFactory) = JmsSinkSettings(connectionFactory)
+  def create(connectionFactory: ConnectionFactory) = JmsProducerSettings(connectionFactory)
 
 }
 
-final case class JmsSinkSettings(connectionFactory: ConnectionFactory,
-                                 destination: Option[Destination] = None,
-                                 credentials: Option[Credentials] = None,
-                                 timeToLive: Option[Duration] = None,
-                                 acknowledgeMode: Option[AcknowledgeMode] = None)
+final case class JmsProducerSettings(connectionFactory: ConnectionFactory,
+                                     destination: Option[Destination] = None,
+                                     credentials: Option[Credentials] = None,
+                                     timeToLive: Option[Duration] = None,
+                                     acknowledgeMode: Option[AcknowledgeMode] = None)
     extends JmsSettings {
-  def withCredential(credentials: Credentials): JmsSinkSettings = copy(credentials = Some(credentials))
-  def withQueue(name: String): JmsSinkSettings = copy(destination = Some(Queue(name)))
-  def withTopic(name: String): JmsSinkSettings = copy(destination = Some(Topic(name)))
-  def withTimeToLive(ttl: Duration): JmsSinkSettings = copy(timeToLive = Some(ttl))
-  def withAcknowledgeMode(acknowledgeMode: AcknowledgeMode): JmsSinkSettings =
+  def withCredential(credentials: Credentials): JmsProducerSettings = copy(credentials = Some(credentials))
+  def withQueue(name: String): JmsProducerSettings = copy(destination = Some(Queue(name)))
+  def withTopic(name: String): JmsProducerSettings = copy(destination = Some(Topic(name)))
+  def withTimeToLive(ttl: Duration): JmsProducerSettings = copy(timeToLive = Some(ttl))
+  def withAcknowledgeMode(acknowledgeMode: AcknowledgeMode): JmsProducerSettings =
     copy(acknowledgeMode = Option(acknowledgeMode))
 }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsBrowseStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsBrowseStage.scala
@@ -10,7 +10,7 @@ import akka.stream.{ActorAttributes, Attributes, Outlet, SourceShape}
 import akka.stream.stage.{GraphStage, GraphStageLogic, OutHandler}
 import java.util.{Enumeration => JEnumeration}
 
-private[stream] final class JmsBrowseStage(settings: JmsBrowseSettings) extends GraphStage[SourceShape[Message]] {
+private[jms] final class JmsBrowseStage(settings: JmsBrowseSettings) extends GraphStage[SourceShape[Message]] {
   private val queue = settings.destination.getOrElse { throw new IllegalArgumentException("Destination is missing") }
 
   private val out = Outlet[Message]("JmsBrowseStage.out")

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -84,7 +84,7 @@ private[jms] trait JmsConnector { this: GraphStageLogic =>
     }
 
     val sessionCount = jmsSettings match {
-      case settings: JmsSourceSettings =>
+      case settings: JmsConsumerSettings =>
         settings.sessionCount
       case _ => 1
     }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
@@ -22,7 +22,7 @@ import scala.util.{Failure, Success}
 final class JmsConsumerStage(settings: JmsConsumerSettings)
     extends GraphStageWithMaterializedValue[SourceShape[Message], KillSwitch] {
 
-  private val out = Outlet[Message]("JmsSource.out")
+  private val out = Outlet[Message]("JmsConsumer.out")
 
   override def shape: SourceShape[Message] = SourceShape[Message](out)
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
@@ -19,7 +19,7 @@ import scala.concurrent.Future
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
-final class JmsSourceStage(settings: JmsConsumerSettings)
+final class JmsConsumerStage(settings: JmsConsumerSettings)
     extends GraphStageWithMaterializedValue[SourceShape[Message], KillSwitch] {
 
   private val out = Outlet[Message]("JmsSource.out")

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
@@ -19,7 +19,7 @@ import scala.concurrent.Future
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
-final class JmsConsumerStage(settings: JmsConsumerSettings)
+private[jms] final class JmsConsumerStage(settings: JmsConsumerSettings)
     extends GraphStageWithMaterializedValue[SourceShape[Message], KillSwitch] {
 
   private val out = Outlet[Message]("JmsConsumer.out")

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -10,7 +10,7 @@ import javax.jms.{Connection, Message, MessageProducer, Session}
 import akka.stream._
 import akka.stream.stage._
 
-final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[FlowShape[JmsMessage, JmsMessage]] {
+final class JmsProducerStage(settings: JmsSinkSettings) extends GraphStage[FlowShape[JmsMessage, JmsMessage]] {
 
   private val in = Inlet[JmsMessage]("JmsSink.in")
   private val out = Outlet[JmsMessage]("JmsSink.out")

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -10,7 +10,8 @@ import javax.jms.{Connection, Message, MessageProducer, Session}
 import akka.stream._
 import akka.stream.stage._
 
-private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducerSettings) extends GraphStage[FlowShape[A, A]] {
+private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducerSettings)
+    extends GraphStage[FlowShape[A, A]] {
 
   private val in = Inlet[A]("JmsProducer.in")
   private val out = Outlet[A]("JmsProducer.out")

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -12,8 +12,8 @@ import akka.stream.stage._
 
 final class JmsProducerStage[A <: JmsMessage](settings: JmsProducerSettings) extends GraphStage[FlowShape[A, A]] {
 
-  private val in = Inlet[A]("JmsSink.in")
-  private val out = Outlet[A]("JmsSink.out")
+  private val in = Inlet[A]("JmsProducer.in")
+  private val out = Outlet[A]("JmsProducer.out")
 
   override def shape: FlowShape[A, A] = FlowShape.of(in, out)
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -10,12 +10,12 @@ import javax.jms.{Connection, Message, MessageProducer, Session}
 import akka.stream._
 import akka.stream.stage._
 
-final class JmsProducerStage(settings: JmsProducerSettings) extends GraphStage[FlowShape[JmsMessage, JmsMessage]] {
+final class JmsProducerStage[A <: JmsMessage](settings: JmsProducerSettings) extends GraphStage[FlowShape[A, A]] {
 
-  private val in = Inlet[JmsMessage]("JmsSink.in")
-  private val out = Outlet[JmsMessage]("JmsSink.out")
+  private val in = Inlet[A]("JmsSink.in")
+  private val out = Outlet[A]("JmsSink.out")
 
-  override def shape: FlowShape[JmsMessage, JmsMessage] = FlowShape.of(in, out)
+  override def shape: FlowShape[A, A] = FlowShape.of(in, out)
 
   override protected def initialAttributes: Attributes =
     ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher")
@@ -54,7 +54,7 @@ final class JmsProducerStage(settings: JmsProducerSettings) extends GraphStage[F
         new InHandler {
           override def onPush(): Unit = {
 
-            val elem: JmsMessage = grab(in)
+            val elem: A = grab(in)
 
             val message: Message = createMessage(jmsSession, elem)
             populateMessageProperties(message, elem.properties)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -10,7 +10,7 @@ import javax.jms.{Connection, Message, MessageProducer, Session}
 import akka.stream._
 import akka.stream.stage._
 
-final class JmsProducerStage(settings: JmsSinkSettings) extends GraphStage[FlowShape[JmsMessage, JmsMessage]] {
+final class JmsProducerStage(settings: JmsProducerSettings) extends GraphStage[FlowShape[JmsMessage, JmsMessage]] {
 
   private val in = Inlet[JmsMessage]("JmsSink.in")
   private val out = Outlet[JmsMessage]("JmsSink.out")

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -10,7 +10,7 @@ import javax.jms.{Connection, Message, MessageProducer, Session}
 import akka.stream._
 import akka.stream.stage._
 
-final class JmsProducerStage[A <: JmsMessage](settings: JmsProducerSettings) extends GraphStage[FlowShape[A, A]] {
+private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducerSettings) extends GraphStage[FlowShape[A, A]] {
 
   private val in = Inlet[A]("JmsProducer.in")
   private val out = Outlet[A]("JmsProducer.out")

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsSinkStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsSinkStage.scala
@@ -7,25 +7,21 @@ package akka.stream.alpakka.jms
 import javax.jms
 import javax.jms.{Connection, Message, MessageProducer, Session}
 
-import akka.Done
-import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, InHandler}
 import akka.stream._
+import akka.stream.stage._
 
-import scala.concurrent.{Future, Promise}
-
-final class JmsSinkStage(settings: JmsSinkSettings)
-    extends GraphStageWithMaterializedValue[SinkShape[JmsMessage], Future[Done]] {
+final class JmsSinkStage(settings: JmsSinkSettings) extends GraphStage[FlowShape[JmsMessage, JmsMessage]] {
 
   private val in = Inlet[JmsMessage]("JmsSink.in")
+  private val out = Outlet[JmsMessage]("JmsSink.out")
 
-  override def shape: SinkShape[JmsMessage] = SinkShape.of(in)
+  override def shape: FlowShape[JmsMessage, JmsMessage] = FlowShape.of(in, out)
 
   override protected def initialAttributes: Attributes =
     ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher")
 
-  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Done]) = {
-    val completionPromise = Promise[Done]()
-    val logic = new GraphStageLogic(shape) with JmsConnector {
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
+    new GraphStageLogic(shape) with JmsConnector {
 
       private var jmsProducer: MessageProducer = _
       private var jmsSession: JmsSession = _
@@ -39,7 +35,6 @@ final class JmsSinkStage(settings: JmsSinkSettings)
       }
 
       override def preStart(): Unit = {
-
         jmsSessions = openSessions()
         // TODO: Remove hack to limit publisher to single session.
         jmsSession = jmsSessions.head
@@ -47,23 +42,16 @@ final class JmsSinkStage(settings: JmsSinkSettings)
         if (settings.timeToLive.nonEmpty) {
           jmsProducer.setTimeToLive(settings.timeToLive.get.toMillis)
         }
-        pull(in)
       }
+
+      setHandler(out, new OutHandler {
+        override def onPull(): Unit =
+          tryPull(in)
+      })
 
       setHandler(
         in,
         new InHandler {
-
-          override def onUpstreamFinish(): Unit = {
-            super.onUpstreamFinish()
-            completionPromise.trySuccess(Done)
-          }
-
-          override def onUpstreamFailure(ex: Throwable): Unit = {
-            super.onUpstreamFailure(ex)
-            completionPromise.tryFailure(ex)
-          }
-
           override def onPush(): Unit = {
 
             val elem: JmsMessage = grab(in)
@@ -85,7 +73,7 @@ final class JmsSinkStage(settings: JmsSinkSettings)
               timeToLiveInMillisOption.getOrElse(jmsProducer.getTimeToLive)
             )
 
-            pull(in)
+            push(out, elem)
           }
         }
       )
@@ -156,14 +144,10 @@ final class JmsSinkStage(settings: JmsSinkSettings)
       }
 
       override def postStop(): Unit = {
-        if (!completionPromise.isCompleted) completionPromise.tryFailure(new AbruptStageTerminationException(this))
         jmsSessions.foreach(_.closeSession())
         jmsConnection.foreach(_.close)
       }
     }
-
-    (logic, completionPromise.future)
-
   }
 
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsSourceStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsSourceStage.scala
@@ -19,7 +19,7 @@ import scala.concurrent.Future
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
-final class JmsSourceStage(settings: JmsSourceSettings)
+final class JmsSourceStage(settings: JmsConsumerSettings)
     extends GraphStageWithMaterializedValue[SourceShape[Message], KillSwitch] {
 
   private val out = Outlet[Message]("JmsSource.out")
@@ -64,7 +64,7 @@ final class JmsSourceStage(settings: JmsSourceSettings)
   }
 }
 
-final class JmsAckSourceStage(settings: JmsSourceSettings)
+final class JmsAckSourceStage(settings: JmsConsumerSettings)
     extends GraphStageWithMaterializedValue[SourceShape[AckEnvelope], KillSwitch] {
 
   private val out = Outlet[AckEnvelope]("JmsSource.out")
@@ -144,7 +144,7 @@ final class JmsAckSourceStage(settings: JmsSourceSettings)
   }
 }
 
-final class JmsTxSourceStage(settings: JmsSourceSettings)
+final class JmsTxSourceStage(settings: JmsConsumerSettings)
     extends GraphStageWithMaterializedValue[SourceShape[TxEnvelope], KillSwitch] {
 
   private val out = Outlet[TxEnvelope]("JmsSource.out")
@@ -195,7 +195,7 @@ final class JmsTxSourceStage(settings: JmsSourceSettings)
 
 abstract class SourceStageLogic[T](shape: SourceShape[T],
                                    out: Outlet[T],
-                                   settings: JmsSourceSettings,
+                                   settings: JmsConsumerSettings,
                                    attributes: Attributes)
     extends GraphStageLogic(shape)
     with JmsConnector

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsConsumer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsConsumer.scala
@@ -17,26 +17,26 @@ object JmsConsumer {
   /**
    * Java API: Creates an [[JmsConsumer]] for [[javax.jms.Message]]
    */
-  def create(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[Message, KillSwitch] =
+  def create(jmsSourceSettings: JmsConsumerSettings): akka.stream.javadsl.Source[Message, KillSwitch] =
     akka.stream.javadsl.Source.fromGraph(new JmsSourceStage(jmsSourceSettings))
 
   /**
    * Java API: Creates an [[JmsConsumer]] for texts
    */
-  def textSource(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[String, KillSwitch] =
+  def textSource(jmsSourceSettings: JmsConsumerSettings): akka.stream.javadsl.Source[String, KillSwitch] =
     akka.stream.alpakka.jms.scaladsl.JmsConsumer.textSource(jmsSourceSettings).asJava
 
   /**
    * Java API: Creates an [[JmsConsumer]] for byte arrays
    */
-  def bytesSource(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[Array[Byte], KillSwitch] =
+  def bytesSource(jmsSourceSettings: JmsConsumerSettings): akka.stream.javadsl.Source[Array[Byte], KillSwitch] =
     akka.stream.alpakka.jms.scaladsl.JmsConsumer.bytesSource(jmsSourceSettings).asJava
 
   /**
    * Java API: Creates an [[JmsConsumer]] for Maps with primitive data types
    */
   def mapSource(
-      jmsSourceSettings: JmsSourceSettings
+      jmsSourceSettings: JmsConsumerSettings
   ): akka.stream.javadsl.Source[java.util.Map[String, Any], KillSwitch] =
     akka.stream.alpakka.jms.scaladsl.JmsConsumer
       .mapSource(jmsSourceSettings)
@@ -47,7 +47,7 @@ object JmsConsumer {
    * Java API: Creates an [[JmsConsumer]] for serializable objects
    */
   def objectSource(
-      jmsSourceSettings: JmsSourceSettings
+      jmsSourceSettings: JmsConsumerSettings
   ): akka.stream.javadsl.Source[java.io.Serializable, KillSwitch] =
     akka.stream.alpakka.jms.scaladsl.JmsConsumer.objectSource(jmsSourceSettings).asJava
 
@@ -58,7 +58,7 @@ object JmsConsumer {
    * @param jmsSettings The settings for the ack source.
    * @return Source for JMS messages in an AckEnvelope.
    */
-  def ackSource(jmsSettings: JmsSourceSettings): akka.stream.javadsl.Source[AckEnvelope, KillSwitch] =
+  def ackSource(jmsSettings: JmsConsumerSettings): akka.stream.javadsl.Source[AckEnvelope, KillSwitch] =
     akka.stream.javadsl.Source.fromGraph(new JmsAckSourceStage(jmsSettings))
 
   /**
@@ -68,7 +68,7 @@ object JmsConsumer {
    * @param jmsSettings The settings for the tx source
    * @return Source of the JMS messages in a TxEnvelope
    */
-  def txSource(jmsSettings: JmsSourceSettings): akka.stream.javadsl.Source[TxEnvelope, KillSwitch] =
+  def txSource(jmsSettings: JmsConsumerSettings): akka.stream.javadsl.Source[TxEnvelope, KillSwitch] =
     akka.stream.javadsl.Source.fromGraph(new JmsTxSourceStage(jmsSettings))
 
   /**

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsConsumer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsConsumer.scala
@@ -18,7 +18,7 @@ object JmsConsumer {
    * Java API: Creates an [[JmsConsumer]] for [[javax.jms.Message]]
    */
   def create(settings: JmsConsumerSettings): akka.stream.javadsl.Source[Message, KillSwitch] =
-    akka.stream.javadsl.Source.fromGraph(new JmsSourceStage(settings))
+    akka.stream.javadsl.Source.fromGraph(new JmsConsumerStage(settings))
 
   /**
    * Java API: Creates an [[JmsConsumer]] for texts

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsConsumer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsConsumer.scala
@@ -17,29 +17,29 @@ object JmsConsumer {
   /**
    * Java API: Creates an [[JmsConsumer]] for [[javax.jms.Message]]
    */
-  def create(jmsSourceSettings: JmsConsumerSettings): akka.stream.javadsl.Source[Message, KillSwitch] =
-    akka.stream.javadsl.Source.fromGraph(new JmsSourceStage(jmsSourceSettings))
+  def create(settings: JmsConsumerSettings): akka.stream.javadsl.Source[Message, KillSwitch] =
+    akka.stream.javadsl.Source.fromGraph(new JmsSourceStage(settings))
 
   /**
    * Java API: Creates an [[JmsConsumer]] for texts
    */
-  def textSource(jmsSourceSettings: JmsConsumerSettings): akka.stream.javadsl.Source[String, KillSwitch] =
-    akka.stream.alpakka.jms.scaladsl.JmsConsumer.textSource(jmsSourceSettings).asJava
+  def textSource(settings: JmsConsumerSettings): akka.stream.javadsl.Source[String, KillSwitch] =
+    akka.stream.alpakka.jms.scaladsl.JmsConsumer.textSource(settings).asJava
 
   /**
    * Java API: Creates an [[JmsConsumer]] for byte arrays
    */
-  def bytesSource(jmsSourceSettings: JmsConsumerSettings): akka.stream.javadsl.Source[Array[Byte], KillSwitch] =
-    akka.stream.alpakka.jms.scaladsl.JmsConsumer.bytesSource(jmsSourceSettings).asJava
+  def bytesSource(settings: JmsConsumerSettings): akka.stream.javadsl.Source[Array[Byte], KillSwitch] =
+    akka.stream.alpakka.jms.scaladsl.JmsConsumer.bytesSource(settings).asJava
 
   /**
    * Java API: Creates an [[JmsConsumer]] for Maps with primitive data types
    */
   def mapSource(
-      jmsSourceSettings: JmsConsumerSettings
+      settings: JmsConsumerSettings
   ): akka.stream.javadsl.Source[java.util.Map[String, Any], KillSwitch] =
     akka.stream.alpakka.jms.scaladsl.JmsConsumer
-      .mapSource(jmsSourceSettings)
+      .mapSource(settings)
       .map(scalaMap => JavaConversions.mapAsJavaMap(scalaMap))
       .asJava
 
@@ -47,33 +47,33 @@ object JmsConsumer {
    * Java API: Creates an [[JmsConsumer]] for serializable objects
    */
   def objectSource(
-      jmsSourceSettings: JmsConsumerSettings
+      settings: JmsConsumerSettings
   ): akka.stream.javadsl.Source[java.io.Serializable, KillSwitch] =
-    akka.stream.alpakka.jms.scaladsl.JmsConsumer.objectSource(jmsSourceSettings).asJava
+    akka.stream.alpakka.jms.scaladsl.JmsConsumer.objectSource(settings).asJava
 
   /**
    * Java API: Creates a [[JmsConsumer]] of envelopes containing messages. It requires explicit acknowledgements
    * on the envelopes. The acknowledgements must be called on the envelope and not on the message inside.
    *
-   * @param jmsSettings The settings for the ack source.
+   * @param settings The settings for the ack source.
    * @return Source for JMS messages in an AckEnvelope.
    */
-  def ackSource(jmsSettings: JmsConsumerSettings): akka.stream.javadsl.Source[AckEnvelope, KillSwitch] =
-    akka.stream.javadsl.Source.fromGraph(new JmsAckSourceStage(jmsSettings))
+  def ackSource(settings: JmsConsumerSettings): akka.stream.javadsl.Source[AckEnvelope, KillSwitch] =
+    akka.stream.javadsl.Source.fromGraph(new JmsAckSourceStage(settings))
 
   /**
    * Java API: Creates a [[JmsConsumer]] of envelopes containing messages. It requires explicit
    * commit or rollback on the envelope.
    *
-   * @param jmsSettings The settings for the tx source
+   * @param settings The settings for the tx source
    * @return Source of the JMS messages in a TxEnvelope
    */
-  def txSource(jmsSettings: JmsConsumerSettings): akka.stream.javadsl.Source[TxEnvelope, KillSwitch] =
-    akka.stream.javadsl.Source.fromGraph(new JmsTxSourceStage(jmsSettings))
+  def txSource(settings: JmsConsumerSettings): akka.stream.javadsl.Source[TxEnvelope, KillSwitch] =
+    akka.stream.javadsl.Source.fromGraph(new JmsTxSourceStage(settings))
 
   /**
    * Java API: Creates a [[JmsConsumer]] for browsing messages non-destructively
    */
-  def browse(jmsSettings: JmsBrowseSettings): akka.stream.javadsl.Source[Message, NotUsed] =
-    akka.stream.javadsl.Source.fromGraph(new JmsBrowseStage(jmsSettings))
+  def browse(settings: JmsBrowseSettings): akka.stream.javadsl.Source[Message, NotUsed] =
+    akka.stream.javadsl.Source.fromGraph(new JmsBrowseStage(settings))
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsConsumer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsConsumer.scala
@@ -12,49 +12,49 @@ import akka.stream.alpakka.jms._
 
 import scala.collection.JavaConversions
 
-@deprecated("Use JmsConsumer instead", "0.18")
-object JmsSource {
+object JmsConsumer {
 
   /**
-   * Java API: Creates an [[JmsSource]] for [[javax.jms.Message]]
+   * Java API: Creates an [[JmsConsumer]] for [[javax.jms.Message]]
    */
   def create(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[Message, KillSwitch] =
     akka.stream.javadsl.Source.fromGraph(new JmsSourceStage(jmsSourceSettings))
 
   /**
-   * Java API: Creates an [[JmsSource]] for texts
+   * Java API: Creates an [[JmsConsumer]] for texts
    */
   def textSource(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[String, KillSwitch] =
-    akka.stream.alpakka.jms.scaladsl.JmsSource.textSource(jmsSourceSettings).asJava
+    akka.stream.alpakka.jms.scaladsl.JmsConsumer.textSource(jmsSourceSettings).asJava
 
   /**
-   * Java API: Creates an [[JmsSource]] for byte arrays
+   * Java API: Creates an [[JmsConsumer]] for byte arrays
    */
   def bytesSource(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[Array[Byte], KillSwitch] =
-    akka.stream.alpakka.jms.scaladsl.JmsSource.bytesSource(jmsSourceSettings).asJava
+    akka.stream.alpakka.jms.scaladsl.JmsConsumer.bytesSource(jmsSourceSettings).asJava
 
   /**
-   * Java API: Creates an [[JmsSource]] for Maps with primitive data types
+   * Java API: Creates an [[JmsConsumer]] for Maps with primitive data types
    */
   def mapSource(
       jmsSourceSettings: JmsSourceSettings
   ): akka.stream.javadsl.Source[java.util.Map[String, Any], KillSwitch] =
-    akka.stream.alpakka.jms.scaladsl.JmsSource
+    akka.stream.alpakka.jms.scaladsl.JmsConsumer
       .mapSource(jmsSourceSettings)
       .map(scalaMap => JavaConversions.mapAsJavaMap(scalaMap))
       .asJava
 
   /**
-   * Java API: Creates an [[JmsSource]] for serializable objects
+   * Java API: Creates an [[JmsConsumer]] for serializable objects
    */
   def objectSource(
       jmsSourceSettings: JmsSourceSettings
   ): akka.stream.javadsl.Source[java.io.Serializable, KillSwitch] =
-    akka.stream.alpakka.jms.scaladsl.JmsSource.objectSource(jmsSourceSettings).asJava
+    akka.stream.alpakka.jms.scaladsl.JmsConsumer.objectSource(jmsSourceSettings).asJava
 
   /**
-   * Java API: Creates a [[JmsSource]] of envelopes containing messages. It requires explicit acknowledgements
+   * Java API: Creates a [[JmsConsumer]] of envelopes containing messages. It requires explicit acknowledgements
    * on the envelopes. The acknowledgements must be called on the envelope and not on the message inside.
+   *
    * @param jmsSettings The settings for the ack source.
    * @return Source for JMS messages in an AckEnvelope.
    */
@@ -62,8 +62,9 @@ object JmsSource {
     akka.stream.javadsl.Source.fromGraph(new JmsAckSourceStage(jmsSettings))
 
   /**
-   * Java API: Creates a [[JmsSource]] of envelopes containing messages. It requires explicit
+   * Java API: Creates a [[JmsConsumer]] of envelopes containing messages. It requires explicit
    * commit or rollback on the envelope.
+   *
    * @param jmsSettings The settings for the tx source
    * @return Source of the JMS messages in a TxEnvelope
    */
@@ -71,7 +72,7 @@ object JmsSource {
     akka.stream.javadsl.Source.fromGraph(new JmsTxSourceStage(jmsSettings))
 
   /**
-   * Java API: Creates a [[JmsSource]] for browsing messages non-destructively
+   * Java API: Creates a [[JmsConsumer]] for browsing messages non-destructively
    */
   def browse(jmsSettings: JmsBrowseSettings): akka.stream.javadsl.Source[Message, NotUsed] =
     akka.stream.javadsl.Source.fromGraph(new JmsBrowseStage(jmsSettings))

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsProducer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsProducer.scala
@@ -19,36 +19,36 @@ object JmsProducer {
    * Java API: Creates an [[JmsProducer]] for [[JmsMessage]]s
    */
   def flow[R <: JmsMessage](
-      jmsSinkSettings: JmsProducerSettings
+      settings: JmsProducerSettings
   ): akka.stream.javadsl.Flow[R, JmsMessage, NotUsed] =
-    akka.stream.alpakka.jms.scaladsl.JmsProducer.flow(jmsSinkSettings).asJava
+    akka.stream.alpakka.jms.scaladsl.JmsProducer.flow(settings).asJava
 
   /**
    * Java API: Creates an [[JmsProducer]] for [[JmsMessage]]s
    */
   def create[R <: JmsMessage](
-      jmsSinkSettings: JmsProducerSettings
+      settings: JmsProducerSettings
   ): akka.stream.javadsl.Sink[R, CompletionStage[Done]] =
     akka.stream.alpakka.jms.scaladsl.JmsProducer
-      .apply(jmsSinkSettings)
+      .apply(settings)
       .mapMaterializedValue(FutureConverters.toJava)
       .asJava
 
   /**
    * Java API: Creates an [[JmsProducer]] for strings
    */
-  def textSink(jmsSinkSettings: JmsProducerSettings): akka.stream.javadsl.Sink[String, CompletionStage[Done]] =
+  def textSink(settings: JmsProducerSettings): akka.stream.javadsl.Sink[String, CompletionStage[Done]] =
     akka.stream.alpakka.jms.scaladsl.JmsProducer
-      .textSink(jmsSinkSettings)
+      .textSink(settings)
       .mapMaterializedValue(FutureConverters.toJava)
       .asJava
 
   /**
    * Java API: Creates an [[JmsProducer]] for bytes
    */
-  def bytesSink(jmsSinkSettings: JmsProducerSettings): akka.stream.javadsl.Sink[Array[Byte], CompletionStage[Done]] =
+  def bytesSink(settings: JmsProducerSettings): akka.stream.javadsl.Sink[Array[Byte], CompletionStage[Done]] =
     akka.stream.alpakka.jms.scaladsl.JmsProducer
-      .bytesSink(jmsSinkSettings)
+      .bytesSink(settings)
       .mapMaterializedValue(FutureConverters.toJava)
       .asJava
 
@@ -56,12 +56,12 @@ object JmsProducer {
    * Java API: Creates an [[JmsProducer]] for maps with primitive datatypes as value
    */
   def mapSink(
-      jmsSinkSettings: JmsProducerSettings
+      settings: JmsProducerSettings
   ): akka.stream.javadsl.Sink[java.util.Map[String, Any], CompletionStage[Done]] = {
 
     val scalaSink =
       akka.stream.alpakka.jms.scaladsl.JmsProducer
-        .mapSink(jmsSinkSettings)
+        .mapSink(settings)
         .mapMaterializedValue(FutureConverters.toJava)
     val javaToScalaConversion =
       Flow.fromFunction((javaMap: java.util.Map[String, Any]) => JavaConversions.mapAsScalaMap(javaMap).toMap)
@@ -72,10 +72,10 @@ object JmsProducer {
    * Java API: Creates an [[JmsProducer]] for serializable objects
    */
   def objectSink(
-      jmsSinkSettings: JmsProducerSettings
+      settings: JmsProducerSettings
   ): akka.stream.javadsl.Sink[java.io.Serializable, CompletionStage[Done]] =
     akka.stream.alpakka.jms.scaladsl.JmsProducer
-      .objectSink(jmsSinkSettings)
+      .objectSink(settings)
       .mapMaterializedValue(FutureConverters.toJava)
       .asJava
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsProducer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsProducer.scala
@@ -20,7 +20,7 @@ object JmsProducer {
    */
   def flow[R <: JmsMessage](
       settings: JmsProducerSettings
-  ): akka.stream.javadsl.Flow[R, JmsMessage, NotUsed] =
+  ): akka.stream.javadsl.Flow[R, R, NotUsed] =
     akka.stream.alpakka.jms.scaladsl.JmsProducer.flow(settings).asJava
 
   /**

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsProducer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsProducer.scala
@@ -6,72 +6,73 @@ package akka.stream.alpakka.jms.javadsl
 
 import java.util.concurrent.CompletionStage
 
-import akka.stream.alpakka.jms.{JmsMessage, JmsSinkSettings}
-import akka.stream.scaladsl.{Flow, Keep}
 import akka.{Done, NotUsed}
+import akka.stream.alpakka.jms.{JmsMessage, JmsProducerStage, JmsSinkSettings}
+import akka.stream.scaladsl.{Flow, Keep}
 
 import scala.collection.JavaConversions
 import scala.compat.java8.FutureConverters
 
-@deprecated("Use JmsProducer instead", "0.18")
-object JmsSink {
+object JmsProducer {
 
   /**
-   * Java API: Creates an [[JmsSink]] for [[JmsMessage]]s
+   * Java API: Creates an [[JmsProducer]] for [[JmsMessage]]s
    */
   def flow[R <: JmsMessage](
       jmsSinkSettings: JmsSinkSettings
   ): akka.stream.javadsl.Flow[R, JmsMessage, NotUsed] =
-    akka.stream.alpakka.jms.scaladsl.JmsSink.flow(jmsSinkSettings).asJava
+    akka.stream.alpakka.jms.scaladsl.JmsProducer.flow(jmsSinkSettings).asJava
 
   /**
-   * Java API: Creates an [[JmsSink]] for [[JmsMessage]]s
+   * Java API: Creates an [[JmsProducer]] for [[JmsMessage]]s
    */
   def create[R <: JmsMessage](jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[R, CompletionStage[Done]] =
-    akka.stream.alpakka.jms.scaladsl.JmsSink
+    akka.stream.alpakka.jms.scaladsl.JmsProducer
       .apply(jmsSinkSettings)
       .mapMaterializedValue(FutureConverters.toJava)
       .asJava
 
   /**
-   * Java API: Creates an [[JmsSink]] for strings
+   * Java API: Creates an [[JmsProducer]] for strings
    */
   def textSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[String, CompletionStage[Done]] =
-    akka.stream.alpakka.jms.scaladsl.JmsSink
+    akka.stream.alpakka.jms.scaladsl.JmsProducer
       .textSink(jmsSinkSettings)
       .mapMaterializedValue(FutureConverters.toJava)
       .asJava
 
   /**
-   * Java API: Creates an [[JmsSink]] for bytes
+   * Java API: Creates an [[JmsProducer]] for bytes
    */
   def bytesSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[Array[Byte], CompletionStage[Done]] =
-    akka.stream.alpakka.jms.scaladsl.JmsSink
+    akka.stream.alpakka.jms.scaladsl.JmsProducer
       .bytesSink(jmsSinkSettings)
       .mapMaterializedValue(FutureConverters.toJava)
       .asJava
 
   /**
-   * Java API: Creates an [[JmsSink]] for maps with primitive datatypes as value
+   * Java API: Creates an [[JmsProducer]] for maps with primitive datatypes as value
    */
   def mapSink(
       jmsSinkSettings: JmsSinkSettings
   ): akka.stream.javadsl.Sink[java.util.Map[String, Any], CompletionStage[Done]] = {
 
     val scalaSink =
-      akka.stream.alpakka.jms.scaladsl.JmsSink.mapSink(jmsSinkSettings).mapMaterializedValue(FutureConverters.toJava)
+      akka.stream.alpakka.jms.scaladsl.JmsProducer
+        .mapSink(jmsSinkSettings)
+        .mapMaterializedValue(FutureConverters.toJava)
     val javaToScalaConversion =
       Flow.fromFunction((javaMap: java.util.Map[String, Any]) => JavaConversions.mapAsScalaMap(javaMap).toMap)
     javaToScalaConversion.toMat(scalaSink)(Keep.right).asJava
   }
 
   /**
-   * Java API: Creates an [[JmsSink]] for serializable objects
+   * Java API: Creates an [[JmsProducer]] for serializable objects
    */
   def objectSink(
       jmsSinkSettings: JmsSinkSettings
   ): akka.stream.javadsl.Sink[java.io.Serializable, CompletionStage[Done]] =
-    akka.stream.alpakka.jms.scaladsl.JmsSink
+    akka.stream.alpakka.jms.scaladsl.JmsProducer
       .objectSink(jmsSinkSettings)
       .mapMaterializedValue(FutureConverters.toJava)
       .asJava

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsProducer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsProducer.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.jms.javadsl
 import java.util.concurrent.CompletionStage
 
 import akka.{Done, NotUsed}
-import akka.stream.alpakka.jms.{JmsMessage, JmsProducerStage, JmsSinkSettings}
+import akka.stream.alpakka.jms.{JmsMessage, JmsProducerSettings, JmsProducerStage}
 import akka.stream.scaladsl.{Flow, Keep}
 
 import scala.collection.JavaConversions
@@ -19,14 +19,16 @@ object JmsProducer {
    * Java API: Creates an [[JmsProducer]] for [[JmsMessage]]s
    */
   def flow[R <: JmsMessage](
-      jmsSinkSettings: JmsSinkSettings
+      jmsSinkSettings: JmsProducerSettings
   ): akka.stream.javadsl.Flow[R, JmsMessage, NotUsed] =
     akka.stream.alpakka.jms.scaladsl.JmsProducer.flow(jmsSinkSettings).asJava
 
   /**
    * Java API: Creates an [[JmsProducer]] for [[JmsMessage]]s
    */
-  def create[R <: JmsMessage](jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[R, CompletionStage[Done]] =
+  def create[R <: JmsMessage](
+      jmsSinkSettings: JmsProducerSettings
+  ): akka.stream.javadsl.Sink[R, CompletionStage[Done]] =
     akka.stream.alpakka.jms.scaladsl.JmsProducer
       .apply(jmsSinkSettings)
       .mapMaterializedValue(FutureConverters.toJava)
@@ -35,7 +37,7 @@ object JmsProducer {
   /**
    * Java API: Creates an [[JmsProducer]] for strings
    */
-  def textSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[String, CompletionStage[Done]] =
+  def textSink(jmsSinkSettings: JmsProducerSettings): akka.stream.javadsl.Sink[String, CompletionStage[Done]] =
     akka.stream.alpakka.jms.scaladsl.JmsProducer
       .textSink(jmsSinkSettings)
       .mapMaterializedValue(FutureConverters.toJava)
@@ -44,7 +46,7 @@ object JmsProducer {
   /**
    * Java API: Creates an [[JmsProducer]] for bytes
    */
-  def bytesSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[Array[Byte], CompletionStage[Done]] =
+  def bytesSink(jmsSinkSettings: JmsProducerSettings): akka.stream.javadsl.Sink[Array[Byte], CompletionStage[Done]] =
     akka.stream.alpakka.jms.scaladsl.JmsProducer
       .bytesSink(jmsSinkSettings)
       .mapMaterializedValue(FutureConverters.toJava)
@@ -54,7 +56,7 @@ object JmsProducer {
    * Java API: Creates an [[JmsProducer]] for maps with primitive datatypes as value
    */
   def mapSink(
-      jmsSinkSettings: JmsSinkSettings
+      jmsSinkSettings: JmsProducerSettings
   ): akka.stream.javadsl.Sink[java.util.Map[String, Any], CompletionStage[Done]] = {
 
     val scalaSink =
@@ -70,7 +72,7 @@ object JmsProducer {
    * Java API: Creates an [[JmsProducer]] for serializable objects
    */
   def objectSink(
-      jmsSinkSettings: JmsSinkSettings
+      jmsSinkSettings: JmsProducerSettings
   ): akka.stream.javadsl.Sink[java.io.Serializable, CompletionStage[Done]] =
     akka.stream.alpakka.jms.scaladsl.JmsProducer
       .objectSink(jmsSinkSettings)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
@@ -6,12 +6,8 @@ package akka.stream.alpakka.jms.javadsl
 
 import java.util.concurrent.CompletionStage
 
+import akka.Done
 import akka.stream.alpakka.jms.{JmsMessage, JmsProducerSettings}
-import akka.stream.scaladsl.{Flow, Keep}
-import akka.{Done, NotUsed}
-
-import scala.collection.JavaConversions
-import scala.compat.java8.FutureConverters
 
 @deprecated("Use JmsProducer instead", "0.18")
 object JmsSink {

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.jms.javadsl
 
 import java.util.concurrent.CompletionStage
 
-import akka.stream.alpakka.jms.{JmsMessage, JmsSinkSettings}
+import akka.stream.alpakka.jms.{JmsMessage, JmsProducerSettings}
 import akka.stream.scaladsl.{Flow, Keep}
 import akka.{Done, NotUsed}
 
@@ -20,14 +20,16 @@ object JmsSink {
    * Java API: Creates an [[JmsSink]] for [[JmsMessage]]s
    */
   def flow[R <: JmsMessage](
-      jmsSinkSettings: JmsSinkSettings
+      jmsSinkSettings: JmsProducerSettings
   ): akka.stream.javadsl.Flow[R, JmsMessage, NotUsed] =
     akka.stream.alpakka.jms.scaladsl.JmsSink.flow(jmsSinkSettings).asJava
 
   /**
    * Java API: Creates an [[JmsSink]] for [[JmsMessage]]s
    */
-  def create[R <: JmsMessage](jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[R, CompletionStage[Done]] =
+  def create[R <: JmsMessage](
+      jmsSinkSettings: JmsProducerSettings
+  ): akka.stream.javadsl.Sink[R, CompletionStage[Done]] =
     akka.stream.alpakka.jms.scaladsl.JmsSink
       .apply(jmsSinkSettings)
       .mapMaterializedValue(FutureConverters.toJava)
@@ -36,7 +38,7 @@ object JmsSink {
   /**
    * Java API: Creates an [[JmsSink]] for strings
    */
-  def textSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[String, CompletionStage[Done]] =
+  def textSink(jmsSinkSettings: JmsProducerSettings): akka.stream.javadsl.Sink[String, CompletionStage[Done]] =
     akka.stream.alpakka.jms.scaladsl.JmsSink
       .textSink(jmsSinkSettings)
       .mapMaterializedValue(FutureConverters.toJava)
@@ -45,7 +47,7 @@ object JmsSink {
   /**
    * Java API: Creates an [[JmsSink]] for bytes
    */
-  def bytesSink(jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[Array[Byte], CompletionStage[Done]] =
+  def bytesSink(jmsSinkSettings: JmsProducerSettings): akka.stream.javadsl.Sink[Array[Byte], CompletionStage[Done]] =
     akka.stream.alpakka.jms.scaladsl.JmsSink
       .bytesSink(jmsSinkSettings)
       .mapMaterializedValue(FutureConverters.toJava)
@@ -55,7 +57,7 @@ object JmsSink {
    * Java API: Creates an [[JmsSink]] for maps with primitive datatypes as value
    */
   def mapSink(
-      jmsSinkSettings: JmsSinkSettings
+      jmsSinkSettings: JmsProducerSettings
   ): akka.stream.javadsl.Sink[java.util.Map[String, Any], CompletionStage[Done]] = {
 
     val scalaSink =
@@ -69,7 +71,7 @@ object JmsSink {
    * Java API: Creates an [[JmsSink]] for serializable objects
    */
   def objectSink(
-      jmsSinkSettings: JmsSinkSettings
+      jmsSinkSettings: JmsProducerSettings
   ): akka.stream.javadsl.Sink[java.io.Serializable, CompletionStage[Done]] =
     akka.stream.alpakka.jms.scaladsl.JmsSink
       .objectSink(jmsSinkSettings)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.jms.javadsl
 
 import java.util.concurrent.CompletionStage
 
-import akka.Done
+import akka.{Done, NotUsed}
 import akka.stream.alpakka.jms.{JmsMessage, JmsSinkSettings, JmsSinkStage}
 import akka.stream.scaladsl.{Flow, Keep}
 
@@ -18,9 +18,17 @@ object JmsSink {
   /**
    * Java API: Creates an [[JmsSink]] for [[JmsMessage]]s
    */
+  def flow[R <: JmsMessage](
+      jmsSinkSettings: JmsSinkSettings
+  ): akka.stream.javadsl.Flow[R, JmsMessage, NotUsed] =
+    akka.stream.alpakka.jms.scaladsl.JmsSink.flow(jmsSinkSettings).asJava
+
+  /**
+   * Java API: Creates an [[JmsSink]] for [[JmsMessage]]s
+   */
   def create[R <: JmsMessage](jmsSinkSettings: JmsSinkSettings): akka.stream.javadsl.Sink[R, CompletionStage[Done]] =
-    akka.stream.scaladsl.Sink
-      .fromGraph(new JmsSinkStage(jmsSinkSettings))
+    akka.stream.alpakka.jms.scaladsl.JmsSink
+      .apply(jmsSinkSettings)
       .mapMaterializedValue(FutureConverters.toJava)
       .asJava
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSink.scala
@@ -19,53 +19,30 @@ object JmsSink {
   /**
    * Java API: Creates an [[JmsSink]] for [[JmsMessage]]s
    */
-  def flow[R <: JmsMessage](
-      jmsSinkSettings: JmsProducerSettings
-  ): akka.stream.javadsl.Flow[R, JmsMessage, NotUsed] =
-    akka.stream.alpakka.jms.scaladsl.JmsSink.flow(jmsSinkSettings).asJava
-
-  /**
-   * Java API: Creates an [[JmsSink]] for [[JmsMessage]]s
-   */
   def create[R <: JmsMessage](
       jmsSinkSettings: JmsProducerSettings
   ): akka.stream.javadsl.Sink[R, CompletionStage[Done]] =
-    akka.stream.alpakka.jms.scaladsl.JmsSink
-      .apply(jmsSinkSettings)
-      .mapMaterializedValue(FutureConverters.toJava)
-      .asJava
+    JmsProducer.create(jmsSinkSettings)
 
   /**
    * Java API: Creates an [[JmsSink]] for strings
    */
   def textSink(jmsSinkSettings: JmsProducerSettings): akka.stream.javadsl.Sink[String, CompletionStage[Done]] =
-    akka.stream.alpakka.jms.scaladsl.JmsSink
-      .textSink(jmsSinkSettings)
-      .mapMaterializedValue(FutureConverters.toJava)
-      .asJava
+    JmsProducer.textSink(jmsSinkSettings)
 
   /**
    * Java API: Creates an [[JmsSink]] for bytes
    */
   def bytesSink(jmsSinkSettings: JmsProducerSettings): akka.stream.javadsl.Sink[Array[Byte], CompletionStage[Done]] =
-    akka.stream.alpakka.jms.scaladsl.JmsSink
-      .bytesSink(jmsSinkSettings)
-      .mapMaterializedValue(FutureConverters.toJava)
-      .asJava
+    JmsProducer.bytesSink(jmsSinkSettings)
 
   /**
    * Java API: Creates an [[JmsSink]] for maps with primitive datatypes as value
    */
   def mapSink(
       jmsSinkSettings: JmsProducerSettings
-  ): akka.stream.javadsl.Sink[java.util.Map[String, Any], CompletionStage[Done]] = {
-
-    val scalaSink =
-      akka.stream.alpakka.jms.scaladsl.JmsSink.mapSink(jmsSinkSettings).mapMaterializedValue(FutureConverters.toJava)
-    val javaToScalaConversion =
-      Flow.fromFunction((javaMap: java.util.Map[String, Any]) => JavaConversions.mapAsScalaMap(javaMap).toMap)
-    javaToScalaConversion.toMat(scalaSink)(Keep.right).asJava
-  }
+  ): akka.stream.javadsl.Sink[java.util.Map[String, Any], CompletionStage[Done]] =
+    JmsProducer.mapSink(jmsSinkSettings)
 
   /**
    * Java API: Creates an [[JmsSink]] for serializable objects
@@ -73,9 +50,6 @@ object JmsSink {
   def objectSink(
       jmsSinkSettings: JmsProducerSettings
   ): akka.stream.javadsl.Sink[java.io.Serializable, CompletionStage[Done]] =
-    akka.stream.alpakka.jms.scaladsl.JmsSink
-      .objectSink(jmsSinkSettings)
-      .mapMaterializedValue(FutureConverters.toJava)
-      .asJava
+    JmsProducer.objectSink(jmsSinkSettings)
 
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSource.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSource.scala
@@ -4,13 +4,10 @@
 
 package akka.stream.alpakka.jms.javadsl
 
-import javax.jms.Message
-
 import akka.NotUsed
 import akka.stream.KillSwitch
 import akka.stream.alpakka.jms._
-
-import scala.collection.JavaConversions
+import javax.jms.Message
 
 @deprecated("Use JmsConsumer instead", "0.18")
 object JmsSource {

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSource.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSource.scala
@@ -18,26 +18,26 @@ object JmsSource {
   /**
    * Java API: Creates an [[JmsSource]] for [[javax.jms.Message]]
    */
-  def create(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[Message, KillSwitch] =
+  def create(jmsSourceSettings: JmsConsumerSettings): akka.stream.javadsl.Source[Message, KillSwitch] =
     akka.stream.javadsl.Source.fromGraph(new JmsSourceStage(jmsSourceSettings))
 
   /**
    * Java API: Creates an [[JmsSource]] for texts
    */
-  def textSource(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[String, KillSwitch] =
+  def textSource(jmsSourceSettings: JmsConsumerSettings): akka.stream.javadsl.Source[String, KillSwitch] =
     akka.stream.alpakka.jms.scaladsl.JmsSource.textSource(jmsSourceSettings).asJava
 
   /**
    * Java API: Creates an [[JmsSource]] for byte arrays
    */
-  def bytesSource(jmsSourceSettings: JmsSourceSettings): akka.stream.javadsl.Source[Array[Byte], KillSwitch] =
+  def bytesSource(jmsSourceSettings: JmsConsumerSettings): akka.stream.javadsl.Source[Array[Byte], KillSwitch] =
     akka.stream.alpakka.jms.scaladsl.JmsSource.bytesSource(jmsSourceSettings).asJava
 
   /**
    * Java API: Creates an [[JmsSource]] for Maps with primitive data types
    */
   def mapSource(
-      jmsSourceSettings: JmsSourceSettings
+      jmsSourceSettings: JmsConsumerSettings
   ): akka.stream.javadsl.Source[java.util.Map[String, Any], KillSwitch] =
     akka.stream.alpakka.jms.scaladsl.JmsSource
       .mapSource(jmsSourceSettings)
@@ -48,7 +48,7 @@ object JmsSource {
    * Java API: Creates an [[JmsSource]] for serializable objects
    */
   def objectSource(
-      jmsSourceSettings: JmsSourceSettings
+      jmsSourceSettings: JmsConsumerSettings
   ): akka.stream.javadsl.Source[java.io.Serializable, KillSwitch] =
     akka.stream.alpakka.jms.scaladsl.JmsSource.objectSource(jmsSourceSettings).asJava
 
@@ -58,7 +58,7 @@ object JmsSource {
    * @param jmsSettings The settings for the ack source.
    * @return Source for JMS messages in an AckEnvelope.
    */
-  def ackSource(jmsSettings: JmsSourceSettings): akka.stream.javadsl.Source[AckEnvelope, KillSwitch] =
+  def ackSource(jmsSettings: JmsConsumerSettings): akka.stream.javadsl.Source[AckEnvelope, KillSwitch] =
     akka.stream.javadsl.Source.fromGraph(new JmsAckSourceStage(jmsSettings))
 
   /**
@@ -67,7 +67,7 @@ object JmsSource {
    * @param jmsSettings The settings for the tx source
    * @return Source of the JMS messages in a TxEnvelope
    */
-  def txSource(jmsSettings: JmsSourceSettings): akka.stream.javadsl.Source[TxEnvelope, KillSwitch] =
+  def txSource(jmsSettings: JmsConsumerSettings): akka.stream.javadsl.Source[TxEnvelope, KillSwitch] =
     akka.stream.javadsl.Source.fromGraph(new JmsTxSourceStage(jmsSettings))
 
   /**

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSource.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsSource.scala
@@ -19,19 +19,19 @@ object JmsSource {
    * Java API: Creates an [[JmsSource]] for [[javax.jms.Message]]
    */
   def create(jmsSourceSettings: JmsConsumerSettings): akka.stream.javadsl.Source[Message, KillSwitch] =
-    akka.stream.javadsl.Source.fromGraph(new JmsSourceStage(jmsSourceSettings))
+    JmsConsumer.create(jmsSourceSettings)
 
   /**
    * Java API: Creates an [[JmsSource]] for texts
    */
   def textSource(jmsSourceSettings: JmsConsumerSettings): akka.stream.javadsl.Source[String, KillSwitch] =
-    akka.stream.alpakka.jms.scaladsl.JmsSource.textSource(jmsSourceSettings).asJava
+    JmsConsumer.textSource(jmsSourceSettings)
 
   /**
    * Java API: Creates an [[JmsSource]] for byte arrays
    */
   def bytesSource(jmsSourceSettings: JmsConsumerSettings): akka.stream.javadsl.Source[Array[Byte], KillSwitch] =
-    akka.stream.alpakka.jms.scaladsl.JmsSource.bytesSource(jmsSourceSettings).asJava
+    JmsConsumer.bytesSource(jmsSourceSettings)
 
   /**
    * Java API: Creates an [[JmsSource]] for Maps with primitive data types
@@ -39,10 +39,7 @@ object JmsSource {
   def mapSource(
       jmsSourceSettings: JmsConsumerSettings
   ): akka.stream.javadsl.Source[java.util.Map[String, Any], KillSwitch] =
-    akka.stream.alpakka.jms.scaladsl.JmsSource
-      .mapSource(jmsSourceSettings)
-      .map(scalaMap => JavaConversions.mapAsJavaMap(scalaMap))
-      .asJava
+    JmsConsumer.mapSource(jmsSourceSettings)
 
   /**
    * Java API: Creates an [[JmsSource]] for serializable objects
@@ -50,7 +47,7 @@ object JmsSource {
   def objectSource(
       jmsSourceSettings: JmsConsumerSettings
   ): akka.stream.javadsl.Source[java.io.Serializable, KillSwitch] =
-    akka.stream.alpakka.jms.scaladsl.JmsSource.objectSource(jmsSourceSettings).asJava
+    JmsConsumer.objectSource(jmsSourceSettings)
 
   /**
    * Java API: Creates a [[JmsSource]] of envelopes containing messages. It requires explicit acknowledgements
@@ -59,7 +56,7 @@ object JmsSource {
    * @return Source for JMS messages in an AckEnvelope.
    */
   def ackSource(jmsSettings: JmsConsumerSettings): akka.stream.javadsl.Source[AckEnvelope, KillSwitch] =
-    akka.stream.javadsl.Source.fromGraph(new JmsAckSourceStage(jmsSettings))
+    JmsConsumer.ackSource(jmsSettings)
 
   /**
    * Java API: Creates a [[JmsSource]] of envelopes containing messages. It requires explicit
@@ -68,11 +65,11 @@ object JmsSource {
    * @return Source of the JMS messages in a TxEnvelope
    */
   def txSource(jmsSettings: JmsConsumerSettings): akka.stream.javadsl.Source[TxEnvelope, KillSwitch] =
-    akka.stream.javadsl.Source.fromGraph(new JmsTxSourceStage(jmsSettings))
+    JmsConsumer.txSource(jmsSettings)
 
   /**
    * Java API: Creates a [[JmsSource]] for browsing messages non-destructively
    */
   def browse(jmsSettings: JmsBrowseSettings): akka.stream.javadsl.Source[Message, NotUsed] =
-    akka.stream.javadsl.Source.fromGraph(new JmsBrowseStage(jmsSettings))
+    JmsConsumer.browse(jmsSettings)
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/package.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/package.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka
+
+package object jms {
+  @deprecated("Use JmsConsumerSettings instead", "0.18")
+  type JmsSourceSettings = JmsConsumerSettings
+  @deprecated("Use JmsConsumerSettings instead", "0.18")
+  val JmsSourceSettings: JmsConsumerSettings.type = JmsConsumerSettings
+
+  @deprecated("Use JmsProducerSettings instead", "0.18")
+  type JmsSinkSettings = JmsProducerSettings
+  @deprecated("Use JmsProducerSettings instead", "0.18")
+  val JmsSinkSettings: JmsProducerSettings.type = JmsProducerSettings
+}

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsConsumer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsConsumer.scala
@@ -18,20 +18,20 @@ object JmsConsumer {
   /**
    * Scala API: Creates an [[JmsConsumer]] for [[javax.jms.Message]] instances
    */
-  def apply(jmsSettings: JmsConsumerSettings): Source[Message, KillSwitch] =
-    Source.fromGraph(new JmsSourceStage(jmsSettings))
+  def apply(settings: JmsConsumerSettings): Source[Message, KillSwitch] =
+    Source.fromGraph(new JmsSourceStage(settings))
 
   /**
    * Scala API: Creates an [[JmsConsumer]] for texts
    */
-  def textSource(jmsSettings: JmsConsumerSettings): Source[String, KillSwitch] =
-    apply(jmsSettings).map(msg => msg.asInstanceOf[TextMessage].getText)
+  def textSource(settings: JmsConsumerSettings): Source[String, KillSwitch] =
+    apply(settings).map(msg => msg.asInstanceOf[TextMessage].getText)
 
   /**
    * Scala API: Creates an [[JmsConsumer]] for Maps with primitive datatypes
    */
-  def mapSource(jmsSettings: JmsConsumerSettings): Source[Map[String, Any], KillSwitch] =
-    apply(jmsSettings).map { msg =>
+  def mapSource(settings: JmsConsumerSettings): Source[Map[String, Any], KillSwitch] =
+    apply(settings).map { msg =>
       val mapMessage = msg.asInstanceOf[MapMessage]
 
       mapMessage.getMapNames.foldLeft(Map[String, Any]()) { (result, key) =>
@@ -44,8 +44,8 @@ object JmsConsumer {
   /**
    * Scala API: Creates an [[JmsConsumer]] for byte arrays
    */
-  def bytesSource(jmsSettings: JmsConsumerSettings): Source[Array[Byte], KillSwitch] =
-    apply(jmsSettings).map { msg =>
+  def bytesSource(settings: JmsConsumerSettings): Source[Array[Byte], KillSwitch] =
+    apply(settings).map { msg =>
       val byteMessage = msg.asInstanceOf[BytesMessage]
       val byteArray = new Array[Byte](byteMessage.getBodyLength.toInt)
       byteMessage.readBytes(byteArray)
@@ -55,32 +55,32 @@ object JmsConsumer {
   /**
    * Scala API: Creates an [[JmsConsumer]] for serializable objects
    */
-  def objectSource(jmsSettings: JmsConsumerSettings): Source[java.io.Serializable, KillSwitch] =
-    apply(jmsSettings).map(msg => msg.asInstanceOf[ObjectMessage].getObject)
+  def objectSource(settings: JmsConsumerSettings): Source[java.io.Serializable, KillSwitch] =
+    apply(settings).map(msg => msg.asInstanceOf[ObjectMessage].getObject)
 
   /**
    * Scala API: Creates a [[JmsConsumer]] of envelopes containing messages. It requires explicit acknowledgements
    * on the envelopes. The acknowledgements must be called on the envelope and not on the message inside.
    *
-   * @param jmsSettings The settings for the ack source.
+   * @param settings The settings for the ack source.
    * @return Source for JMS messages in an AckEnvelope.
    */
-  def ackSource(jmsSettings: JmsConsumerSettings): Source[AckEnvelope, KillSwitch] =
-    Source.fromGraph(new JmsAckSourceStage(jmsSettings))
+  def ackSource(settings: JmsConsumerSettings): Source[AckEnvelope, KillSwitch] =
+    Source.fromGraph(new JmsAckSourceStage(settings))
 
   /**
    * Scala API: Creates a [[JmsConsumer]] of envelopes containing messages. It requires explicit
    * commit or rollback on the envelope.
    *
-   * @param jmsSettings The settings for the tx source
+   * @param settings The settings for the tx source
    * @return Source of the JMS messages in a TxEnvelope
    */
-  def txSource(jmsSettings: JmsConsumerSettings): Source[TxEnvelope, KillSwitch] =
-    Source.fromGraph(new JmsTxSourceStage(jmsSettings))
+  def txSource(settings: JmsConsumerSettings): Source[TxEnvelope, KillSwitch] =
+    Source.fromGraph(new JmsTxSourceStage(settings))
 
   /**
    * Scala API: Creates a [[JmsConsumer]] for browsing messages non-destructively
    */
-  def browse(jmsSettings: JmsBrowseSettings): Source[Message, NotUsed] =
-    Source.fromGraph(new JmsBrowseStage(jmsSettings))
+  def browse(settings: JmsBrowseSettings): Source[Message, NotUsed] =
+    Source.fromGraph(new JmsBrowseStage(settings))
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsConsumer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsConsumer.scala
@@ -18,19 +18,19 @@ object JmsConsumer {
   /**
    * Scala API: Creates an [[JmsConsumer]] for [[javax.jms.Message]] instances
    */
-  def apply(jmsSettings: JmsSourceSettings): Source[Message, KillSwitch] =
+  def apply(jmsSettings: JmsConsumerSettings): Source[Message, KillSwitch] =
     Source.fromGraph(new JmsSourceStage(jmsSettings))
 
   /**
    * Scala API: Creates an [[JmsConsumer]] for texts
    */
-  def textSource(jmsSettings: JmsSourceSettings): Source[String, KillSwitch] =
+  def textSource(jmsSettings: JmsConsumerSettings): Source[String, KillSwitch] =
     apply(jmsSettings).map(msg => msg.asInstanceOf[TextMessage].getText)
 
   /**
    * Scala API: Creates an [[JmsConsumer]] for Maps with primitive datatypes
    */
-  def mapSource(jmsSettings: JmsSourceSettings): Source[Map[String, Any], KillSwitch] =
+  def mapSource(jmsSettings: JmsConsumerSettings): Source[Map[String, Any], KillSwitch] =
     apply(jmsSettings).map { msg =>
       val mapMessage = msg.asInstanceOf[MapMessage]
 
@@ -44,7 +44,7 @@ object JmsConsumer {
   /**
    * Scala API: Creates an [[JmsConsumer]] for byte arrays
    */
-  def bytesSource(jmsSettings: JmsSourceSettings): Source[Array[Byte], KillSwitch] =
+  def bytesSource(jmsSettings: JmsConsumerSettings): Source[Array[Byte], KillSwitch] =
     apply(jmsSettings).map { msg =>
       val byteMessage = msg.asInstanceOf[BytesMessage]
       val byteArray = new Array[Byte](byteMessage.getBodyLength.toInt)
@@ -55,7 +55,7 @@ object JmsConsumer {
   /**
    * Scala API: Creates an [[JmsConsumer]] for serializable objects
    */
-  def objectSource(jmsSettings: JmsSourceSettings): Source[java.io.Serializable, KillSwitch] =
+  def objectSource(jmsSettings: JmsConsumerSettings): Source[java.io.Serializable, KillSwitch] =
     apply(jmsSettings).map(msg => msg.asInstanceOf[ObjectMessage].getObject)
 
   /**
@@ -65,7 +65,7 @@ object JmsConsumer {
    * @param jmsSettings The settings for the ack source.
    * @return Source for JMS messages in an AckEnvelope.
    */
-  def ackSource(jmsSettings: JmsSourceSettings): Source[AckEnvelope, KillSwitch] =
+  def ackSource(jmsSettings: JmsConsumerSettings): Source[AckEnvelope, KillSwitch] =
     Source.fromGraph(new JmsAckSourceStage(jmsSettings))
 
   /**
@@ -75,7 +75,7 @@ object JmsConsumer {
    * @param jmsSettings The settings for the tx source
    * @return Source of the JMS messages in a TxEnvelope
    */
-  def txSource(jmsSettings: JmsSourceSettings): Source[TxEnvelope, KillSwitch] =
+  def txSource(jmsSettings: JmsConsumerSettings): Source[TxEnvelope, KillSwitch] =
     Source.fromGraph(new JmsTxSourceStage(jmsSettings))
 
   /**

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsConsumer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsConsumer.scala
@@ -13,23 +13,22 @@ import akka.stream.scaladsl.Source
 
 import scala.collection.JavaConversions._
 
-@deprecated("Use JmsConsumer instead", "0.18")
-object JmsSource {
+object JmsConsumer {
 
   /**
-   * Scala API: Creates an [[JmsSource]] for [[javax.jms.Message]] instances
+   * Scala API: Creates an [[JmsConsumer]] for [[javax.jms.Message]] instances
    */
   def apply(jmsSettings: JmsSourceSettings): Source[Message, KillSwitch] =
     Source.fromGraph(new JmsSourceStage(jmsSettings))
 
   /**
-   * Scala API: Creates an [[JmsSource]] for texts
+   * Scala API: Creates an [[JmsConsumer]] for texts
    */
   def textSource(jmsSettings: JmsSourceSettings): Source[String, KillSwitch] =
     apply(jmsSettings).map(msg => msg.asInstanceOf[TextMessage].getText)
 
   /**
-   * Scala API: Creates an [[JmsSource]] for Maps with primitive datatypes
+   * Scala API: Creates an [[JmsConsumer]] for Maps with primitive datatypes
    */
   def mapSource(jmsSettings: JmsSourceSettings): Source[Map[String, Any], KillSwitch] =
     apply(jmsSettings).map { msg =>
@@ -43,7 +42,7 @@ object JmsSource {
     }
 
   /**
-   * Scala API: Creates an [[JmsSource]] for byte arrays
+   * Scala API: Creates an [[JmsConsumer]] for byte arrays
    */
   def bytesSource(jmsSettings: JmsSourceSettings): Source[Array[Byte], KillSwitch] =
     apply(jmsSettings).map { msg =>
@@ -54,14 +53,15 @@ object JmsSource {
     }
 
   /**
-   * Scala API: Creates an [[JmsSource]] for serializable objects
+   * Scala API: Creates an [[JmsConsumer]] for serializable objects
    */
   def objectSource(jmsSettings: JmsSourceSettings): Source[java.io.Serializable, KillSwitch] =
     apply(jmsSettings).map(msg => msg.asInstanceOf[ObjectMessage].getObject)
 
   /**
-   * Scala API: Creates a [[JmsSource]] of envelopes containing messages. It requires explicit acknowledgements
+   * Scala API: Creates a [[JmsConsumer]] of envelopes containing messages. It requires explicit acknowledgements
    * on the envelopes. The acknowledgements must be called on the envelope and not on the message inside.
+   *
    * @param jmsSettings The settings for the ack source.
    * @return Source for JMS messages in an AckEnvelope.
    */
@@ -69,8 +69,9 @@ object JmsSource {
     Source.fromGraph(new JmsAckSourceStage(jmsSettings))
 
   /**
-   * Scala API: Creates a [[JmsSource]] of envelopes containing messages. It requires explicit
+   * Scala API: Creates a [[JmsConsumer]] of envelopes containing messages. It requires explicit
    * commit or rollback on the envelope.
+   *
    * @param jmsSettings The settings for the tx source
    * @return Source of the JMS messages in a TxEnvelope
    */
@@ -78,7 +79,7 @@ object JmsSource {
     Source.fromGraph(new JmsTxSourceStage(jmsSettings))
 
   /**
-   * Scala API: Creates a [[JmsSource]] for browsing messages non-destructively
+   * Scala API: Creates a [[JmsConsumer]] for browsing messages non-destructively
    */
   def browse(jmsSettings: JmsBrowseSettings): Source[Message, NotUsed] =
     Source.fromGraph(new JmsBrowseStage(jmsSettings))

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsConsumer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsConsumer.scala
@@ -19,7 +19,7 @@ object JmsConsumer {
    * Scala API: Creates an [[JmsConsumer]] for [[javax.jms.Message]] instances
    */
   def apply(settings: JmsConsumerSettings): Source[Message, KillSwitch] =
-    Source.fromGraph(new JmsSourceStage(settings))
+    Source.fromGraph(new JmsConsumerStage(settings))
 
   /**
    * Scala API: Creates an [[JmsConsumer]] for texts

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsProducer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsProducer.scala
@@ -15,37 +15,37 @@ object JmsProducer {
   /**
    * Scala API: Creates an [[JmsProducer]] for [[JmsMessage]]s
    */
-  def flow(jmsSettings: JmsProducerSettings): Flow[JmsMessage, JmsMessage, NotUsed] =
-    Flow.fromGraph(new JmsProducerStage(jmsSettings))
+  def flow(settings: JmsProducerSettings): Flow[JmsMessage, JmsMessage, NotUsed] =
+    Flow.fromGraph(new JmsProducerStage(settings))
 
   /**
    * Scala API: Creates an [[JmsProducer]] for [[JmsMessage]]s
    */
-  def apply(jmsSettings: JmsProducerSettings): Sink[JmsMessage, Future[Done]] =
-    flow(jmsSettings).toMat(Sink.ignore)(Keep.right)
+  def apply(settings: JmsProducerSettings): Sink[JmsMessage, Future[Done]] =
+    flow(settings).toMat(Sink.ignore)(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsProducer]] for strings
    */
-  def textSink(jmsSettings: JmsProducerSettings): Sink[String, Future[Done]] =
-    Flow.fromFunction((s: String) => JmsTextMessage(s)).toMat(apply(jmsSettings))(Keep.right)
+  def textSink(settings: JmsProducerSettings): Sink[String, Future[Done]] =
+    Flow.fromFunction((s: String) => JmsTextMessage(s)).toMat(apply(settings))(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsProducer]] for bytes
    */
-  def bytesSink(jmsSettings: JmsProducerSettings): Sink[Array[Byte], Future[Done]] =
-    Flow.fromFunction((s: Array[Byte]) => JmsByteMessage(s)).toMat(apply(jmsSettings))(Keep.right)
+  def bytesSink(settings: JmsProducerSettings): Sink[Array[Byte], Future[Done]] =
+    Flow.fromFunction((s: Array[Byte]) => JmsByteMessage(s)).toMat(apply(settings))(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsProducer]] for maps with primitive data types
    */
-  def mapSink(jmsSettings: JmsProducerSettings): Sink[Map[String, Any], Future[Done]] =
-    Flow.fromFunction((s: Map[String, Any]) => JmsMapMessage(s)).toMat(apply(jmsSettings))(Keep.right)
+  def mapSink(settings: JmsProducerSettings): Sink[Map[String, Any], Future[Done]] =
+    Flow.fromFunction((s: Map[String, Any]) => JmsMapMessage(s)).toMat(apply(settings))(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsProducer]] for serializable objects
    */
-  def objectSink(jmsSettings: JmsProducerSettings): Sink[java.io.Serializable, Future[Done]] =
-    Flow.fromFunction((s: java.io.Serializable) => JmsObjectMessage(s)).toMat(apply(jmsSettings))(Keep.right)
+  def objectSink(settings: JmsProducerSettings): Sink[java.io.Serializable, Future[Done]] =
+    Flow.fromFunction((s: java.io.Serializable) => JmsObjectMessage(s)).toMat(apply(settings))(Keep.right)
 
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsProducer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsProducer.scala
@@ -15,7 +15,7 @@ object JmsProducer {
   /**
    * Scala API: Creates an [[JmsProducer]] for [[JmsMessage]]s
    */
-  def flow(settings: JmsProducerSettings): Flow[JmsMessage, JmsMessage, NotUsed] =
+  def flow[T <: JmsMessage](settings: JmsProducerSettings): Flow[T, T, NotUsed] =
     Flow.fromGraph(new JmsProducerStage(settings))
 
   /**

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsProducer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsProducer.scala
@@ -10,41 +10,40 @@ import akka.stream.scaladsl.{Flow, Keep, Sink}
 
 import scala.concurrent.Future
 
-@deprecated("Use JmsProducer instead", "0.18")
-object JmsSink {
+object JmsProducer {
 
   /**
-   * Scala API: Creates an [[JmsSink]] for [[JmsMessage]]s
+   * Scala API: Creates an [[JmsProducer]] for [[JmsMessage]]s
    */
   def flow(jmsSettings: JmsSinkSettings): Flow[JmsMessage, JmsMessage, NotUsed] =
     Flow.fromGraph(new JmsProducerStage(jmsSettings))
 
   /**
-   * Scala API: Creates an [[JmsSink]] for [[JmsMessage]]s
+   * Scala API: Creates an [[JmsProducer]] for [[JmsMessage]]s
    */
   def apply(jmsSettings: JmsSinkSettings): Sink[JmsMessage, Future[Done]] =
     flow(jmsSettings).toMat(Sink.ignore)(Keep.right)
 
   /**
-   * Scala API: Creates an [[JmsSink]] for strings
+   * Scala API: Creates an [[JmsProducer]] for strings
    */
   def textSink(jmsSettings: JmsSinkSettings): Sink[String, Future[Done]] =
     Flow.fromFunction((s: String) => JmsTextMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
   /**
-   * Scala API: Creates an [[JmsSink]] for bytes
+   * Scala API: Creates an [[JmsProducer]] for bytes
    */
   def bytesSink(jmsSettings: JmsSinkSettings): Sink[Array[Byte], Future[Done]] =
     Flow.fromFunction((s: Array[Byte]) => JmsByteMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
   /**
-   * Scala API: Creates an [[JmsSink]] for maps with primitive data types
+   * Scala API: Creates an [[JmsProducer]] for maps with primitive data types
    */
   def mapSink(jmsSettings: JmsSinkSettings): Sink[Map[String, Any], Future[Done]] =
     Flow.fromFunction((s: Map[String, Any]) => JmsMapMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
   /**
-   * Scala API: Creates an [[JmsSink]] for serializable objects
+   * Scala API: Creates an [[JmsProducer]] for serializable objects
    */
   def objectSink(jmsSettings: JmsSinkSettings): Sink[java.io.Serializable, Future[Done]] =
     Flow.fromFunction((s: java.io.Serializable) => JmsObjectMessage(s)).toMat(apply(jmsSettings))(Keep.right)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsProducer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsProducer.scala
@@ -15,37 +15,37 @@ object JmsProducer {
   /**
    * Scala API: Creates an [[JmsProducer]] for [[JmsMessage]]s
    */
-  def flow(jmsSettings: JmsSinkSettings): Flow[JmsMessage, JmsMessage, NotUsed] =
+  def flow(jmsSettings: JmsProducerSettings): Flow[JmsMessage, JmsMessage, NotUsed] =
     Flow.fromGraph(new JmsProducerStage(jmsSettings))
 
   /**
    * Scala API: Creates an [[JmsProducer]] for [[JmsMessage]]s
    */
-  def apply(jmsSettings: JmsSinkSettings): Sink[JmsMessage, Future[Done]] =
+  def apply(jmsSettings: JmsProducerSettings): Sink[JmsMessage, Future[Done]] =
     flow(jmsSettings).toMat(Sink.ignore)(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsProducer]] for strings
    */
-  def textSink(jmsSettings: JmsSinkSettings): Sink[String, Future[Done]] =
+  def textSink(jmsSettings: JmsProducerSettings): Sink[String, Future[Done]] =
     Flow.fromFunction((s: String) => JmsTextMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsProducer]] for bytes
    */
-  def bytesSink(jmsSettings: JmsSinkSettings): Sink[Array[Byte], Future[Done]] =
+  def bytesSink(jmsSettings: JmsProducerSettings): Sink[Array[Byte], Future[Done]] =
     Flow.fromFunction((s: Array[Byte]) => JmsByteMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsProducer]] for maps with primitive data types
    */
-  def mapSink(jmsSettings: JmsSinkSettings): Sink[Map[String, Any], Future[Done]] =
+  def mapSink(jmsSettings: JmsProducerSettings): Sink[Map[String, Any], Future[Done]] =
     Flow.fromFunction((s: Map[String, Any]) => JmsMapMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsProducer]] for serializable objects
    */
-  def objectSink(jmsSettings: JmsSinkSettings): Sink[java.io.Serializable, Future[Done]] =
+  def objectSink(jmsSettings: JmsProducerSettings): Sink[java.io.Serializable, Future[Done]] =
     Flow.fromFunction((s: java.io.Serializable) => JmsObjectMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSink.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSink.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.jms.scaladsl
 
-import akka.Done
+import akka.{Done, NotUsed}
 import akka.stream.alpakka.jms._
 import akka.stream.scaladsl.{Flow, Keep, Sink}
 
@@ -15,39 +15,37 @@ object JmsSink {
   /**
    * Scala API: Creates an [[JmsSink]] for [[JmsMessage]]s
    */
+  def flow(jmsSettings: JmsSinkSettings): Flow[JmsMessage, JmsMessage, NotUsed] =
+    Flow.fromGraph(new JmsSinkStage(jmsSettings))
+
+  /**
+   * Scala API: Creates an [[JmsSink]] for [[JmsMessage]]s
+   */
   def apply(jmsSettings: JmsSinkSettings): Sink[JmsMessage, Future[Done]] =
-    Sink.fromGraph(new JmsSinkStage(jmsSettings))
+    flow(jmsSettings).toMat(Sink.ignore)(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsSink]] for strings
    */
-  def textSink(jmsSettings: JmsSinkSettings): Sink[String, Future[Done]] = {
-    val jmsMsgSink = Sink.fromGraph(new JmsSinkStage(jmsSettings))
-    Flow.fromFunction((s: String) => JmsTextMessage(s)).toMat(jmsMsgSink)(Keep.right)
-  }
+  def textSink(jmsSettings: JmsSinkSettings): Sink[String, Future[Done]] =
+    Flow.fromFunction((s: String) => JmsTextMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsSink]] for bytes
    */
-  def bytesSink(jmsSettings: JmsSinkSettings): Sink[Array[Byte], Future[Done]] = {
-    val jmsMsgSink = Sink.fromGraph(new JmsSinkStage(jmsSettings))
-    Flow.fromFunction((s: Array[Byte]) => JmsByteMessage(s)).toMat(jmsMsgSink)(Keep.right)
-  }
+  def bytesSink(jmsSettings: JmsSinkSettings): Sink[Array[Byte], Future[Done]] =
+    Flow.fromFunction((s: Array[Byte]) => JmsByteMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsSink]] for maps with primitive data types
    */
-  def mapSink(jmsSettings: JmsSinkSettings): Sink[Map[String, Any], Future[Done]] = {
-    val jmsMsgSink = Sink.fromGraph(new JmsSinkStage(jmsSettings))
-    Flow.fromFunction((s: Map[String, Any]) => JmsMapMessage(s)).toMat(jmsMsgSink)(Keep.right)
-  }
+  def mapSink(jmsSettings: JmsSinkSettings): Sink[Map[String, Any], Future[Done]] =
+    Flow.fromFunction((s: Map[String, Any]) => JmsMapMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsSink]] for serializable objects
    */
-  def objectSink(jmsSettings: JmsSinkSettings): Sink[java.io.Serializable, Future[Done]] = {
-    val jmsMsgSink = Sink.fromGraph(new JmsSinkStage(jmsSettings))
-    Flow.fromFunction((s: java.io.Serializable) => JmsObjectMessage(s)).toMat(jmsMsgSink)(Keep.right)
-  }
+  def objectSink(jmsSettings: JmsSinkSettings): Sink[java.io.Serializable, Future[Done]] =
+    Flow.fromFunction((s: java.io.Serializable) => JmsObjectMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSink.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSink.scala
@@ -4,9 +4,9 @@
 
 package akka.stream.alpakka.jms.scaladsl
 
-import akka.{Done, NotUsed}
+import akka.Done
 import akka.stream.alpakka.jms._
-import akka.stream.scaladsl.{Flow, Keep, Sink}
+import akka.stream.scaladsl.Sink
 
 import scala.concurrent.Future
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSink.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSink.scala
@@ -16,37 +16,37 @@ object JmsSink {
   /**
    * Scala API: Creates an [[JmsSink]] for [[JmsMessage]]s
    */
-  def flow(jmsSettings: JmsSinkSettings): Flow[JmsMessage, JmsMessage, NotUsed] =
+  def flow(jmsSettings: JmsProducerSettings): Flow[JmsMessage, JmsMessage, NotUsed] =
     Flow.fromGraph(new JmsProducerStage(jmsSettings))
 
   /**
    * Scala API: Creates an [[JmsSink]] for [[JmsMessage]]s
    */
-  def apply(jmsSettings: JmsSinkSettings): Sink[JmsMessage, Future[Done]] =
+  def apply(jmsSettings: JmsProducerSettings): Sink[JmsMessage, Future[Done]] =
     flow(jmsSettings).toMat(Sink.ignore)(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsSink]] for strings
    */
-  def textSink(jmsSettings: JmsSinkSettings): Sink[String, Future[Done]] =
+  def textSink(jmsSettings: JmsProducerSettings): Sink[String, Future[Done]] =
     Flow.fromFunction((s: String) => JmsTextMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsSink]] for bytes
    */
-  def bytesSink(jmsSettings: JmsSinkSettings): Sink[Array[Byte], Future[Done]] =
+  def bytesSink(jmsSettings: JmsProducerSettings): Sink[Array[Byte], Future[Done]] =
     Flow.fromFunction((s: Array[Byte]) => JmsByteMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsSink]] for maps with primitive data types
    */
-  def mapSink(jmsSettings: JmsSinkSettings): Sink[Map[String, Any], Future[Done]] =
+  def mapSink(jmsSettings: JmsProducerSettings): Sink[Map[String, Any], Future[Done]] =
     Flow.fromFunction((s: Map[String, Any]) => JmsMapMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
   /**
    * Scala API: Creates an [[JmsSink]] for serializable objects
    */
-  def objectSink(jmsSettings: JmsSinkSettings): Sink[java.io.Serializable, Future[Done]] =
+  def objectSink(jmsSettings: JmsProducerSettings): Sink[java.io.Serializable, Future[Done]] =
     Flow.fromFunction((s: java.io.Serializable) => JmsObjectMessage(s)).toMat(apply(jmsSettings))(Keep.right)
 
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSink.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSink.scala
@@ -16,37 +16,31 @@ object JmsSink {
   /**
    * Scala API: Creates an [[JmsSink]] for [[JmsMessage]]s
    */
-  def flow(jmsSettings: JmsProducerSettings): Flow[JmsMessage, JmsMessage, NotUsed] =
-    Flow.fromGraph(new JmsProducerStage(jmsSettings))
-
-  /**
-   * Scala API: Creates an [[JmsSink]] for [[JmsMessage]]s
-   */
   def apply(jmsSettings: JmsProducerSettings): Sink[JmsMessage, Future[Done]] =
-    flow(jmsSettings).toMat(Sink.ignore)(Keep.right)
+    JmsProducer.apply(jmsSettings)
 
   /**
    * Scala API: Creates an [[JmsSink]] for strings
    */
   def textSink(jmsSettings: JmsProducerSettings): Sink[String, Future[Done]] =
-    Flow.fromFunction((s: String) => JmsTextMessage(s)).toMat(apply(jmsSettings))(Keep.right)
+    JmsProducer.textSink(jmsSettings)
 
   /**
    * Scala API: Creates an [[JmsSink]] for bytes
    */
   def bytesSink(jmsSettings: JmsProducerSettings): Sink[Array[Byte], Future[Done]] =
-    Flow.fromFunction((s: Array[Byte]) => JmsByteMessage(s)).toMat(apply(jmsSettings))(Keep.right)
+    JmsProducer.bytesSink(jmsSettings)
 
   /**
    * Scala API: Creates an [[JmsSink]] for maps with primitive data types
    */
   def mapSink(jmsSettings: JmsProducerSettings): Sink[Map[String, Any], Future[Done]] =
-    Flow.fromFunction((s: Map[String, Any]) => JmsMapMessage(s)).toMat(apply(jmsSettings))(Keep.right)
+    JmsProducer.mapSink(jmsSettings)
 
   /**
    * Scala API: Creates an [[JmsSink]] for serializable objects
    */
   def objectSink(jmsSettings: JmsProducerSettings): Sink[java.io.Serializable, Future[Done]] =
-    Flow.fromFunction((s: java.io.Serializable) => JmsObjectMessage(s)).toMat(apply(jmsSettings))(Keep.right)
+    JmsProducer.objectSink(jmsSettings)
 
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSource.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSource.scala
@@ -20,44 +20,31 @@ object JmsSource {
    * Scala API: Creates an [[JmsSource]] for [[javax.jms.Message]] instances
    */
   def apply(jmsSettings: JmsConsumerSettings): Source[Message, KillSwitch] =
-    Source.fromGraph(new JmsSourceStage(jmsSettings))
+    JmsConsumer.apply(jmsSettings)
 
   /**
    * Scala API: Creates an [[JmsSource]] for texts
    */
   def textSource(jmsSettings: JmsConsumerSettings): Source[String, KillSwitch] =
-    apply(jmsSettings).map(msg => msg.asInstanceOf[TextMessage].getText)
+    JmsConsumer.textSource(jmsSettings)
 
   /**
    * Scala API: Creates an [[JmsSource]] for Maps with primitive datatypes
    */
   def mapSource(jmsSettings: JmsConsumerSettings): Source[Map[String, Any], KillSwitch] =
-    apply(jmsSettings).map { msg =>
-      val mapMessage = msg.asInstanceOf[MapMessage]
-
-      mapMessage.getMapNames.foldLeft(Map[String, Any]()) { (result, key) =>
-        val keyAsString = key.toString
-        val value = mapMessage.getObject(keyAsString)
-        result.+(keyAsString -> value)
-      }
-    }
+    JmsConsumer.mapSource(jmsSettings)
 
   /**
    * Scala API: Creates an [[JmsSource]] for byte arrays
    */
   def bytesSource(jmsSettings: JmsConsumerSettings): Source[Array[Byte], KillSwitch] =
-    apply(jmsSettings).map { msg =>
-      val byteMessage = msg.asInstanceOf[BytesMessage]
-      val byteArray = new Array[Byte](byteMessage.getBodyLength.toInt)
-      byteMessage.readBytes(byteArray)
-      byteArray
-    }
+    JmsConsumer.bytesSource(jmsSettings)
 
   /**
    * Scala API: Creates an [[JmsSource]] for serializable objects
    */
   def objectSource(jmsSettings: JmsConsumerSettings): Source[java.io.Serializable, KillSwitch] =
-    apply(jmsSettings).map(msg => msg.asInstanceOf[ObjectMessage].getObject)
+    JmsConsumer.objectSource(jmsSettings)
 
   /**
    * Scala API: Creates a [[JmsSource]] of envelopes containing messages. It requires explicit acknowledgements
@@ -66,7 +53,7 @@ object JmsSource {
    * @return Source for JMS messages in an AckEnvelope.
    */
   def ackSource(jmsSettings: JmsConsumerSettings): Source[AckEnvelope, KillSwitch] =
-    Source.fromGraph(new JmsAckSourceStage(jmsSettings))
+    JmsConsumer.ackSource(jmsSettings)
 
   /**
    * Scala API: Creates a [[JmsSource]] of envelopes containing messages. It requires explicit
@@ -75,11 +62,11 @@ object JmsSource {
    * @return Source of the JMS messages in a TxEnvelope
    */
   def txSource(jmsSettings: JmsConsumerSettings): Source[TxEnvelope, KillSwitch] =
-    Source.fromGraph(new JmsTxSourceStage(jmsSettings))
+    JmsConsumer.txSource(jmsSettings)
 
   /**
    * Scala API: Creates a [[JmsSource]] for browsing messages non-destructively
    */
   def browse(jmsSettings: JmsBrowseSettings): Source[Message, NotUsed] =
-    Source.fromGraph(new JmsBrowseStage(jmsSettings))
+    JmsConsumer.browse(jmsSettings)
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSource.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSource.scala
@@ -19,19 +19,19 @@ object JmsSource {
   /**
    * Scala API: Creates an [[JmsSource]] for [[javax.jms.Message]] instances
    */
-  def apply(jmsSettings: JmsSourceSettings): Source[Message, KillSwitch] =
+  def apply(jmsSettings: JmsConsumerSettings): Source[Message, KillSwitch] =
     Source.fromGraph(new JmsSourceStage(jmsSettings))
 
   /**
    * Scala API: Creates an [[JmsSource]] for texts
    */
-  def textSource(jmsSettings: JmsSourceSettings): Source[String, KillSwitch] =
+  def textSource(jmsSettings: JmsConsumerSettings): Source[String, KillSwitch] =
     apply(jmsSettings).map(msg => msg.asInstanceOf[TextMessage].getText)
 
   /**
    * Scala API: Creates an [[JmsSource]] for Maps with primitive datatypes
    */
-  def mapSource(jmsSettings: JmsSourceSettings): Source[Map[String, Any], KillSwitch] =
+  def mapSource(jmsSettings: JmsConsumerSettings): Source[Map[String, Any], KillSwitch] =
     apply(jmsSettings).map { msg =>
       val mapMessage = msg.asInstanceOf[MapMessage]
 
@@ -45,7 +45,7 @@ object JmsSource {
   /**
    * Scala API: Creates an [[JmsSource]] for byte arrays
    */
-  def bytesSource(jmsSettings: JmsSourceSettings): Source[Array[Byte], KillSwitch] =
+  def bytesSource(jmsSettings: JmsConsumerSettings): Source[Array[Byte], KillSwitch] =
     apply(jmsSettings).map { msg =>
       val byteMessage = msg.asInstanceOf[BytesMessage]
       val byteArray = new Array[Byte](byteMessage.getBodyLength.toInt)
@@ -56,7 +56,7 @@ object JmsSource {
   /**
    * Scala API: Creates an [[JmsSource]] for serializable objects
    */
-  def objectSource(jmsSettings: JmsSourceSettings): Source[java.io.Serializable, KillSwitch] =
+  def objectSource(jmsSettings: JmsConsumerSettings): Source[java.io.Serializable, KillSwitch] =
     apply(jmsSettings).map(msg => msg.asInstanceOf[ObjectMessage].getObject)
 
   /**
@@ -65,7 +65,7 @@ object JmsSource {
    * @param jmsSettings The settings for the ack source.
    * @return Source for JMS messages in an AckEnvelope.
    */
-  def ackSource(jmsSettings: JmsSourceSettings): Source[AckEnvelope, KillSwitch] =
+  def ackSource(jmsSettings: JmsConsumerSettings): Source[AckEnvelope, KillSwitch] =
     Source.fromGraph(new JmsAckSourceStage(jmsSettings))
 
   /**
@@ -74,7 +74,7 @@ object JmsSource {
    * @param jmsSettings The settings for the tx source
    * @return Source of the JMS messages in a TxEnvelope
    */
-  def txSource(jmsSettings: JmsSourceSettings): Source[TxEnvelope, KillSwitch] =
+  def txSource(jmsSettings: JmsConsumerSettings): Source[TxEnvelope, KillSwitch] =
     Source.fromGraph(new JmsTxSourceStage(jmsSettings))
 
   /**

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSource.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsSource.scala
@@ -4,14 +4,11 @@
 
 package akka.stream.alpakka.jms.scaladsl
 
-import javax.jms._
-
 import akka.NotUsed
 import akka.stream.KillSwitch
 import akka.stream.alpakka.jms._
 import akka.stream.scaladsl.Source
-
-import scala.collection.JavaConversions._
+import javax.jms._
 
 @deprecated("Use JmsConsumer instead", "0.18")
 object JmsSource {

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsAckConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsAckConnectorsTest.java
@@ -56,7 +56,7 @@ public class JmsAckConnectorsTest {
         withServer(ctx -> {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<String, CompletionStage<Done>> jmsSink = JmsSink
+            Sink<String, CompletionStage<Done>> jmsSink = JmsProducer
                 .textSink(
                     JmsSinkSettings
                             .create(connectionFactory)
@@ -66,7 +66,7 @@ public class JmsAckConnectorsTest {
             List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
             Source.from(in).runWith(jmsSink, materializer);
 
-            Source<AckEnvelope, KillSwitch> jmsSource = JmsSource
+            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer
                     .ackSource(JmsSourceSettings
                             .create(connectionFactory)
                             .withSessionCount(5)
@@ -91,7 +91,7 @@ public class JmsAckConnectorsTest {
         withServer(ctx -> {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer
                 .create(
                     JmsSinkSettings
                             .create(connectionFactory)
@@ -102,7 +102,7 @@ public class JmsAckConnectorsTest {
 
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
-            Source<AckEnvelope, KillSwitch> jmsSource = JmsSource
+            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer
                 .ackSource(JmsSourceSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
@@ -139,7 +139,7 @@ public class JmsAckConnectorsTest {
         withServer(ctx -> {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink.create(
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -153,7 +153,7 @@ public class JmsAckConnectorsTest {
 
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
-            Source<AckEnvelope, KillSwitch> jmsSource = JmsSource.ackSource(JmsSourceSettings
+            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer.ackSource(JmsSourceSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withBufferSize(0)
@@ -191,7 +191,7 @@ public class JmsAckConnectorsTest {
         withServer(ctx -> {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink.create(
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -201,7 +201,7 @@ public class JmsAckConnectorsTest {
 
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
-            Source<AckEnvelope, KillSwitch> jmsSource = JmsSource.ackSource(JmsSourceSettings
+            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer.ackSource(JmsSourceSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withBufferSize(0)
@@ -247,25 +247,25 @@ public class JmsAckConnectorsTest {
             List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
             List<String> inNumbers = IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
 
-            Sink<String, CompletionStage<Done>> jmsTopicSink = JmsSink.textSink(
+            Sink<String, CompletionStage<Done>> jmsTopicSink = JmsProducer.textSink(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withTopic("topic")
             );
-            Sink<String, CompletionStage<Done>> jmsTopicSink2 = JmsSink.textSink(
+            Sink<String, CompletionStage<Done>> jmsTopicSink2 = JmsProducer.textSink(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withTopic("topic")
             );
 
-            Source<AckEnvelope, KillSwitch> jmsTopicSource = JmsSource
+            Source<AckEnvelope, KillSwitch> jmsTopicSource = JmsConsumer
                     .ackSource(JmsSourceSettings
                             .create(connectionFactory)
                             .withSessionCount(1)
                             .withBufferSize(0)
                             .withTopic("topic")
                     );
-            Source<AckEnvelope, KillSwitch> jmsTopicSource2 = JmsSource
+            Source<AckEnvelope, KillSwitch> jmsTopicSource2 = JmsConsumer
                     .ackSource(JmsSourceSettings
                             .create(connectionFactory)
                             .withSessionCount(1)

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsAckConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsAckConnectorsTest.java
@@ -58,7 +58,7 @@ public class JmsAckConnectorsTest {
 
             Sink<String, CompletionStage<Done>> jmsSink = JmsProducer
                 .textSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
                 );
@@ -67,7 +67,7 @@ public class JmsAckConnectorsTest {
             Source.from(in).runWith(jmsSink, materializer);
 
             Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer
-                    .ackSource(JmsSourceSettings
+                    .ackSource(JmsConsumerSettings
                             .create(connectionFactory)
                             .withSessionCount(5)
                             .withBufferSize(0)
@@ -93,7 +93,7 @@ public class JmsAckConnectorsTest {
 
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer
                 .create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
                 );
@@ -103,7 +103,7 @@ public class JmsAckConnectorsTest {
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
             Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer
-                .ackSource(JmsSourceSettings
+                .ackSource(JmsConsumerSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withBufferSize(0)
@@ -140,7 +140,7 @@ public class JmsAckConnectorsTest {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -153,7 +153,7 @@ public class JmsAckConnectorsTest {
 
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
-            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer.ackSource(JmsSourceSettings
+            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer.ackSource(JmsConsumerSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withBufferSize(0)
@@ -192,7 +192,7 @@ public class JmsAckConnectorsTest {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -201,7 +201,7 @@ public class JmsAckConnectorsTest {
 
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
-            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer.ackSource(JmsSourceSettings
+            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer.ackSource(JmsConsumerSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withBufferSize(0)
@@ -248,25 +248,25 @@ public class JmsAckConnectorsTest {
             List<String> inNumbers = IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
 
             Sink<String, CompletionStage<Done>> jmsTopicSink = JmsProducer.textSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withTopic("topic")
             );
             Sink<String, CompletionStage<Done>> jmsTopicSink2 = JmsProducer.textSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withTopic("topic")
             );
 
             Source<AckEnvelope, KillSwitch> jmsTopicSource = JmsConsumer
-                    .ackSource(JmsSourceSettings
+                    .ackSource(JmsConsumerSettings
                             .create(connectionFactory)
                             .withSessionCount(1)
                             .withBufferSize(0)
                             .withTopic("topic")
                     );
             Source<AckEnvelope, KillSwitch> jmsTopicSource2 = JmsConsumer
-                    .ackSource(JmsSourceSettings
+                    .ackSource(JmsConsumerSettings
                             .create(connectionFactory)
                             .withSessionCount(1)
                             .withBufferSize(0)

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsBufferedAckConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsBufferedAckConnectorsTest.java
@@ -56,7 +56,7 @@ public class JmsBufferedAckConnectorsTest {
         withServer(ctx -> {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<String, CompletionStage<Done>> jmsSink = JmsSink.textSink(
+            Sink<String, CompletionStage<Done>> jmsSink = JmsProducer.textSink(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -65,7 +65,7 @@ public class JmsBufferedAckConnectorsTest {
             List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
             Source.from(in).runWith(jmsSink, materializer);
 
-            Source<AckEnvelope, KillSwitch> jmsSource = JmsSource
+            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer
                     .ackSource(JmsSourceSettings
                             .create(connectionFactory)
                             .withSessionCount(5)
@@ -90,7 +90,7 @@ public class JmsBufferedAckConnectorsTest {
         withServer(ctx -> {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink.create(
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -101,7 +101,7 @@ public class JmsBufferedAckConnectorsTest {
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
             //#create-jms-source
-            Source<AckEnvelope, KillSwitch> jmsSource = JmsSource
+            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer
                 .ackSource(JmsSourceSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
@@ -144,7 +144,7 @@ public class JmsBufferedAckConnectorsTest {
         withServer(ctx -> {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink.create(
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -158,7 +158,7 @@ public class JmsBufferedAckConnectorsTest {
 
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
-            Source<AckEnvelope, KillSwitch> jmsSource = JmsSource.ackSource(JmsSourceSettings
+            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer.ackSource(JmsSourceSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withBufferSize(5)
@@ -196,7 +196,7 @@ public class JmsBufferedAckConnectorsTest {
         withServer(ctx -> {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink.create(
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -206,7 +206,7 @@ public class JmsBufferedAckConnectorsTest {
 
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
-            Source<AckEnvelope, KillSwitch> jmsSource = JmsSource.ackSource(JmsSourceSettings
+            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer.ackSource(JmsSourceSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withBufferSize(5)
@@ -252,25 +252,25 @@ public class JmsBufferedAckConnectorsTest {
             List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
             List<String> inNumbers = IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
 
-            Sink<String, CompletionStage<Done>> jmsTopicSink = JmsSink.textSink(
+            Sink<String, CompletionStage<Done>> jmsTopicSink = JmsProducer.textSink(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withTopic("topic")
             );
-            Sink<String, CompletionStage<Done>> jmsTopicSink2 = JmsSink.textSink(
+            Sink<String, CompletionStage<Done>> jmsTopicSink2 = JmsProducer.textSink(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withTopic("topic")
             );
 
-            Source<AckEnvelope, KillSwitch> jmsTopicSource = JmsSource
+            Source<AckEnvelope, KillSwitch> jmsTopicSource = JmsConsumer
                     .ackSource(JmsSourceSettings
                             .create(connectionFactory)
                             .withSessionCount(1)
                             .withBufferSize(5)
                             .withTopic("topic")
                     );
-            Source<AckEnvelope, KillSwitch> jmsTopicSource2 = JmsSource
+            Source<AckEnvelope, KillSwitch> jmsTopicSource2 = JmsConsumer
                     .ackSource(JmsSourceSettings
                             .create(connectionFactory)
                             .withSessionCount(1)

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsBufferedAckConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsBufferedAckConnectorsTest.java
@@ -57,7 +57,7 @@ public class JmsBufferedAckConnectorsTest {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             Sink<String, CompletionStage<Done>> jmsSink = JmsProducer.textSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -66,7 +66,7 @@ public class JmsBufferedAckConnectorsTest {
             Source.from(in).runWith(jmsSink, materializer);
 
             Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer
-                    .ackSource(JmsSourceSettings
+                    .ackSource(JmsConsumerSettings
                             .create(connectionFactory)
                             .withSessionCount(5)
                             .withBufferSize(5)
@@ -91,7 +91,7 @@ public class JmsBufferedAckConnectorsTest {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -102,7 +102,7 @@ public class JmsBufferedAckConnectorsTest {
 
             //#create-jms-source
             Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer
-                .ackSource(JmsSourceSettings
+                .ackSource(JmsConsumerSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withBufferSize(5)
@@ -145,7 +145,7 @@ public class JmsBufferedAckConnectorsTest {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -158,7 +158,7 @@ public class JmsBufferedAckConnectorsTest {
 
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
-            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer.ackSource(JmsSourceSettings
+            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer.ackSource(JmsConsumerSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withBufferSize(5)
@@ -197,7 +197,7 @@ public class JmsBufferedAckConnectorsTest {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -206,7 +206,7 @@ public class JmsBufferedAckConnectorsTest {
 
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
-            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer.ackSource(JmsSourceSettings
+            Source<AckEnvelope, KillSwitch> jmsSource = JmsConsumer.ackSource(JmsConsumerSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withBufferSize(5)
@@ -253,25 +253,25 @@ public class JmsBufferedAckConnectorsTest {
             List<String> inNumbers = IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
 
             Sink<String, CompletionStage<Done>> jmsTopicSink = JmsProducer.textSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withTopic("topic")
             );
             Sink<String, CompletionStage<Done>> jmsTopicSink2 = JmsProducer.textSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withTopic("topic")
             );
 
             Source<AckEnvelope, KillSwitch> jmsTopicSource = JmsConsumer
-                    .ackSource(JmsSourceSettings
+                    .ackSource(JmsConsumerSettings
                             .create(connectionFactory)
                             .withSessionCount(1)
                             .withBufferSize(5)
                             .withTopic("topic")
                     );
             Source<AckEnvelope, KillSwitch> jmsTopicSource2 = JmsConsumer
-                    .ackSource(JmsSourceSettings
+                    .ackSource(JmsConsumerSettings
                             .create(connectionFactory)
                             .withSessionCount(1)
                             .withBufferSize(5)

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
@@ -685,7 +685,7 @@ public class JmsConnectorsTest {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             //#create-flow-producer
-            Flow<JmsTextMessage, JmsMessage, NotUsed> flowSink = JmsProducer.flow(
+            Flow<JmsTextMessage, JmsTextMessage, NotUsed> flowSink = JmsProducer.flow(
                     JmsProducerSettings.create(connectionFactory).withQueue("test")
             );
             //#create-flow-producer
@@ -693,7 +693,7 @@ public class JmsConnectorsTest {
             //#run-flow-producer
             List<JmsTextMessage> input = createTestMessageList();
 
-            CompletionStage<List<JmsMessage>> result = Source.from(input)
+            CompletionStage<List<JmsTextMessage>> result = Source.from(input)
                     .via(flowSink)
                     .runWith(Sink.seq(), materializer);
             //#run-flow-producer

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
@@ -27,7 +27,6 @@ import javax.jms.ConnectionFactory;
 import javax.jms.DeliveryMode;
 import javax.jms.JMSException;
 import javax.jms.Message;
-import javax.jms.TextMessage;
 import java.nio.charset.Charset;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -102,7 +101,7 @@ public class JmsConnectorsTest {
             //#connection-factory
 
             //#create-text-sink
-            Sink<String, CompletionStage<Done>> jmsSink = JmsSink
+            Sink<String, CompletionStage<Done>> jmsSink = JmsProducer
                 .textSink(
                     JmsSinkSettings
                         .create(connectionFactory)
@@ -118,7 +117,7 @@ public class JmsConnectorsTest {
             //#run-text-sink
 
             //#create-text-source
-            Source<String, KillSwitch> jmsSource = JmsSource
+            Source<String, KillSwitch> jmsSource = JmsConsumer
                 .textSource(JmsSourceSettings
                     .create(connectionFactory)
                     .withQueue("test")
@@ -150,7 +149,7 @@ public class JmsConnectorsTest {
             //#connection-factory-object
 
             //#create-object-sink
-            Sink<java.io.Serializable, CompletionStage<Done>> jmsSink = JmsSink
+            Sink<java.io.Serializable, CompletionStage<Done>> jmsSink = JmsProducer
                 .objectSink(
                     JmsSinkSettings
                         .create(connectionFactory)
@@ -166,7 +165,7 @@ public class JmsConnectorsTest {
             //#run-object-sink
 
             //#create-object-source
-            Source<java.io.Serializable, KillSwitch> jmsSource = JmsSource
+            Source<java.io.Serializable, KillSwitch> jmsSource = JmsConsumer
                 .objectSource(JmsSourceSettings
                     .create(connectionFactory)
                     .withQueue("test")
@@ -192,7 +191,7 @@ public class JmsConnectorsTest {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             //#create-bytearray-sink
-            Sink<byte[], CompletionStage<Done>> jmsSink = JmsSink
+            Sink<byte[], CompletionStage<Done>> jmsSink = JmsProducer
                 .bytesSink(
                     JmsSinkSettings
                         .create(connectionFactory)
@@ -208,7 +207,7 @@ public class JmsConnectorsTest {
             //#run-bytearray-sink
 
             //#create-bytearray-source
-            Source<byte[], KillSwitch> jmsSource = JmsSource
+            Source<byte[], KillSwitch> jmsSource = JmsConsumer
                 .bytesSource(
                     JmsSourceSettings
                         .create(connectionFactory)
@@ -235,7 +234,7 @@ public class JmsConnectorsTest {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             //#create-map-sink
-            Sink<Map<String, Object>, CompletionStage<Done>> jmsSink = JmsSink
+            Sink<Map<String, Object>, CompletionStage<Done>> jmsSink = JmsProducer
                 .mapSink(
                     JmsSinkSettings
                         .create(connectionFactory)
@@ -260,7 +259,7 @@ public class JmsConnectorsTest {
             //#run-map-sink
 
             //#create-map-source
-            Source<Map<String, Object>, KillSwitch> jmsSource = JmsSource
+            Source<Map<String, Object>, KillSwitch> jmsSource = JmsConsumer
                 .mapSource(
                     JmsSourceSettings
                         .create(connectionFactory)
@@ -297,7 +296,7 @@ public class JmsConnectorsTest {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             //#create-jms-sink
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer
                 .create(
                     JmsSinkSettings
                         .create(connectionFactory)
@@ -314,7 +313,7 @@ public class JmsConnectorsTest {
             //#run-jms-sink
 
             //#create-jms-source
-            Source<Message, KillSwitch> jmsSource = JmsSource
+            Source<Message, KillSwitch> jmsSource = JmsConsumer
                 .create(
                     JmsSourceSettings
                         .create(connectionFactory)
@@ -345,7 +344,7 @@ public class JmsConnectorsTest {
         withServer(ctx -> {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer
                 .create(
                     JmsSinkSettings
                         .create(connectionFactory)
@@ -367,7 +366,7 @@ public class JmsConnectorsTest {
 
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
-            Source<Message, KillSwitch> jmsSource = JmsSource.create(JmsSourceSettings
+            Source<Message, KillSwitch> jmsSource = JmsConsumer.create(JmsSourceSettings
                     .create(connectionFactory)
                     .withQueue("test")
                     .withBufferSize(10)
@@ -400,7 +399,7 @@ public class JmsConnectorsTest {
         withServer(ctx -> {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink.create(
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -411,7 +410,7 @@ public class JmsConnectorsTest {
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
             //#create-jms-source-with-selector
-            Source<Message, KillSwitch> jmsSource = JmsSource
+            Source<Message, KillSwitch> jmsSource = JmsConsumer
                 .create(
                     JmsSourceSettings
                         .create(connectionFactory)
@@ -453,14 +452,14 @@ public class JmsConnectorsTest {
             List<String> inNumbers = IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
 
             //#create-topic-sink
-            Sink<String, CompletionStage<Done>> jmsTopicSink = JmsSink
+            Sink<String, CompletionStage<Done>> jmsTopicSink = JmsProducer
                 .textSink(
                     JmsSinkSettings
                         .create(connectionFactory)
                         .withTopic("topic")
                 );
             //#create-topic-sink
-            Sink<String, CompletionStage<Done>> jmsTopicSink2 = JmsSink
+            Sink<String, CompletionStage<Done>> jmsTopicSink2 = JmsProducer
                 .textSink(
                     JmsSinkSettings
                         .create(connectionFactory)
@@ -468,7 +467,7 @@ public class JmsConnectorsTest {
                 );
 
             //#create-topic-source
-            Source<String, KillSwitch> jmsTopicSource = JmsSource
+            Source<String, KillSwitch> jmsTopicSource = JmsConsumer
                 .textSource(
                     JmsSourceSettings
                         .create(connectionFactory)
@@ -476,7 +475,7 @@ public class JmsConnectorsTest {
                         .withBufferSize(10)
                 );
             //#create-topic-source
-            Source<String, KillSwitch> jmsTopicSource2 = JmsSource
+            Source<String, KillSwitch> jmsTopicSource2 = JmsConsumer
                 .textSource(
                     JmsSourceSettings
                         .create(connectionFactory)
@@ -515,7 +514,7 @@ public class JmsConnectorsTest {
         withServer(ctx -> {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink.create(
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -529,7 +528,7 @@ public class JmsConnectorsTest {
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
             //#create-jms-source-client-ack
-            Source<Message, KillSwitch> jmsSource = JmsSource
+            Source<Message, KillSwitch> jmsSource = JmsConsumer
                 .create(
                     JmsSourceSettings
                         .create(connectionFactory)
@@ -563,7 +562,7 @@ public class JmsConnectorsTest {
         withServer(ctx -> {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink.create(
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -582,7 +581,7 @@ public class JmsConnectorsTest {
         withServer(ctx -> {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink.create(
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -606,7 +605,7 @@ public class JmsConnectorsTest {
         withServer(ctx -> {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink.create(
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -642,7 +641,7 @@ public class JmsConnectorsTest {
         withServer(ctx -> {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<String, CompletionStage<Done>> jmsSink = JmsSink.textSink(
+            Sink<String, CompletionStage<Done>> jmsSink = JmsProducer.textSink(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -653,7 +652,7 @@ public class JmsConnectorsTest {
             Source.from(in).runWith(jmsSink, materializer).toCompletableFuture().get();
 
             //#create-browse-source
-            Source<Message, NotUsed> browseSource = JmsSource.browse(
+            Source<Message, NotUsed> browseSource = JmsConsumer.browse(
                     JmsBrowseSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -686,7 +685,7 @@ public class JmsConnectorsTest {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             //#create-flow-producer
-            Flow<JmsTextMessage, JmsMessage, NotUsed> flowSink = JmsSink.flow(
+            Flow<JmsTextMessage, JmsMessage, NotUsed> flowSink = JmsProducer.flow(
                     JmsSinkSettings.create(connectionFactory).withQueue("test")
             );
             //#create-flow-producer

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
@@ -103,7 +103,7 @@ public class JmsConnectorsTest {
             //#create-text-sink
             Sink<String, CompletionStage<Done>> jmsSink = JmsProducer
                 .textSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                         .create(connectionFactory)
                         .withQueue("test")
                 );
@@ -118,7 +118,7 @@ public class JmsConnectorsTest {
 
             //#create-text-source
             Source<String, KillSwitch> jmsSource = JmsConsumer
-                .textSource(JmsSourceSettings
+                .textSource(JmsConsumerSettings
                     .create(connectionFactory)
                     .withQueue("test")
                     .withBufferSize(10)
@@ -151,7 +151,7 @@ public class JmsConnectorsTest {
             //#create-object-sink
             Sink<java.io.Serializable, CompletionStage<Done>> jmsSink = JmsProducer
                 .objectSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                         .create(connectionFactory)
                         .withQueue("test")
                 );
@@ -166,7 +166,7 @@ public class JmsConnectorsTest {
 
             //#create-object-source
             Source<java.io.Serializable, KillSwitch> jmsSource = JmsConsumer
-                .objectSource(JmsSourceSettings
+                .objectSource(JmsConsumerSettings
                     .create(connectionFactory)
                     .withQueue("test")
                 );
@@ -193,7 +193,7 @@ public class JmsConnectorsTest {
             //#create-bytearray-sink
             Sink<byte[], CompletionStage<Done>> jmsSink = JmsProducer
                 .bytesSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                         .create(connectionFactory)
                         .withQueue("test")
                 );
@@ -209,7 +209,7 @@ public class JmsConnectorsTest {
             //#create-bytearray-source
             Source<byte[], KillSwitch> jmsSource = JmsConsumer
                 .bytesSource(
-                    JmsSourceSettings
+                    JmsConsumerSettings
                         .create(connectionFactory)
                         .withQueue("test")
                 );
@@ -236,7 +236,7 @@ public class JmsConnectorsTest {
             //#create-map-sink
             Sink<Map<String, Object>, CompletionStage<Done>> jmsSink = JmsProducer
                 .mapSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                         .create(connectionFactory)
                         .withQueue("test")
                 );
@@ -261,7 +261,7 @@ public class JmsConnectorsTest {
             //#create-map-source
             Source<Map<String, Object>, KillSwitch> jmsSource = JmsConsumer
                 .mapSource(
-                    JmsSourceSettings
+                    JmsConsumerSettings
                         .create(connectionFactory)
                         .withQueue("test")
                 );
@@ -298,7 +298,7 @@ public class JmsConnectorsTest {
             //#create-jms-sink
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer
                 .create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                         .create(connectionFactory)
                         .withQueue("test")
                 );
@@ -315,7 +315,7 @@ public class JmsConnectorsTest {
             //#create-jms-source
             Source<Message, KillSwitch> jmsSource = JmsConsumer
                 .create(
-                    JmsSourceSettings
+                    JmsConsumerSettings
                         .create(connectionFactory)
                         .withQueue("test")
                         .withBufferSize(10)
@@ -346,7 +346,7 @@ public class JmsConnectorsTest {
 
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer
                 .create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                         .create(connectionFactory)
                         .withQueue("test")
                 );
@@ -366,7 +366,7 @@ public class JmsConnectorsTest {
 
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
-            Source<Message, KillSwitch> jmsSource = JmsConsumer.create(JmsSourceSettings
+            Source<Message, KillSwitch> jmsSource = JmsConsumer.create(JmsConsumerSettings
                     .create(connectionFactory)
                     .withQueue("test")
                     .withBufferSize(10)
@@ -400,7 +400,7 @@ public class JmsConnectorsTest {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -412,7 +412,7 @@ public class JmsConnectorsTest {
             //#create-jms-source-with-selector
             Source<Message, KillSwitch> jmsSource = JmsConsumer
                 .create(
-                    JmsSourceSettings
+                    JmsConsumerSettings
                         .create(connectionFactory)
                         .withQueue("test")
                         .withBufferSize(10)
@@ -454,14 +454,14 @@ public class JmsConnectorsTest {
             //#create-topic-sink
             Sink<String, CompletionStage<Done>> jmsTopicSink = JmsProducer
                 .textSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                         .create(connectionFactory)
                         .withTopic("topic")
                 );
             //#create-topic-sink
             Sink<String, CompletionStage<Done>> jmsTopicSink2 = JmsProducer
                 .textSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                         .create(connectionFactory)
                         .withTopic("topic")
                 );
@@ -469,7 +469,7 @@ public class JmsConnectorsTest {
             //#create-topic-source
             Source<String, KillSwitch> jmsTopicSource = JmsConsumer
                 .textSource(
-                    JmsSourceSettings
+                    JmsConsumerSettings
                         .create(connectionFactory)
                         .withTopic("topic")
                         .withBufferSize(10)
@@ -477,7 +477,7 @@ public class JmsConnectorsTest {
             //#create-topic-source
             Source<String, KillSwitch> jmsTopicSource2 = JmsConsumer
                 .textSource(
-                    JmsSourceSettings
+                    JmsConsumerSettings
                         .create(connectionFactory)
                         .withTopic("topic")
                         .withBufferSize(10)
@@ -515,7 +515,7 @@ public class JmsConnectorsTest {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -530,7 +530,7 @@ public class JmsConnectorsTest {
             //#create-jms-source-client-ack
             Source<Message, KillSwitch> jmsSource = JmsConsumer
                 .create(
-                    JmsSourceSettings
+                    JmsConsumerSettings
                         .create(connectionFactory)
                         .withQueue("test")
                         .withAcknowledgeMode(AcknowledgeMode.ClientAcknowledge())
@@ -563,7 +563,7 @@ public class JmsConnectorsTest {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -582,7 +582,7 @@ public class JmsConnectorsTest {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -606,7 +606,7 @@ public class JmsConnectorsTest {
             ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -642,7 +642,7 @@ public class JmsConnectorsTest {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             Sink<String, CompletionStage<Done>> jmsSink = JmsProducer.textSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -686,7 +686,7 @@ public class JmsConnectorsTest {
 
             //#create-flow-producer
             Flow<JmsTextMessage, JmsMessage, NotUsed> flowSink = JmsProducer.flow(
-                    JmsSinkSettings.create(connectionFactory).withQueue("test")
+                    JmsProducerSettings.create(connectionFactory).withQueue("test")
             );
             //#create-flow-producer
 

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsTxConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsTxConnectorsTest.java
@@ -62,7 +62,7 @@ public class JmsTxConnectorsTest {
             //#connection-factory
 
             //#create-text-sink
-            Sink<String, CompletionStage<Done>> jmsSink = JmsSink.textSink(
+            Sink<String, CompletionStage<Done>> jmsSink = JmsProducer.textSink(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -75,7 +75,7 @@ public class JmsTxConnectorsTest {
             //#run-text-sink
 
             //#create-text-source
-            Source<TxEnvelope, KillSwitch> jmsSource = JmsSource
+            Source<TxEnvelope, KillSwitch> jmsSource = JmsConsumer
                     .txSource(JmsSourceSettings
                             .create(connectionFactory)
                             .withSessionCount(5)
@@ -103,7 +103,7 @@ public class JmsTxConnectorsTest {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             //#create-jms-sink
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink.create(
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -119,7 +119,7 @@ public class JmsTxConnectorsTest {
             //#run-jms-sink
 
             //#create-jms-source
-            Source<TxEnvelope, KillSwitch> jmsSource = JmsSource.txSource(JmsSourceSettings
+            Source<TxEnvelope, KillSwitch> jmsSource = JmsConsumer.txSource(JmsSourceSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withQueue("test")
@@ -158,7 +158,7 @@ public class JmsTxConnectorsTest {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             //#create-jms-sink
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink.create(
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -178,7 +178,7 @@ public class JmsTxConnectorsTest {
             //#run-jms-sink
 
             //#create-jms-source
-            Source<TxEnvelope, KillSwitch> jmsSource = JmsSource.txSource(JmsSourceSettings
+            Source<TxEnvelope, KillSwitch> jmsSource = JmsConsumer.txSource(JmsSourceSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withQueue("test")
@@ -218,7 +218,7 @@ public class JmsTxConnectorsTest {
         withServer(ctx -> {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
-            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsSink.create(
+            Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withQueue("test")
@@ -229,7 +229,7 @@ public class JmsTxConnectorsTest {
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
             //#create-jms-source-with-selector
-            Source<TxEnvelope, KillSwitch> jmsSource = JmsSource.txSource(JmsSourceSettings
+            Source<TxEnvelope, KillSwitch> jmsSource = JmsConsumer.txSource(JmsSourceSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withQueue("test")
@@ -278,27 +278,27 @@ public class JmsTxConnectorsTest {
             List<String> inNumbers = IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
 
             //#create-topic-sink
-            Sink<String, CompletionStage<Done>> jmsTopicSink = JmsSink.textSink(
+            Sink<String, CompletionStage<Done>> jmsTopicSink = JmsProducer.textSink(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withTopic("topic")
             );
             //#create-topic-sink
-            Sink<String, CompletionStage<Done>> jmsTopicSink2 = JmsSink.textSink(
+            Sink<String, CompletionStage<Done>> jmsTopicSink2 = JmsProducer.textSink(
                     JmsSinkSettings
                             .create(connectionFactory)
                             .withTopic("topic")
             );
 
             //#create-topic-source
-            Source<TxEnvelope, KillSwitch> jmsTopicSource = JmsSource
+            Source<TxEnvelope, KillSwitch> jmsTopicSource = JmsConsumer
                     .txSource(JmsSourceSettings
                             .create(connectionFactory)
                             .withSessionCount(1)
                             .withTopic("topic")
                     );
             //#create-topic-source
-            Source<TxEnvelope, KillSwitch> jmsTopicSource2 = JmsSource
+            Source<TxEnvelope, KillSwitch> jmsTopicSource2 = JmsConsumer
                     .txSource(JmsSourceSettings
                             .create(connectionFactory)
                             .withSessionCount(1)

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsTxConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsTxConnectorsTest.java
@@ -63,7 +63,7 @@ public class JmsTxConnectorsTest {
 
             //#create-text-sink
             Sink<String, CompletionStage<Done>> jmsSink = JmsProducer.textSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -76,7 +76,7 @@ public class JmsTxConnectorsTest {
 
             //#create-text-source
             Source<TxEnvelope, KillSwitch> jmsSource = JmsConsumer
-                    .txSource(JmsSourceSettings
+                    .txSource(JmsConsumerSettings
                             .create(connectionFactory)
                             .withSessionCount(5)
                             .withQueue("test")
@@ -104,7 +104,7 @@ public class JmsTxConnectorsTest {
 
             //#create-jms-sink
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -119,7 +119,7 @@ public class JmsTxConnectorsTest {
             //#run-jms-sink
 
             //#create-jms-source
-            Source<TxEnvelope, KillSwitch> jmsSource = JmsConsumer.txSource(JmsSourceSettings
+            Source<TxEnvelope, KillSwitch> jmsSource = JmsConsumer.txSource(JmsConsumerSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withQueue("test")
@@ -159,7 +159,7 @@ public class JmsTxConnectorsTest {
 
             //#create-jms-sink
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -178,7 +178,7 @@ public class JmsTxConnectorsTest {
             //#run-jms-sink
 
             //#create-jms-source
-            Source<TxEnvelope, KillSwitch> jmsSource = JmsConsumer.txSource(JmsSourceSettings
+            Source<TxEnvelope, KillSwitch> jmsSource = JmsConsumer.txSource(JmsConsumerSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withQueue("test")
@@ -219,7 +219,7 @@ public class JmsTxConnectorsTest {
             ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
             Sink<JmsTextMessage, CompletionStage<Done>> jmsSink = JmsProducer.create(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withQueue("test")
             );
@@ -229,7 +229,7 @@ public class JmsTxConnectorsTest {
             Source.from(msgsIn).runWith(jmsSink, materializer);
 
             //#create-jms-source-with-selector
-            Source<TxEnvelope, KillSwitch> jmsSource = JmsConsumer.txSource(JmsSourceSettings
+            Source<TxEnvelope, KillSwitch> jmsSource = JmsConsumer.txSource(JmsConsumerSettings
                     .create(connectionFactory)
                     .withSessionCount(5)
                     .withQueue("test")
@@ -279,27 +279,27 @@ public class JmsTxConnectorsTest {
 
             //#create-topic-sink
             Sink<String, CompletionStage<Done>> jmsTopicSink = JmsProducer.textSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withTopic("topic")
             );
             //#create-topic-sink
             Sink<String, CompletionStage<Done>> jmsTopicSink2 = JmsProducer.textSink(
-                    JmsSinkSettings
+                    JmsProducerSettings
                             .create(connectionFactory)
                             .withTopic("topic")
             );
 
             //#create-topic-source
             Source<TxEnvelope, KillSwitch> jmsTopicSource = JmsConsumer
-                    .txSource(JmsSourceSettings
+                    .txSource(JmsConsumerSettings
                             .create(connectionFactory)
                             .withSessionCount(1)
                             .withTopic("topic")
                     );
             //#create-topic-source
             Source<TxEnvelope, KillSwitch> jmsTopicSource2 = JmsConsumer
-                    .txSource(JmsSourceSettings
+                    .txSource(JmsConsumerSettings
                             .create(connectionFactory)
                             .withSessionCount(1)
                             .withTopic("topic")

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
@@ -29,14 +29,14 @@ class JmsAckConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsSink: Sink[String, Future[Done]] = JmsProducer.textSink(
-        JmsSinkSettings(connectionFactory).withQueue("test")
+        JmsProducerSettings(connectionFactory).withQueue("test")
       )
 
       val in = 0 to 25 map (i => ('a' + i).asInstanceOf[Char].toString)
       Source(in).runWith(jmsSink)
 
       val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("test")
+        JmsConsumerSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("test")
       )
 
       val result = jmsSource
@@ -52,7 +52,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
 
       val msgsIn = 1 to 100 map { n =>
@@ -65,7 +65,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
       Source(msgsIn).runWith(jmsSink)
 
       val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("numbers")
+        JmsConsumerSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("numbers")
       )
 
       val result = jmsSource
@@ -91,7 +91,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
         val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
         val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-          JmsSinkSettings(connectionFactory).withQueue("numbers")
+          JmsProducerSettings(connectionFactory).withQueue("numbers")
         )
 
         val msgsIn = 1 to 100 map { n =>
@@ -103,7 +103,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
         Source(msgsIn).runWith(jmsSink)
 
         val jmsSource = JmsConsumer.ackSource(
-          JmsSourceSettings(connectionFactory)
+          JmsConsumerSettings(connectionFactory)
             .withSessionCount(5)
             .withBufferSize(0)
             .withQueue("numbers")
@@ -133,10 +133,10 @@ class JmsAckConnectorsSpec extends JmsSpec {
     "applying backpressure when the consumer is slower than the producer" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
       val in = 0 to 25 map (i => ('a' + i).asInstanceOf[Char].toString)
-      Source(in).runWith(JmsProducer.textSink(JmsSinkSettings(connectionFactory).withQueue("test")))
+      Source(in).runWith(JmsProducer.textSink(JmsProducerSettings(connectionFactory).withQueue("test")))
 
       val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("test")
+        JmsConsumerSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("test")
       )
 
       val result = jmsSource
@@ -153,7 +153,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
       val result = JmsConsumer
         .ackSource(
-          JmsSourceSettings(connectionFactory)
+          JmsConsumerSettings(connectionFactory)
             .withSessionCount(5)
             .withBufferSize(0)
             .withQueue("test")
@@ -170,20 +170,20 @@ class JmsAckConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsTopicSink: Sink[String, Future[Done]] = JmsProducer.textSink(
-        JmsSinkSettings(connectionFactory).withTopic("topic")
+        JmsProducerSettings(connectionFactory).withTopic("topic")
       )
       val jmsTopicSink2: Sink[String, Future[Done]] = JmsProducer.textSink(
-        JmsSinkSettings(connectionFactory).withTopic("topic")
+        JmsProducerSettings(connectionFactory).withTopic("topic")
       )
 
       val in = List("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")
       val inNumbers = (1 to 10).map(_.toString)
 
       val jmsTopicSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory).withSessionCount(1).withBufferSize(0).withTopic("topic")
+        JmsConsumerSettings(connectionFactory).withSessionCount(1).withBufferSize(0).withTopic("topic")
       )
       val jmsSource2: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory).withSessionCount(1).withBufferSize(0).withTopic("topic")
+        JmsConsumerSettings(connectionFactory).withSessionCount(1).withBufferSize(0).withTopic("topic")
       )
 
       val expectedSize = in.size + inNumbers.size
@@ -215,7 +215,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
 
       val (publishKillSwitch, publishedData) = Source
@@ -227,7 +227,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
         .run()
 
       val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("numbers")
+        JmsConsumerSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("numbers")
       )
 
       val resultQueue = new LinkedBlockingQueue[String]()
@@ -289,7 +289,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
 
       val (publishKillSwitch, publishedData) = Source
@@ -301,7 +301,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
         .run()
 
       val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("numbers")
+        JmsConsumerSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("numbers")
       )
 
       val resultQueue = new LinkedBlockingQueue[String]()

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
@@ -28,14 +28,14 @@ class JmsAckConnectorsSpec extends JmsSpec {
     "publish and consume strings through a queue" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsSink: Sink[String, Future[Done]] = JmsSink.textSink(
+      val jmsSink: Sink[String, Future[Done]] = JmsProducer.textSink(
         JmsSinkSettings(connectionFactory).withQueue("test")
       )
 
       val in = 0 to 25 map (i => ('a' + i).asInstanceOf[Char].toString)
       Source(in).runWith(jmsSink)
 
-      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("test")
       )
 
@@ -51,7 +51,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
     "publish and consume JMS text messages with properties through a queue" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
 
@@ -64,7 +64,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
 
       Source(msgsIn).runWith(jmsSink)
 
-      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("numbers")
       )
 
@@ -90,7 +90,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
       ctx =>
         val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-        val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+        val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
           JmsSinkSettings(connectionFactory).withQueue("numbers")
         )
 
@@ -102,7 +102,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
         }
         Source(msgsIn).runWith(jmsSink)
 
-        val jmsSource = JmsSource.ackSource(
+        val jmsSource = JmsConsumer.ackSource(
           JmsSourceSettings(connectionFactory)
             .withSessionCount(5)
             .withBufferSize(0)
@@ -133,9 +133,9 @@ class JmsAckConnectorsSpec extends JmsSpec {
     "applying backpressure when the consumer is slower than the producer" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
       val in = 0 to 25 map (i => ('a' + i).asInstanceOf[Char].toString)
-      Source(in).runWith(JmsSink.textSink(JmsSinkSettings(connectionFactory).withQueue("test")))
+      Source(in).runWith(JmsProducer.textSink(JmsSinkSettings(connectionFactory).withQueue("test")))
 
-      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("test")
       )
 
@@ -151,7 +151,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
 
     "disconnection should fail the stage" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
-      val result = JmsSource
+      val result = JmsConsumer
         .ackSource(
           JmsSourceSettings(connectionFactory)
             .withSessionCount(5)
@@ -169,20 +169,20 @@ class JmsAckConnectorsSpec extends JmsSpec {
 
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsTopicSink: Sink[String, Future[Done]] = JmsSink.textSink(
+      val jmsTopicSink: Sink[String, Future[Done]] = JmsProducer.textSink(
         JmsSinkSettings(connectionFactory).withTopic("topic")
       )
-      val jmsTopicSink2: Sink[String, Future[Done]] = JmsSink.textSink(
+      val jmsTopicSink2: Sink[String, Future[Done]] = JmsProducer.textSink(
         JmsSinkSettings(connectionFactory).withTopic("topic")
       )
 
       val in = List("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")
       val inNumbers = (1 to 10).map(_.toString)
 
-      val jmsTopicSource: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsTopicSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory).withSessionCount(1).withBufferSize(0).withTopic("topic")
       )
-      val jmsSource2: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsSource2: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory).withSessionCount(1).withBufferSize(0).withTopic("topic")
       )
 
@@ -214,7 +214,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
     "ensure no message loss when stopping a stream" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
 
@@ -226,7 +226,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
         .toMat(Sink.seq)(Keep.both)
         .run()
 
-      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("numbers")
       )
 
@@ -288,7 +288,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
     "ensure no message loss when aborting a stream" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
 
@@ -300,7 +300,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
         .toMat(Sink.seq)(Keep.both)
         .run()
 
-      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("numbers")
       )
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsBufferedAckConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsBufferedAckConnectorsSpec.scala
@@ -28,14 +28,14 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
     "publish and consume strings through a queue" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsSink: Sink[String, Future[Done]] = JmsSink.textSink(
+      val jmsSink: Sink[String, Future[Done]] = JmsProducer.textSink(
         JmsSinkSettings(connectionFactory).withQueue("test")
       )
 
       val in = 0 to 25 map (i => ('a' + i).asInstanceOf[Char].toString)
       Source(in).runWith(jmsSink)
 
-      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("test")
       )
 
@@ -51,7 +51,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
     "publish and consume JMS text messages with properties through a queue" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
 
@@ -65,7 +65,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
       Source(msgsIn).runWith(jmsSink)
 
       //#create-jms-source
-      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("numbers")
       )
       //#create-jms-source
@@ -94,7 +94,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
       ctx =>
         val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-        val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+        val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
           JmsSinkSettings(connectionFactory).withQueue("numbers")
         )
 
@@ -106,7 +106,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
         }
         Source(msgsIn).runWith(jmsSink)
 
-        val jmsSource = JmsSource.ackSource(
+        val jmsSource = JmsConsumer.ackSource(
           JmsSourceSettings(connectionFactory)
             .withSessionCount(5)
             .withBufferSize(5)
@@ -138,9 +138,9 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
     "applying backpressure when the consumer is slower than the producer" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
       val in = 0 to 25 map (i => ('a' + i).asInstanceOf[Char].toString)
-      Source(in).runWith(JmsSink.textSink(JmsSinkSettings(connectionFactory).withQueue("test")))
+      Source(in).runWith(JmsProducer.textSink(JmsSinkSettings(connectionFactory).withQueue("test")))
 
-      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("test")
       )
 
@@ -156,7 +156,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
 
     "disconnection should fail the stage" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
-      val result = JmsSource.ackSource(JmsSourceSettings(connectionFactory).withQueue("test")).runWith(Sink.seq)
+      val result = JmsConsumer.ackSource(JmsSourceSettings(connectionFactory).withQueue("test")).runWith(Sink.seq)
       Thread.sleep(500)
       ctx.broker.stop()
       result.failed.futureValue shouldBe an[JMSException]
@@ -167,20 +167,20 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
 
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsTopicSink: Sink[String, Future[Done]] = JmsSink.textSink(
+      val jmsTopicSink: Sink[String, Future[Done]] = JmsProducer.textSink(
         JmsSinkSettings(connectionFactory).withTopic("topic")
       )
-      val jmsTopicSink2: Sink[String, Future[Done]] = JmsSink.textSink(
+      val jmsTopicSink2: Sink[String, Future[Done]] = JmsProducer.textSink(
         JmsSinkSettings(connectionFactory).withTopic("topic")
       )
 
       val in = List("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")
       val inNumbers = (1 to 10).map(_.toString)
 
-      val jmsTopicSource: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsTopicSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory).withSessionCount(1).withBufferSize(5).withTopic("topic")
       )
-      val jmsSource2: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsSource2: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory).withSessionCount(1).withBufferSize(5).withTopic("topic")
       )
 
@@ -212,7 +212,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
     "ensure no message loss when stopping a stream" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
 
@@ -224,7 +224,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
         .toMat(Sink.seq)(Keep.both)
         .run()
 
-      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("numbers")
       )
 
@@ -288,7 +288,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
     "ensure no message loss when aborting a stream" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
 
@@ -303,7 +303,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
       // We need this ack mode for AMQ to not lose messages as ack normally acks any messages read on the session.
       val individualAck = new AcknowledgeMode(ActiveMQSession.INDIVIDUAL_ACKNOWLEDGE)
 
-      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory)
           .withSessionCount(5)
           .withBufferSize(5)

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsBufferedAckConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsBufferedAckConnectorsSpec.scala
@@ -29,14 +29,14 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsSink: Sink[String, Future[Done]] = JmsProducer.textSink(
-        JmsSinkSettings(connectionFactory).withQueue("test")
+        JmsProducerSettings(connectionFactory).withQueue("test")
       )
 
       val in = 0 to 25 map (i => ('a' + i).asInstanceOf[Char].toString)
       Source(in).runWith(jmsSink)
 
       val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("test")
+        JmsConsumerSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("test")
       )
 
       val result = jmsSource
@@ -52,7 +52,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
 
       val msgsIn = 1 to 100 map { n =>
@@ -66,7 +66,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
 
       //#create-jms-source
       val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("numbers")
+        JmsConsumerSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("numbers")
       )
       //#create-jms-source
 
@@ -95,7 +95,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
         val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
         val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-          JmsSinkSettings(connectionFactory).withQueue("numbers")
+          JmsProducerSettings(connectionFactory).withQueue("numbers")
         )
 
         val msgsIn = 1 to 100 map { n =>
@@ -107,7 +107,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
         Source(msgsIn).runWith(jmsSink)
 
         val jmsSource = JmsConsumer.ackSource(
-          JmsSourceSettings(connectionFactory)
+          JmsConsumerSettings(connectionFactory)
             .withSessionCount(5)
             .withBufferSize(5)
             .withQueue("numbers")
@@ -138,10 +138,10 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
     "applying backpressure when the consumer is slower than the producer" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
       val in = 0 to 25 map (i => ('a' + i).asInstanceOf[Char].toString)
-      Source(in).runWith(JmsProducer.textSink(JmsSinkSettings(connectionFactory).withQueue("test")))
+      Source(in).runWith(JmsProducer.textSink(JmsProducerSettings(connectionFactory).withQueue("test")))
 
       val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("test")
+        JmsConsumerSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("test")
       )
 
       val result = jmsSource
@@ -156,7 +156,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
 
     "disconnection should fail the stage" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
-      val result = JmsConsumer.ackSource(JmsSourceSettings(connectionFactory).withQueue("test")).runWith(Sink.seq)
+      val result = JmsConsumer.ackSource(JmsConsumerSettings(connectionFactory).withQueue("test")).runWith(Sink.seq)
       Thread.sleep(500)
       ctx.broker.stop()
       result.failed.futureValue shouldBe an[JMSException]
@@ -168,20 +168,20 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsTopicSink: Sink[String, Future[Done]] = JmsProducer.textSink(
-        JmsSinkSettings(connectionFactory).withTopic("topic")
+        JmsProducerSettings(connectionFactory).withTopic("topic")
       )
       val jmsTopicSink2: Sink[String, Future[Done]] = JmsProducer.textSink(
-        JmsSinkSettings(connectionFactory).withTopic("topic")
+        JmsProducerSettings(connectionFactory).withTopic("topic")
       )
 
       val in = List("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")
       val inNumbers = (1 to 10).map(_.toString)
 
       val jmsTopicSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory).withSessionCount(1).withBufferSize(5).withTopic("topic")
+        JmsConsumerSettings(connectionFactory).withSessionCount(1).withBufferSize(5).withTopic("topic")
       )
       val jmsSource2: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory).withSessionCount(1).withBufferSize(5).withTopic("topic")
+        JmsConsumerSettings(connectionFactory).withSessionCount(1).withBufferSize(5).withTopic("topic")
       )
 
       val expectedSize = in.size + inNumbers.size
@@ -213,7 +213,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
 
       val (publishKillSwitch, publishedData) = Source
@@ -225,7 +225,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
         .run()
 
       val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("numbers")
+        JmsConsumerSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("numbers")
       )
 
       val resultQueue = new LinkedBlockingQueue[String]()
@@ -289,7 +289,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
 
       val (publishKillSwitch, publishedData) = Source
@@ -304,7 +304,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
       val individualAck = new AcknowledgeMode(ActiveMQSession.INDIVIDUAL_ACKNOWLEDGE)
 
       val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory)
+        JmsConsumerSettings(connectionFactory)
           .withSessionCount(5)
           .withBufferSize(5)
           .withQueue("numbers")

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
@@ -37,7 +37,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       //#create-text-sink
       val jmsSink: Sink[String, Future[Done]] = JmsProducer.textSink(
-        JmsSinkSettings(connectionFactory).withQueue("test")
+        JmsProducerSettings(connectionFactory).withQueue("test")
       )
       //#create-text-sink
 
@@ -48,7 +48,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       //#create-text-source
       val jmsSource: Source[String, KillSwitch] = JmsConsumer.textSource(
-        JmsSourceSettings(connectionFactory).withBufferSize(10).withQueue("test")
+        JmsConsumerSettings(connectionFactory).withBufferSize(10).withQueue("test")
       )
       //#create-text-source
 
@@ -67,7 +67,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       //#create-object-sink
       val jmsSink: Sink[Serializable, Future[Done]] = JmsProducer.objectSink(
-        JmsSinkSettings(connectionFactory).withQueue("test")
+        JmsProducerSettings(connectionFactory).withQueue("test")
       )
       //#create-object-sink
 
@@ -79,7 +79,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       //#create-object-source
       val jmsSource: Source[java.io.Serializable, KillSwitch] = JmsConsumer.objectSource(
-        JmsSourceSettings(connectionFactory).withQueue("test")
+        JmsConsumerSettings(connectionFactory).withQueue("test")
       )
       //#create-object-source
 
@@ -95,7 +95,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       //#create-bytearray-sink
       val jmsSink: Sink[Array[Byte], Future[Done]] = JmsProducer.bytesSink(
-        JmsSinkSettings(connectionFactory).withQueue("test")
+        JmsProducerSettings(connectionFactory).withQueue("test")
       )
       //#create-bytearray-sink
 
@@ -106,7 +106,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       //#create-bytearray-source
       val jmsSource: Source[Array[Byte], KillSwitch] = JmsConsumer.bytesSource(
-        JmsSourceSettings(connectionFactory).withQueue("test")
+        JmsConsumerSettings(connectionFactory).withQueue("test")
       )
       //#create-bytearray-source
 
@@ -122,7 +122,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       //#create-map-sink
       val jmsSink: Sink[Map[String, Any], Future[Done]] = JmsProducer.mapSink(
-        JmsSinkSettings(connectionFactory).withQueue("test")
+        JmsProducerSettings(connectionFactory).withQueue("test")
       )
       //#create-map-sink
 
@@ -145,7 +145,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       //#create-map-source
       val jmsSource: Source[Map[String, Any], KillSwitch] = JmsConsumer.mapSource(
-        JmsSourceSettings(connectionFactory).withQueue("test")
+        JmsConsumerSettings(connectionFactory).withQueue("test")
       )
       //#create-map-source
 
@@ -172,7 +172,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
 
       //#create-messages-with-properties
@@ -188,7 +188,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       //#create-jms-source
       val jmsSource: Source[Message, KillSwitch] = JmsConsumer(
-        JmsSourceSettings(connectionFactory).withBufferSize(10).withQueue("numbers")
+        JmsConsumerSettings(connectionFactory).withBufferSize(10).withQueue("numbers")
       )
       //#create-jms-source
 
@@ -210,7 +210,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       //#create-jms-sink
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
       //#create-jms-sink
 
@@ -229,7 +229,7 @@ class JmsConnectorsSpec extends JmsSpec {
       Source(msgsIn).runWith(jmsSink)
 
       val jmsSource: Source[Message, KillSwitch] = JmsConsumer(
-        JmsSourceSettings(connectionFactory).withBufferSize(10).withQueue("numbers")
+        JmsConsumerSettings(connectionFactory).withBufferSize(10).withQueue("numbers")
       )
 
       val result: Future[Seq[Message]] = jmsSource.take(msgsIn.size).runWith(Sink.seq)
@@ -250,7 +250,7 @@ class JmsConnectorsSpec extends JmsSpec {
         val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
         val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-          JmsSinkSettings(connectionFactory).withQueue("numbers")
+          JmsProducerSettings(connectionFactory).withQueue("numbers")
         )
 
         val msgsIn = (1 to 10).toList.map { n =>
@@ -263,7 +263,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
         //#create-jms-source-with-selector
         val jmsSource = JmsConsumer(
-          JmsSourceSettings(connectionFactory).withBufferSize(10).withQueue("numbers").withSelector("IsOdd = TRUE")
+          JmsConsumerSettings(connectionFactory).withBufferSize(10).withQueue("numbers").withSelector("IsOdd = TRUE")
         )
         //#create-jms-source-with-selector
 
@@ -285,10 +285,10 @@ class JmsConnectorsSpec extends JmsSpec {
     "applying backpressure when the consumer is slower than the producer" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
       val in = List("a", "b", "c")
-      Source(in).runWith(JmsProducer.textSink(JmsSinkSettings(connectionFactory).withQueue("test")))
+      Source(in).runWith(JmsProducer.textSink(JmsProducerSettings(connectionFactory).withQueue("test")))
 
       val result = JmsConsumer
-        .textSource(JmsSourceSettings(connectionFactory).withBufferSize(1).withQueue("test"))
+        .textSource(JmsConsumerSettings(connectionFactory).withBufferSize(1).withQueue("test"))
         .throttle(1, 1.second, 1, ThrottleMode.shaping)
         .take(in.size)
         .runWith(Sink.seq)
@@ -298,7 +298,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
     "disconnection should fail the stage" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
-      val result = JmsConsumer(JmsSourceSettings(connectionFactory).withQueue("test")).runWith(Sink.seq)
+      val result = JmsConsumer(JmsConsumerSettings(connectionFactory).withQueue("test")).runWith(Sink.seq)
       Thread.sleep(500)
       ctx.broker.stop()
       result.failed.futureValue shouldBe an[JMSException]
@@ -311,11 +311,11 @@ class JmsConnectorsSpec extends JmsSpec {
 
       //#create-topic-sink
       val jmsTopicSink: Sink[String, Future[Done]] = JmsProducer.textSink(
-        JmsSinkSettings(connectionFactory).withTopic("topic")
+        JmsProducerSettings(connectionFactory).withTopic("topic")
       )
       //#create-topic-sink
       val jmsTopicSink2: Sink[String, Future[Done]] = JmsProducer.textSink(
-        JmsSinkSettings(connectionFactory).withTopic("topic")
+        JmsProducerSettings(connectionFactory).withTopic("topic")
       )
 
       val in = List("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")
@@ -323,11 +323,11 @@ class JmsConnectorsSpec extends JmsSpec {
 
       //#create-topic-source
       val jmsTopicSource: Source[String, KillSwitch] = JmsConsumer.textSource(
-        JmsSourceSettings(connectionFactory).withBufferSize(10).withTopic("topic")
+        JmsConsumerSettings(connectionFactory).withBufferSize(10).withTopic("topic")
       )
       //#create-topic-source
       val jmsSource2: Source[String, KillSwitch] = JmsConsumer.textSource(
-        JmsSourceSettings(connectionFactory).withBufferSize(10).withTopic("topic")
+        JmsConsumerSettings(connectionFactory).withBufferSize(10).withTopic("topic")
       )
 
       val expectedSize = in.size + inNumbers.size
@@ -353,7 +353,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
 
       val msgsIn = (1 to 10).toList.map { n =>
@@ -364,7 +364,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       //#create-jms-source-client-ack
       val jmsSource: Source[Message, KillSwitch] = JmsConsumer(
-        JmsSourceSettings(connectionFactory)
+        JmsConsumerSettings(connectionFactory)
           .withQueue("numbers")
           .withAcknowledgeMode(AcknowledgeMode.ClientAcknowledge)
       )
@@ -395,7 +395,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
 
       val msgsIn = (1 to 10).toList.map { n =>
@@ -405,7 +405,7 @@ class JmsConnectorsSpec extends JmsSpec {
       Source(msgsIn).runWith(jmsSink)
 
       val jmsSource: Source[Message, KillSwitch] = JmsConsumer(
-        JmsSourceSettings(connectionFactory)
+        JmsConsumerSettings(connectionFactory)
           .withBufferSize(10)
           .withQueue("numbers")
           .withAcknowledgeMode(AcknowledgeMode.ClientAcknowledge)
@@ -433,7 +433,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val connectionFactory = new CachedConnectionFactory(url)
 
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
 
       val msgsIn = (1 to 10).toList.map { n =>
@@ -451,7 +451,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val connectionFactory = new CachedConnectionFactory(url)
 
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
 
       val completionFuture: Future[Done] = Source
@@ -469,7 +469,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val connectionFactory = new CachedConnectionFactory(url)
 
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
 
       val completionFuture: Future[Done] = Source(0 to 10)
@@ -493,7 +493,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
 
       val (publishKillSwitch, publishedData) = Source
@@ -505,7 +505,7 @@ class JmsConnectorsSpec extends JmsSpec {
         .run()
 
       val jmsSource: Source[Message, KillSwitch] = JmsConsumer(
-        JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("numbers")
+        JmsConsumerSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("numbers")
       )
 
       val resultQueue = new LinkedBlockingQueue[String]()
@@ -557,7 +557,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
-        JmsSinkSettings(connectionFactory).withQueue("numbers")
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
       )
 
       val (publishKillSwitch, publishedData) = Source
@@ -569,7 +569,7 @@ class JmsConnectorsSpec extends JmsSpec {
         .run()
 
       val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
-        JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("numbers")
+        JmsConsumerSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("numbers")
       )
 
       val resultQueue = new LinkedBlockingQueue[String]()
@@ -639,7 +639,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       withClue("write some messages") {
         Source(in)
-          .runWith(JmsProducer.textSink(JmsSinkSettings(connectionFactory).withQueue("test")))
+          .runWith(JmsProducer.textSink(JmsProducerSettings(connectionFactory).withQueue("test")))
           .futureValue
       }
 
@@ -673,7 +673,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       //#create-flow-producer
       val flowSink: Flow[JmsMessage, JmsMessage, NotUsed] = JmsProducer.flow(
-        JmsSinkSettings(connectionFactory).withQueue("test")
+        JmsProducerSettings(connectionFactory).withQueue("test")
       )
       //#create-flow-producer
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
@@ -36,7 +36,7 @@ class JmsConnectorsSpec extends JmsSpec {
       //#connection-factory
 
       //#create-text-sink
-      val jmsSink: Sink[String, Future[Done]] = JmsSink.textSink(
+      val jmsSink: Sink[String, Future[Done]] = JmsProducer.textSink(
         JmsSinkSettings(connectionFactory).withQueue("test")
       )
       //#create-text-sink
@@ -47,7 +47,7 @@ class JmsConnectorsSpec extends JmsSpec {
       //#run-text-sink
 
       //#create-text-source
-      val jmsSource: Source[String, KillSwitch] = JmsSource.textSource(
+      val jmsSource: Source[String, KillSwitch] = JmsConsumer.textSource(
         JmsSourceSettings(connectionFactory).withBufferSize(10).withQueue("test")
       )
       //#create-text-source
@@ -66,7 +66,7 @@ class JmsConnectorsSpec extends JmsSpec {
       //#connection-factory-object
 
       //#create-object-sink
-      val jmsSink: Sink[Serializable, Future[Done]] = JmsSink.objectSink(
+      val jmsSink: Sink[Serializable, Future[Done]] = JmsProducer.objectSink(
         JmsSinkSettings(connectionFactory).withQueue("test")
       )
       //#create-object-sink
@@ -78,7 +78,7 @@ class JmsConnectorsSpec extends JmsSpec {
       //#run-object-sink
 
       //#create-object-source
-      val jmsSource: Source[java.io.Serializable, KillSwitch] = JmsSource.objectSource(
+      val jmsSource: Source[java.io.Serializable, KillSwitch] = JmsConsumer.objectSource(
         JmsSourceSettings(connectionFactory).withQueue("test")
       )
       //#create-object-source
@@ -94,7 +94,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       //#create-bytearray-sink
-      val jmsSink: Sink[Array[Byte], Future[Done]] = JmsSink.bytesSink(
+      val jmsSink: Sink[Array[Byte], Future[Done]] = JmsProducer.bytesSink(
         JmsSinkSettings(connectionFactory).withQueue("test")
       )
       //#create-bytearray-sink
@@ -105,7 +105,7 @@ class JmsConnectorsSpec extends JmsSpec {
       //#run-bytearray-sink
 
       //#create-bytearray-source
-      val jmsSource: Source[Array[Byte], KillSwitch] = JmsSource.bytesSource(
+      val jmsSource: Source[Array[Byte], KillSwitch] = JmsConsumer.bytesSource(
         JmsSourceSettings(connectionFactory).withQueue("test")
       )
       //#create-bytearray-source
@@ -121,7 +121,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       //#create-map-sink
-      val jmsSink: Sink[Map[String, Any], Future[Done]] = JmsSink.mapSink(
+      val jmsSink: Sink[Map[String, Any], Future[Done]] = JmsProducer.mapSink(
         JmsSinkSettings(connectionFactory).withQueue("test")
       )
       //#create-map-sink
@@ -144,7 +144,7 @@ class JmsConnectorsSpec extends JmsSpec {
       //#run-map-sink
 
       //#create-map-source
-      val jmsSource: Source[Map[String, Any], KillSwitch] = JmsSource.mapSource(
+      val jmsSource: Source[Map[String, Any], KillSwitch] = JmsConsumer.mapSource(
         JmsSourceSettings(connectionFactory).withQueue("test")
       )
       //#create-map-source
@@ -171,7 +171,7 @@ class JmsConnectorsSpec extends JmsSpec {
     "publish and consume JMS text messages with properties through a queue" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
 
@@ -187,7 +187,7 @@ class JmsConnectorsSpec extends JmsSpec {
       Source(msgsIn).runWith(jmsSink)
 
       //#create-jms-source
-      val jmsSource: Source[Message, KillSwitch] = JmsSource(
+      val jmsSource: Source[Message, KillSwitch] = JmsConsumer(
         JmsSourceSettings(connectionFactory).withBufferSize(10).withQueue("numbers")
       )
       //#create-jms-source
@@ -209,7 +209,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       //#create-jms-sink
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
       //#create-jms-sink
@@ -228,7 +228,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       Source(msgsIn).runWith(jmsSink)
 
-      val jmsSource: Source[Message, KillSwitch] = JmsSource(
+      val jmsSource: Source[Message, KillSwitch] = JmsConsumer(
         JmsSourceSettings(connectionFactory).withBufferSize(10).withQueue("numbers")
       )
 
@@ -249,7 +249,7 @@ class JmsConnectorsSpec extends JmsSpec {
       ctx =>
         val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-        val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+        val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
           JmsSinkSettings(connectionFactory).withQueue("numbers")
         )
 
@@ -262,7 +262,7 @@ class JmsConnectorsSpec extends JmsSpec {
         Source(msgsIn).runWith(jmsSink)
 
         //#create-jms-source-with-selector
-        val jmsSource = JmsSource(
+        val jmsSource = JmsConsumer(
           JmsSourceSettings(connectionFactory).withBufferSize(10).withQueue("numbers").withSelector("IsOdd = TRUE")
         )
         //#create-jms-source-with-selector
@@ -285,9 +285,9 @@ class JmsConnectorsSpec extends JmsSpec {
     "applying backpressure when the consumer is slower than the producer" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
       val in = List("a", "b", "c")
-      Source(in).runWith(JmsSink.textSink(JmsSinkSettings(connectionFactory).withQueue("test")))
+      Source(in).runWith(JmsProducer.textSink(JmsSinkSettings(connectionFactory).withQueue("test")))
 
-      val result = JmsSource
+      val result = JmsConsumer
         .textSource(JmsSourceSettings(connectionFactory).withBufferSize(1).withQueue("test"))
         .throttle(1, 1.second, 1, ThrottleMode.shaping)
         .take(in.size)
@@ -298,7 +298,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
     "disconnection should fail the stage" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
-      val result = JmsSource(JmsSourceSettings(connectionFactory).withQueue("test")).runWith(Sink.seq)
+      val result = JmsConsumer(JmsSourceSettings(connectionFactory).withQueue("test")).runWith(Sink.seq)
       Thread.sleep(500)
       ctx.broker.stop()
       result.failed.futureValue shouldBe an[JMSException]
@@ -310,11 +310,11 @@ class JmsConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       //#create-topic-sink
-      val jmsTopicSink: Sink[String, Future[Done]] = JmsSink.textSink(
+      val jmsTopicSink: Sink[String, Future[Done]] = JmsProducer.textSink(
         JmsSinkSettings(connectionFactory).withTopic("topic")
       )
       //#create-topic-sink
-      val jmsTopicSink2: Sink[String, Future[Done]] = JmsSink.textSink(
+      val jmsTopicSink2: Sink[String, Future[Done]] = JmsProducer.textSink(
         JmsSinkSettings(connectionFactory).withTopic("topic")
       )
 
@@ -322,11 +322,11 @@ class JmsConnectorsSpec extends JmsSpec {
       val inNumbers = (1 to 10).map(_.toString)
 
       //#create-topic-source
-      val jmsTopicSource: Source[String, KillSwitch] = JmsSource.textSource(
+      val jmsTopicSource: Source[String, KillSwitch] = JmsConsumer.textSource(
         JmsSourceSettings(connectionFactory).withBufferSize(10).withTopic("topic")
       )
       //#create-topic-source
-      val jmsSource2: Source[String, KillSwitch] = JmsSource.textSource(
+      val jmsSource2: Source[String, KillSwitch] = JmsConsumer.textSource(
         JmsSourceSettings(connectionFactory).withBufferSize(10).withTopic("topic")
       )
 
@@ -352,7 +352,7 @@ class JmsConnectorsSpec extends JmsSpec {
     "publish and consume JMS text messages through a queue with client ack" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
 
@@ -363,7 +363,7 @@ class JmsConnectorsSpec extends JmsSpec {
       Source(msgsIn).runWith(jmsSink)
 
       //#create-jms-source-client-ack
-      val jmsSource: Source[Message, KillSwitch] = JmsSource(
+      val jmsSource: Source[Message, KillSwitch] = JmsConsumer(
         JmsSourceSettings(connectionFactory)
           .withQueue("numbers")
           .withAcknowledgeMode(AcknowledgeMode.ClientAcknowledge)
@@ -394,7 +394,7 @@ class JmsConnectorsSpec extends JmsSpec {
     "publish and consume JMS text messages through a queue without acknowledgingg them" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
 
@@ -404,7 +404,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       Source(msgsIn).runWith(jmsSink)
 
-      val jmsSource: Source[Message, KillSwitch] = JmsSource(
+      val jmsSource: Source[Message, KillSwitch] = JmsConsumer(
         JmsSourceSettings(connectionFactory)
           .withBufferSize(10)
           .withQueue("numbers")
@@ -432,7 +432,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val url: String = ctx.url
       val connectionFactory = new CachedConnectionFactory(url)
 
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
 
@@ -450,7 +450,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val url: String = ctx.url
       val connectionFactory = new CachedConnectionFactory(url)
 
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
 
@@ -468,7 +468,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val url: String = ctx.url
       val connectionFactory = new CachedConnectionFactory(url)
 
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
 
@@ -492,7 +492,7 @@ class JmsConnectorsSpec extends JmsSpec {
     "ensure no message loss when stopping a stream" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
 
@@ -504,7 +504,7 @@ class JmsConnectorsSpec extends JmsSpec {
         .toMat(Sink.seq)(Keep.both)
         .run()
 
-      val jmsSource: Source[Message, KillSwitch] = JmsSource(
+      val jmsSource: Source[Message, KillSwitch] = JmsConsumer(
         JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("numbers")
       )
 
@@ -556,7 +556,7 @@ class JmsConnectorsSpec extends JmsSpec {
     "lose some elements when aborting a stream" in withServer() { ctx =>
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
-      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsSink(
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
         JmsSinkSettings(connectionFactory).withQueue("numbers")
       )
 
@@ -568,7 +568,7 @@ class JmsConnectorsSpec extends JmsSpec {
         .toMat(Sink.seq)(Keep.both)
         .run()
 
-      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsSource.ackSource(
+      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
         JmsSourceSettings(connectionFactory).withSessionCount(5).withBufferSize(5).withQueue("numbers")
       )
 
@@ -639,13 +639,13 @@ class JmsConnectorsSpec extends JmsSpec {
 
       withClue("write some messages") {
         Source(in)
-          .runWith(JmsSink.textSink(JmsSinkSettings(connectionFactory).withQueue("test")))
+          .runWith(JmsProducer.textSink(JmsSinkSettings(connectionFactory).withQueue("test")))
           .futureValue
       }
 
       withClue("browse the messages") {
         //#create-browse-source
-        val browseSource: Source[Message, NotUsed] = JmsSource.browse(
+        val browseSource: Source[Message, NotUsed] = JmsConsumer.browse(
           JmsBrowseSettings(connectionFactory).withQueue("test")
         )
         //#create-browse-source
@@ -659,7 +659,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       withClue("browse the messages again") {
         // the messages should not have been consumed
-        val result = JmsSource
+        val result = JmsConsumer
           .browse(JmsBrowseSettings(connectionFactory).withQueue("test"))
           .collect { case msg: TextMessage => msg.getText }
           .runWith(Sink.seq)
@@ -672,7 +672,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
 
       //#create-flow-producer
-      val flowSink: Flow[JmsMessage, JmsMessage, NotUsed] = JmsSink.flow(
+      val flowSink: Flow[JmsMessage, JmsMessage, NotUsed] = JmsProducer.flow(
         JmsSinkSettings(connectionFactory).withQueue("test")
       )
       //#create-flow-producer


### PR DESCRIPTION
This allows the JMS producer (`JmsSink`) to also act as a flow, similar to what's offered by the [kafka producer](https://doc.akka.io/docs/akka-stream-kafka/current/producer.html). For example, you can ensure that a message is persisted to the queue before subsequent processing.

This actually eliminates the need for #691 since we can pipe the flow to `Sink.ignore` to get a sink with materialized `Future[Done]`. As a bonus, you get the actual exception instead of a generic `AbruptStageTerminationException`.

`JmsProducer` might be a better name than `JmsSink` at this point. However I didn't want to go and rename things without getting feedback first.