### PR TITLE
Kinesis Firehose support #122

### DIFF
--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseErrors.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseErrors.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesisfirehose
+
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResponseEntry
+
+import scala.util.control.NoStackTrace
+
+object KinesisFirehoseErrors {
+  sealed trait KinesisSourceError extends NoStackTrace
+  case object NoShardsError extends KinesisSourceError
+  case object GetShardIteratorError extends KinesisSourceError
+  case object GetRecordsError extends KinesisSourceError
+
+  sealed trait KinesisFlowErrors extends NoStackTrace
+  case class FailurePublishingRecords(e: Exception) extends RuntimeException(e) with KinesisFlowErrors
+  case class ErrorPublishingRecords(attempts: Int, records: Seq[PutRecordBatchResponseEntry])
+      extends RuntimeException(s"Unable to publish records after $attempts attempts")
+      with KinesisFlowErrors
+
+}

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSettings.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSettings.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.kinesisfirehose
 
-import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseFlowSettings.{Exponential, Lineal, RetryBackoffStrategy}
+import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseFlowSettings.{Exponential, Linear, RetryBackoffStrategy}
 
 import scala.concurrent.duration._
 
@@ -37,7 +37,7 @@ case class KinesisFirehoseFlowSettings(parallelism: Int,
 
   def withBackoffStrategyExponential(): KinesisFirehoseFlowSettings = copy(backoffStrategy = Exponential)
 
-  def withBackoffStrategyLineal(): KinesisFirehoseFlowSettings = copy(backoffStrategy = Lineal)
+  def withBackoffStrategyLinear(): KinesisFirehoseFlowSettings = copy(backoffStrategy = Linear)
 
   def withBackoffStrategy(backoffStrategy: RetryBackoffStrategy): KinesisFirehoseFlowSettings =
     copy(backoffStrategy = backoffStrategy)
@@ -53,10 +53,10 @@ object KinesisFirehoseFlowSettings {
 
   sealed trait RetryBackoffStrategy
   case object Exponential extends RetryBackoffStrategy
-  case object Lineal extends RetryBackoffStrategy
+  case object Linear extends RetryBackoffStrategy
 
   val exponential: RetryBackoffStrategy = Exponential
-  val lineal: RetryBackoffStrategy = Lineal
+  val linear: RetryBackoffStrategy = Linear
 
   val defaultInstance: KinesisFirehoseFlowSettings = KinesisFirehoseFlowSettings(
     parallelism = MaxRecordsPerSecond / MaxRecordsPerRequest,

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSettings.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSettings.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesisfirehose
+
+import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseFlowSettings.{Exponential, Lineal, RetryBackoffStrategy}
+
+import scala.concurrent.duration._
+
+case class KinesisFirehoseFlowSettings(parallelism: Int,
+                                       maxBatchSize: Int,
+                                       maxRecordsPerSecond: Int,
+                                       maxBytesPerSecond: Int,
+                                       maxRetries: Int,
+                                       backoffStrategy: RetryBackoffStrategy,
+                                       retryInitialTimeout: FiniteDuration) {
+  require(
+    maxBatchSize >= 1 && maxBatchSize <= 500,
+    "Limit must be between 1 and 500. See: https://docs.aws.amazon.com/firehose/latest/APIReference/API_PutRecordBatch.html"
+  )
+  require(maxRecordsPerSecond >= 1)
+  require(maxBytesPerSecond >= 1)
+  require(maxRetries >= 0)
+
+  def withParallelism(parallelism: Int): KinesisFirehoseFlowSettings = copy(parallelism = parallelism)
+
+  def withMaxBatchSize(maxBatchSize: Int): KinesisFirehoseFlowSettings = copy(maxBatchSize = maxBatchSize)
+
+  def withMaxRecordsPerSecond(maxRecordsPerSecond: Int): KinesisFirehoseFlowSettings =
+    copy(maxRecordsPerSecond = maxRecordsPerSecond)
+
+  def withMaxBytesPerSecond(maxBytesPerSecond: Int): KinesisFirehoseFlowSettings =
+    copy(maxBytesPerSecond = maxBytesPerSecond)
+
+  def withMaxRetries(maxRetries: Int): KinesisFirehoseFlowSettings = copy(maxRetries = maxRetries)
+
+  def withBackoffStrategyExponential(): KinesisFirehoseFlowSettings = copy(backoffStrategy = Exponential)
+
+  def withBackoffStrategyLineal(): KinesisFirehoseFlowSettings = copy(backoffStrategy = Lineal)
+
+  def withBackoffStrategy(backoffStrategy: RetryBackoffStrategy): KinesisFirehoseFlowSettings =
+    copy(backoffStrategy = backoffStrategy)
+
+  def withRetryInitialTimeout(timeout: Long, unit: java.util.concurrent.TimeUnit): KinesisFirehoseFlowSettings =
+    copy(retryInitialTimeout = FiniteDuration(timeout, unit))
+}
+
+object KinesisFirehoseFlowSettings {
+  private val MaxRecordsPerRequest = 500
+  private val MaxRecordsPerSecond = 5000
+  private val MaxBytesPerSecond = 4000000
+
+  sealed trait RetryBackoffStrategy
+  case object Exponential extends RetryBackoffStrategy
+  case object Lineal extends RetryBackoffStrategy
+
+  val exponential: RetryBackoffStrategy = Exponential
+  val lineal: RetryBackoffStrategy = Lineal
+
+  val defaultInstance: KinesisFirehoseFlowSettings = KinesisFirehoseFlowSettings(
+    parallelism = MaxRecordsPerSecond / MaxRecordsPerRequest,
+    maxBatchSize = MaxRecordsPerRequest,
+    maxRecordsPerSecond = MaxRecordsPerSecond,
+    maxBytesPerSecond = MaxBytesPerSecond,
+    maxRetries = 5,
+    backoffStrategy = Exponential,
+    retryInitialTimeout = 100.millis
+  )
+
+  def create(): KinesisFirehoseFlowSettings = defaultInstance
+}

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowStage.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowStage.scala
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesisfirehose
+
+import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseFlowSettings.{Exponential, Lineal, RetryBackoffStrategy}
+import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseErrors.{ErrorPublishingRecords, FailurePublishingRecords}
+import akka.stream.stage._
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync
+import com.amazonaws.services.kinesisfirehose.model.{
+  PutRecordBatchRequest,
+  PutRecordBatchResponseEntry,
+  PutRecordBatchResult,
+  Record
+}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.concurrent.duration.{FiniteDuration, _}
+import scala.concurrent.{Future, Promise}
+import scala.language.postfixOps
+import scala.util.{Failure, Success, Try}
+
+private[kinesisfirehose] final class KinesisFirehoseFlowStage(
+    streamName: String,
+    maxRetries: Int,
+    backoffStrategy: RetryBackoffStrategy,
+    retryInitialTimeout: FiniteDuration
+)(implicit kinesisClient: AmazonKinesisFirehoseAsync)
+    extends GraphStage[FlowShape[Seq[Record], Future[PutRecordBatchResult]]] {
+  import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseFlowStage._
+
+  private val in = Inlet[Seq[Record]]("KinesisFirehoseFlowStage.in")
+  private val out = Outlet[Future[PutRecordBatchResult]]("KinesisFirehoseFlowStage.out")
+  override val shape = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new TimerGraphStageLogic(shape) with StageLogging with InHandler with OutHandler {
+
+      type Token = Int
+      type RetryCount = Int
+
+      private val retryBaseInMillis = retryInitialTimeout.toMillis
+
+      private var completionState: Option[Try[Unit]] = _
+
+      private val pendingRequests: mutable.Queue[Job] = mutable.Queue.empty
+      private var resultCallback: AsyncCallback[Result] = _
+      private var inFlight: Int = _
+
+      private val waitingRetries: mutable.HashMap[Token, Job] = mutable.HashMap.empty
+      private var retryToken: Token = _
+
+      private def tryToExecute() =
+        if (pendingRequests.nonEmpty && isAvailable(out)) {
+          log.debug("Executing PutRecordBatch call")
+          inFlight += 1
+          val job = pendingRequests.dequeue()
+          push(
+            out,
+            putRecordBatch(
+              streamName,
+              job.records,
+              recordsToRetry => resultCallback.invoke(Result(job.attempt, recordsToRetry))
+            )
+          )
+        }
+
+      private def handleResult(result: Result): Unit = result match {
+        case Result(_, Nil) =>
+          log.debug("PutRecordBatch call finished successfully")
+          inFlight -= 1
+          tryToExecute()
+          if (!hasBeenPulled(in)) tryPull(in)
+          checkForCompletion()
+        case Result(attempt, errors) if attempt > maxRetries =>
+          log.debug("PutRecordBatch call finished with partial errors after {} attempts", attempt)
+          failStage(ErrorPublishingRecords(attempt, errors.map(_._1)))
+        case Result(attempt, errors) =>
+          log.debug("PutRecordBatch call finished with partial errors; scheduling retry")
+          inFlight -= 1
+          waitingRetries.put(retryToken, Job(attempt + 1, errors.map(_._2)))
+          scheduleOnce(retryToken, backoffStrategy match {
+            case Exponential => scala.math.pow(retryBaseInMillis, attempt).toInt millis
+            case Lineal => retryInitialTimeout * attempt
+          })
+          retryToken += 1
+      }
+
+      private def checkForCompletion() =
+        if (inFlight == 0 && pendingRequests.isEmpty && waitingRetries.isEmpty && isClosed(in)) {
+          completionState match {
+            case Some(Success(_)) => completeStage()
+            case Some(Failure(ex)) => failStage(ex)
+            case None => failStage(new IllegalStateException("Stage completed, but there is no info about status"))
+          }
+        }
+
+      override protected def onTimer(timerKey: Any) =
+        waitingRetries.remove(timerKey.asInstanceOf[Token]) foreach { job =>
+          log.debug("New PutRecordBatch retry attempt available")
+          pendingRequests.enqueue(job)
+          tryToExecute()
+        }
+
+      override def preStart() = {
+        completionState = None
+        inFlight = 0
+        retryToken = 0
+        resultCallback = getAsyncCallback[Result](handleResult)
+        pull(in)
+      }
+
+      override def postStop(): Unit = {
+        pendingRequests.clear()
+        waitingRetries.clear()
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        completionState = Some(Success(()))
+        checkForCompletion()
+      }
+
+      override def onUpstreamFailure(ex: Throwable): Unit = {
+        completionState = Some(Failure(ex))
+        checkForCompletion()
+      }
+
+      override def onPull(): Unit = {
+        tryToExecute()
+        if (waitingRetries.isEmpty && !hasBeenPulled(in)) tryPull(in)
+      }
+
+      override def onPush(): Unit = {
+        log.debug("New PutRecordBatch request available")
+        pendingRequests.enqueue(Job(1, grab(in)))
+        tryToExecute()
+      }
+
+      setHandlers(in, out, this)
+    }
+
+}
+
+object KinesisFirehoseFlowStage {
+  private def putRecordBatch(
+      streamName: String,
+      recordEntries: Seq[Record],
+      retryRecordsCallback: Seq[(PutRecordBatchResponseEntry, Record)] => Unit
+  )(implicit kinesisClient: AmazonKinesisFirehoseAsync): Future[PutRecordBatchResult] = {
+
+    val p = Promise[PutRecordBatchResult]
+
+    kinesisClient
+      .putRecordBatchAsync(
+        new PutRecordBatchRequest()
+          .withDeliveryStreamName(streamName)
+          .withRecords(recordEntries.asJavaCollection),
+        new AsyncHandler[PutRecordBatchRequest, PutRecordBatchResult] {
+
+          override def onError(exception: Exception): Unit =
+            p.failure(FailurePublishingRecords(exception))
+
+          override def onSuccess(request: PutRecordBatchRequest, result: PutRecordBatchResult): Unit = {
+            if (result.getFailedPutCount > 0) {
+              retryRecordsCallback(
+                result.getRequestResponses.asScala
+                  .zip(request.getRecords.asScala)
+                  .filter(_._1.getErrorCode != null)
+              )
+            } else {
+              retryRecordsCallback(Nil)
+            }
+            p.success(result)
+          }
+        }
+      )
+
+    p.future
+  }
+
+  private case class Result(attempt: Int, recordsToRetry: Seq[(PutRecordBatchResponseEntry, Record)])
+  private case class Job(attempt: Int, records: Seq[Record])
+}

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowStage.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowStage.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.kinesisfirehose
 
-import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseFlowSettings.{Exponential, Lineal, RetryBackoffStrategy}
+import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseFlowSettings.{Exponential, Linear, RetryBackoffStrategy}
 import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseErrors.{ErrorPublishingRecords, FailurePublishingRecords}
 import akka.stream.stage._
 import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
@@ -85,7 +85,7 @@ private[kinesisfirehose] final class KinesisFirehoseFlowStage(
           waitingRetries.put(retryToken, Job(attempt + 1, errors.map(_._2)))
           scheduleOnce(retryToken, backoffStrategy match {
             case Exponential => scala.math.pow(retryBaseInMillis, attempt).toInt millis
-            case Lineal => retryInitialTimeout * attempt
+            case Linear => retryInitialTimeout * attempt
           })
           retryToken += 1
       }

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/javadsl/KinesisFirehoseFlow.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/javadsl/KinesisFirehoseFlow.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesisfirehose.javadsl
+
+import akka.NotUsed
+import akka.stream.alpakka.kinesisfirehose.{scaladsl, KinesisFirehoseFlowSettings}
+import akka.stream.javadsl.Flow
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync
+import com.amazonaws.services.kinesisfirehose.model.{PutRecordBatchResponseEntry, Record}
+
+object KinesisFirehoseFlow {
+
+  def apply(streamName: String,
+            kinesisClient: AmazonKinesisFirehoseAsync): Flow[Record, PutRecordBatchResponseEntry, NotUsed] =
+    apply(streamName, KinesisFirehoseFlowSettings.defaultInstance, kinesisClient)
+
+  def apply(streamName: String,
+            settings: KinesisFirehoseFlowSettings,
+            kinesisClient: AmazonKinesisFirehoseAsync): Flow[Record, PutRecordBatchResponseEntry, NotUsed] =
+    scaladsl.KinesisFirehoseFlow.apply(streamName, settings)(kinesisClient).asJava
+
+}

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/javadsl/KinesisFirehoseSink.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/javadsl/KinesisFirehoseSink.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesisfirehose.javadsl
+
+import akka.NotUsed
+import akka.stream.alpakka.kinesisfirehose.{scaladsl, KinesisFirehoseFlowSettings}
+import akka.stream.javadsl.Sink
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync
+import com.amazonaws.services.kinesisfirehose.model.Record
+
+object KinesisFirehoseSink {
+
+  def apply(streamName: String, kinesisClient: AmazonKinesisFirehoseAsync): Sink[Record, NotUsed] =
+    apply(streamName, KinesisFirehoseFlowSettings.defaultInstance, kinesisClient)
+
+  def apply(streamName: String,
+            settings: KinesisFirehoseFlowSettings,
+            kinesisClient: AmazonKinesisFirehoseAsync): Sink[Record, NotUsed] =
+    (scaladsl.KinesisFirehoseSink.apply(streamName, settings)(kinesisClient)).asJava
+
+}

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/scaladsl/KinesisFirehoseFlow.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/scaladsl/KinesisFirehoseFlow.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesisfirehose.scaladsl
+
+import akka.NotUsed
+import akka.stream.ThrottleMode
+import akka.stream.alpakka.kinesisfirehose.{KinesisFirehoseFlowSettings, KinesisFirehoseFlowStage}
+import akka.stream.scaladsl.Flow
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync
+import com.amazonaws.services.kinesisfirehose.model.{PutRecordBatchResponseEntry, Record}
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.{Iterable, Queue}
+import scala.concurrent.duration._
+
+object KinesisFirehoseFlow {
+  def apply(streamName: String, settings: KinesisFirehoseFlowSettings = KinesisFirehoseFlowSettings.defaultInstance)(
+      implicit kinesisClient: AmazonKinesisFirehoseAsync
+  ): Flow[Record, PutRecordBatchResponseEntry, NotUsed] =
+    Flow[Record]
+      .throttle(settings.maxRecordsPerSecond, 1.second, settings.maxRecordsPerSecond, ThrottleMode.Shaping)
+      .throttle(settings.maxBytesPerSecond, 1.second, settings.maxBytesPerSecond, getByteSize, ThrottleMode.Shaping)
+      .batch(settings.maxBatchSize, Queue(_))(_ :+ _)
+      .via(
+        new KinesisFirehoseFlowStage(
+          streamName,
+          settings.maxRetries,
+          settings.backoffStrategy,
+          settings.retryInitialTimeout
+        )
+      )
+      .mapAsync(settings.parallelism)(identity)
+      .mapConcat(_.getRequestResponses.asScala.to[Iterable])
+      .filter(_.getErrorCode == null) // TODO: Do we want this...?
+
+  private def getByteSize(record: Record): Int = record.getData.position
+
+}

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/scaladsl/KinesisFirehoseFlow.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/scaladsl/KinesisFirehoseFlow.scala
@@ -33,7 +33,7 @@ object KinesisFirehoseFlow {
       )
       .mapAsync(settings.parallelism)(identity)
       .mapConcat(_.getRequestResponses.asScala.to[Iterable])
-      .filter(_.getErrorCode == null) // TODO: Do we want this...?
+      .filter(_.getErrorCode == null)
 
   private def getByteSize(record: Record): Int = record.getData.position
 

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/scaladsl/KinesisFirehoseSink.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/scaladsl/KinesisFirehoseSink.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesisfirehose.scaladsl
+
+import akka.NotUsed
+import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseFlowSettings
+import akka.stream.scaladsl.Sink
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync
+import com.amazonaws.services.kinesisfirehose.model.Record
+
+object KinesisFirehoseSink {
+  def apply(streamName: String, settings: KinesisFirehoseFlowSettings = KinesisFirehoseFlowSettings.defaultInstance)(
+      implicit kinesisClient: AmazonKinesisFirehoseAsync
+  ): Sink[Record, NotUsed] =
+    KinesisFirehoseFlow(streamName, settings).to(Sink.ignore)
+}

--- a/kinesis/src/test/java/akka/stream/alpakka/kinesisfirehose/javadsl/Examples.java
+++ b/kinesis/src/test/java/akka/stream/alpakka/kinesisfirehose/javadsl/Examples.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesisfirehose.javadsl;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseFlowSettings;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Sink;
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsyncClientBuilder;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResponseEntry;
+import com.amazonaws.services.kinesisfirehose.model.Record;
+
+import java.util.concurrent.TimeUnit;
+
+public class Examples {
+
+    //#init-client
+    final ActorSystem system = ActorSystem.create();
+    final ActorMaterializer materializer = ActorMaterializer.create(system);
+
+    final com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync amazonKinesisFirehoseAsync
+            = AmazonKinesisFirehoseAsyncClientBuilder.defaultClient();
+    //#init-client
+
+    {
+        //#init-client
+
+        system.registerOnTermination(amazonKinesisFirehoseAsync::shutdown);
+        //#init-client
+    }
+
+    //#flow-settings
+    final KinesisFirehoseFlowSettings flowSettings = KinesisFirehoseFlowSettings.create()
+            .withParallelism(1)
+            .withMaxBatchSize(500)
+            .withMaxRecordsPerSecond(1_000)
+            .withMaxBytesPerSecond(1_000_000)
+            .withMaxRecordsPerSecond(5)
+            .withBackoffStrategyExponential()
+            .withRetryInitialTimeout(100L, TimeUnit.MILLISECONDS);
+
+    final KinesisFirehoseFlowSettings defaultFlowSettings = KinesisFirehoseFlowSettings.create();
+    //#flow-settings
+
+    //#flow-sink
+    final Flow<Record, PutRecordBatchResponseEntry, NotUsed> flow
+            = KinesisFirehoseFlow.apply("streamName", flowSettings, amazonKinesisFirehoseAsync);
+
+    final Flow<Record, PutRecordBatchResponseEntry, NotUsed> defaultSettingsFlow
+            = KinesisFirehoseFlow.apply("streamName", amazonKinesisFirehoseAsync);
+
+    final Sink<Record, NotUsed> sink
+            = KinesisFirehoseSink.apply("streamName", flowSettings, amazonKinesisFirehoseAsync);
+
+    final Sink<Record, NotUsed> defaultSettingsSink
+            = KinesisFirehoseSink.apply("streamName", amazonKinesisFirehoseAsync);
+    //#flow-sink
+
+}

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/DefaultTestContext.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/DefaultTestContext.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesisfirehose
+
+import akka.actor.ActorSystem
+import akka.stream.{ActorMaterializer, Materializer}
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync
+import org.mockito.Mockito.reset
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+trait DefaultTestContext extends BeforeAndAfterAll with BeforeAndAfterEach with MockitoSugar { this: Suite =>
+
+  implicit protected val system: ActorSystem = ActorSystem()
+  implicit protected val materializer: Materializer = ActorMaterializer()
+  implicit protected val amazonKinesisFirehoseAsync: AmazonKinesisFirehoseAsync = mock[AmazonKinesisFirehoseAsync]
+
+  override protected def beforeEach(): Unit =
+    reset(amazonKinesisFirehoseAsync)
+
+  override protected def afterAll(): Unit =
+    Await.ready(system.terminate(), 5.seconds)
+
+}

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSpec.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesisfirehose
+
+import java.util.concurrent.CompletableFuture
+
+import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseErrors.{ErrorPublishingRecords, FailurePublishingRecords}
+import akka.stream.alpakka.kinesisfirehose.scaladsl.KinesisFirehoseFlow
+import akka.stream.scaladsl.Keep
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
+import akka.util.ByteString
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.services.kinesisfirehose.model._
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.scalatest.{Matchers, WordSpecLike}
+
+import scala.collection.JavaConverters._
+
+class KinesisFirehoseFlowSpec extends WordSpecLike with Matchers with DefaultTestContext {
+
+  "KinesisFirehoseFlow" must {
+
+    "publish records" in new DefaultSettings with KinesisFirehoseFlowProbe with WithPutRecordsSuccess {
+      sourceProbe.sendNext(record)
+      sourceProbe.sendNext(record)
+      sourceProbe.sendNext(record)
+      sourceProbe.sendNext(record)
+      sourceProbe.sendNext(record)
+
+      sinkProbe.requestNext() shouldBe publishedRecord
+      sinkProbe.requestNext() shouldBe publishedRecord
+      sinkProbe.requestNext() shouldBe publishedRecord
+      sinkProbe.requestNext() shouldBe publishedRecord
+      sinkProbe.requestNext() shouldBe publishedRecord
+
+      sourceProbe.sendComplete()
+      sinkProbe.expectComplete()
+    }
+    "publish records with retries" in new DefaultSettings with KinesisFirehoseFlowProbe {
+      when(amazonKinesisFirehoseAsync.putRecordBatchAsync(any(), any()))
+        .thenAnswer(new Answer[AnyRef] {
+          override def answer(invocation: InvocationOnMock) = {
+            val request = invocation
+              .getArgument[PutRecordBatchRequest](0)
+            val result = new PutRecordBatchResult()
+              .withFailedPutCount(request.getRecords.size())
+              .withRequestResponses(
+                request.getRecords.asScala
+                  .map(_ => failingRecord)
+                  .asJava
+              )
+            invocation
+              .getArgument[AsyncHandler[PutRecordBatchRequest, PutRecordBatchResult]](1)
+              .onSuccess(request, result)
+            CompletableFuture.completedFuture(result)
+          }
+        })
+        .thenAnswer(new Answer[AnyRef] {
+          override def answer(invocation: InvocationOnMock) = {
+            val request = invocation
+              .getArgument[PutRecordBatchRequest](0)
+            val result = new PutRecordBatchResult()
+              .withFailedPutCount(0)
+              .withRequestResponses(request.getRecords.asScala.map(_ => publishedRecord).asJava)
+            invocation
+              .getArgument[AsyncHandler[PutRecordBatchRequest, PutRecordBatchResult]](1)
+              .onSuccess(request, result)
+            CompletableFuture.completedFuture(result)
+          }
+        })
+
+      sourceProbe.sendNext(record)
+
+      sinkProbe.requestNext(settings.retryInitialTimeout * 2) shouldBe publishedRecord
+
+      sourceProbe.sendComplete()
+      sinkProbe.expectComplete()
+    }
+    "fail after trying to publish records with no retires" in new NoRetries with KinesisFirehoseFlowProbe
+    with WithPutRecordsWithPartialErrors {
+      sourceProbe.sendNext(record)
+
+      sinkProbe.request(1)
+      sinkProbe.expectError(ErrorPublishingRecords(1, Seq(failingRecord)))
+    }
+    "fail after trying to publish records with several retries" in new DefaultSettings with KinesisFirehoseFlowProbe
+    with WithPutRecordsWithPartialErrors {
+      sourceProbe.sendNext(record)
+
+      sinkProbe.request(1)
+      sinkProbe.expectError(ErrorPublishingRecords(settings.maxRetries + 1, Seq(failingRecord)))
+    }
+    "fails when request returns an error" in new DefaultSettings with KinesisFirehoseFlowProbe
+    with WithPutRecordsFailure {
+      sourceProbe.sendNext(record)
+
+      sinkProbe.request(1)
+      sinkProbe.expectError(FailurePublishingRecords(requestError))
+    }
+  }
+
+  sealed trait Settings {
+    val settings: KinesisFirehoseFlowSettings
+  }
+  trait DefaultSettings extends Settings {
+    val settings = KinesisFirehoseFlowSettings.defaultInstance.copy(maxRetries = 1)
+  }
+  trait NoRetries extends Settings {
+    val settings = KinesisFirehoseFlowSettings.defaultInstance.copy(maxRetries = 0)
+  }
+
+  trait KinesisFirehoseFlowProbe { self: Settings =>
+    val streamName = "stream-name"
+    val record =
+      new Record().withData(ByteString("data").asByteBuffer)
+    val publishedRecord = new PutRecordBatchResponseEntry()
+    val failingRecord = new PutRecordBatchResponseEntry().withErrorCode("error-code").withErrorMessage("error-message")
+    val requestError = new RuntimeException("kinesisfirehose-error")
+
+    val (sourceProbe, sinkProbe) =
+      TestSource
+        .probe[Record]
+        .via(KinesisFirehoseFlow(streamName, settings))
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+  }
+
+  trait WithPutRecordsSuccess { self: KinesisFirehoseFlowProbe =>
+    when(amazonKinesisFirehoseAsync.putRecordBatchAsync(any(), any())).thenAnswer(new Answer[AnyRef] {
+      override def answer(invocation: InvocationOnMock) = {
+        val request = invocation
+          .getArgument[PutRecordBatchRequest](0)
+        val result = new PutRecordBatchResult()
+          .withFailedPutCount(0)
+          .withRequestResponses(request.getRecords.asScala.map(_ => publishedRecord).asJava)
+        invocation
+          .getArgument[AsyncHandler[PutRecordBatchRequest, PutRecordBatchResult]](1)
+          .onSuccess(request, result)
+        CompletableFuture.completedFuture(result)
+      }
+    })
+  }
+
+  trait WithPutRecordsWithPartialErrors { self: KinesisFirehoseFlowProbe =>
+    when(amazonKinesisFirehoseAsync.putRecordBatchAsync(any(), any()))
+      .thenAnswer(new Answer[AnyRef] {
+        override def answer(invocation: InvocationOnMock) = {
+          val request = invocation
+            .getArgument[PutRecordBatchRequest](0)
+          val result = new PutRecordBatchResult()
+            .withFailedPutCount(request.getRecords.size())
+            .withRequestResponses(
+              request.getRecords.asScala
+                .map(_ => failingRecord)
+                .asJava
+            )
+          invocation
+            .getArgument[AsyncHandler[PutRecordBatchRequest, PutRecordBatchResult]](1)
+            .onSuccess(request, result)
+          CompletableFuture.completedFuture(result)
+        }
+      })
+  }
+
+  trait WithPutRecordsFailure { self: KinesisFirehoseFlowProbe =>
+    when(amazonKinesisFirehoseAsync.putRecordBatchAsync(any(), any())).thenAnswer(new Answer[AnyRef] {
+      override def answer(invocation: InvocationOnMock) = {
+        invocation
+          .getArgument[AsyncHandler[PutRecordBatchRequest, PutRecordBatchResult]](1)
+          .onError(requestError)
+        val future = new CompletableFuture()
+        future.completeExceptionally(requestError)
+        future
+      }
+    })
+  }
+
+}

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/scaladsl/Examples.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/scaladsl/Examples.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesisfirehose.scaladsl
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseFlowSettings
+import akka.stream.scaladsl.{Flow, Sink}
+import akka.stream.{ActorMaterializer, Materializer}
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsyncClientBuilder
+import com.amazonaws.services.kinesisfirehose.model.{PutRecordBatchResponseEntry, Record}
+
+import scala.concurrent.duration._
+
+object Examples {
+
+  //#init-client
+  implicit val system: ActorSystem = ActorSystem()
+  implicit val materializer: Materializer = ActorMaterializer()
+
+  implicit val amazonKinesisFirehoseAsync: com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync =
+    AmazonKinesisFirehoseAsyncClientBuilder.defaultClient()
+
+  system.registerOnTermination(amazonKinesisFirehoseAsync.shutdown())
+  //#init-client
+
+  //#flow-settings
+  val flowSettings = KinesisFirehoseFlowSettings(
+    parallelism = 1,
+    maxBatchSize = 500,
+    maxRecordsPerSecond = 5000,
+    maxBytesPerSecond = 4000000,
+    maxRetries = 5,
+    backoffStrategy = KinesisFirehoseFlowSettings.Exponential,
+    retryInitialTimeout = 100.millis
+  )
+
+  val defaultFlowSettings = KinesisFirehoseFlowSettings.defaultInstance
+  //#flow-settings
+
+  //#flow-sink
+  val flow1: Flow[Record, PutRecordBatchResponseEntry, NotUsed] = KinesisFirehoseFlow("myStreamName")
+
+  val flow2: Flow[Record, PutRecordBatchResponseEntry, NotUsed] = KinesisFirehoseFlow("myStreamName", flowSettings)
+
+  val sink1: Sink[Record, NotUsed] = KinesisFirehoseSink("myStreamName")
+  val sink2: Sink[Record, NotUsed] = KinesisFirehoseSink("myStreamName", flowSettings)
+  //#flow-sink
+
+}


### PR DESCRIPTION
This direct port of the relevant Kinesis functionality to use the Kinesis Firehose types for #122. I put it in the `kinesis` project rather than creating a new one as this matches the way AWS ship their own libraries. Similarly the `kinesisfirehose` package is used to match AWS.

It's not exactly an elegant solution to have significant portions of the Kinesis code duplicated with just package and type names changed. However, I spent a good while looking at some way to generalise the code but there isn't really that much that can be shared. The graph logic could be extracted out for the flow stage, but it starts to get a little messy and would have an impact on the existing interface, such as requiring exceptions to be generic and adding more methods to `KinesisFlowSettings` with sensible defaults for additional stream types.

My feeling was that the deduplication internally wasn't worth the (mildly) detrimental effect it had on the external interface, and given the connector doesn't currently support either Video or Analytics streams it's possibly too early to try and generalise the implementation (rule of threes and all that).

Thoughts on this approach are welcome. If people are happy with it I'll squash the commits.