### PR TITLE
Support Mongodb codec and macros for MongoSource

### DIFF
--- a/mongodb/src/main/scala/akka/stream/alpakka/mongodb/scaladsl/MongoSource.scala
+++ b/mongodb/src/main/scala/akka/stream/alpakka/mongodb/scaladsl/MongoSource.scala
@@ -8,10 +8,15 @@ import akka.NotUsed
 import akka.stream.alpakka.mongodb.ObservableToPublisher
 import akka.stream.scaladsl.Source
 import org.mongodb.scala.{Document, Observable}
+import scala.reflect.ClassTag
+
 
 object MongoSource {
 
   def apply(query: Observable[Document]): Source[Document, NotUsed] =
     Source.fromPublisher(ObservableToPublisher(query))
+
+  def apply[T: ClassTag](query: Observable[T]): Source[T, NotUsed] =
+    Source.fromPublisher(ObservableToPublisher[T](query))
 
 }


### PR DESCRIPTION
This PR allows to use Mongodb codecs and macros in MongoSource to directly read case class objects from Mongodb.
It introduces a new apply function with a classtag parameter and corresponding test.

For reference on mongodb and case class integration:
[mongodb <-> case class](https://github.com/mongodb/mongo-scala-driver/blob/master/docs/reference/content/getting-started/quick-tour-case-classes.md)