### PR TITLE
Empty s3 upload fails

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -240,6 +240,8 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
       .zip(Source.fromIterator(() => Iterator.from(1)))
 
   //todo: this seems like a general purpose 'gadget', is there a better place for this kind of beasts?
+  val conditionalAppendFl = Flow[ByteString].orElse(Source.single(ByteString.empty))/*
+
   private def conditionalAppendFl: Flow[ByteString, ByteString, NotUsed.type] =
     Flow
       .fromGraph {
@@ -272,7 +274,7 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
           FlowShape.of(bcast.in, concat.out)
         }
       }
-      .mapMaterializedValue(_ => NotUsed)
+      .mapMaterializedValue(_ => NotUsed)*/
 
   private def createRequests(
       s3Location: S3Location,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -239,42 +239,7 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
       .mapConcat(r => Stream.continually(r))
       .zip(Source.fromIterator(() => Iterator.from(1)))
 
-  //todo: this seems like a general purpose 'gadget', is there a better place for this kind of beasts?
-  val conditionalAppendFl = Flow[ByteString].orElse(Source.single(ByteString.empty)) /*
-
-  private def conditionalAppendFl: Flow[ByteString, ByteString, NotUsed.type] =
-    Flow
-      .fromGraph {
-        import mat.executionContext
-        val extraSink = Sink
-          .fold(0) { (acc: Int, inp: ByteString) =>
-            acc + 1
-          }
-          .mapMaterializedValue { f =>
-            f.map {
-              case 0 => Some(ByteString.empty)
-              case _ => None
-            }
-          }
-        GraphDSL.create(extraSink) { implicit builder => extra =>
-          val extraSrc =
-            builder.materializedValue
-              .mapAsync(1)(identity)
-              .collect {
-                case Some(b) => b
-              }
-          val bcast = builder.add(Broadcast[ByteString](2))
-          val concat = builder.add(Concat[ByteString]())
-
-          bcast.out(0) ~> extra
-
-          bcast.out(1) ~> concat.in(0)
-          extraSrc ~> concat.in(1)
-
-          FlowShape.of(bcast.in, concat.out)
-        }
-      }
-      .mapMaterializedValue(_ => NotUsed)*/
+  val conditionalAppendFl = Flow[ByteString].orElse(Source.single(ByteString.empty))
 
   private def createRequests(
       s3Location: S3Location,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -240,7 +240,7 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
       .zip(Source.fromIterator(() => Iterator.from(1)))
 
   //todo: this seems like a general purpose 'gadget', is there a better place for this kind of beasts?
-  val conditionalAppendFl = Flow[ByteString].orElse(Source.single(ByteString.empty))/*
+  val conditionalAppendFl = Flow[ByteString].orElse(Source.single(ByteString.empty)) /*
 
   private def conditionalAppendFl: Flow[ByteString, ByteString, NotUsed.type] =
     Flow

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -239,6 +239,37 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
       .mapConcat(r => Stream.continually(r))
       .zip(Source.fromIterator(() => Iterator.from(1)))
 
+  //todo: this seems like a general purpose 'gadget', is there a better place for this kind of beasts?
+  private def conditionalAppendFl: Flow[ByteString, ByteString, NotUsed.type] = Flow.fromGraph{
+    import mat.executionContext
+    val extraSink = Sink
+      .fold(0){ (acc : Int, inp : ByteString) => acc + 1}
+      .mapMaterializedValue{ f =>
+        f.map{
+          case 0 => Some(ByteString.empty)
+          case _ => None
+        }
+      }
+    GraphDSL.create(extraSink){ implicit builder => extra =>
+      val extraSrc =
+        builder
+          .materializedValue
+          .mapAsync(1)(identity)
+          .collect{
+            case Some(b) => b
+          }
+      val bcast = builder.add(Broadcast[ByteString](2))
+      val concat = builder.add(Concat[ByteString]())
+
+      bcast.out(0) ~> extra
+
+      bcast.out(1) ~> concat.in(0)
+      extraSrc ~> concat.in(1)
+
+      FlowShape.of(bcast.in, concat.out)
+    }
+  }.mapMaterializedValue(_ => NotUsed)
+
   private def createRequests(
       s3Location: S3Location,
       contentType: ContentType,
@@ -268,40 +299,7 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
 
     val headers: S3Headers = S3Headers(sse.fold[Seq[HttpHeader]](Seq.empty) { _.headersFor(UploadPart) })
 
-    import mat.executionContext
-
-    val extraSink = Sink
-      .fold(0){ (acc : Int, inp : ByteString) => acc + 1}
-      .mapMaterializedValue{ f =>
-        f.map{
-          case 0 => Some(ByteString.empty)
-          case _ => None
-        }
-      }
-
-    val conditionalAppendFl = Flow.fromGraph{
-      GraphDSL.create(extraSink){ implicit builder => extra =>
-        val extraSrc =
-          builder
-            .materializedValue
-            .mapAsync(1)(identity)
-            .collect{
-              case Some(b) => b
-            }
-        val bcast = builder.add(Broadcast[ByteString](2))
-        val concat = builder.add(Concat[ByteString]())
-
-        bcast.out(0) ~> extra
-
-        bcast.out(1) ~> concat.in(0)
-        extraSrc ~> concat.in(1)
-
-        FlowShape.of(bcast.in, concat.out)
-      }
-    }.mapMaterializedValue(_ => NotUsed)
-
-
-    SplitAfterSize(chunkSize)(/*Flow.apply[ByteString]*/conditionalAppendFl)
+    SplitAfterSize(chunkSize)(conditionalAppendFl)
       .via(getChunkBuffer(chunkSize)) //creates the chunks
       .concatSubstreams
       .zipWith(requestInfo) {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
@@ -4,21 +4,27 @@
 
 package akka.stream.alpakka.s3.impl
 
+import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.headers.ByteRange
 import akka.stream.alpakka.s3.{MemoryBufferType, S3Settings}
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.TestKit
+import akka.util.ByteString
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.regions.AwsRegionProvider
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FlatSpecLike, Matchers, PrivateMethodTester}
 
 class S3StreamSpec(_system: ActorSystem)
     extends TestKit(_system)
     with FlatSpecLike
     with Matchers
-    with PrivateMethodTester {
+    with PrivateMethodTester
+    with ScalaFutures
+    with IntegrationPatience {
 
   import HttpRequests._
 
@@ -73,4 +79,45 @@ class S3StreamSpec(_system: ActorSystem)
     result.headers.seq.exists(_.lowercaseName() == "range")
 
   }
+
+  it should "properly handle input streams, even when empty" in  {
+    val credentialsProvider =
+      new AWSStaticCredentialsProvider(
+        new BasicAWSCredentials(
+          "test-Id",
+          "test-key"
+        )
+      )
+    val regionProvider =
+      new AwsRegionProvider {
+        def getRegion: String = "us-east-1"
+      }
+    implicit val settings = new S3Settings(MemoryBufferType, None, credentialsProvider, regionProvider, false, None)
+    val s3stream = new S3Stream(settings)
+
+    def nonEmptySrc = Source.repeat(ByteString("hello world"))
+    val conditionallyAppended = s3stream invokePrivate PrivateMethod[Flow[ByteString, ByteString, NotUsed]]('conditionalAppendFl)()
+
+    nonEmptySrc
+      .take(1)
+      .via(conditionallyAppended)
+      .toMat(Sink.seq[ByteString])(Keep.right)
+      .run()
+      .futureValue should equal (Seq(ByteString("hello world")))
+
+    nonEmptySrc
+      .take(10)
+      .via(conditionallyAppended)
+      .toMat(Sink.seq[ByteString])(Keep.right)
+      .run()
+      .futureValue should equal (Seq.fill(10)(ByteString("hello world")))
+
+    nonEmptySrc
+      .take(0)
+      .via(conditionallyAppended)
+      .toMat(Sink.seq[ByteString])(Keep.right)
+      .run()
+      .futureValue should equal (Seq(ByteString.empty))
+  }
+
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
@@ -80,7 +80,7 @@ class S3StreamSpec(_system: ActorSystem)
 
   }
 
-  it should "properly handle input streams, even when empty" in  {
+  it should "properly handle input streams, even when empty" in {
     val credentialsProvider =
       new AWSStaticCredentialsProvider(
         new BasicAWSCredentials(
@@ -96,28 +96,30 @@ class S3StreamSpec(_system: ActorSystem)
     val s3stream = new S3Stream(settings)
 
     def nonEmptySrc = Source.repeat(ByteString("hello world"))
-    val conditionallyAppended = s3stream invokePrivate PrivateMethod[Flow[ByteString, ByteString, NotUsed]]('conditionalAppendFl)()
+    val conditionallyAppended = s3stream invokePrivate PrivateMethod[Flow[ByteString, ByteString, NotUsed]](
+      'conditionalAppendFl
+    )()
 
     nonEmptySrc
       .take(1)
       .via(conditionallyAppended)
       .toMat(Sink.seq[ByteString])(Keep.right)
       .run()
-      .futureValue should equal (Seq(ByteString("hello world")))
+      .futureValue should equal(Seq(ByteString("hello world")))
 
     nonEmptySrc
       .take(10)
       .via(conditionallyAppended)
       .toMat(Sink.seq[ByteString])(Keep.right)
       .run()
-      .futureValue should equal (Seq.fill(10)(ByteString("hello world")))
+      .futureValue should equal(Seq.fill(10)(ByteString("hello world")))
 
     nonEmptySrc
       .take(0)
       .via(conditionallyAppended)
       .toMat(Sink.seq[ByteString])(Keep.right)
       .run()
-      .futureValue should equal (Seq(ByteString.empty))
+      .futureValue should equal(Seq(ByteString.empty))
   }
 
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
@@ -53,8 +53,6 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     result.futureValue shouldBe MultipartUploadResult(url, bucket, bucketKey, etag)
   }
 
-
-
   it should "upload a stream of bytes to S3 with custom headers" in {
 
     //mockUpload()
@@ -79,7 +77,6 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
 
     result.failed.futureValue.getMessage shouldBe "No key found"
   }
-
 
   override protected def afterAll(): Unit = {
     super.afterAll()

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
@@ -26,6 +26,20 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
   val settings = new S3Settings(MemoryBufferType, proxy, awsCredentialsProvider, regionProvider, false, None)
   val s3Client = new S3Client(settings)(system, materializer)
 
+  it should "succeed uploading an empty file" in {
+    mockUpload(expectedBody = "")
+
+    //#upload
+    val s3Sink: Sink[ByteString, Future[MultipartUploadResult]] = s3Client.multipartUpload(bucket, bucketKey)
+    //#upload
+
+    val src = Source.empty[ByteString]
+
+    val result: Future[MultipartUploadResult] = src.runWith(s3Sink)
+
+    result.futureValue shouldBe MultipartUploadResult(url, bucket, bucketKey, etag)
+  }
+
   "S3Sink" should "upload a stream of bytes to S3" in {
 
     mockUpload()
@@ -39,9 +53,11 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     result.futureValue shouldBe MultipartUploadResult(url, bucket, bucketKey, etag)
   }
 
+
+
   it should "upload a stream of bytes to S3 with custom headers" in {
 
-    mockUpload()
+    //mockUpload()
 
     //#upload
     val s3Sink: Sink[ByteString, Future[MultipartUploadResult]] =
@@ -64,20 +80,6 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     result.failed.futureValue.getMessage shouldBe "No key found"
   }
 
-  it should "succeed uploading an empty file" in {
-    mockUpload()
-
-    //#upload
-    val s3Sink: Sink[ByteString, Future[MultipartUploadResult]] =
-      s3Client.multipartUploadWithHeaders(bucket, bucketKey, s3Headers = Some(S3Headers(ServerSideEncryption.AES256)))
-    //#upload
-
-    val src = Source.empty[ByteString]
-
-    val result: Future[MultipartUploadResult] = src.runWith(s3Sink)
-
-    result.futureValue shouldBe MultipartUploadResult(url, bucket, bucketKey, etag)
-  }
 
   override protected def afterAll(): Unit = {
     super.afterAll()

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
@@ -55,7 +55,7 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
 
   it should "upload a stream of bytes to S3 with custom headers" in {
 
-    //mockUpload()
+    mockUpload()
 
     //#upload
     val s3Sink: Sink[ByteString, Future[MultipartUploadResult]] =

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
@@ -64,6 +64,21 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     result.failed.futureValue.getMessage shouldBe "No key found"
   }
 
+  it should "succeed uploading an empty file" in {
+    mockUpload()
+
+    //#upload
+    val s3Sink: Sink[ByteString, Future[MultipartUploadResult]] =
+      s3Client.multipartUploadWithHeaders(bucket, bucketKey, s3Headers = Some(S3Headers(ServerSideEncryption.AES256)))
+    //#upload
+
+    val src = Source.empty[ByteString]
+
+    val result: Future[MultipartUploadResult] = src.runWith(s3Sink)
+
+    result.futureValue shouldBe MultipartUploadResult(url, bucket, bucketKey, etag)
+  }
+
   override protected def afterAll(): Unit = {
     super.afterAll()
     stopWireMockServer()

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -165,7 +165,8 @@ abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockSer
         )
       )
 
-  def mockUpload(): Unit = {
+  def mockUpload() : Unit = mockUpload(body)
+  def mockUpload(expectedBody : String): Unit = {
     mock
       .register(
         post(urlEqualTo(s"/$bucketKey?uploads")).willReturn(
@@ -184,7 +185,7 @@ abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockSer
 
     mock.register(
       put(urlEqualTo(s"/$bucketKey?partNumber=1&uploadId=$uploadId"))
-        .withRequestBody(matching(body))
+        .withRequestBody(matching(expectedBody))
         .willReturn(
           aResponse()
             .withStatus(200)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -165,8 +165,8 @@ abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockSer
         )
       )
 
-  def mockUpload() : Unit = mockUpload(body)
-  def mockUpload(expectedBody : String): Unit = {
+  def mockUpload(): Unit = mockUpload(body)
+  def mockUpload(expectedBody: String): Unit = {
     mock
       .register(
         post(urlEqualTo(s"/$bucketKey?uploads")).willReturn(


### PR DESCRIPTION
fixes #806 

basic idea,
when uploading to s3, if the input stream is empty append a single empty ByteString to the input. this forces the library to actually send request to s3.