### PR TITLE
Cassandra: add Flow using unlogged batches

### DIFF
--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/CassandraBatchSettings.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/CassandraBatchSettings.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.cassandra
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
+
+object CassandraBatchSettings {
+  val Defaults = CassandraBatchSettings(50, 500.millis)
+}
+
+final case class CassandraBatchSettings(maxGroupSize: Int, maxGroupWait: FiniteDuration) {
+  require(
+    maxGroupSize > 0,
+    s"Invalid value for maxGroupSize: $maxGroupSize. It should be > 0."
+  )
+
+  def withMaxGroupSize(maxGroupSize: Int): CassandraBatchSettings =
+    copy(maxGroupSize = maxGroupSize)
+
+  def withMaxGroupWait(maxGroupWait: Long, timeUnit: TimeUnit): CassandraBatchSettings =
+    copy(maxGroupWait = Duration(maxGroupWait, timeUnit))
+}

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraFlow.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraFlow.scala
@@ -5,8 +5,10 @@
 package akka.stream.alpakka.cassandra.javadsl
 
 import java.util.function.BiFunction
+import java.util.function.Function
 
 import akka.NotUsed
+import akka.stream.alpakka.cassandra.CassandraBatchSettings
 import com.datastax.driver.core.{BoundStatement, PreparedStatement, Session}
 import akka.stream.alpakka.cassandra.scaladsl.{CassandraFlow => ScalaCFlow}
 import akka.stream.javadsl.Flow
@@ -21,5 +23,27 @@ object CassandraFlow {
                                ec: ExecutionContext): Flow[T, T, NotUsed] =
     ScalaCFlow
       .createWithPassThrough[T](parallelism, statement, (t, p) => statementBinder.apply(t, p))(session, ec)
+      .asJava
+
+  /**
+   * Creates a flow that batches using an unlogged batch. Use this when most of the elements in the stream
+   * share the same partition key. Cassandra unlogged batches that share the same partition key will only
+   * resolve to one write internally in Cassandra, boosting write performance.
+   *
+   * Be aware that this stage does not preserve the upstream order.
+   */
+  def createUnloggedBatchWithPassThrough[T, K](parallelism: Int,
+                                               statement: PreparedStatement,
+                                               statementBinder: BiFunction[T, PreparedStatement, BoundStatement],
+                                               partitionKey: Function[T, K],
+                                               settings: CassandraBatchSettings = CassandraBatchSettings.Defaults,
+                                               session: Session,
+                                               ec: ExecutionContext): Flow[T, T, NotUsed] =
+    ScalaCFlow
+      .createUnloggedBatchWithPassThrough[T, K](parallelism,
+                                                statement,
+                                                (t, p) => statementBinder.apply(t, p),
+                                                t => partitionKey.apply(t),
+                                                settings)(session, ec)
       .asJava
 }

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraSink.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraSink.scala
@@ -8,9 +8,9 @@ import java.util.concurrent.CompletionStage
 import java.util.function.BiFunction
 
 import akka.Done
+import akka.stream.alpakka.cassandra.scaladsl.{CassandraSink => ScalaCSink}
 import akka.stream.javadsl.Sink
 import com.datastax.driver.core.{BoundStatement, PreparedStatement, Session}
-import akka.stream.alpakka.cassandra.scaladsl.{CassandraSink => ScalaCSink}
 
 import scala.compat.java8.FutureConverters._
 
@@ -25,5 +25,4 @@ object CassandraSink {
 
     sink.mapMaterializedValue(_.toJava).asJava
   }
-
 }

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraFlow.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraFlow.scala
@@ -5,12 +5,18 @@
 package akka.stream.alpakka.cassandra.scaladsl
 
 import akka.NotUsed
-import akka.stream.scaladsl.Flow
-import com.datastax.driver.core.{BoundStatement, PreparedStatement, Session}
+import akka.stream.FlowShape
+import akka.stream.alpakka.cassandra.CassandraBatchSettings
+import akka.stream.scaladsl.{Flow, GraphDSL}
+import com.datastax.driver.core.{BatchStatement, BoundStatement, PreparedStatement, Session}
 import akka.stream.alpakka.cassandra.GuavaFutures._
+import scala.collection.JavaConverters._
 
 import scala.concurrent.ExecutionContext
 
+/**
+ * Scala API to create Cassandra flows.
+ */
 object CassandraFlow {
   def createWithPassThrough[T](
       parallelism: Int,
@@ -20,4 +26,46 @@ object CassandraFlow {
     Flow[T].mapAsync(parallelism)(
       t ⇒ session.executeAsync(statementBinder(t, statement)).asScala().map(_ => t)
     )
+
+  /**
+   * Creates a flow that batches using an unlogged batch. Use this when most of the elements in the stream
+   * share the same partition key. Cassandra unlogged batches that share the same partition key will only
+   * resolve to one write internally in Cassandra, boosting write performance.
+   *
+   * Be aware that this stage does not preserve the upstream order.
+   */
+  def createUnloggedBatchWithPassThrough[T, K](
+      parallelism: Int,
+      statement: PreparedStatement,
+      statementBinder: (T, PreparedStatement) => BoundStatement,
+      partitionKey: T => K,
+      settings: CassandraBatchSettings = CassandraBatchSettings.Defaults
+  )(implicit session: Session, ec: ExecutionContext): Flow[T, T, NotUsed] = {
+    val graph = GraphDSL.create() { implicit builder =>
+      import GraphDSL.Implicits._
+
+      val groupStage: FlowShape[T, Seq[T]] =
+        builder.add(Flow[T].groupedWithin(settings.maxGroupSize, settings.maxGroupWait))
+
+      val groupByKeyStage: FlowShape[Seq[T], Seq[T]] =
+        builder.add(Flow[Seq[T]].map(_.groupBy(partitionKey).values.toList).mapConcat(identity))
+
+      val batchStatementStage: FlowShape[Seq[T], Seq[T]] = builder.add(
+        Flow[Seq[T]].mapAsyncUnordered(parallelism)(
+          list => {
+            val boundStatements = list.map(t => statementBinder(t, statement))
+            val batchStatement = new BatchStatement(BatchStatement.Type.UNLOGGED).addAll(boundStatements.asJava)
+            session.executeAsync(batchStatement).asScala().map(_ => list)
+          }
+        )
+      )
+
+      val flattenResults: FlowShape[Seq[T], T] = builder.add(Flow[Seq[T]].mapConcat(_.toList))
+
+      groupStage ~> groupByKeyStage ~> batchStatementStage ~> flattenResults
+
+      FlowShape(groupStage.in, flattenResults.out)
+    }
+    Flow.fromGraph(graph)
+  }
 }

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSink.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSink.scala
@@ -5,13 +5,15 @@
 package akka.stream.alpakka.cassandra.scaladsl
 
 import akka.Done
+import akka.stream.alpakka.cassandra.GuavaFutures._
 import akka.stream.scaladsl.{Flow, Keep, Sink}
 import com.datastax.driver.core.{BoundStatement, PreparedStatement, Session}
 
 import scala.concurrent.Future
 
-import akka.stream.alpakka.cassandra.GuavaFutures._
-
+/**
+ * Scala API to create Cassandra Sinks.
+ */
 object CassandraSink {
   def apply[T](
       parallelism: Int,

--- a/cassandra/src/test/java/akka/stream/alpakka/cassandra/javadsl/CassandraSourceTest.java
+++ b/cassandra/src/test/java/akka/stream/alpakka/cassandra/javadsl/CassandraSourceTest.java
@@ -6,6 +6,7 @@ package akka.stream.alpakka.cassandra.javadsl;
 
 import akka.Done;
 import akka.NotUsed;
+import akka.stream.alpakka.cassandra.CassandraBatchSettings;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
@@ -36,6 +37,18 @@ import java.util.stream.IntStream;
  * All the tests must be run with a local Cassandra running on default port 9042.
  */
 public class CassandraSourceTest {
+
+  //#element-to-insert
+  private class ToInsert {
+    Integer id;
+    Integer cc;
+
+    public ToInsert(Integer id, Integer cc) {
+      this.id = id;
+      this.cc = cc;
+    }
+  }
+  //#element-to-insert
 
   private static ActorSystem system;
   private static Materializer materializer;
@@ -78,6 +91,9 @@ public class CassandraSourceTest {
     );
     session.execute(
       "CREATE TABLE IF NOT EXISTS akka_stream_java_test.test (id int PRIMARY KEY);"
+    );
+    session.execute(
+      "CREATE TABLE IF NOT EXISTS akka_stream_java_test.test_batch (id int, cc int, PRIMARY KEY (id, cc));"
     );
   }
 
@@ -140,6 +156,37 @@ public class CassandraSourceTest {
   }
 
   @Test
+  public void flowBatchInputValues() throws Exception {
+
+    //#prepared-statement-batching-flow
+    final PreparedStatement preparedStatement = session.prepare("insert into akka_stream_java_test.test_batch(id, cc) values (?, ?)");
+    //#prepared-statement-batching-flow
+
+    //#statement-binder-batching-flow
+    BiFunction<ToInsert, PreparedStatement,BoundStatement> statementBinder = (toInsert, statement) -> statement.bind(toInsert.id, toInsert.cc);
+    //#statement-binder-batching-flow
+    Source<ToInsert, NotUsed> source = Source.from(IntStream.range(1, 100).boxed().map(i -> new ToInsert(i %2, i)).collect(Collectors.toList()));
+
+    //#settings-batching-flow
+    CassandraBatchSettings defaultSettings = CassandraBatchSettings.Defaults();
+    //#settings-batching-flow
+
+
+      //#run-batching-flow
+    final Flow<ToInsert, ToInsert, NotUsed> flow = CassandraFlow.createUnloggedBatchWithPassThrough(2, preparedStatement,
+            statementBinder, (ti) -> ti.id, defaultSettings, session, ec);
+
+    CompletionStage<List<ToInsert>> result = source.via(flow).runWith(Sink.seq(), materializer);
+    //#run-batching-flow
+
+    Set<Integer> resultToAssert = result.toCompletableFuture().get().stream().map(ti -> ti.cc).collect(Collectors.toSet());
+    Set<Integer> found = session.execute("select * from akka_stream_java_test.test_batch").all().stream().map(r -> r.getInt("cc")).collect(Collectors.toSet());
+
+    assertEquals(resultToAssert, IntStream.range(1, 100).boxed().collect(Collectors.toSet()));
+    assertEquals(found, IntStream.range(1, 100).boxed().collect(Collectors.toSet()));
+  }
+
+  @Test
   public void sinkInputValues() throws Exception {
 
     //#prepared-statement
@@ -162,7 +209,6 @@ public class CassandraSourceTest {
     result.toCompletableFuture().get();
 
     Set<Integer> found = session.execute("select * from akka_stream_java_test.test").all().stream().map(r -> r.getInt("id")).collect(Collectors.toSet());
-
     assertEquals(found, IntStream.range(1, 10).boxed().collect(Collectors.toSet()));
   }
 }


### PR DESCRIPTION
* Add flow that uses unlogged batches to improve throughput when stream elements share the same 
partition key
* Implements tests for both Scala and Java.
* Documentation updated describing the new flow.