### PR TITLE
Kinesis fix spelling errors in API #816

### DIFF
--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisFlowSettings.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisFlowSettings.scala
@@ -36,7 +36,7 @@ case class KinesisFlowSettings(parallelism: Int,
 
   def withBackoffStrategyExponential(): KinesisFlowSettings = copy(backoffStrategy = Exponential)
 
-  def withBackoffStrategyLineal(): KinesisFlowSettings = copy(backoffStrategy = Lineal)
+  def withBackoffStrategyLinear(): KinesisFlowSettings = copy(backoffStrategy = Linear)
 
   def withBackoffStrategy(backoffStrategy: RetryBackoffStrategy): KinesisFlowSettings =
     copy(backoffStrategy = backoffStrategy)
@@ -46,17 +46,16 @@ case class KinesisFlowSettings(parallelism: Int,
 }
 
 object KinesisFlowSettings {
-
   private val MAX_RECORDS_PER_REQUEST = 500
   private val MAX_RECORDS_PER_SHARD_PER_SECOND = 1000
   private val MAX_BYTES_PER_SHARD_PER_SECOND = 1000000
 
   sealed trait RetryBackoffStrategy
   case object Exponential extends RetryBackoffStrategy
-  case object Lineal extends RetryBackoffStrategy
+  case object Linear extends RetryBackoffStrategy
 
   val exponential: RetryBackoffStrategy = Exponential
-  val lineal: RetryBackoffStrategy = Lineal
+  val linear: RetryBackoffStrategy = Linear
 
   val defaultInstance: KinesisFlowSettings = byNumberOfShards(1)
 

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisFlowStage.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisFlowStage.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.kinesis
 
 import akka.stream.alpakka.kinesis.KinesisErrors.{ErrorPublishingRecords, FailurePublishingRecords}
-import akka.stream.alpakka.kinesis.KinesisFlowSettings.{Exponential, Lineal, RetryBackoffStrategy}
+import akka.stream.alpakka.kinesis.KinesisFlowSettings.{Exponential, Linear, RetryBackoffStrategy}
 import akka.stream.alpakka.kinesis.KinesisFlowStage._
 import akka.stream.stage._
 import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
@@ -87,7 +87,7 @@ private[kinesis] final class KinesisFlowStage(
           waitingRetries.put(retryToken, Job(attempt + 1, errors.map(_._2)))
           scheduleOnce(retryToken, backoffStrategy match {
             case Exponential => scala.math.pow(retryBaseInMillis, attempt).toInt millis
-            case Lineal => retryInitialTimeout * attempt
+            case Linear => retryInitialTimeout * attempt
           })
           retryToken += 1
       }

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisFlow.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisFlow.scala
@@ -59,7 +59,7 @@ object KinesisFlow {
       }
       .via(apply(streamName, settings))
 
-  def byParititonAndBytes(
+  def byPartitionAndBytes(
       streamName: String,
       settings: KinesisFlowSettings = KinesisFlowSettings.defaultInstance
   )(

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisSink.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisSink.scala
@@ -28,12 +28,12 @@ object KinesisSink {
   ): Sink[(String, ByteBuffer), NotUsed] =
     KinesisFlow.byPartitionAndData(streamName, settings).to(Sink.ignore)
 
-  def byParititonAndBytes(
+  def byPartitionAndBytes(
       streamName: String,
       settings: KinesisFlowSettings = KinesisFlowSettings.defaultInstance
   )(
       implicit kinesisClient: AmazonKinesisAsync
   ): Sink[(String, ByteString), NotUsed] =
-    KinesisFlow.byParititonAndBytes(streamName, settings).to(Sink.ignore)
+    KinesisFlow.byPartitionAndBytes(streamName, settings).to(Sink.ignore)
 
 }

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/scaladsl/Examples.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/scaladsl/Examples.scala
@@ -84,14 +84,14 @@ object Examples {
   val flow2: Flow[PutRecordsRequestEntry, PutRecordsResultEntry, NotUsed] = KinesisFlow("myStreamName", flowSettings)
 
   val flow3: Flow[(String, ByteString), PutRecordsResultEntry, NotUsed] =
-    KinesisFlow.byParititonAndBytes("myStreamName")
+    KinesisFlow.byPartitionAndBytes("myStreamName")
 
   val flow4: Flow[(String, ByteBuffer), PutRecordsResultEntry, NotUsed] =
     KinesisFlow.byPartitionAndData("myStreamName")
 
   val sink1: Sink[PutRecordsRequestEntry, NotUsed] = KinesisSink("myStreamName")
   val sink2: Sink[PutRecordsRequestEntry, NotUsed] = KinesisSink("myStreamName", flowSettings)
-  val sink3: Sink[(String, ByteString), NotUsed] = KinesisSink.byParititonAndBytes("myStreamName")
+  val sink3: Sink[(String, ByteString), NotUsed] = KinesisSink.byPartitionAndBytes("myStreamName")
   val sink4: Sink[(String, ByteBuffer), NotUsed] = KinesisSink.byPartitionAndData("myStreamName")
   //#flow-sink
 


### PR DESCRIPTION
Fix for #816. Changes "parititon" to "partition" and "lineal" (consisting of lines) to "linear" (a sequence of steps).