### PR TITLE
Reset pendingAck variable if session has been aborted/shutdown.

### DIFF
--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -134,7 +134,13 @@ private[jms] class JmsAckSession(override val connection: jms.Connection,
 
   def ack(message: jms.Message): Unit = ackQueue.put(message.acknowledge _)
 
+  override def closeSession(): Unit = {
+    pendingAck = 0
+    session.close()
+  }
+
   override def abortSession(): Unit = {
+    pendingAck = 0
     ackQueue.put(() => throw new java.lang.IllegalStateException("Shutdown"))
     session.close()
   }


### PR DESCRIPTION
Closes #820 

I believe when the `ackSource` is shutdown or aborted the `listenerStopped` variable is never set to `true` (this is probably wrong but I'm not sure how to make it be set). It would be ok but the `ackQueue` is emptied and the number of `pendingAck`s not reset leading to an indefinite `take` operation on the `ackQueue`. By resetting `pendingAck` we avoid trying to process any more acks and the stream completes.