### PR TITLE
JMS: Fix shutting down and aborting of streams with a JmsConsumer.ackSource (#820)

### DIFF
--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -109,3 +109,5 @@ final case class JmsBrowseSettings(connectionFactory: ConnectionFactory,
   def withAcknowledgeMode(acknowledgeMode: AcknowledgeMode): JmsBrowseSettings =
     copy(acknowledgeMode = Option(acknowledgeMode))
 }
+
+final case class StopMessageListenerException() extends Exception("Stopping MessageListener.")

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -134,13 +134,12 @@ private[jms] class JmsAckSession(override val connection: jms.Connection,
 
   def ack(message: jms.Message): Unit = ackQueue.put(message.acknowledge _)
 
-  override def closeSession(): Unit = {
-    ackQueue.put(() => throw new java.lang.IllegalStateException("Shutdown"))
-    session.close()
-  }
+  override def closeSession(): Unit = stopMessageListenerAndCloseSession
 
-  override def abortSession(): Unit = {
-    ackQueue.put(() => throw new java.lang.IllegalStateException("Shutdown"))
+  override def abortSession(): Unit = stopMessageListenerAndCloseSession
+
+  private def stopMessageListenerAndCloseSession(): Unit = {
+    ackQueue.put(() => throw StopMessageListenerException())
     session.close()
   }
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -134,6 +134,11 @@ private[jms] class JmsAckSession(override val connection: jms.Connection,
 
   def ack(message: jms.Message): Unit = ackQueue.put(message.acknowledge _)
 
+  override def closeSession(): Unit = {
+    ackQueue.put(() => throw new java.lang.IllegalStateException("Shutdown"))
+    session.close()
+  }
+
   override def abortSession(): Unit = {
     ackQueue.put(() => throw new java.lang.IllegalStateException("Shutdown"))
     session.close()

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
@@ -257,7 +257,7 @@ abstract class SourceStageLogic[T](shape: SourceShape[T],
     if (stopping.compareAndSet(false, true)) {
       val closeSessionFutures = jmsSessions.map { s =>
         val f = s.closeSessionAsync()
-        f.onFailure { case e => log.error(e, "Error closing jms session") }
+        f.failed.foreach(e => log.error(e, "Error closing jms session"))
         f
       }
       Future

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
@@ -103,7 +103,7 @@ final class JmsAckSourceStage(settings: JmsConsumerSettings)
                             action()
                             session.pendingAck -= 1
                           } catch {
-                            case _: java.lang.IllegalStateException =>
+                            case _: StopMessageListenerException =>
                               listenerStopped = true
                           }
                           if (!listenerStopped) ackQueued()
@@ -121,7 +121,7 @@ final class JmsAckSourceStage(settings: JmsConsumerSettings)
                         }
                         ackQueued()
                       } catch {
-                        case _: java.lang.IllegalStateException =>
+                        case _: StopMessageListenerException =>
                           listenerStopped = true
                         case e: JMSException =>
                           handleError.invoke(e)

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
@@ -282,7 +282,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
 
       killSwitch2.shutdown()
 
-      resultList should contain theSameElementsAs numsIn.map(_.toString)
+      resultList.to[SortedSet] should contain theSameElementsAs numsIn.map(_.toString)
     }
 
     "ensure no message loss when aborting a stream" in withServer() { ctx =>
@@ -363,6 +363,86 @@ class JmsAckConnectorsSpec extends JmsSpec {
         s.toInt
       }
       resultList.to[SortedSet] should contain theSameElementsAs numsIn.map(_.toString)
+    }
+
+    "shutdown when waiting to acknowledge messages" in withServer() { ctx =>
+      val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
+
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
+      )
+
+      val (publishKillSwitch, _) = Source
+        .unfold(1)(n => Some(n + 1 -> n))
+        .throttle(15, 1.second, 2, ThrottleMode.shaping) // Higher than consumption rate.
+        .viaMat(KillSwitches.single)(Keep.right)
+        .alsoTo(Flow[Int].map(n => JmsTextMessage(n.toString).withProperty("Number", n)).to(jmsSink))
+        .toMat(Sink.seq)(Keep.both)
+        .run()
+
+      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
+        JmsConsumerSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("numbers")
+      )
+
+      val resultQueue = new LinkedBlockingQueue[String]()
+
+      val (killSwitch, streamDone) = jmsSource
+        .throttle(10, 1.second, 2, ThrottleMode.shaping)
+        .toMat(
+          Sink.foreach { env =>
+            resultQueue.add(env.message.asInstanceOf[TextMessage].getText)
+          //message not acknowledged
+          }
+        )(Keep.both)
+        .run()
+
+      // Need to wait for the stream to have started and running for sometime.
+      Thread.sleep(2000)
+
+      killSwitch.shutdown()
+      publishKillSwitch.shutdown()
+
+      streamDone.futureValue shouldBe Done
+    }
+
+    "abort when waiting to acknowledge messages" in withServer() { ctx =>
+      val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
+
+      val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer(
+        JmsProducerSettings(connectionFactory).withQueue("numbers")
+      )
+
+      val (publishKillSwitch, _) = Source
+        .unfold(1)(n => Some(n + 1 -> n))
+        .throttle(15, 1.second, 2, ThrottleMode.shaping) // Higher than consumption rate.
+        .viaMat(KillSwitches.single)(Keep.right)
+        .alsoTo(Flow[Int].map(n => JmsTextMessage(n.toString).withProperty("Number", n)).to(jmsSink))
+        .toMat(Sink.seq)(Keep.both)
+        .run()
+
+      val jmsSource: Source[AckEnvelope, KillSwitch] = JmsConsumer.ackSource(
+        JmsConsumerSettings(connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("numbers")
+      )
+
+      val resultQueue = new LinkedBlockingQueue[String]()
+
+      val (killSwitch, streamDone) = jmsSource
+        .throttle(10, 1.second, 2, ThrottleMode.shaping)
+        .toMat(
+          Sink.foreach { env =>
+            resultQueue.add(env.message.asInstanceOf[TextMessage].getText)
+          //message not acknowledged
+          }
+        )(Keep.both)
+        .run()
+
+      // Need to wait for the stream to have started and running for sometime.
+      Thread.sleep(2000)
+
+      killSwitch.abort(new Exception("aborted"))
+      publishKillSwitch.shutdown()
+
+      streamDone.failed.futureValue.getMessage shouldBe "aborted"
     }
   }
 }


### PR DESCRIPTION
Previously if a stream with a `JmsConsumer.ackSource` had messages left to acknowledge (greater than the `bufferSize`) when it was being shutdown or aborted it would hang. This is because the `MessageListener` threads would be blocking on the `take` operation on the `ackQueue` and would never return which is required by the JMS spec when a `Connection` is being closed:

> From JMS 1.1:

> 4.3.4 Pausing Delivery of Incoming Messages 
If MessageListeners are running when stop is invoked, stop must wait until all of them have returned before it may return. While these MessageListeners are completing, they must have the full services of the connection available to them. 

 
Now when a `shutdown` or `abort` is called on the `KillSwitch` we close the `JmsSession` before the `Connection` as a message with an `Exception` on the `ackQueue` unblocks the `MessageListener`s and they return.