### PR TITLE
CSV: support/document conversion to String

### DIFF
--- a/csv/src/main/java/akka/stream/alpakka/csv/javadsl/CsvToMap.java
+++ b/csv/src/main/java/akka/stream/alpakka/csv/javadsl/CsvToMap.java
@@ -4,11 +4,10 @@
 
 package akka.stream.alpakka.csv.javadsl;
 
-
+import akka.stream.alpakka.csv.CsvToMapAsStringsJavaStage;
 import akka.stream.alpakka.csv.CsvToMapJavaStage;
 import akka.stream.javadsl.Flow;
 import akka.util.ByteString;
-import scala.Option;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -20,7 +19,7 @@ import java.util.Optional;
 public class CsvToMap {
 
     /**
-     * A flow translating incoming {@link Collection<ByteString>} to a {@link Map<String, ByteString>} using the streams first
+     * A flow translating incoming {@link Collection<ByteString>} to a {@link Map<String, ByteString>} using the stream's first
      * element's values as keys. The charset to decode [[ByteString]] to [[String]] defaults to UTF-8.
      */
     public static Flow<Collection<ByteString>, Map<String, ByteString>, ?> toMap() {
@@ -28,12 +27,21 @@ public class CsvToMap {
     }
 
     /**
-     * A flow translating incoming {@link Collection<ByteString>} to a {@link Map<String, ByteString>} using the streams first
+     * A flow translating incoming {@link Collection<ByteString>} to a {@link Map<String, ByteString>} using the stream's first
      * element's values as keys.
      * @param charset the charset to decode {@link ByteString} to {@link String}
      */
     public static Flow<Collection<ByteString>, Map<String, ByteString>, ?> toMap(Charset charset) {
         return Flow.fromGraph(new CsvToMapJavaStage(Optional.empty(), charset));
+    }
+
+    /**
+     * A flow translating incoming {@link Collection<ByteString>} to a {@link Map<String, ByteString>} using the stream's first
+     * element's values as keys.
+     * @param charset the charset to decode {@link ByteString} to {@link String}
+     */
+    public static Flow<Collection<ByteString>, Map<String, String>, ?> toMapAsStrings(Charset charset) {
+        return Flow.fromGraph(new CsvToMapAsStringsJavaStage(Optional.empty(), charset));
     }
 
     /**
@@ -43,5 +51,14 @@ public class CsvToMap {
      */
     public static Flow<Collection<ByteString>, Map<String, ByteString>, ?> withHeaders(String... headers) {
         return Flow.fromGraph(new CsvToMapJavaStage(Optional.of(Arrays.asList(headers)), StandardCharsets.UTF_8));
+    }
+
+    /**
+     * A flow translating incoming {@link Collection<ByteString>} to a {@link Map<String, ByteString>} using the given headers
+     * as keys.
+     * @param headers column names to be used as map keys
+     */
+    public static Flow<Collection<ByteString>, Map<String, String>, ?> withHeadersAsStrings(Charset charset, String... headers) {
+        return Flow.fromGraph(new CsvToMapAsStringsJavaStage(Optional.of(Arrays.asList(headers)), charset));
     }
 }

--- a/csv/src/main/scala/akka/stream/alpakka/csv/CsvToMapJavaStage.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/CsvToMapJavaStage.scala
@@ -18,18 +18,23 @@ import akka.util.ByteString
  * @param columnNames If given, these names are used as map keys; if not first stream element is used
  * @param charset     Character set used to convert header line ByteString to String
  */
-private[csv] class CsvToMapJavaStage(columnNames: ju.Optional[ju.Collection[String]], charset: Charset)
-    extends GraphStage[FlowShape[ju.Collection[ByteString], ju.Map[String, ByteString]]] {
+private[csv] abstract class CsvToMapJavaStageBase[V](columnNames: ju.Optional[ju.Collection[String]], charset: Charset)
+    extends GraphStage[FlowShape[ju.Collection[ByteString], ju.Map[String, V]]] {
 
   override protected def initialAttributes: Attributes = Attributes.name("CsvToMap")
 
   private val in = Inlet[ju.Collection[ByteString]]("CsvToMap.in")
-  private val out = Outlet[ju.Map[String, ByteString]]("CsvToMap.out")
+  private val out = Outlet[ju.Map[String, V]]("CsvToMap.out")
   override val shape = FlowShape.of(in, out)
+
+  protected def transformElements(elements: ju.Collection[ByteString]): ju.Collection[V]
 
   private final val decodeByteString = new java.util.function.Function[ByteString, String]() {
     override def apply(t: ByteString): String = t.decodeString(charset)
   }
+
+  protected def decode(elem: ju.Collection[ByteString]): ju.List[String] =
+    elem.stream().map[String](decodeByteString).collect(Collectors.toList())
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) {
@@ -41,7 +46,7 @@ private[csv] class CsvToMapJavaStage(columnNames: ju.Optional[ju.Collection[Stri
           override def onPush(): Unit = {
             val elem = grab(in)
             if (headers.isPresent) {
-              val map = zipWithHeaders(elem)
+              val map = zipWithHeaders(transformElements(elem))
               push(out, map)
             } else {
               headers = ju.Optional.of(decode(elem))
@@ -55,11 +60,8 @@ private[csv] class CsvToMapJavaStage(columnNames: ju.Optional[ju.Collection[Stri
         override def onPull(): Unit = pull(in)
       })
 
-      private def decode(elem: ju.Collection[ByteString]) =
-        elem.stream().map[String](decodeByteString).collect(Collectors.toList())
-
-      private def zipWithHeaders(elem: ju.Collection[ByteString]): ju.Map[String, ByteString] = {
-        val map = new ju.HashMap[String, ByteString]()
+      private def zipWithHeaders(elem: ju.Collection[V]): ju.Map[String, V] = {
+        val map = new ju.HashMap[String, V]()
         val hIter = headers.get.iterator()
         val colIter = elem.iterator()
         while (hIter.hasNext && colIter.hasNext) {
@@ -69,4 +71,18 @@ private[csv] class CsvToMapJavaStage(columnNames: ju.Optional[ju.Collection[Stri
       }
     }
 
+}
+
+private[csv] class CsvToMapJavaStage(columnNames: ju.Optional[ju.Collection[String]], charset: Charset)
+    extends CsvToMapJavaStageBase[ByteString](columnNames, charset) {
+
+  override protected def transformElements(elements: ju.Collection[ByteString]): ju.Collection[ByteString] =
+    elements
+}
+
+private[csv] class CsvToMapAsStringsJavaStage(columnNames: ju.Optional[ju.Collection[String]], charset: Charset)
+    extends CsvToMapJavaStageBase[String](columnNames, charset) {
+
+  override protected def transformElements(elements: ju.Collection[ByteString]): ju.Collection[String] =
+    decode(elements)
 }

--- a/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
@@ -7,19 +7,27 @@ package akka.stream.alpakka.csv.scaladsl
 import java.nio.charset.{Charset, StandardCharsets}
 
 import akka.NotUsed
-import akka.stream.alpakka.csv.CsvToMapStage
+import akka.stream.alpakka.csv.{CsvToMapAsStringsStage, CsvToMapStage}
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 
 object CsvToMap {
 
   /**
-   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String and ByteString using the streams first
+   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String and ByteString using the stream's first
    * element's values as keys.
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
    */
   def toMap(charset: Charset = StandardCharsets.UTF_8): Flow[List[ByteString], Map[String, ByteString], NotUsed] =
     Flow.fromGraph(new CsvToMapStage(columnNames = None, charset))
+
+  /**
+   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String keys and values using the stream's first
+   * element's values as keys.
+   * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
+   */
+  def toMapAsStrings(charset: Charset = StandardCharsets.UTF_8): Flow[List[ByteString], Map[String, String], NotUsed] =
+    Flow.fromGraph(new CsvToMapAsStringsStage(columnNames = None, charset))
 
   /**
    * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String and ByteString using the given headers
@@ -28,4 +36,16 @@ object CsvToMap {
    */
   def withHeaders(headers: String*): Flow[List[ByteString], Map[String, ByteString], NotUsed] =
     Flow.fromGraph(new CsvToMapStage(Some(headers.toList), StandardCharsets.UTF_8))
+
+  /**
+   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String keys and values using the given headers
+   * as keys.
+   * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
+   * @param headers column names to be used as map keys
+   */
+  def withHeadersAsStrings(
+      charset: Charset,
+      headers: String*
+  ): Flow[List[ByteString], Map[String, String], NotUsed] =
+    Flow.fromGraph(new CsvToMapAsStringsStage(Some(headers.toList), StandardCharsets.UTF_8))
 }

--- a/csv/src/test/java/akka/stream/alpakka/csv/javadsl/CsvParsingTest.java
+++ b/csv/src/test/java/akka/stream/alpakka/csv/javadsl/CsvParsingTest.java
@@ -19,13 +19,19 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 // #line-scanner
+        import akka.stream.alpakka.csv.javadsl.CsvParsing;
 
 // #line-scanner
+// #line-scanner-string
+        import akka.stream.alpakka.csv.javadsl.CsvParsing;
+
+// #line-scanner-string
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -51,15 +57,30 @@ public class CsvParsingTest {
     public void lineParserShouldParseOneLine() throws Exception {
         CompletionStage<Collection<ByteString>> completionStage =
         // #line-scanner
-            Source.single(ByteString.fromString("eins,zwei,drei\n"))
-                .via(CsvParsing.lineScanner())
-                .runWith(Sink.head(), materializer);
+        Source.single(ByteString.fromString("eins,zwei,drei\n"))
+            .via(CsvParsing.lineScanner())
+            .runWith(Sink.head(), materializer);
         // #line-scanner
         Collection<ByteString> list = completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
         String[] res = list.stream().map(ByteString::utf8String).toArray(String[]::new);
         assertThat(res[0], equalTo("eins"));
         assertThat(res[1], equalTo("zwei"));
         assertThat(res[2], equalTo("drei"));
+    }
+
+    @Test
+    public void lineParserShouldParseOneLineAsString() throws Exception {
+        CompletionStage<List<String>> completionStage =
+        // #line-scanner-string
+        Source.single(ByteString.fromString("eins,zwei,drei\n"))
+            .via(CsvParsing.lineScanner())
+            .map(line -> line.stream().map(ByteString::utf8String).collect(Collectors.toList()))
+            .runWith(Sink.head(), materializer);
+        // #line-scanner-string
+        List<String> res = completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+        assertThat(res.get(0), equalTo("eins"));
+        assertThat(res.get(1), equalTo("zwei"));
+        assertThat(res.get(2), equalTo("drei"));
     }
 
     @Test

--- a/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvParsingSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvParsingSpec.scala
@@ -40,12 +40,37 @@ class CsvParsingSpec extends CsvSpec {
       val fut =
         // format: off
       // #line-scanner
-        Source.single(ByteString("eins,zwei,drei\n"))
-          .via(CsvParsing.lineScanner())
-          .runWith(Sink.head)
+      Source.single(ByteString("eins,zwei,drei\n"))
+        .via(CsvParsing.lineScanner())
+        .runWith(Sink.head)
       // #line-scanner
       // format: on
-      fut.futureValue should be(List(ByteString("eins"), ByteString("zwei"), ByteString("drei")))
+      val result = fut.futureValue
+      // #line-scanner
+
+      result should be(List(ByteString("eins"), ByteString("zwei"), ByteString("drei")))
+      // #line-scanner
+    }
+
+    "parse one line and map to String" in {
+      // #line-scanner-string
+      import akka.stream.alpakka.csv.scaladsl.CsvParsing
+
+      // #line-scanner-string
+      val fut =
+        // format: off
+      // #line-scanner-string
+      Source.single(ByteString("eins,zwei,drei\n"))
+        .via(CsvParsing.lineScanner())
+        .map(_.map(_.utf8String))
+        .runWith(Sink.head)
+      // #line-scanner-string
+      // format: on
+      val result = fut.futureValue
+      // #line-scanner-string
+
+      result should be(List("eins", "zwei", "drei"))
+      // #line-scanner-string
     }
 
     "parse two lines" in {

--- a/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvToMapSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvToMapSpec.scala
@@ -17,6 +17,7 @@ class CsvToMapSpec extends CsvSpec {
     // #flow-type
     import akka.stream.alpakka.csv.scaladsl.CsvToMap
 
+    // keep values as ByteString
     val flow1: Flow[List[ByteString], Map[String, ByteString], NotUsed]
       = CsvToMap.toMap()
 
@@ -25,6 +26,13 @@ class CsvToMapSpec extends CsvSpec {
 
     val flow3: Flow[List[ByteString], Map[String, ByteString], NotUsed]
       = CsvToMap.withHeaders("column1", "column2", "column3")
+
+    // values as String (decode ByteString)
+    val flow4: Flow[List[ByteString], Map[String, String], NotUsed]
+    = CsvToMap.toMapAsStrings(StandardCharsets.UTF_8)
+
+    val flow5: Flow[List[ByteString], Map[String, String], NotUsed]
+    = CsvToMap.withHeadersAsStrings(StandardCharsets.UTF_8, "column1", "column2", "column3")
     // #flow-type
     // format: on
   }
@@ -38,24 +46,35 @@ class CsvToMapSpec extends CsvSpec {
       val future =
         // format: off
       // #header-line
+      // values as ByteString
       Source
         .single(ByteString("""eins,zwei,drei
-                             |1,2,3""".stripMargin))
+                             |11,12,13
+                             |21,22,23
+                             |""".stripMargin))
         .via(CsvParsing.lineScanner())
         .via(CsvToMap.toMap())
-        .runWith(Sink.head)
+        .runWith(Sink.seq)
       // #header-line
       // format: on
-      future.futureValue should be(
-        Map("eins" -> ByteString("1"), "zwei" -> ByteString("2"), "drei" -> ByteString("3"))
+      val result = future.futureValue
+      // #header-line
+
+      result should be(
+        Seq(
+          Map("eins" -> ByteString("11"), "zwei" -> ByteString("12"), "drei" -> ByteString("13")),
+          Map("eins" -> ByteString("21"), "zwei" -> ByteString("22"), "drei" -> ByteString("23"))
+        )
       )
+      // #header-line
     }
 
     "be OK with fewer header columns than data" in {
       val future =
         Source
           .single(ByteString("""eins,zwei
-                               |1,2,3""".stripMargin))
+                               |1,2,3
+                               |""".stripMargin))
           .via(CsvParsing.lineScanner())
           .via(CsvToMap.toMap())
           .runWith(Sink.head)
@@ -66,13 +85,42 @@ class CsvToMapSpec extends CsvSpec {
       val future =
         Source
           .single(ByteString("""eins,zwei,drei,vier
-                               |1,2,3""".stripMargin))
+                               |1,2,3
+                               |""".stripMargin))
           .via(CsvParsing.lineScanner())
           .via(CsvToMap.toMap())
           .runWith(Sink.head)
       future.futureValue should be(
         Map("eins" -> ByteString("1"), "zwei" -> ByteString("2"), "drei" -> ByteString("3"))
       )
+    }
+
+    "parse header line and decode data line" in {
+      val future =
+        // format: off
+      // #header-line
+
+      // values as String
+      Source
+        .single(ByteString("""eins,zwei,drei
+                             |11,12,13
+                             |21,22,23
+                             |""".stripMargin))
+        .via(CsvParsing.lineScanner())
+        .via(CsvToMap.toMapAsStrings())
+        .runWith(Sink.seq)
+      // #header-line
+      // format: on
+      val result = future.futureValue
+      // #header-line
+
+      result should be(
+        Seq(
+          Map("eins" -> "11", "zwei" -> "12", "drei" -> "13"),
+          Map("eins" -> "21", "zwei" -> "22", "drei" -> "23")
+        )
+      )
+      // #header-line
     }
 
     "use column names and data line into map" in {
@@ -83,16 +131,54 @@ class CsvToMapSpec extends CsvSpec {
       val future =
         // format: off
       // #column-names
+      // values as ByteString
       Source
-        .single(ByteString("""1,2,3"""))
+        .single(ByteString(
+          """11,12,13
+            |21,22,23
+            |""".stripMargin))
         .via(CsvParsing.lineScanner())
         .via(CsvToMap.withHeaders("eins", "zwei", "drei"))
-        .runWith(Sink.head)
+        .runWith(Sink.seq)
       // #column-names
       // format: on
-      future.futureValue should be(
-        Map("eins" -> ByteString("1"), "zwei" -> ByteString("2"), "drei" -> ByteString("3"))
+      val result = future.futureValue
+      // #column-names
+
+      result should be(
+        Seq(
+          Map("eins" -> ByteString("11"), "zwei" -> ByteString("12"), "drei" -> ByteString("13")),
+          Map("eins" -> ByteString("21"), "zwei" -> ByteString("22"), "drei" -> ByteString("23"))
+        )
       )
+      // #column-names
+    }
+
+    "use column names and decode data line into map" in {
+      val future =
+        // format: off
+      // #column-names
+
+      // values as String
+      Source
+        .single(ByteString("""11,12,13
+                             |21,22,23
+                             |""".stripMargin))
+        .via(CsvParsing.lineScanner())
+        .via(CsvToMap.withHeadersAsStrings(StandardCharsets.UTF_8, "eins", "zwei", "drei"))
+        .runWith(Sink.seq)
+      // #column-names
+      // format: on
+      val result = future.futureValue
+      // #column-names
+
+      result should be(
+        Seq(
+          Map("eins" -> "11", "zwei" -> "12", "drei" -> "13"),
+          Map("eins" -> "21", "zwei" -> "22", "drei" -> "23")
+        )
+      )
+      // #column-names
     }
 
   }

--- a/docs/src/main/paradox/data-transformations/csv.md
+++ b/docs/src/main/paradox/data-transformations/csv.md
@@ -66,11 +66,23 @@ Java
 @java[@github[Source on Github](/csv/src/test/java/akka/stream/alpakka/csv/javadsl/CsvParsingTest.java)]
 
 
+To convert the `ByteString` columns as `String`, a `map` operation can be added to the Flow:
+
+Scala
+: @@snip ($alpakka$/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvParsingSpec.scala) { #line-scanner-string }
+
+Java
+: @@snip ($alpakka$/csv/src/test/java/akka/stream/alpakka/csv/javadsl/CsvParsingTest.java) { #line-scanner-string }
+
+@scala[@github[Source on Github](/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvParsingSpec.scala)]
+@java[@github[Source on Github](/csv/src/test/java/akka/stream/alpakka/csv/javadsl/CsvParsingTest.java)]
+
+
 ## CSV conversion into a map
 
 The column-based nature of CSV files can be used to read it into a map of column names
-and their `ByteStrng` values. The column names can be either provided in code or the first line
-of data can be interpreted as the column names.
+and their `ByteString` values, or alternatively to `String` values. The column names can be either provided in code or 
+the first line of data can be interpreted as the column names.
 
 Scala
 : @@snip ($alpakka$/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvToMapSpec.scala) { #flow-type }
@@ -79,7 +91,7 @@ Java
 : @@snip ($alpakka$/csv/src/test/java/akka/stream/alpakka/csv/javadsl/CsvToMapTest.java) { #flow-type }
 
 
-This example uses the first line in the CSV data as column names:
+This example uses the first line (the header line) in the CSV data as column names:
 
 Scala
 : @@snip ($alpakka$/csv/src/test/scala/akka/stream/alpakka/csv/scaladsl/CsvToMapSpec.scala) { #header-line }


### PR DESCRIPTION
As most users will operate on String columns instead of the raw ByteString, I added decoding of ByteString directly in the CsvToMap stages. 
This could have been implemented via an extra map operation in the Flow, but I decided to code the conversion directly into the stages to reduce the number of intermediary data structures.