### PR TITLE
JMS: Accept redelivery of messages

### DIFF
--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsTxConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsTxConnectorsSpec.scala
@@ -313,7 +313,8 @@ class JmsTxConnectorsSpec extends JmsSpec {
 
       killSwitch2.shutdown()
 
-      resultList should contain theSameElementsAs numsIn.map(_.toString)
+      // messages might get delivered more than once, use set to ignore duplicates
+      resultList.toSet should contain theSameElementsAs numsIn.map(_.toString)
     }
 
     "ensure no message loss when aborting a stream" in withServer() { ctx =>
@@ -390,7 +391,8 @@ class JmsTxConnectorsSpec extends JmsSpec {
 
       killSwitch2.shutdown()
 
-      resultList should contain theSameElementsAs numsIn.map(_.toString)
+      // messages might get delivered more than once, use set to ignore duplicates
+      resultList.toSet should contain theSameElementsAs numsIn.map(_.toString)
     }
   }
 }


### PR DESCRIPTION
The JMS tests have been failing quite a lot since the recent changes.
One problem are message duplicates in the "no message loss" tests, this change ignores duplicates.