### PR TITLE
Fix AMQP connection release from throwing

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectionProvider.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectionProvider.scala
@@ -18,7 +18,7 @@ import scala.annotation.tailrec
 @DoNotInherit
 sealed trait AmqpConnectionProvider {
   def get: Connection
-  def release(connection: Connection): Unit = connection.close()
+  def release(connection: Connection): Unit = if (connection.isOpen) connection.close()
 }
 
 /**

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectionProvidersTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectionProvidersTest.java
@@ -24,6 +24,14 @@ public class AmqpConnectionProvidersTest {
   }
 
   @Test
+  public void LocalAmqpConnectionReleaseClosedConnectionDoNotError() throws Exception {
+    AmqpConnectionProvider connectionProvider = AmqpLocalConnectionProvider.getInstance();
+    Connection connection1 = connectionProvider.get();
+    connectionProvider.release(connection1);
+    connectionProvider.release(connection1);
+  }
+
+  @Test
   public void AmqpConnectionUriCreatesNewConnection() throws Exception {
     AmqpConnectionProvider connectionProvider = AmqpUriConnectionProvider.create("amqp://localhost:5672");
     Connection connection1 = connectionProvider.get();
@@ -31,6 +39,14 @@ public class AmqpConnectionProvidersTest {
     assertNotEquals(connection1, connection2);
     connectionProvider.release(connection1);
     connectionProvider.release(connection2);
+  }
+
+  @Test
+  public void AmqpConnectionUriReleaseClosedConnectionDoNotError() throws Exception {
+    AmqpConnectionProvider connectionProvider = AmqpUriConnectionProvider.create("amqp://localhost:5672");
+    Connection connection1 = connectionProvider.get();
+    connectionProvider.release(connection1);
+    connectionProvider.release(connection1);
   }
 
   @Test
@@ -44,6 +60,14 @@ public class AmqpConnectionProvidersTest {
   }
 
   @Test
+  public void AmqpConnectionDetailsReleaseClosedConnectionDoNotError() throws Exception {
+    AmqpConnectionProvider connectionProvider = AmqpDetailsConnectionProvider.create("localhost", 5672);
+    Connection connection1 = connectionProvider.get();
+    connectionProvider.release(connection1);
+    connectionProvider.release(connection1);
+  }
+
+  @Test
   public void AmqpConnectionFactoryCreatesNewConnection() throws Exception {
     ConnectionFactory connectionFactory = new ConnectionFactory();
     @SuppressWarnings("unchecked")
@@ -54,6 +78,17 @@ public class AmqpConnectionProvidersTest {
     assertNotEquals(connection1, connection2);
     connectionProvider.release(connection1);
     connectionProvider.release(connection2);
+  }
+
+  @Test
+  public void AmqpConnectionFactoryReleaseClosedConnectionDoNotError() throws Exception {
+    ConnectionFactory connectionFactory = new ConnectionFactory();
+    @SuppressWarnings("unchecked")
+    AmqpConnectionProvider connectionProvider = AmqpConnectionFactoryConnectionProvider.create(connectionFactory)
+            .withHostsAndPorts(Pair.create("localhost", 5672));
+    Connection connection1 = connectionProvider.get();
+    connectionProvider.release(connection1);
+    connectionProvider.release(connection1);
   }
 
   @Test

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectionProvidersSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectionProvidersSpec.scala
@@ -18,6 +18,13 @@ class AmqpConnectionProvidersSpec extends AmqpSpec {
       connectionProvider.release(connection2)
     }
 
+    "not error if releasing an already closed LocalAmqpConnection" in {
+      val connectionProvider = AmqpLocalConnectionProvider
+      val connection1 = connectionProvider.get
+      connectionProvider.release(connection1)
+      connectionProvider.release(connection1)
+    }
+
     "create a new connection per invocation of AmqpConnectionUri" in {
       val connectionProvider = AmqpUriConnectionProvider("amqp://localhost:5672")
       val connection1 = connectionProvider.get
@@ -25,6 +32,13 @@ class AmqpConnectionProvidersSpec extends AmqpSpec {
       connection1 should not equal connection2
       connectionProvider.release(connection1)
       connectionProvider.release(connection2)
+    }
+
+    "not error if releasing an already closed AmqpConnectionUri" in {
+      val connectionProvider = AmqpUriConnectionProvider("amqp://localhost:5672")
+      val connection1 = connectionProvider.get
+      connectionProvider.release(connection1)
+      connectionProvider.release(connection1)
     }
 
     "create a new connection per invocation of AmqpConnectionDetails" in {
@@ -36,6 +50,13 @@ class AmqpConnectionProvidersSpec extends AmqpSpec {
       connectionProvider.release(connection2)
     }
 
+    "not error if releasing an already closed AmqpConnectionDetails" in {
+      val connectionProvider = AmqpDetailsConnectionProvider(List(("localhost", 5672)))
+      val connection1 = connectionProvider.get
+      connectionProvider.release(connection1)
+      connectionProvider.release(connection1)
+    }
+
     "create a new connection per invocation of AmqpConnectionFactory" in {
       val connectionFactory = new ConnectionFactory()
       val connectionProvider = AmqpConnectionFactoryConnectionProvider(connectionFactory, List(("localhost", 5672)))
@@ -44,6 +65,14 @@ class AmqpConnectionProvidersSpec extends AmqpSpec {
       connection1 should not equal connection2
       connectionProvider.release(connection1)
       connectionProvider.release(connection2)
+    }
+
+    "not error if releasing an already closed AmqpConnectionFactory" in {
+      val connectionFactory = new ConnectionFactory()
+      val connectionProvider = AmqpConnectionFactoryConnectionProvider(connectionFactory, List(("localhost", 5672)))
+      val connection1 = connectionProvider.get
+      connectionProvider.release(connection1)
+      connectionProvider.release(connection1)
     }
   }
 


### PR DESCRIPTION
Fix AMQP connection release from throwing if the connection is already closed

Closes #842 