### PR TITLE
Add STOMP connectors: StompClientSource and StompClientSink #514

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ lazy val modules: Seq[ProjectReference] = Seq(
   solr,
   sqs,
   sse,
+  stomp,
   unixdomainsocket,
   xml
 )
@@ -147,6 +148,8 @@ lazy val sqs = alpakkaProject("sqs",
                               parallelExecution in Test := false)
 
 lazy val sse = alpakkaProject("sse", "sse", Dependencies.Sse)
+
+lazy val stomp = alpakkaProject("stomp", "stomp", Dependencies.Stomp)
 
 lazy val unixdomainsocket = alpakkaProject("unix-domain-socket", "unixdomainsocket", Dependencies.UnixDomainSocket)
 

--- a/docs/src/main/paradox/connectors.md
+++ b/docs/src/main/paradox/connectors.md
@@ -26,6 +26,7 @@
 * [Server-sent Events (SSE)](sse.md)
 * [Slick (JDBC) Connector](slick.md)
 * [Spring Web](spring-web.md)
+* [STOMP Protocol Connector](stomp.md)
 * [Unix Domain Sockets](unix-domain-socket.md)
 
 @@@

--- a/docs/src/main/paradox/stomp.md
+++ b/docs/src/main/paradox/stomp.md
@@ -1,0 +1,80 @@
+# STOMP Protocol Connector
+
+The Stomp Protocol connector provides Akka Stream sources and sinks to connect to STOMP servers.
+
+## Reported issues
+
+[Tagged issues at Github](https://github.com/akka/alpakka/labels/p%3Astomp)
+
+
+## Artifacts
+
+@@dependency [sbt,Maven,Gradle] {
+  group=com.lightbend.akka
+  artifact=akka-stream-alpakka-stomp_$scalaBinaryVersion$
+  version=$version$
+}
+
+## Usage
+
+### Connecting to a STOMP server
+
+All the STOMP connectors are configured using a @scaladoc[ConnectionProvider](akka.stream.alpakka.stomp.ConnectionProvider).
+
+There are some types of @scaladoc[ConnectionProvider](akka.stream.alpakka.stomp.ConnectionProvider):
+
+* @scaladoc[LocalConnectionProvider](akka.stream.alpakka.stomp.LocalConnectionProvider) which connects to the default localhost. It creates a new connection for each stage.
+* @scaladoc[DetailsConnectionProvider](akka.stream.alpakka.stomp.DetailsConnectionProvider) which supports more fine-grained configuration. It creates a new connection for each stage.
+
+### Sinking messages into a STOMP server
+
+Create the ConnectorSettings
+
+Scala
+: @@snip ($alpakka$/stomp/src/test/scala/akka/stream/alpakka/stomp/scaladsl/StompClientSinkSpec.scala) { #connector-settings }
+
+@scaladoc[StompClientSink](akka.stream.alpakka.stomp.scaladsl.StompClientSink) is a collection of factory methods that facilitates creation of sinks. 
+
+Create a sink, that accepts and forwards @scaladoc[SendingFrame](akka.stream.alpakka.stomp.client.SendingFrame)s to the STOMP server.
+
+Scala
+: @@snip ($alpakka$/stomp/src/test/scala/akka/stream/alpakka/stomp/scaladsl/StompClientSinkSpec.scala) { #stomp-client-sink }
+
+Last step is to @extref[materialize](akka-docs:scala/stream/stream-flows-and-basics) and run the sink we created.
+
+Scala
+: @@snip ($alpakka$/stomp/src/test/scala/akka/stream/alpakka/stomp/scaladsl/StompClientSinkSpec.scala) { #stomp-client-sink-materialization }
+
+### Receiving messages from STOMP server using a StompClientSource
+
+Create the [ConnectorSettings] that specifies the STOMP server to connect, and the STOMP `destination` that you want receive messages from
+
+: @@snip ($alpakka$/stomp/src/test/scala/akka/stream/alpakka/stomp/scaladsl/StompClientSourceSpec.scala) { #connector-settings }
+
+Create a source, that generates @scaladoc[SendingFrame](akka.stream.alpakka.stomp.client.SendingFrame$)
+
+: @@snip ($alpakka$/stomp/src/test/scala/akka/stream/alpakka/stomp/scaladsl/StompClientSourceSpec.scala) { #stomp-client-source }
+
+Last step is to @extref[materialize](akka-docs:scala/stream/stream-flows-and-basics) and run the source we created.
+
+: @@snip ($alpakka$/stomp/src/test/scala/akka/stream/alpakka/stomp/scaladsl/StompClientSourceSpec.scala) { #materialization }
+
+
+
+### Running the example code
+
+The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
+
+Test code does not require an STOMP server running in the background, since it creates one per test using Vertx Stomp library. 
+
+Scala
+:   ```
+    sbt
+    > stomp/testOnly *.StompClientSourceSpec
+    ```
+
+
+
+
+
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -263,6 +263,13 @@ object Dependencies {
     )
   )
 
+  val Stomp = Seq(
+    libraryDependencies ++= Seq(
+      // https://mvnrepository.com/artifact/io.vertx/vertx-stomp
+      "io.vertx" % "vertx-stomp" % "3.5.1" // ApacheV2/EPL1
+    )
+  )
+
   val UnixDomainSocket = Seq(
     libraryDependencies ++= Seq(
       "com.github.jnr" % "jnr-unixsocket" % "0.18" // BSD/ApacheV2/CPL/MIT as per https://github.com/akka/alpakka/issues/620#issuecomment-348727265

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/ConnectorLogic.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/ConnectorLogic.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.client
+
+import akka.Done
+import akka.stream.stage.GraphStageLogic
+import io.vertx.ext.stomp.{Frame => VertxFrame, StompClientConnection}
+
+import scala.concurrent.Promise
+
+/**
+ * Shared logic for Source and Sink
+ */
+private[client] trait ConnectorLogic {
+  this: GraphStageLogic =>
+
+  val closeCallback = getAsyncCallback[StompClientConnection](_ => {
+    promise.trySuccess(Done)
+    completeStage()
+  })
+  val errorCallback = getAsyncCallback[VertxFrame](frame => {
+    acknowledge(frame)
+    val ex = StompProtocolError(frame)
+    failCallback.invoke(ex)
+  })
+  val dropCallback = getAsyncCallback[StompClientConnection]((dropped: StompClientConnection) => {
+    val ex = StompClientConnectionDropped(dropped)
+    failCallback.invoke(ex)
+  })
+  val failCallback = getAsyncCallback[Throwable](ex => {
+    promise.tryFailure(ex)
+    failStage(ex)
+  })
+  val fullFillOnConnection = false
+  var connection: StompClientConnection = _
+
+  def settings: ConnectorSettings
+
+  def promise: Promise[Done]
+
+  def whenConnected(): Unit
+
+  def onFailure(ex: Throwable): Unit
+
+  override def preStart(): Unit = {
+
+    val connectCallback = getAsyncCallback[StompClientConnection](conn => {
+      connection = conn
+      addHandlers()
+      whenConnected()
+      if (fullFillOnConnection) promise.trySuccess(Done)
+    })
+
+    // connecting async
+    settings.connectionProvider.getStompClient
+      .connect(
+        ar => {
+          if (ar.succeeded()) {
+            connectCallback.invoke(ar.result())
+          } else {
+            if (fullFillOnConnection) promise.tryFailure(ar.cause)
+            throw ar.cause()
+          }
+        }
+      )
+  }
+
+  def acknowledge(frame: VertxFrame): Unit =
+    if (settings.withAck && frame.getHeaders.containsKey(VertxFrame.ACK)) {
+      connection.ack(frame.getAck)
+    }
+
+  def addHandlers(): Unit = {
+    failHandler(connection)
+    closeHandler(connection)
+    errorHandler(connection)
+    writeHandler(connection)
+    dropHandler(connection)
+    receiveHandler(connection)
+    writeHandler(connection)
+  }
+
+  def writeHandler(connection: StompClientConnection): Unit = ()
+
+  /**
+   * When a message is received by the connection
+   */
+  def receiveHandler(connection: StompClientConnection)
+
+  def dropHandler(connection: StompClientConnection): Unit =
+    connection.connectionDroppedHandler(dropped => dropCallback.invoke(dropped))
+
+  /**
+   * An ERROR frame is received
+   */
+  def errorHandler(connection: StompClientConnection): Unit =
+    connection.errorHandler(frame => errorCallback.invoke(frame))
+
+  /**
+   * When connection get closed
+   */
+  def closeHandler(connection: StompClientConnection): Unit =
+    connection.closeHandler(conn => closeCallback.invoke(conn))
+
+  /**
+   * Upon TCP-errors
+   */
+  private def failHandler(connection: StompClientConnection): Unit =
+    connection.exceptionHandler(ex => failCallback.invoke(ex))
+
+  /** remember to call if overriding! */
+  override def postStop(): Unit =
+    if (connection != null && connection.isConnected) connection.disconnect()
+
+}

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/ConnectorLogic.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/ConnectorLogic.scala
@@ -56,8 +56,8 @@ private[client] trait ConnectorLogic {
 
     // connecting async
     settings.connectionProvider.getStompClient
-      .connect({
-        ar: AsyncResult[StompClientConnection] => {
+      .connect({ ar: AsyncResult[StompClientConnection] =>
+        {
           if (ar.succeeded()) {
             connectCallback.invoke(ar.result())
           } else {
@@ -65,8 +65,7 @@ private[client] trait ConnectorLogic {
             throw ar.cause()
           }
         }
-      }
-      )
+      })
   }
 
   def acknowledge(frame: VertxFrame): Unit =

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/ConnectorSettings.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/ConnectorSettings.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.stomp.client
 
-import io.vertx.core.Vertx
+import io.vertx.core.{AsyncResult, Vertx}
 import io.vertx.core.json.JsonObject
 import io.vertx.ext.stomp.{StompClient, StompClientConnection, StompClientOptions}
 
@@ -28,6 +28,7 @@ case class ConnectorSettings(
 }
 
 trait ConnectionProvider {
+  import VertxStompConversions._
   def vertx: Vertx = Vertx.vertx()
   val noHeartBeatObject = new JsonObject().put("x", 0).put("y", 0)
 
@@ -35,15 +36,16 @@ trait ConnectionProvider {
 
   def get: Future[StompClientConnection] = {
     val promise = Promise[StompClientConnection]()
-    getStompClient.connect(
-      ar => {
+    getStompClient.connect({ ar: AsyncResult[StompClientConnection] =>
+      {
         if (ar.succeeded()) {
           promise.trySuccess(ar.result())
         } else {
           promise.tryFailure(ar.cause())
         }
+        ()
       }
-    )
+    })
     promise.future
   }
 

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/ConnectorSettings.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/ConnectorSettings.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.client
+
+import io.vertx.core.Vertx
+import io.vertx.core.json.JsonObject
+import io.vertx.ext.stomp.{StompClient, StompClientConnection, StompClientOptions}
+
+import scala.concurrent.{Future, Promise}
+
+object ConnectorSettings {
+
+  def apply(): ConnectorSettings =
+    ConnectorSettings(connectionProvider = LocalConnectionProvider)
+}
+
+case class ConnectorSettings(
+    connectionProvider: ConnectionProvider,
+    destination: Option[String] = None,
+    withAck: Boolean = true
+) {
+  def withConnectionProvider(other: ConnectionProvider) = copy(connectionProvider = other)
+  def withTopic(other: Option[String]) = copy(destination = other)
+  def withAck(other: Boolean) = copy(withAck = other)
+
+}
+
+trait ConnectionProvider {
+  def vertx: Vertx = Vertx.vertx()
+  val noHeartBeatObject = new JsonObject().put("x", 0).put("y", 0)
+
+  def stompClientOptions: StompClientOptions
+
+  def get: Future[StompClientConnection] = {
+    val promise = Promise[StompClientConnection]()
+    getStompClient.connect(
+      ar => {
+        if (ar.succeeded()) {
+          promise.trySuccess(ar.result())
+        } else {
+          promise.tryFailure(ar.cause())
+        }
+      }
+    )
+    promise.future
+  }
+
+  private[client] def getStompClient: StompClient = StompClient.create(vertx, stompClientOptions)
+
+  def release(connection: StompClientConnection): StompClientConnection = connection.disconnect()
+
+  def release(connection: StompClient): Unit = connection.close()
+}
+
+/**
+ * Connects to a local STOMP server at the default port with no credentials.
+ */
+case object LocalConnectionProvider extends ConnectionProvider {
+  val stompClientOptions: StompClientOptions =
+    DetailsConnectionProvider("0.0.0.0", 61613).stompClientOptions.setHeartbeat(noHeartBeatObject)
+}
+
+final case class Credentials(
+    username: String,
+    password: String
+) {
+  override def toString: String = s"Credentials($username,*****)"
+}
+
+final case class DetailsConnectionProvider(
+    host: String,
+    port: Int,
+    credentials: Option[Credentials] = None
+) extends ConnectionProvider {
+
+  def stompClientOptions: StompClientOptions = {
+    val opt = new StompClientOptions()
+    opt.setHost(host)
+    opt.setPort(port)
+    credentials.foreach { c =>
+      opt.setLogin(c.username)
+      opt.setPasscode(c.password)
+    }
+    opt.setHeartbeat(noHeartBeatObject)
+    opt
+  }
+}

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/SendingFrame.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/SendingFrame.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.client
+
+import java.util
+
+import io.vertx.core.buffer.{Buffer => VertxBuffer}
+import io.vertx.ext.stomp.{Frame => VertxFrame}
+
+case class SendingFrame(headers: Map[String, String], body: Vector[Byte]) {
+
+  import scala.collection.JavaConverters._
+  def toVertexFrame: VertxFrame = {
+    val obj = new VertxFrame().setCommand(VertxFrame.Command.SEND)
+    val h: util.Map[String, String] = headers.asJava
+    if (!h.isEmpty) {
+      obj.setHeaders(h)
+    }
+    if (body.nonEmpty) {
+      obj.setBody(VertxBuffer.buffer(body.toArray))
+    }
+    obj
+  }
+
+  def withDestination(destination: String) =
+    copy(headers + ("destination" -> destination))
+}
+
+object SendingFrame {
+  import scala.collection.JavaConverters._
+  def from(frame: VertxFrame): SendingFrame = {
+    val body: scala.collection.immutable.Vector[Byte] =
+      if (!frame.hasEmptyBody) frame.getBodyAsByteArray.toVector
+      else {
+        Vector()
+      }
+    val headers: scala.collection.immutable.Map[String, String] = if (frame.getHeaders == null) {
+      Map()
+    } else frame.getHeaders.asScala.toMap
+    SendingFrame(headers, body)
+  }
+  def from(bodyStr: String): SendingFrame =
+    from(bodyStr.getBytes().toVector)
+  def from(body: Vector[Byte]): SendingFrame =
+    SendingFrame(Map(), body)
+  def from(destination: String, body: Vector[Byte]): SendingFrame =
+    from(body).withDestination(destination)
+}

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/SinkStage.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/SinkStage.scala
@@ -62,7 +62,10 @@ final class SinkStage(settings: ConnectorSettings)
               pull(in)
             }
             if (settings.withAck) {
-              connection.send(vertxFrame, continue.invoke(_))
+              import VertxStompConversions._
+              connection.send(vertxFrame, { frame: Frame =>
+                continue.invoke(frame)
+              })
             } else {
               connection.send(vertxFrame)
               pull(in)

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/SinkStage.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/SinkStage.scala
@@ -62,10 +62,7 @@ final class SinkStage(settings: ConnectorSettings)
               pull(in)
             }
             if (settings.withAck) {
-              connection.send(vertxFrame, (frame: Frame) => {
-                // server receive the message, continue pulling
-                continue.invoke(frame)
-              })
+              connection.send(vertxFrame, continue.invoke(_))
             } else {
               connection.send(vertxFrame)
               pull(in)

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/SinkStage.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/SinkStage.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.client
+
+import akka.Done
+import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, InHandler}
+import akka.stream.{ActorAttributes, Attributes, Inlet, SinkShape}
+import io.vertx.ext.stomp.{Frame, StompClientConnection}
+
+import scala.concurrent.{Future, Promise}
+
+/**
+ * Connects to a STOMP server upon materialization and sends incoming messages to the server.
+ * Each materialized sink will create one connection to the server.
+ */
+final class SinkStage(settings: ConnectorSettings)
+    extends GraphStageWithMaterializedValue[SinkShape[SendingFrame], Future[Done]] {
+  stage =>
+
+  override def shape: SinkShape[SendingFrame] = SinkShape.of(in)
+
+  override def toString: String = "StompClientSink"
+
+  override protected def initialAttributes: Attributes = SinkStage.defaultAttributes
+
+  val in = Inlet[SendingFrame]("StompClientSink.in")
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Done]) = {
+    val thePromise = Promise[Done]()
+    (new GraphStageLogic(shape) with ConnectorLogic {
+      override val settings: ConnectorSettings = stage.settings
+      override val promise: Promise[Done] = thePromise
+
+      override def receiveHandler(connection: StompClientConnection): Unit = ()
+
+      override def whenConnected(): Unit = pull(in)
+
+      setHandler(
+        in,
+        new InHandler {
+
+          override def onUpstreamFailure(ex: Throwable): Unit = {
+            promise.tryFailure(ex)
+            super.onUpstreamFailure(ex)
+          }
+
+          override def onUpstreamFinish(): Unit = {
+            promise.trySuccess(Done)
+            super.onUpstreamFinish()
+          }
+
+          override def onPush(): Unit = {
+            val originalFrame: SendingFrame = grab(in)
+
+            // mutable vertxFrame
+            val vertxFrame = originalFrame.toVertexFrame
+            // will not override if already set
+            settings.destination.foreach(vertxFrame.setDestination)
+            val continue = getAsyncCallback[Frame] { _ =>
+              pull(in)
+            }
+            if (settings.withAck) {
+              connection.send(vertxFrame, (frame: Frame) => {
+                // server receive the message, continue pulling
+                continue.invoke(frame)
+              })
+            } else {
+              connection.send(vertxFrame)
+              pull(in)
+            }
+
+          }
+        }
+      )
+
+      override def postStop(): Unit = {
+        promise.tryFailure(new RuntimeException("stage stopped unexpectedly"))
+        super.postStop()
+      }
+
+      override def onFailure(ex: Throwable): Unit =
+        promise.tryFailure(ex)
+
+    }, thePromise.future)
+  }
+
+}
+
+object SinkStage {
+  private val defaultAttributes =
+    Attributes.name("StompClientSink").and(ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher"))
+}

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/SourceStage.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/SourceStage.scala
@@ -47,18 +47,18 @@ final class SourceStage(settings: ConnectorSettings)
         import JavaConverters._
         connection.subscribe(
           settings.destination.get,
-          headers.asJava, { frame =>
-            receiveSubscriptionMessage.invoke(frame)
-          }, { frameSubscribe =>
-            acknowledge(frameSubscribe)
-          }
+          headers.asJava,
+            receiveSubscriptionMessage.invoke(_)
+         , acknowledge(_)
         )
       }
 
       override def receiveHandler(connection: StompClientConnection): Unit =
-        connection.receivedFrameHandler(frame => {
-          if (!settings.destination.contains(frame.getDestination)) {
-            acknowledge(frame)
+        connection.receivedFrameHandler({
+          frame: Frame => {
+            if (!settings.destination.contains(frame.getDestination)) {
+              acknowledge(frame)
+            }
           }
         })
 

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/SourceStage.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/SourceStage.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.client
+
+import akka.Done
+import akka.stream._
+import akka.stream.stage._
+import io.vertx.ext.stomp.{Frame, StompClientConnection}
+
+import scala.collection.{mutable, JavaConverters}
+import scala.concurrent.{Future, Promise}
+
+/**
+ * Connects to a STOMP server upon materialization and receives incoming messages from the server to the stream.
+ * Each materialized sink will create one connection to the server.
+ */
+final class SourceStage(settings: ConnectorSettings)
+    extends GraphStageWithMaterializedValue[SourceShape[SendingFrame], Future[Done]] {
+  stage =>
+
+  val out = Outlet[SendingFrame]("StompClientSource.out")
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Done]) = {
+    val thePromise = Promise[Done]()
+    val graphStageLogic = new GraphStageLogic(shape) with ConnectorLogic {
+
+      override val settings: ConnectorSettings = stage.settings
+
+      override val promise: Promise[Done] = thePromise
+      override val fullFillOnConnection: Boolean = true
+
+      private val headers: mutable.Map[String, String] =
+        if (settings.withAck) mutable.Map(Frame.ACK -> "client-individual") else mutable.Map()
+
+      var pending: Option[Frame] = None
+      override def whenConnected(): Unit = {
+        val receiveSubscriptionMessage = getAsyncCallback[Frame] { frame =>
+          {
+            pending = Some(frame)
+            handleDelivery(frame)
+          }
+
+        }
+
+        import JavaConverters._
+        connection.subscribe(
+          settings.destination.get,
+          headers.asJava, { frame =>
+            receiveSubscriptionMessage.invoke(frame)
+          }, { frameSubscribe =>
+            acknowledge(frameSubscribe)
+          }
+        )
+      }
+
+      override def receiveHandler(connection: StompClientConnection): Unit =
+        connection.receivedFrameHandler(frame => {
+          if (!settings.destination.contains(frame.getDestination)) {
+            acknowledge(frame)
+          }
+        })
+
+      def handleDelivery(frame: Frame): Unit =
+        if (isAvailable(out)) {
+          pushMessage(frame)
+        }
+
+      setHandler(
+        out,
+        new OutHandler {
+          override def onPull(): Unit = pending.foreach(pushMessage)
+
+          override def onDownstreamFinish(): Unit =
+            completeStage()
+        }
+      )
+
+      def pushMessage(frame: Frame): Unit = {
+        push(out, SendingFrame.from(frame))
+        pending = None
+        acknowledge(frame)
+      }
+
+      override def postStop(): Unit = {
+        promise.trySuccess(Done)
+        super.postStop()
+      }
+
+      override def onFailure(ex: Throwable): Unit = {
+        promise.trySuccess(Done)
+        ()
+      }
+
+    }
+    (graphStageLogic, thePromise.future)
+  }
+
+  override def shape: SourceShape[SendingFrame] = SourceShape.of(out)
+
+  override def toString: String = "StompClientSink"
+
+  override protected def initialAttributes: Attributes = SourceStage.defaultAttributes
+
+}
+
+object SourceStage {
+  private val defaultAttributes =
+    Attributes.name("StompClientSource").and(ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher"))
+}

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/SourceStage.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/SourceStage.scala
@@ -48,14 +48,14 @@ final class SourceStage(settings: ConnectorSettings)
         connection.subscribe(
           settings.destination.get,
           headers.asJava,
-            receiveSubscriptionMessage.invoke(_)
-         , acknowledge(_)
+          receiveSubscriptionMessage.invoke(_),
+          acknowledge(_)
         )
       }
 
       override def receiveHandler(connection: StompClientConnection): Unit =
-        connection.receivedFrameHandler({
-          frame: Frame => {
+        connection.receivedFrameHandler({ frame: Frame =>
+          {
             if (!settings.destination.contains(frame.getDestination)) {
               acknowledge(frame)
             }

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/StompThrowable.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/StompThrowable.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.client
+
+import io.vertx.ext.stomp.{Frame, StompClientConnection}
+
+sealed trait StompThrowable extends Exception
+
+case class StompProtocolError(frame: Frame) extends StompThrowable {
+  override def toString: String = super.toString + frame.toString
+}
+
+case class StompClientConnectionDropped(clientConnection: StompClientConnection) extends StompThrowable {
+  override def toString: String = super.toString + clientConnection.toString
+}

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/VertxStompConversions.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/VertxStompConversions.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.client
+
+import io.vertx.core.Handler
+
+object VertxStompConversions {
+  import scala.language.implicitConversions
+
+  implicit def toHandler[T](x: T => Unit): Handler[T] = new Handler[T] {
+    override def handle(event: T): Unit = x(event)
+  }
+}

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/package.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/package.scala
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp
+
+import io.vertx.ext.stomp.{Frame, StompClientConnection}
+
+package object client {}

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/client/package.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/client/package.scala
@@ -4,6 +4,4 @@
 
 package akka.stream.alpakka.stomp
 
-import io.vertx.ext.stomp.{Frame, StompClientConnection}
-
 package object client {}

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/javadsl/StompClientSink.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/javadsl/StompClientSink.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.javadsl
+
+import java.util.concurrent.CompletionStage
+
+import akka.Done
+import akka.stream.alpakka.stomp.client.{ConnectorSettings, SendingFrame}
+
+import scala.compat.java8.FutureConverters._
+
+object StompClientSink {
+
+  /**
+   * Java API: Creates[[StompClientSink]] that accepts [[SendingFrame]] elements, and deliver them to a stomp server.
+   *
+   * This stage materializes to a CompletionStage<Done>, which can be used to know when the Sink completes either normally or because of a stomp server failure.
+   *
+   */
+  def create(settings: ConnectorSettings): akka.stream.javadsl.Sink[SendingFrame, CompletionStage[Done]] =
+    akka.stream.alpakka.stomp.scaladsl.StompClientSink(settings).mapMaterializedValue(f => f.toJava).asJava
+
+}

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/javadsl/StompClientSource.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/javadsl/StompClientSource.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.javadsl
+
+import java.util.concurrent.CompletionStage
+
+import akka.Done
+import akka.stream.alpakka.stomp.client.{ConnectorSettings, SendingFrame}
+
+import scala.compat.java8.FutureConverters._
+
+object StompClientSource {
+
+  /**
+   * Java API: Create a Source [[StompClientSource]] that receives
+   * message from a stomp server. It listens to message at the `destination` described in settings.topic. It handles backpressure.
+   */
+  def create(settings: ConnectorSettings): akka.stream.javadsl.Source[SendingFrame, CompletionStage[Done]] =
+    akka.stream.alpakka.stomp.scaladsl.StompClientSource(settings).mapMaterializedValue(f => f.toJava).asJava
+}

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/scaladsl/StompClientSink.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/scaladsl/StompClientSink.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.scaladsl
+
+import akka.Done
+import akka.stream.alpakka.stomp.client.{ConnectorSettings, SendingFrame, SinkStage}
+import akka.stream.scaladsl.Sink
+
+import scala.concurrent.Future
+
+object StompClientSink {
+
+  /**
+   * Scala API: Connects to a STOMP server upon materialization and sends incoming messages to the server.
+   * Each materialized sink will create one connection to the broker. This stage sends messages to the destination
+   * named in the settings options, if present, instead of the one written in the incoming message to the Sink.
+   *
+   * This stage materializes to a Future[Done], which can be used to know when the Sink completes, either normally
+   * or because of a stomp failure.
+   */
+  def apply(settings: ConnectorSettings): Sink[SendingFrame, Future[Done]] = Sink.fromGraph(new SinkStage(settings))
+}

--- a/stomp/src/main/scala/akka/stream/alpakka/stomp/scaladsl/StompClientSource.scala
+++ b/stomp/src/main/scala/akka/stream/alpakka/stomp/scaladsl/StompClientSource.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.scaladsl
+
+import akka.Done
+import akka.stream.alpakka.stomp.client.{ConnectorSettings, SendingFrame, SourceStage}
+import akka.stream.scaladsl.Source
+
+import scala.concurrent.Future
+
+object StompClientSource {
+
+  /**
+   * Scala API: Upon materialization this source [[StompClientSource]] connects and subscribes to a topic (set in settings) published in a Stomp server. Each message may be Ack, and handles backpressure.
+   */
+  def apply(settings: ConnectorSettings): Source[SendingFrame, Future[Done]] =
+    Source.fromGraph(new SourceStage(settings))
+
+}

--- a/stomp/src/test/scala/akka.stream.alpakka.stomp.client/Server.scala
+++ b/stomp/src/test/scala/akka.stream.alpakka.stomp.client/Server.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.client
+
+import akka.Done
+import io.vertx.core.Vertx
+import io.vertx.ext.stomp.{
+  Destination,
+  Frame,
+  StompServer,
+  StompServerConnection,
+  StompServerHandler,
+  StompServerOptions
+}
+import io.vertx.ext.stomp.impl.Topic
+import io.vertx.ext.stomp.impl.Topic.Subscription
+
+import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.duration._
+
+private[stomp] object Server {
+
+//  val vertx: Vertx = Vertx.vertx(new VertxOptions().setBlockedThreadCheckInterval(10))
+  val vertx = Vertx.vertx()
+  val patienceWithServer: FiniteDuration = 1.seconds
+
+  def getStompServer(handler: Option[StompServerHandler] = None, port: Int = 61613): StompServer =
+    Await.result(stompServerFuture(handler, port), patienceWithServer)
+
+  private def stompServerFuture(handler: Option[StompServerHandler] = None, port: Int = 61613) = {
+    val serverHandler = handler.getOrElse(StompServerHandler.create(vertx))
+    val promise = Promise[StompServer]()
+    StompServer
+      .create(vertx, new StompServerOptions().setPort(port))
+      .handler(serverHandler)
+      .listen(
+        ar =>
+          if (ar.succeeded()) {
+            promise success ar.result()
+          } else {
+            promise failure ar.cause()
+        }
+      )
+    promise.future
+  }
+
+  def closeAwaitStompServer(server: StompServer): Future[Done] = {
+    val promise = Promise[Done]()
+    server.close(
+      ar =>
+        if (ar.succeeded()) promise.success(Done)
+        else promise.failure(ar.cause())
+    )
+    Await.ready(promise.future, patienceWithServer)
+  }
+
+  def accumulateHandler(accumulator: Frame => Unit): StompServerHandler =
+    StompServerHandler
+      .create(vertx)
+      .receivedFrameHandler(ar => {
+        // accumulate SEND received by Server
+        if (ar.frame().getCommand() == Frame.Command.SEND) {
+          accumulator(ar.frame())
+        }
+      })
+
+  def stompServerWithTopicAndQueue(port: Int): StompServer =
+    getStompServer(
+      Some(
+        StompServerHandler
+          .create(vertx)
+          .destinationFactory((v, name) => {
+            new StompServerTopic(v, name)
+          })
+      ),
+      port
+    )
+
+  /**
+   * Describe a topic in the stomp server, that is able to `feel` the ack.
+   *
+   * Current vertx-stomp-server with vertx-stomp-server-topic does not handle the `ack`. We extend the default Topic implementation in order to handle a Queues of messages and ack of them.
+   *
+   */
+  class StompServerTopic(vertx: Vertx, destination: String) extends Topic(vertx, destination) {
+    import collection.mutable.{Queue => mQueue}
+    case class Subs(stompServerConnection: StompServerConnection,
+                    var waitingAck: Option[String] = None,
+                    var pendingFrames: mQueue[Frame] = mQueue())
+
+    var internalSubs: Map[Subscription, Subs] = Map()
+
+    override def subscribe(connection: StompServerConnection, frame: Frame): Destination = {
+      super.subscribe(connection, frame)
+      // hack to be able to access the connection
+      val i = subscriptions.size()
+      val last = subscriptions.get(i - 1)
+      internalSubs = internalSubs + (last -> Subs(connection))
+      this
+    }
+
+    override def ack(connection: StompServerConnection, frame: Frame): Boolean = {
+      val ack = frame.getId
+
+      internalSubs
+        .find(_._2.stompServerConnection == connection)
+        .find(_._2.waitingAck.contains(ack))
+        .map {
+          case (subscription: Subscription, subs: Subs) =>
+            subs.waitingAck = None
+            if (subs.pendingFrames.nonEmpty) deliver(subs, subscription, subs.pendingFrames.dequeue())
+        }
+        .nonEmpty
+    }
+
+    def deliver(subs: Subs, subscription: Subscription, frame: Frame): StompServerConnection = {
+      import collection.JavaConverters._
+
+      val messageId = java.util.UUID.randomUUID().toString
+      val message = Topic.transform(frame, subscription, messageId)
+      if (message.getHeaders.asScala.contains(Frame.ACK)) {
+        subs.waitingAck = Some(message.getAck)
+      }
+      subs.stompServerConnection.write(message)
+    }
+    def enqueue(subs: Subs, frame: Frame): Unit =
+      subs.pendingFrames.enqueue(frame)
+
+    override def dispatch(connection: StompServerConnection, frame: Frame): Destination = {
+      import collection.JavaConverters._
+      val coll = for {
+        subscription <- subscriptions.asScala
+        sub: Subs <- internalSubs.get(subscription)
+      } yield (sub, subscription)
+      coll.foreach {
+        case (subs: Subs, subscription: Subscription) if subs.waitingAck.isEmpty =>
+          deliver(subs, subscription, frame)
+        case (subs, _) => enqueue(subs, frame)
+      }
+      this
+    }
+  }
+}

--- a/stomp/src/test/scala/akka.stream.alpakka.stomp.client/StompClientSpec.scala
+++ b/stomp/src/test/scala/akka.stream.alpakka.stomp.client/StompClientSpec.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.client
+
+import akka.actor.ActorSystem
+import akka.dispatch.ExecutionContexts
+import akka.stream.ActorMaterializer
+import io.vertx.core.{Vertx, VertxOptions}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpec}
+import scala.concurrent.duration._
+
+trait StompClientSpec extends WordSpec with Matchers with BeforeAndAfterAll with BeforeAndAfterEach with ScalaFutures {
+
+  implicit val system = ActorSystem(this.getClass.getSimpleName)
+  implicit val materializer = ActorMaterializer()(system)
+
+  val patience = 2.seconds
+
+  override implicit val patienceConfig = PatienceConfig(patience)
+  implicit val executionContext = ExecutionContexts.sameThreadExecutionContext
+
+  override def afterAll(): Unit = {
+    system.terminate()
+    super.afterAll()
+  }
+}

--- a/stomp/src/test/scala/akka/stream/alpakka/stomp/scaladsl/StompClientSinkSpec.scala
+++ b/stomp/src/test/scala/akka/stream/alpakka/stomp/scaladsl/StompClientSinkSpec.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.scaladsl
+
+import akka.Done
+import akka.stream.OverflowStrategy
+import akka.stream.alpakka.stomp.client.StompClientSpec
+import io.vertx.ext.stomp.{Frame => VertxFrame}
+
+import scala.collection.mutable.ArrayBuffer
+import akka.stream.alpakka.stomp.client._
+import akka.stream.scaladsl.{Keep, Sink, Source}
+
+import scala.concurrent.Future
+
+class StompClientSinkSpec extends StompClientSpec {
+
+  "A Stomp Client SinkStage" should {
+    "deliver messages to a stomp server and complete when downstream completes" in {
+
+      // #connector-settings
+      val host = "localhost"
+      val port = 61613
+      val topic = "AnyTopic"
+      val settings =
+        ConnectorSettings(connectionProvider = DetailsConnectionProvider(host, port), destination = Some(topic))
+      // #connector-settings
+
+      // test helper: creates a stomp server locally, which will buffer incoming messages for inspection
+      import Server._
+      val receivedFrameOnServer: ArrayBuffer[VertxFrame] = ArrayBuffer()
+      val server = getStompServer(Some(accumulateHandler(f => receivedFrameOnServer += f)), port)
+
+      // #stomp-client-sink
+      val sinkToStomp: Sink[SendingFrame, Future[Done]] = StompClientSink(settings)
+      // #stomp-client-sink
+
+      // #stomp-client-sink-materialization
+      val input = Vector("one", "two")
+      val source = Source(input).map(SendingFrame.from)
+      val sinkDone = source.runWith(sinkToStomp)
+      // #stomp-client-sink-materialization
+
+      sinkDone.futureValue shouldBe Done
+
+      receivedFrameOnServer
+        .result()
+        .map(_.getBodyAsString) should contain theSameElementsInOrderAs input
+
+      closeAwaitStompServer(server)
+    }
+
+    "fail when no destination is set" in {
+      // creating a stomp server
+      import Server._
+      val port = 61667
+      val server = getStompServer(None, port)
+
+      val settings = ConnectorSettings(connectionProvider = DetailsConnectionProvider("localhost", port))
+
+      // functionality to test
+      val sinkToStomp = StompClientSink(settings)
+      val queueSource = Source.queue[SendingFrame](100, OverflowStrategy.backpressure)
+      val (queue, sinkDone) = queueSource.toMat(sinkToStomp)(Keep.both).run()
+
+      queue.offer(SendingFrame(Map(), "msg".toCharArray.toVector.map(_.toByte)))
+
+      sinkDone.failed.futureValue shouldBe an[StompProtocolError]
+
+      closeAwaitStompServer(server)
+    }
+
+    "settings topic should set frame destination if not already present" in {
+      // creating a stomp server
+      import Server._
+      val receivedFrameOnServer: ArrayBuffer[VertxFrame] = ArrayBuffer()
+      val port = 61668
+      val server = getStompServer(Some(accumulateHandler(f => receivedFrameOnServer += f)), port)
+
+      // connection settings
+      val topic = "AnyTopic"
+      val settings =
+        ConnectorSettings(connectionProvider = DetailsConnectionProvider("localhost", port), destination = Some(topic))
+
+      // functionality to test
+      val sinkToStomp = StompClientSink(settings)
+      val queueSource = Source.queue[SendingFrame](100, OverflowStrategy.backpressure)
+      val (queue, sinkDone) = queueSource.toMat(sinkToStomp)(Keep.both).run()
+
+      queue.offer(SendingFrame(Map(("destination" -> "another destination")), "msg".toCharArray.toVector.map(_.toByte)))
+      queue.offer(SendingFrame(Map(), "msg".toCharArray.toVector.map(_.toByte)))
+      queue.complete()
+      queue.watchCompletion().futureValue shouldBe Done
+      sinkDone.futureValue shouldBe Done
+
+      receivedFrameOnServer.result().map(_.getDestination) should contain theSameElementsInOrderAs Seq(
+        "another destination",
+        "AnyTopic"
+      )
+
+      closeAwaitStompServer(server)
+    }
+
+    "handle failure on downstream" in {
+
+      // creating a stomp server
+      import Server._
+      val receivedFrameOnServer: ArrayBuffer[VertxFrame] = ArrayBuffer()
+      val port = 61669
+      val server = getStompServer(Some(accumulateHandler(f => receivedFrameOnServer += f)), port)
+
+      // connection settings
+      val topic = "AnyTopic"
+      val settings =
+        ConnectorSettings(connectionProvider = DetailsConnectionProvider("localhost", port), destination = Some(topic))
+
+      // functionality to test
+      val sinkToStomp = StompClientSink(settings)
+      val queueSource = Source.queue[SendingFrame](100, OverflowStrategy.backpressure)
+      val (queue, sinkDone) = queueSource.toMat(sinkToStomp)(Keep.both).run()
+
+      queue.offer(SendingFrame(Map(("destination" -> "another destination")), "msg".toCharArray.toVector.map(_.toByte)))
+      queue.offer(SendingFrame(Map(), "msg".toCharArray.toVector.map(_.toByte)))
+      queue.fail(new Exception("on purpose"))
+
+      sinkDone.failed.futureValue shouldBe an[Exception]
+      sinkDone.failed.futureValue.getMessage shouldBe "on purpose"
+
+      closeAwaitStompServer(server)
+    }
+  }
+}

--- a/stomp/src/test/scala/akka/stream/alpakka/stomp/scaladsl/StompClientSourceSpec.scala
+++ b/stomp/src/test/scala/akka/stream/alpakka/stomp/scaladsl/StompClientSourceSpec.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.stomp.scaladsl
+
+import akka.stream.alpakka.stomp.client._
+import akka.Done
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import io.vertx.ext.stomp.Frame
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import io.vertx.core.buffer.{Buffer => VertxBuffer}
+import akka.stream.testkit.scaladsl.TestSink
+
+class StompClientSourceSpec extends StompClientSpec {
+
+  "A Stomp Client SourceStage" should {
+    "receive a message published in a topic of a stomp server" in {
+
+      import akka.stream.alpakka.stomp.client.Server._
+
+      // #connector-settings
+      val host = "localhost"
+      val port = 61667
+      val destination = "/topic/topic2"
+      val settings = ConnectorSettings(DetailsConnectionProvider(host, port, None), Some(destination))
+      // #connector-settings
+
+      // create stomp server
+      val server = stompServerWithTopicAndQueue(port)
+
+      // #stomp-client-source
+      val source: Source[SendingFrame, Future[Done]] = StompClientSource(settings)
+      // #stomp-client-source
+
+      // #materialization
+      val sink = Sink.head[SendingFrame]
+      val (futConnected: Future[Done], futHead: Future[SendingFrame]) = source.toMat(sink)(Keep.both).run()
+      // #materialization
+
+      // to make a predictable test, wait until graph connects to stomp server
+      Await.ready(futConnected, patience)
+
+      // create another connection, to send to the stomp topic we have registered in SourceStage
+      val futstompClient = settings.connectionProvider.get
+      val msg = "Hola source"
+      val stomp = Await.result(futstompClient, patience)
+
+      stomp.send(
+        new Frame().setCommand(Frame.Command.SEND).setDestination(destination).setBody(VertxBuffer.buffer(msg))
+      )
+
+      futHead.futureValue.body.map(_.toChar).mkString("") shouldBe msg
+
+      closeAwaitStompServer(server)
+    }
+
+    "receive sequentially the messages received in a stomp server when ack them" in {
+
+      import Server._
+      val port = 61613
+      val server = stompServerWithTopicAndQueue(port)
+      val topic = "/topic/mytopic"
+      val connectionProvider = DetailsConnectionProvider("localhost", port)
+      val settings =
+        ConnectorSettings(connectionProvider = connectionProvider, withAck = true, destination = Some(topic))
+
+      // testing source
+      val sink = TestSink.probe[String]
+      val source: Source[String, Future[Done]] =
+        StompClientSource(settings).map(_.body.map(_.toChar).mkString(""))
+
+      val (futConnected, sub) = source.toMat(sink)(Keep.both).run()
+
+      // to make a predictable test, wait until graph connects to stomp server
+      Await.ready(futConnected, patience)
+
+      // create another connection, to send to the stomp topic we have registered in SourceStage
+      val futstompClient = settings.connectionProvider.get
+      val stomp = Await.result(futstompClient, patience)
+
+      def sendToStomp(msg: String) =
+        stomp.send(new Frame().setCommand(Frame.Command.SEND).setDestination(topic).setBody(VertxBuffer.buffer(msg)))
+
+      sub.request(1)
+      sendToStomp("1")
+      sub.expectNext("1")
+      sendToStomp("2")
+      sub.requestNext("2")
+      sendToStomp("3")
+      sub.requestNext("3")
+
+      sub.request(1)
+      sendToStomp("4")
+      sub.expectNext("4")
+      sendToStomp("5")
+      sendToStomp("6")
+      sub.request(4)
+      sendToStomp("7")
+      sendToStomp("8")
+      sendToStomp("9")
+      sendToStomp("10")
+      sendToStomp("11")
+      sub.expectNext("5", "6", "7", "8")
+      sub.expectNoMessage(500.millisecond)
+      sub.requestNext("9")
+      sub.requestNext("10")
+      sub.requestNext("11")
+      sub.request(10)
+      sub.expectNoMessage(500.milliseconds)
+      sendToStomp("12")
+      sub.expectNext("12")
+
+      closeAwaitStompServer(server)
+    }
+  }
+}


### PR DESCRIPTION
Add connectors to a STOMP server as a stream client or source.

Ref #514 

Before finishing the documentation and test for java, I wish this to be reviewed.

As stated in https://github.com/akka/alpakka/issues/514#issuecomment-368509908 here we have
the
- StompClientSource
- StompClientSink
and both support backpropagation

