### PR TITLE
AWS S3: Expose Content-Type as part of ObjectMetaData

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -13,7 +13,7 @@ import akka.{Done, NotUsed}
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.StatusCodes.{NoContent, NotFound, OK}
-import akka.http.scaladsl.model.headers.{ByteRange, CustomHeader, `Content-Length`}
+import akka.http.scaladsl.model.headers.{`Content-Length`, ByteRange, CustomHeader}
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import akka.stream.Materializer
@@ -220,14 +220,14 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
     }
   }
 
-  private def computeMetaData(headers:Seq[HttpHeader], entity:ResponseEntity):ObjectMetadata = {
-    ObjectMetadata(headers ++
+  private def computeMetaData(headers: Seq[HttpHeader], entity: ResponseEntity): ObjectMetadata =
+    ObjectMetadata(
+      headers ++
       Seq(
-          `Content-Length`(entity.contentLengthOption.getOrElse(0)),
-          CustomContentTypeHeader(entity.contentType)
+        `Content-Length`(entity.contentLengthOption.getOrElse(0)),
+        CustomContentTypeHeader(entity.contentType)
       )
     )
-  }
 
   //`Content-Type` header is by design not accessible as header. So need to have a custom
   //header implementation to expose that

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3Client.scala
@@ -128,7 +128,7 @@ final class ObjectMetadata private (
    * @see ObjectMetadata#setContentType(String)
    */
   lazy val contentType: Option[String] = metadata.collectFirst {
-    case ct: ContentType => ct.value
+    case h if h.lowercaseName() == "content-type" => h.value
   }
 
   /**

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.s3.scaladsl
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.model.ContentTypes
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.s3.S3Settings
 import akka.stream.alpakka.s3.impl.{MetaHeaders, S3Headers}
@@ -144,6 +145,7 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
     val (body, meta) = Await.ready(result, 5.seconds).futureValue
     body shouldBe objectValue
     meta.eTag should not be empty
+    meta.contentType shouldBe ContentTypes.`application/octet-stream`.value
   }
 
   it should "delete with real credentials" in {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -110,6 +110,7 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
     val (putResult, deleteResult, metaBefore, metaAfter) = Await.ready(result, 90.seconds).futureValue
     putResult.eTag should not be empty
     metaBefore should not be empty
+    metaBefore.get.contentType shouldBe Some(ContentTypes.`application/octet-stream`.value)
     metaAfter shouldBe empty
   }
 
@@ -145,7 +146,7 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
     val (body, meta) = Await.ready(result, 5.seconds).futureValue
     body shouldBe objectValue
     meta.eTag should not be empty
-    meta.contentType shouldBe ContentTypes.`application/octet-stream`.value
+    meta.contentType shouldBe Some(ContentTypes.`application/octet-stream`.value)
   }
 
   it should "delete with real credentials" in {


### PR DESCRIPTION
Fix for #853

To expose the `Content-Type` I had to implement a `CustomContentTypeHeader`  as akka http [by design](https://github.com/akka/akka/issues/16523) does not provide a way to construct this header. 

Further `akka.http.scaladsl.model.ContentType` is a sealed trait so its not possible to have an implementation which extends both `ContentType` and `HttpHeader`. So the logic in `ObjectMetadata` also had to be changed to explicitly match header by name. Not sure if there is a better way possible to do this