### PR TITLE
Support specifying version type for ElasticSearch Flow or Sink

### DIFF
--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -101,6 +101,7 @@ Java
 | maxRetry            | 100     | `ElasticsearchSink` give up and fails the stage if it gets this number of consective failures.         | 
 | retryPartialFailure | true    | A bulk request might fails partially for some reason. If this parameter is true, then `ElasticsearchSink` retries to request these failed messages. Otherwise, failed messages are discarded (or pushed to downstream if you use `ElasticsearchFlow` instead of the sink). |
 | docAsUpsert         | false   | If this parameter is true, `ElasticsearchSink` uses the upsert method to index documents. By default, documents are added using the standard index method (which create or replace). |
+| versionType         | None    | If set, `ElasticsearchSink` uses the chosen versionType to index documents. See [Version types](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types) for accepted settings. |
 
 ## Elasticsearch as Flow
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
@@ -221,6 +221,9 @@ class ElasticsearchFlowStage[T, C](
                   message.version.map { version =>
                     "_version" -> JsNumber(version)
                   },
+                  settings.versionType.map { versionType =>
+                    "version_type" -> JsString(versionType)
+                  },
                   message.id.map { id =>
                     "_id" -> JsString(id)
                   }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSinkSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSinkSettings.scala
@@ -19,44 +19,58 @@ final class ElasticsearchSinkSettings(val bufferSize: Int,
                                       val retryInterval: Int,
                                       val maxRetry: Int,
                                       val retryPartialFailure: Boolean,
-                                      val docAsUpsert: Boolean) {
+                                      val docAsUpsert: Boolean,
+                                      val versionType: Option[String]) {
 
-  def this() = this(10, 5000, 100, false, false)
+  def this() = this(10, 5000, 100, false, false, None)
 
   def withBufferSize(bufferSize: Int): ElasticsearchSinkSettings =
     new ElasticsearchSinkSettings(bufferSize,
                                   this.retryInterval,
                                   this.maxRetry,
                                   this.retryPartialFailure,
-                                  this.docAsUpsert)
+                                  this.docAsUpsert,
+                                  this.versionType)
 
   def withRetryInterval(retryInterval: Int): ElasticsearchSinkSettings =
     new ElasticsearchSinkSettings(this.bufferSize,
                                   retryInterval,
                                   this.maxRetry,
                                   this.retryPartialFailure,
-                                  this.docAsUpsert)
+                                  this.docAsUpsert,
+                                  this.versionType)
 
   def withMaxRetry(maxRetry: Int): ElasticsearchSinkSettings =
     new ElasticsearchSinkSettings(this.bufferSize,
                                   this.retryInterval,
                                   maxRetry,
                                   this.retryPartialFailure,
-                                  this.docAsUpsert)
+                                  this.docAsUpsert,
+                                  this.versionType)
 
   def withRetryPartialFailure(retryPartialFailure: Boolean): ElasticsearchSinkSettings =
     new ElasticsearchSinkSettings(this.bufferSize,
                                   this.retryInterval,
                                   this.maxRetry,
                                   retryPartialFailure,
-                                  this.docAsUpsert)
+                                  this.docAsUpsert,
+                                  this.versionType)
 
   def withDocAsUpsert(docAsUpsert: Boolean): ElasticsearchSinkSettings =
     new ElasticsearchSinkSettings(this.bufferSize,
                                   this.retryInterval,
                                   this.maxRetry,
                                   this.retryPartialFailure,
-                                  docAsUpsert)
+                                  docAsUpsert,
+                                  this.versionType)
+
+  def withVersionType(versionType: String): ElasticsearchSinkSettings =
+    new ElasticsearchSinkSettings(this.bufferSize,
+                                  this.retryInterval,
+                                  this.maxRetry,
+                                  this.retryPartialFailure,
+                                  this.docAsUpsert,
+                                  Some(versionType))
 
   private[javadsl] def asScala: ScalaElasticsearchSinkSettings =
     ScalaElasticsearchSinkSettings(
@@ -64,7 +78,8 @@ final class ElasticsearchSinkSettings(val bufferSize: Int,
       retryInterval = this.retryInterval,
       maxRetry = this.maxRetry,
       retryPartialFailure = this.retryPartialFailure,
-      docAsUpsert = this.docAsUpsert
+      docAsUpsert = this.docAsUpsert,
+      versionType = this.versionType
     )
 
 }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSinkSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSinkSettings.scala
@@ -17,5 +17,6 @@ final case class ElasticsearchSinkSettings(bufferSize: Int = 10,
                                            retryInterval: Int = 5000,
                                            maxRetry: Int = 100,
                                            retryPartialFailure: Boolean = false,
-                                           docAsUpsert: Boolean = false)
+                                           docAsUpsert: Boolean = false,
+                                           versionType: Option[String] = None)
 //#sink-settings


### PR DESCRIPTION
Fix for #813. I also fix a Java test case on versioning support (currently it tests the wrong thing).