### PR TITLE
JMS: Add support for durable subscriptions

### DIFF
--- a/docs/src/main/paradox/jms.md
+++ b/docs/src/main/paradox/jms.md
@@ -472,6 +472,27 @@ Such sink and source can be started the same way as in the previous example.
 * Explicit acknowledgement sources and transactional sources work with topics the same way they work with queues.
 * **DO NOT** set the `sessionCount` greater than 1 for topics. Doing so will result in duplicate messages being delivered. Each topic message is delivered to each JMS session and all the messages feed to the same `Source`. JMS 2.0 created shared consumers to solve this problem and multiple sessions without duplication may be supported in the future.
 
+### Using a durable Topic subscription with a JMS provider
+
+Using a durable topic subscription works mostly like a normal topic source.
+
+You need to specify a client ID for the connection factory you use to create the consumer with, however:
+ 
+Scala
+: @@snip ($alpakka$/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #create-connection-factory-with-client-id }
+
+Java
+: @@snip ($alpakka$/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-connection-factory-with-client-id }
+
+In addition, use `withDurableTopic` and specify a name for the durable subscriber:
+
+Scala
+: @@snip ($alpakka$/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #create-durable-topic-source }
+
+Java
+: @@snip ($alpakka$/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-durable-topic-source }
+
+
 ### Running the example code
 
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.

--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -33,7 +33,7 @@ sealed trait JmsSettings {
 }
 
 sealed trait Destination
-final case class Topic(name: String) extends Destination
+final case class Topic(name: String, subscriberName: Option[String] = None) extends Destination
 final case class Queue(name: String) extends Destination
 
 final class AcknowledgeMode(val mode: Int)
@@ -64,6 +64,8 @@ final case class JmsConsumerSettings(connectionFactory: ConnectionFactory,
   def withBufferSize(size: Int): JmsConsumerSettings = copy(bufferSize = size)
   def withQueue(name: String): JmsConsumerSettings = copy(destination = Some(Queue(name)))
   def withTopic(name: String): JmsConsumerSettings = copy(destination = Some(Topic(name)))
+  def withTopic(name: String, subscriberName: String): JmsConsumerSettings =
+    copy(destination = Some(Topic(name, Some(subscriberName))))
   def withSelector(selector: String): JmsConsumerSettings = copy(selector = Some(selector))
   def withAcknowledgeMode(acknowledgeMode: AcknowledgeMode): JmsConsumerSettings =
     copy(acknowledgeMode = Option(acknowledgeMode))

--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -33,7 +33,8 @@ sealed trait JmsSettings {
 }
 
 sealed trait Destination
-final case class Topic(name: String, subscriberName: Option[String] = None) extends Destination
+final case class Topic(name: String) extends Destination
+final case class DurableTopic(name: String, subscriberName: String) extends Destination
 final case class Queue(name: String) extends Destination
 
 final class AcknowledgeMode(val mode: Int)
@@ -64,8 +65,8 @@ final case class JmsConsumerSettings(connectionFactory: ConnectionFactory,
   def withBufferSize(size: Int): JmsConsumerSettings = copy(bufferSize = size)
   def withQueue(name: String): JmsConsumerSettings = copy(destination = Some(Queue(name)))
   def withTopic(name: String): JmsConsumerSettings = copy(destination = Some(Topic(name)))
-  def withTopic(name: String, subscriberName: String): JmsConsumerSettings =
-    copy(destination = Some(Topic(name, Some(subscriberName))))
+  def withDurableTopic(name: String, subscriberName: String): JmsConsumerSettings =
+    copy(destination = Some(DurableTopic(name, subscriberName)))
   def withSelector(selector: String): JmsConsumerSettings = copy(selector = Some(selector))
   def withAcknowledgeMode(acknowledgeMode: AcknowledgeMode): JmsConsumerSettings =
     copy(acknowledgeMode = Option(acknowledgeMode))

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -101,7 +101,7 @@ private[jms] trait JmsConnector { this: GraphStageLogic =>
 private[jms] class JmsSession(val connection: jms.Connection,
                               val session: jms.Session,
                               val jmsDestination: jms.Destination,
-                              val destination: Destination) {
+                              val settingsDestination: Destination) {
 
   private[jms] def closeSessionAsync()(implicit ec: ExecutionContext): Future[Unit] = Future { closeSession() }
 
@@ -120,7 +120,7 @@ private[jms] class JmsSession(val connection: jms.Connection,
       selector: Option[String]
   )(implicit ec: ExecutionContext): Future[jms.MessageConsumer] =
     Future {
-      (selector, destination) match {
+      (selector, settingsDestination) match {
         case (None, DurableTopic(_, subscriberName)) =>
           session.createDurableSubscriber(jmsDestination.asInstanceOf[jms.Topic], subscriberName)
 
@@ -139,9 +139,9 @@ private[jms] class JmsSession(val connection: jms.Connection,
 private[jms] class JmsAckSession(override val connection: jms.Connection,
                                  override val session: jms.Session,
                                  override val jmsDestination: jms.Destination,
-                                 override val destination: Destination,
+                                 override val settingsDestination: Destination,
                                  val maxPendingAcks: Int)
-    extends JmsSession(connection, session, jmsDestination, destination) {
+    extends JmsSession(connection, session, jmsDestination, settingsDestination) {
 
   private[jms] var pendingAck = 0
   private[jms] val ackQueue = new ArrayBlockingQueue[() => Unit](maxPendingAcks + 1)
@@ -161,8 +161,8 @@ private[jms] class JmsAckSession(override val connection: jms.Connection,
 private[jms] class JmsTxSession(override val connection: jms.Connection,
                                 override val session: jms.Session,
                                 override val jmsDestination: jms.Destination,
-                                override val destination: Destination)
-    extends JmsSession(connection, session, jmsDestination, destination) {
+                                override val settingsDestination: Destination)
+    extends JmsSession(connection, session, jmsDestination, settingsDestination) {
 
   private[jms] val commitQueue = new ArrayBlockingQueue[() => Unit](1)
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
@@ -36,7 +36,7 @@ private[jms] final class JmsConsumerStage(settings: JmsConsumerSettings)
       private[jms] def createSession(connection: Connection, createDestination: Session => javax.jms.Destination) = {
         val session =
           connection.createSession(false, settings.acknowledgeMode.getOrElse(AcknowledgeMode.AutoAcknowledge).mode)
-        new JmsSession(connection, session, createDestination(session))
+        new JmsSession(connection, session, createDestination(session), settings.destination.get)
       }
 
       private[jms] def pushMessage(msg: Message): Unit = {
@@ -79,7 +79,11 @@ final class JmsAckSourceStage(settings: JmsConsumerSettings)
       private[jms] def createSession(connection: Connection, createDestination: Session => javax.jms.Destination) = {
         val session =
           connection.createSession(false, settings.acknowledgeMode.getOrElse(AcknowledgeMode.ClientAcknowledge).mode)
-        new JmsAckSession(connection, session, createDestination(session), settings.bufferSize)
+        new JmsAckSession(connection,
+                          session,
+                          createDestination(session),
+                          settings.destination.get,
+                          settings.bufferSize)
       }
 
       private[jms] def pushMessage(msg: AckEnvelope): Unit = push(out, msg)
@@ -156,7 +160,7 @@ final class JmsTxSourceStage(settings: JmsConsumerSettings)
       private[jms] def createSession(connection: Connection, createDestination: Session => javax.jms.Destination) = {
         val session =
           connection.createSession(true, settings.acknowledgeMode.getOrElse(AcknowledgeMode.SessionTransacted).mode)
-        new JmsTxSession(connection, session, createDestination(session))
+        new JmsTxSession(connection, session, createDestination(session), settings.destination.get)
       }
 
       private[jms] def pushMessage(msg: TxEnvelope): Unit = push(out, msg)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -134,7 +134,8 @@ private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducer
         def createDestination(destination: Destination): _root_.javax.jms.Destination =
           destination match {
             case Queue(name) => jmsSession.session.createQueue(name)
-            case Topic(name, _) => jmsSession.session.createTopic(name)
+            case Topic(name) => jmsSession.session.createTopic(name)
+            case DurableTopic(name, _) => jmsSession.session.createTopic(name)
           }
 
         headers.foreach {

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
@@ -702,6 +702,47 @@ public class JmsConnectorsTest {
         });
     }
 
+    @Test
+    public void publishAndConsumeDurableTopic() throws Exception {
+        withServer(ctx -> {
+            ConnectionFactory producerConnectionFactory = new ActiveMQConnectionFactory(ctx.url);
+            //#create-connection-factory-with-client-id
+            ConnectionFactory consumerConnectionFactory = new ActiveMQConnectionFactory(ctx.url);
+            ((ActiveMQConnectionFactory) consumerConnectionFactory).setClientID(getClass().getSimpleName());
+            //#create-connection-factory-with-client-id
+
+            List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
+
+            Sink<String, CompletionStage<Done>> jmsTopicSink = JmsProducer
+                    .textSink(
+                            JmsProducerSettings
+                                    .create(producerConnectionFactory)
+                                    .withTopic("topic")
+                    );
+
+            //#create-durable-topic-source
+            Source<String, KillSwitch> jmsTopicSource = JmsConsumer
+                    .textSource(
+                            JmsConsumerSettings
+                                    .create(consumerConnectionFactory)
+                                    .withDurableTopic("topic", "durable-test")
+                    );
+            //#create-durable-topic-source
+
+            //#run-durable-topic-source
+            CompletionStage<List<String>> result = jmsTopicSource
+                    .take(in.size())
+                    .runWith(Sink.seq(), materializer);
+            //#run-durable-topic-source
+
+            Thread.sleep(500);
+
+            Source.from(in).runWith(jmsTopicSink, materializer);
+
+            assertEquals(in, result.toCompletableFuture().get(5, TimeUnit.SECONDS));
+        });
+    }
+
     private static ActorSystem system;
     private static Materializer materializer;
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
@@ -703,7 +703,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val jmsTopicSource1: Source[String, KillSwitch] = JmsConsumer.textSource(
         JmsConsumerSettings(consumerConnectionFactory)
           .withBufferSize(size / 4)
-          .withTopic("topic", "durable-test")
+          .withDurableTopic("topic", "durable-test")
       )
 
       val (kill1, run1) = jmsTopicSource1.take(size / 2).toMat(Sink.seq)(Keep.both).run()


### PR DESCRIPTION
Support durable topic subscriptions by adding `withTopic(name, subscriptionName)` to `JmsConsumerSettings`.

Documentation is missing but I'll certainly add it if the change looks good otherwise.