### PR TITLE
Latest versions: Scala, Scalatest, Akka, Akka Http

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 scala:
   - "2.11.12"
-  - "2.12.4"
+  - "2.12.5"
 
 jdk:
   - oraclejdk8

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,11 +5,11 @@ object Dependencies {
 
   val AkkaVersion = sys.env.get("AKKA_SERIES") match {
     case Some("2.4") => sys.error("Akka 2.4 is not supported anymore")
-    case _ => "2.5.9"
+    case _ => "2.5.11"
   }
 
   val AwsSdkVersion = "1.11.226"
-  val AkkaHttpVersion = "10.0.11"
+  val AkkaHttpVersion = "10.0.13"
 
   val Common = Seq(
     // These libraries are added to all modules via the `Common` AutoPlugin
@@ -18,7 +18,7 @@ object Dependencies {
       "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
       "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion % Test,
       "ch.qos.logback" % "logback-classic" % "1.2.3" % Test, // Eclipse Public License 1.0
-      "org.scalatest" %% "scalatest" % "3.0.4" % Test, // ApacheV2
+      "org.scalatest" %% "scalatest" % "3.0.5" % Test, // ApacheV2
       "com.novocode" % "junit-interface" % "0.11" % Test, // BSD-style
       "junit" % "junit" % "4.12" % Test // Eclipse Public License 1.0
     )

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3Client.scala
@@ -11,7 +11,6 @@ import java.util.concurrent.CompletionStage
 import scala.compat.java8.FutureConverters._
 import akka.{Done, NotUsed}
 import akka.actor.ActorSystem
-import akka.http.impl.model.JavaUri
 import akka.http.javadsl.model.headers.ByteRange
 import akka.http.javadsl.model._
 import akka.http.scaladsl.model.headers.{ByteRange => ScalaByteRange}
@@ -144,7 +143,7 @@ final class ObjectMetadata private[javadsl] (
 
 object MultipartUploadResult {
   def create(r: CompleteMultipartUploadResult): MultipartUploadResult =
-    new MultipartUploadResult(JavaUri(r.location), r.bucket, r.key, r.etag)
+    new MultipartUploadResult(Uri.create(r.location), r.bucket, r.key, r.etag)
 }
 
 object S3Client {

--- a/sse/src/main/scala/akka/stream/alpakka/sse/javadsl/EventSource.scala
+++ b/sse/src/main/scala/akka/stream/alpakka/sse/javadsl/EventSource.scala
@@ -77,7 +77,7 @@ object EventSource {
              mat: Materializer): Source[ServerSentEvent, NotUsed] = {
     val eventSource =
       scaladsl.EventSource(
-        uri.asInstanceOf[akka.http.impl.model.JavaUri].uri,
+        uri.asScala,
         send(_).toScala.map(_.asInstanceOf[SHttpResponse])(mat.executionContext),
         lastEventId.asScala
       )(mat)


### PR DESCRIPTION
Scala 2.11.12 + 2.12.5
Akka 2.5.11
Akka Http 10.0.13 (including backports to support 10.1.1 see #847)
Scalatest 3.0.5