### PR TITLE
FTP: Support custom SSH configuration

### DIFF
--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -38,6 +38,14 @@ For non-anonymous connection, please provide an instance of @scaladoc[NonAnonFtp
 
 For connection using a private key, please provide an instance of @scaladoc[SftpIdentity](akka.stream.alpakka.ftp.SftpIdentity) to @scaladoc[SftpSettings](akka.stream.alpakka.ftp.RemoteFileSettings$$SftpSettings).
 
+In order to use a custom SSH client for SFTP please provide an instance of @scaladoc[SSHClient](net.schmizz.sshj.SSHClient).
+
+Scala
+: @@snip ($alpakka$/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #configure-custom-ssh-client }
+
+Java
+: @@snip ($alpakka$/ftp/src/test/java/akka/stream/alpakka/ftp/examples/ConfigureCustomSSHClient.java) { #configure-custom-ssh-client }
+
 ### Traversing a remote FTP folder recursively
 
 In order to traverse a remote folder recursively, you need to use the `ls` method in the FTP API:

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.ftp.impl
 
 import akka.stream.alpakka.ftp.FtpCredentials.{AnonFtpCredentials, NonAnonFtpCredentials}
 import akka.stream.alpakka.ftp.{FtpFile, FtpFileSettings, FtpSettings, FtpsSettings, RemoteFileSettings, SftpSettings}
-import net.schmizz.sshj.{Config => SSHConfig, DefaultConfig, SSHClient}
+import net.schmizz.sshj.SSHClient
 import org.apache.commons.net.ftp.FTPClient
 import java.net.InetAddress
 
@@ -117,8 +117,8 @@ private[ftp] trait SftpSource extends FtpSourceFactory[SSHClient] {
   protected final val sFtpBrowserSourceName = "sFtpBrowserSource"
   protected final val sFtpIOSourceName = "sFtpIOSource"
   protected final val sFtpIOSinkName = "sFtpIOSink"
-  def sshConfig: SSHConfig = new DefaultConfig
-  protected val ftpClient: () => SSHClient = () => new SSHClient(sshConfig)
+  def sshClient(): SSHClient = new SSHClient()
+  protected val ftpClient: () => SSHClient = sshClient
   protected val ftpBrowserSourceName: String = sFtpBrowserSourceName
   protected val ftpIOSourceName: String = sFtpIOSourceName
   protected val ftpIOSinkName: String = sFtpIOSinkName

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.ftp.impl
 
 import akka.stream.alpakka.ftp.FtpCredentials.{AnonFtpCredentials, NonAnonFtpCredentials}
 import akka.stream.alpakka.ftp.{FtpFile, FtpFileSettings, FtpSettings, FtpsSettings, RemoteFileSettings, SftpSettings}
-import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.{Config => SSHConfig, DefaultConfig, SSHClient}
 import org.apache.commons.net.ftp.FTPClient
 import java.net.InetAddress
 
@@ -117,7 +117,8 @@ private[ftp] trait SftpSource extends FtpSourceFactory[SSHClient] {
   protected final val sFtpBrowserSourceName = "sFtpBrowserSource"
   protected final val sFtpIOSourceName = "sFtpIOSource"
   protected final val sFtpIOSinkName = "sFtpIOSink"
-  protected val ftpClient: () => SSHClient = () => new SSHClient
+  def sshConfig: SSHConfig = new DefaultConfig
+  protected val ftpClient: () => SSHClient = () => new SSHClient(sshConfig)
   protected val ftpBrowserSourceName: String = sFtpBrowserSourceName
   protected val ftpIOSourceName: String = sFtpIOSourceName
   protected val ftpIOSinkName: String = sFtpIOSinkName

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -235,19 +235,19 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
 
   protected[this] implicit def ftpLike: FtpLike[FtpClient, S]
 }
-
+class SftpApi extends FtpApi[SSHClient] with SftpSourceParams
 object Ftp extends FtpApi[FTPClient] with FtpSourceParams
 object Ftps extends FtpApi[FTPClient] with FtpsSourceParams
-object Sftp extends FtpApi[SSHClient] with SftpSourceParams {
+object Sftp extends SftpApi {
 
   /**
-   * Java API: creates a [[akka.stream.alpakka.ftp.javadsl.FtpApi]] of [[net.schmizz.sshj.SSHClient]] with [[akka.stream.alpakka.ftp.impl.SftpSourceParams]]
+   * Java API: creates a [[akka.stream.alpakka.ftp.javadsl.SftpApi]]
    *
    * @param customSshClient custom ssh client
-   * @return A [[akka.stream.alpakka.ftp.javadsl.FtpApi]] of [[net.schmizz.sshj.SSHClient]] with [[akka.stream.alpakka.ftp.impl.SftpSourceParams]]
+   * @return A [[akka.stream.alpakka.ftp.javadsl.SftpApi]]
    */
-  def create(customSshClient: SSHClient): FtpApi[SSHClient] with SftpSourceParams =
-    new FtpApi[SSHClient] with SftpSourceParams {
+  def create(customSshClient: SSHClient): SftpApi =
+    new SftpApi {
       override val sshClient = customSshClient
     }
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -238,9 +238,18 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
 
 object Ftp extends FtpApi[FTPClient] with FtpSourceParams
 object Ftps extends FtpApi[FTPClient] with FtpsSourceParams
-object Sftp extends FtpApi[SSHClient] with SftpSourceParams {
-  def withSshClient(customSshClient: SSHClient): FtpApi[SSHClient] with SftpSourceParams =
-    new FtpApi[SSHClient] with SftpSourceParams {
+class Sftp extends FtpApi[SSHClient] with SftpSourceParams
+
+object Sftp extends Sftp {
+
+  /**
+    * Java API: creates a [[akka.stream.alpakka.ftp.javadsl.Sftp]]
+    *
+    * @param customSshClient custom ssh client
+    * @return A [[akka.stream.alpakka.ftp.javadsl.Sftp]]
+    */
+  def withSshClient(customSshClient: SSHClient): Sftp =
+    new Sftp {
       override val sshClient = customSshClient
     }
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -14,7 +14,7 @@ import akka.stream.javadsl.Sink
 import akka.stream.scaladsl.{Source => ScalaSource}
 import akka.stream.scaladsl.{Sink => ScalaSink}
 import akka.util.ByteString
-import net.schmizz.sshj.{Config => SSHConfig, SSHClient}
+import net.schmizz.sshj.SSHClient
 import org.apache.commons.net.ftp.FTPClient
 import java.util.concurrent.CompletionStage
 import java.util.function._
@@ -239,8 +239,8 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
 object Ftp extends FtpApi[FTPClient] with FtpSourceParams
 object Ftps extends FtpApi[FTPClient] with FtpsSourceParams
 object Sftp extends FtpApi[SSHClient] with SftpSourceParams {
-  def sshConfig(customSshConfig: SSHConfig): FtpApi[SSHClient] with SftpSourceParams =
+  def withSshClient(customSshClient: SSHClient): FtpApi[SSHClient] with SftpSourceParams =
     new FtpApi[SSHClient] with SftpSourceParams {
-      override val sshConfig = customSshConfig
+      override val sshClient = customSshClient
     }
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -14,7 +14,7 @@ import akka.stream.javadsl.Sink
 import akka.stream.scaladsl.{Source => ScalaSource}
 import akka.stream.scaladsl.{Sink => ScalaSink}
 import akka.util.ByteString
-import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.{Config => SSHConfig, SSHClient}
 import org.apache.commons.net.ftp.FTPClient
 import java.util.concurrent.CompletionStage
 import java.util.function._
@@ -238,4 +238,9 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
 
 object Ftp extends FtpApi[FTPClient] with FtpSourceParams
 object Ftps extends FtpApi[FTPClient] with FtpsSourceParams
-object Sftp extends FtpApi[SSHClient] with SftpSourceParams
+object Sftp extends FtpApi[SSHClient] with SftpSourceParams {
+  def sshConfig(customSshConfig: SSHConfig): FtpApi[SSHClient] with SftpSourceParams =
+    new FtpApi[SSHClient] with SftpSourceParams {
+      override val sshConfig = customSshConfig
+    }
+}

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -238,18 +238,16 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
 
 object Ftp extends FtpApi[FTPClient] with FtpSourceParams
 object Ftps extends FtpApi[FTPClient] with FtpsSourceParams
-class Sftp extends FtpApi[SSHClient] with SftpSourceParams
-
-object Sftp extends Sftp {
+object Sftp extends FtpApi[SSHClient] with SftpSourceParams {
 
   /**
-    * Java API: creates a [[akka.stream.alpakka.ftp.javadsl.Sftp]]
-    *
-    * @param customSshClient custom ssh client
-    * @return A [[akka.stream.alpakka.ftp.javadsl.Sftp]]
-    */
-  def withSshClient(customSshClient: SSHClient): Sftp =
-    new Sftp {
+   * Java API: creates a [[akka.stream.alpakka.ftp.javadsl.FtpApi]] of [[net.schmizz.sshj.SSHClient]] with [[akka.stream.alpakka.ftp.impl.SftpSourceParams]]
+   *
+   * @param customSshClient custom ssh client
+   * @return A [[akka.stream.alpakka.ftp.javadsl.FtpApi]] of [[net.schmizz.sshj.SSHClient]] with [[akka.stream.alpakka.ftp.impl.SftpSourceParams]]
+   */
+  def withSshClient(customSshClient: SSHClient): FtpApi[SSHClient] with SftpSourceParams =
+    new FtpApi[SSHClient] with SftpSourceParams {
       override val sshClient = customSshClient
     }
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -246,7 +246,7 @@ object Sftp extends FtpApi[SSHClient] with SftpSourceParams {
    * @param customSshClient custom ssh client
    * @return A [[akka.stream.alpakka.ftp.javadsl.FtpApi]] of [[net.schmizz.sshj.SSHClient]] with [[akka.stream.alpakka.ftp.impl.SftpSourceParams]]
    */
-  def withSshClient(customSshClient: SSHClient): FtpApi[SSHClient] with SftpSourceParams =
+  def create(customSshClient: SSHClient): FtpApi[SSHClient] with SftpSourceParams =
     new FtpApi[SSHClient] with SftpSourceParams {
       override val sshClient = customSshClient
     }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -169,9 +169,18 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
 
 object Ftp extends FtpApi[FTPClient] with FtpSourceParams
 object Ftps extends FtpApi[FTPClient] with FtpsSourceParams
-object Sftp extends FtpApi[SSHClient] with SftpSourceParams {
-  def apply(customSshClient: SSHClient): FtpApi[SSHClient] with SftpSourceParams =
-    new FtpApi[SSHClient] with SftpSourceParams {
+class Sftp extends FtpApi[SSHClient] with SftpSourceParams
+
+object Sftp extends Sftp {
+
+  /**
+   * Scala API: creates a [[akka.stream.alpakka.ftp.scaladsl.Sftp]]
+   *
+   * @param customSshClient custom ssh client
+   * @return A [[akka.stream.alpakka.ftp.scaladsl.Sftp]]
+   */
+  def apply(customSshClient: SSHClient): Sftp =
+    new Sftp {
       override val sshClient = customSshClient
     }
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -10,7 +10,7 @@ import akka.stream.alpakka.ftp.impl.{FtpLike, FtpSourceFactory, FtpSourceParams,
 import akka.stream.alpakka.ftp.{FtpFile, RemoteFileSettings}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
-import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.{Config => SSHConfig, SSHClient}
 import org.apache.commons.net.ftp.FTPClient
 import scala.concurrent.Future
 
@@ -169,4 +169,9 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
 
 object Ftp extends FtpApi[FTPClient] with FtpSourceParams
 object Ftps extends FtpApi[FTPClient] with FtpsSourceParams
-object Sftp extends FtpApi[SSHClient] with SftpSourceParams
+object Sftp extends FtpApi[SSHClient] with SftpSourceParams {
+  def sshConfig(customSshConfig: SSHConfig): FtpApi[SSHClient] with SftpSourceParams =
+    new FtpApi[SSHClient] with SftpSourceParams {
+      override val sshConfig = customSshConfig
+    }
+}

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -10,7 +10,7 @@ import akka.stream.alpakka.ftp.impl.{FtpLike, FtpSourceFactory, FtpSourceParams,
 import akka.stream.alpakka.ftp.{FtpFile, RemoteFileSettings}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
-import net.schmizz.sshj.{Config => SSHConfig, SSHClient}
+import net.schmizz.sshj.SSHClient
 import org.apache.commons.net.ftp.FTPClient
 import scala.concurrent.Future
 
@@ -170,8 +170,8 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
 object Ftp extends FtpApi[FTPClient] with FtpSourceParams
 object Ftps extends FtpApi[FTPClient] with FtpsSourceParams
 object Sftp extends FtpApi[SSHClient] with SftpSourceParams {
-  def sshConfig(customSshConfig: SSHConfig): FtpApi[SSHClient] with SftpSourceParams =
+  def apply(customSshClient: SSHClient): FtpApi[SSHClient] with SftpSourceParams =
     new FtpApi[SSHClient] with SftpSourceParams {
-      override val sshConfig = customSshConfig
+      override val sshClient = customSshClient
     }
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -167,20 +167,20 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
   protected[this] implicit def ftpLike: FtpLike[FtpClient, S]
 }
 
+class SftpApi extends FtpApi[SSHClient] with SftpSourceParams
 object Ftp extends FtpApi[FTPClient] with FtpSourceParams
 object Ftps extends FtpApi[FTPClient] with FtpsSourceParams
-class Sftp extends FtpApi[SSHClient] with SftpSourceParams
 
-object Sftp extends Sftp {
+object Sftp extends SftpApi {
 
   /**
-   * Scala API: creates a [[akka.stream.alpakka.ftp.scaladsl.Sftp]]
+   * Scala API: creates a [[akka.stream.alpakka.ftp.scaladsl.SftpApi]]
    *
    * @param customSshClient custom ssh client
-   * @return A [[akka.stream.alpakka.ftp.scaladsl.Sftp]]
+   * @return A [[akka.stream.alpakka.ftp.scaladsl.SftpApi]]
    */
-  def apply(customSshClient: SSHClient): Sftp =
-    new Sftp {
+  def apply(customSshClient: SSHClient): SftpApi =
+    new SftpApi {
       override val sshClient = customSshClient
     }
 }

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/examples/ConfigureCustomSSHClient.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/examples/ConfigureCustomSSHClient.java
@@ -1,0 +1,17 @@
+package akka.stream.alpakka.ftp.examples;
+
+//#configure-custom-ssh-client
+
+import akka.stream.alpakka.ftp.javadsl.Sftp;
+import net.schmizz.sshj.DefaultConfig;
+import net.schmizz.sshj.SSHClient;
+
+public class ConfigureCustomSSHClient {
+
+    public ConfigureCustomSSHClient() {
+        SSHClient sshClient = new SSHClient(new DefaultConfig());
+        Sftp sftp = Sftp.withSshClient(sshClient);
+
+    }
+}
+//#configure-custom-ssh-client

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/examples/ConfigureCustomSSHClient.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/examples/ConfigureCustomSSHClient.java
@@ -6,8 +6,8 @@ package akka.stream.alpakka.ftp.examples;
 
 //#configure-custom-ssh-client
 
-import akka.stream.alpakka.ftp.javadsl.FtpApi;
 import akka.stream.alpakka.ftp.javadsl.Sftp;
+import akka.stream.alpakka.ftp.javadsl.SftpApi;
 import net.schmizz.sshj.DefaultConfig;
 import net.schmizz.sshj.SSHClient;
 
@@ -15,7 +15,7 @@ public class ConfigureCustomSSHClient {
 
     public ConfigureCustomSSHClient() {
         SSHClient sshClient = new SSHClient(new DefaultConfig());
-        FtpApi<SSHClient> sftp = Sftp.create(sshClient);
+        SftpApi sftp = Sftp.create(sshClient);
 
     }
 }

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/examples/ConfigureCustomSSHClient.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/examples/ConfigureCustomSSHClient.java
@@ -1,7 +1,12 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
 package akka.stream.alpakka.ftp.examples;
 
 //#configure-custom-ssh-client
 
+import akka.stream.alpakka.ftp.javadsl.FtpApi;
 import akka.stream.alpakka.ftp.javadsl.Sftp;
 import net.schmizz.sshj.DefaultConfig;
 import net.schmizz.sshj.SSHClient;
@@ -10,7 +15,7 @@ public class ConfigureCustomSSHClient {
 
     public ConfigureCustomSSHClient() {
         SSHClient sshClient = new SSHClient(new DefaultConfig());
-        Sftp sftp = Sftp.withSshClient(sshClient);
+        FtpApi<SSHClient> sftp = Sftp.withSshClient(sshClient);
 
     }
 }

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/examples/ConfigureCustomSSHClient.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/examples/ConfigureCustomSSHClient.java
@@ -15,7 +15,7 @@ public class ConfigureCustomSSHClient {
 
     public ConfigureCustomSSHClient() {
         SSHClient sshClient = new SSHClient(new DefaultConfig());
-        FtpApi<SSHClient> sftp = Sftp.withSshClient(sshClient);
+        FtpApi<SSHClient> sftp = Sftp.create(sshClient);
 
     }
 }

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala
@@ -4,6 +4,9 @@
 
 package akka.stream.alpakka.ftp
 
+import akka.stream.alpakka.ftp.scaladsl.{FtpApi, Sftp}
+import net.schmizz.sshj.DefaultConfig
+
 object scalaExamples {
 
   // settings
@@ -19,6 +22,15 @@ object scalaExamples {
       passiveMode = true
     )
     //#create-settings
+  }
+
+  object sshConfigure {
+    //#configure-custom-ssh-client
+    import net.schmizz.sshj.SSHClient
+
+    val sshClient: SSHClient = new SSHClient(new DefaultConfig)
+    val configuredClient: Sftp = Sftp(sshClient)
+    //#configure-custom-ssh-client
   }
 
   object traversing {

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.ftp
 
-import akka.stream.alpakka.ftp.scaladsl.{FtpApi, Sftp}
+import akka.stream.alpakka.ftp.scaladsl.{FtpApi, Sftp, SftpApi}
 import net.schmizz.sshj.DefaultConfig
 
 object scalaExamples {
@@ -29,7 +29,7 @@ object scalaExamples {
     import net.schmizz.sshj.SSHClient
 
     val sshClient: SSHClient = new SSHClient(new DefaultConfig)
-    val configuredClient: Sftp = Sftp(sshClient)
+    val configuredClient: SftpApi = Sftp(sshClient)
     //#configure-custom-ssh-client
   }
 


### PR DESCRIPTION
Made it possible to use a custom SSH configuration.

An alternative would be the possibility to inject an `SSHClient` instance.

This should help with #874.
Worked together with @HarrisonBaxter