### PR TITLE
DynamoDB: Fix parallelism #876

### DIFF
--- a/dynamodb/src/main/resources/reference.conf
+++ b/dynamodb/src/main/resources/reference.conf
@@ -8,6 +8,6 @@ akka.stream.alpakka.dynamodb {
   # The AWS port, https is used as default scheme - 443 will result in not using port in url
   port: -1
 
-  # Max number of in flight requests from the AwsClient
-  parallelism = 10
+  # Max number of in flight requests from the AwsClient - must be a power of 2
+  parallelism = 32
 }

--- a/dynamodb/src/test/resources/application.conf
+++ b/dynamodb/src/test/resources/application.conf
@@ -2,7 +2,7 @@ akka.stream.alpakka.dynamodb {
   host = "localhost"
   port: 8001
   region = "us-east-1"
-  parallelism = 5
+  parallelism = 4
 }
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]


### PR DESCRIPTION
This PR fixes #876 by changing the parallelism in DynamoDB so that it is applied to the HTTP connection pool.

I upped the default parallelism to 32 as this is the nearest power of 2 below 50, which is the default that [AWS used in their own SDK before deprecating the methods](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/dynamodbv2/AmazonDynamoDBAsyncClient.html). I've run up to 128 connections in production (by setting the akka-http config properties) without any problems so 32 seems perfectly safe.