### PR TITLE
Unix Domain Socket - don't close socket when finished reading (may still have writes)

### DIFF
--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -148,8 +148,6 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
                       key.interestOps(key.interestOps() & ~SelectionKey.OP_READ)
                     } else {
                       queue.complete()
-                      key.cancel()
-                      key.channel.close()
                     }
                   case PendingReceiveAck(receiveQueue, receiveBuffer, pendingResult) if pendingResult.isCompleted =>
                     pendingResult.value.get match {


### PR DESCRIPTION
The Unix Domain Socket connector was closing connections when it was done reading from them. This is slightly problematic -- the server may still wish to write data to the socket even though the client has closed its write side. This PR simply removes the key cancellation and channel closing when reads have completed.

Thus, only when the source (from server -> client) has terminated, will the connection be closed. See https://github.com/akka/alpakka/blob/master/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala#L264-L269

I have prepared some sample programs here to help illustrate the problem: https://github.com/longshorej/garbage/tree/master/unix-domain-socket-close

The program, `rust-client`, writes some data to the socket and closes its write side. It will then read the rest of the data from its read side and print it to the stdout.

When the client connects to `rust-server` it behaves as expected, i.e. the client receives the same data back from the server that it wrote to it.

However, `akka-streams-server` will immediately drop the connection, so the client won't receive any data. With this change, it behaves as expected.
