### PR TITLE
 Unix Domain Socket - more fixes

### DIFF
--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -280,7 +280,7 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
             }
             .runWith(Sink.ignore)
         }
-    (sendReceiveContext, Flow.fromSinkAndSourceCoupled(sendSink, Source.fromFutureSource(receiveSource)))
+    (sendReceiveContext, Flow.fromSinkAndSource(sendSink, Source.fromFutureSource(receiveSource)))
   }
 
   /*

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -123,8 +123,20 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
               case sendReceiveContext: SendReceiveContext =>
                 sendReceiveContext.send match {
                   case SendRequested(buffer, sent) if keySelectable && key.isWritable =>
-                    key.channel().asInstanceOf[UnixSocketChannel].write(buffer)
-                    if (buffer.remaining == 0) {
+                    val channel = key.channel().asInstanceOf[UnixSocketChannel]
+
+                    val written =
+                      try {
+                        channel.write(buffer)
+                        true
+                      } catch {
+                        case _: IOException =>
+                          key.cancel()
+                          key.channel.close()
+                          false
+                      }
+
+                    if (written && buffer.remaining == 0) {
                       sendReceiveContext.send = SendAvailable(buffer)
                       key.interestOps(key.interestOps() & ~SelectionKey.OP_WRITE)
                       sent.success(Done)


### PR DESCRIPTION
Another round of a few small tweaks. Hopefully after this it is quite stable :)

* `channel.write()` can throw an exception if writing to a closed socket, similar to the fix for read, see #873
* Following up on #878, `sendSink` shouldn't be coupled to `receiveSource`. This allows the server to continue to write data when the client has closed its write side.

/cc @huntc