### PR TITLE
Fix AMQP cached connection memory leak

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSinkStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSinkStage.scala
@@ -60,18 +60,7 @@ final class AmqpSinkStage(settings: AmqpSinkSettings)
       private val exchange = settings.exchange.getOrElse("")
       private val routingKey = settings.routingKey.getOrElse("")
 
-      override def whenConnected(): Unit = {
-        val shutdownCallback = getAsyncCallback[ShutdownSignalException] { ex =>
-          onFailure(ex)
-        }
-        channel.addShutdownListener(
-          new ShutdownListener {
-            override def shutdownCompleted(cause: ShutdownSignalException): Unit =
-              shutdownCallback.invoke(cause)
-          }
-        )
-        pull(in)
-      }
+      override def whenConnected(): Unit = pull(in)
 
       setHandler(
         in,
@@ -145,18 +134,7 @@ final class AmqpReplyToSinkStage(settings: AmqpReplyToSinkSettings)
     (new GraphStageLogic(shape) with AmqpConnectorLogic {
       override val settings = stage.settings
 
-      override def whenConnected(): Unit = {
-        val shutdownCallback = getAsyncCallback[ShutdownSignalException] { ex =>
-          onFailure(ex)
-        }
-        channel.addShutdownListener(
-          new ShutdownListener {
-            override def shutdownCompleted(cause: ShutdownSignalException): Unit =
-              shutdownCallback.invoke(cause)
-          }
-        )
-        pull(in)
-      }
+      override def whenConnected(): Unit = pull(in)
 
       override def postStop(): Unit = {
         promise.tryFailure(new RuntimeException("stage stopped unexpectedly"))


### PR DESCRIPTION
Might close (totally or partially) #883

The problem is that we were setting too many `shutdownListener` (in the connector logic and in the stages) and what is worse we were never removing them. So if the app is running within a retry with backoff kind of block, we are adding more are more handlers to the connection for no reason.