### PR TITLE
JMS: Tombstone the message handling on abort (#904) 

### DIFF
--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -20,9 +20,9 @@ case class TxEnvelope private[jms] (message: Message, private val jmsSession: Jm
 
   val processed = new AtomicBoolean(false)
 
-  def commit(): Unit = if (processed.compareAndSet(false, true)) jmsSession.commit()
+  def commit(): Unit = if (processed.compareAndSet(false, true)) jmsSession.commit(this)
 
-  def rollback(): Unit = if (processed.compareAndSet(false, true)) jmsSession.rollback()
+  def rollback(): Unit = if (processed.compareAndSet(false, true)) jmsSession.rollback(this)
 }
 
 sealed trait JmsSettings {

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -134,9 +134,9 @@ private[jms] class JmsAckSession(override val connection: jms.Connection,
 
   def ack(message: jms.Message): Unit = ackQueue.put(message.acknowledge _)
 
-  override def closeSession(): Unit = stopMessageListenerAndCloseSession
+  override def closeSession(): Unit = stopMessageListenerAndCloseSession()
 
-  override def abortSession(): Unit = stopMessageListenerAndCloseSession
+  override def abortSession(): Unit = stopMessageListenerAndCloseSession()
 
   private def stopMessageListenerAndCloseSession(): Unit = {
     ackQueue.put(() => throw StopMessageListenerException())
@@ -149,14 +149,21 @@ private[jms] class JmsTxSession(override val connection: jms.Connection,
                                 override val destination: jms.Destination)
     extends JmsSession(connection, session, destination) {
 
-  private[jms] val commitQueue = new ArrayBlockingQueue[() => Unit](1)
+  private[jms] val commitQueue = new ArrayBlockingQueue[TxEnvelope => Unit](1)
 
-  def commit(): Unit = commitQueue.put(session.commit _)
+  def commit(commitEnv: TxEnvelope): Unit = commitQueue.put { srcEnv =>
+    require(srcEnv == commitEnv, s"Source envelope mismatch on commit. Source: $srcEnv Commit: $commitEnv")
+    session.commit()
+  }
 
-  def rollback(): Unit = commitQueue.put(session.rollback _)
+  def rollback(commitEnv: TxEnvelope): Unit = commitQueue.put { srcEnv =>
+    require(srcEnv == commitEnv, s"Source envelope mismatch on rollback. Source: $srcEnv Commit: $commitEnv")
+    session.rollback()
+  }
 
   override def abortSession(): Unit = {
-    rollback()
+    // On abort, tombstone the onMessage loop to stop processing messages even if more messages are delivered.
+    commitQueue.put(_ => throw StopMessageListenerException())
     session.close()
   }
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
@@ -167,15 +167,21 @@ final class JmsTxSourceStage(settings: JmsConsumerSettings)
             session.createConsumer(settings.selector).onComplete {
               case Success(consumer) =>
                 consumer.setMessageListener(new MessageListener {
+
+                  var listenerStopped = false
+
                   def onMessage(message: Message): Unit =
-                    try {
-                      handleMessage.invoke(TxEnvelope(message, session))
-                      val action = session.commitQueue.take()
-                      action()
-                    } catch {
-                      case e: JMSException =>
-                        handleError.invoke(e)
-                    }
+                    if (!listenerStopped)
+                      try {
+                        val envelope = TxEnvelope(message, session)
+                        handleMessage.invoke(envelope)
+                        val action = session.commitQueue.take()
+                        action(envelope)
+                      } catch {
+                        case _: StopMessageListenerException => listenerStopped = true // Tombstone.
+                        case e: IllegalArgumentException => handleError.invoke(e) // Invalid envelope. Fail the stage.
+                        case e: JMSException => handleError.invoke(e)
+                      }
                 })
               case Failure(e) =>
                 fail.invoke(e)


### PR DESCRIPTION
... and validate the TxEnvelope on commit/rollback - hopefully at no or very minimal performance impact.

Unfortunately, cannot recreate issue on unit-test broker. Can consistently recreate issue on same 'abort message loss' test with our internal broker.