### PR TITLE
Fix AQMP prefetch configuration for cached connections

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpRpcFlowStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpRpcFlowStage.scala
@@ -64,8 +64,7 @@ final class AmqpRpcFlowStage(settings: AmqpSinkSettings, bufferSize: Int, respon
 
         pull(in)
 
-        // we have only one consumer per connection so global is ok
-        channel.basicQos(bufferSize, true)
+        channel.basicQos(bufferSize)
         val consumerCallback = getAsyncCallback(handleDelivery)
 
         val commitCallback = getAsyncCallback[CommitCallback] {

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpSourceStage.scala
@@ -55,8 +55,7 @@ final class AmqpSourceStage(settings: AmqpSourceSettings, bufferSize: Int)
 
       override def whenConnected(): Unit = {
         import scala.collection.JavaConverters._
-        // we have only one consumer per connection so global is ok
-        channel.basicQos(bufferSize, true)
+        channel.basicQos(bufferSize)
         val consumerCallback = getAsyncCallback(handleDelivery)
         val shutdownCallback = getAsyncCallback[Option[ShutdownSignalException]] {
           case Some(ex) => onFailure(ex)


### PR DESCRIPTION
Closes #897 

As stated in https://www.rabbitmq.com/consumer-prefetch.html, setting the basicQos global flag to false makes the limit shared by all the consumers on the channel. Since each stage has a single channel and a single consumer, that's the appropriate configuration.