### PR TITLE
MQTT: Improve test stability

### DIFF
--- a/mqtt/src/test/java/akka/stream/alpakka/mqtt/javadsl/MqttSourceTest.java
+++ b/mqtt/src/test/java/akka/stream/alpakka/mqtt/javadsl/MqttSourceTest.java
@@ -213,8 +213,8 @@ public class MqttSourceTest {
 
   @Test
   public void supportWillMessage() throws Exception {
-    String topic1 = "source-spec/topic1";
-    String willTopic = "source-spec/will";
+    String topic1 = "source-test/topic1";
+    String willTopic = "source-test/will";
     final MqttConnectionSettings baseConnectionSettings = MqttConnectionSettings.create(
             "tcp://localhost:1883",
             "test-java-client",

--- a/mqtt/src/test/java/akka/stream/alpakka/mqtt/javadsl/MqttSourceTest.java
+++ b/mqtt/src/test/java/akka/stream/alpakka/mqtt/javadsl/MqttSourceTest.java
@@ -234,8 +234,9 @@ public class MqttSourceTest {
     //#will-message
 
     // Create a proxy to RabbitMQ so it can be shutdown
+    int proxyPort = 1347; // make sure to keep it separate from ports used by other tests
     Pair<CompletionStage<Tcp.ServerBinding>, CompletionStage<Tcp.IncomingConnection>> result1 = Tcp.get(system)
-            .bind("localhost", 1337).toMat(Sink.head(), Keep.both()).run(materializer);
+            .bind("localhost", proxyPort).toMat(Sink.head(), Keep.both()).run(materializer);
 
     CompletionStage<UniqueKillSwitch> proxyKs = result1.second().toCompletableFuture().thenApply(conn ->
       conn.handleWith(
@@ -252,7 +253,7 @@ public class MqttSourceTest {
     MqttSourceSettings settings1 = MqttSourceSettings.create(
       sourceSettings
         .withClientId("source-spec/testator")
-        .withBroker("tcp://localhost:1337")
+        .withBroker("tcp://localhost:" + String.valueOf(proxyPort))
         .withWill(lastWill)
     ).withSubscriptions(Pair.create(topic1, MqttQoS.atLeastOnce()));
 

--- a/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala
+++ b/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala
@@ -284,8 +284,10 @@ class MqttSourceSpec
 
       val msg = MqttMessage(topic1, ByteString("ohi"))
 
+
       // Create a proxy to RabbitMQ so it can be shutdown
-      val (proxyBinding, connection) = Tcp().bind("localhost", 1337).toMat(Sink.head)(Keep.both).run()
+      val proxyPort = 1337 // make sure to keep it separate from ports used by other tests
+      val (proxyBinding, connection) = Tcp().bind("localhost", proxyPort).toMat(Sink.head)(Keep.both).run()
       val proxyKs = connection.map(
         _.handleWith(
           Tcp()
@@ -299,7 +301,7 @@ class MqttSourceSpec
         sourceSettings
           .withAutomaticReconnect(true)
           .withCleanSession(false)
-          .withBroker("tcp://localhost:1337"),
+          .withBroker(s"tcp://localhost:$proxyPort"),
         Map(topic1 -> MqttQoS.AtLeastOnce)
       )
 
@@ -314,7 +316,7 @@ class MqttSourceSpec
       Await.result(proxyKs, timeout).shutdown()
 
       // Restart the proxy
-      val (proxyBinding2, connection2) = Tcp().bind("localhost", 1337).toMat(Sink.head)(Keep.both).run()
+      val (proxyBinding2, connection2) = Tcp().bind("localhost", proxyPort).toMat(Sink.head)(Keep.both).run()
       val proxyKs2 = connection2.map(
         _.handleWith(
           Tcp()
@@ -340,7 +342,8 @@ class MqttSourceSpec
       //#will-message
 
       // Create a proxy to RabbitMQ so it can be shutdown
-      val (proxyBinding, connection) = Tcp().bind("localhost", 1337).toMat(Sink.head)(Keep.both).run()
+      val proxyPort = 1338 // make sure to keep it separate from ports used by other tests
+      val (proxyBinding, connection) = Tcp().bind("localhost", proxyPort).toMat(Sink.head)(Keep.both).run()
       val proxyKs = connection.map(
         _.handleWith(
           Tcp()
@@ -353,7 +356,7 @@ class MqttSourceSpec
       val settings1 = MqttSourceSettings(
         sourceSettings
           .withClientId("source-spec/testator")
-          .withBroker("tcp://localhost:1337")
+          .withBroker(s"tcp://localhost:$proxyPort")
           .withWill(lastWill),
         Map(topic1 -> MqttQoS.AtLeastOnce)
       )

--- a/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala
+++ b/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala
@@ -308,7 +308,7 @@ class MqttSourceSpec
       // Ensure that the connection made it all the way to the server by waiting until it receives a message
       Await.ready(subscribed, timeout)
       Source.single(msg).runWith(MqttSink(sinkSettings, MqttQoS.AtLeastOnce))
-      probe.requestNext()
+      probe.requestNext() shouldBe msg
 
       // Kill the proxy, producing an unexpected disconnection of the client
       Await.result(proxyKs, timeout).shutdown()
@@ -325,7 +325,7 @@ class MqttSourceSpec
       Await.ready(proxyBinding2, timeout)
 
       Source.single(msg).runWith(MqttSink(sinkSettings, MqttQoS.AtLeastOnce))
-      probe.requestNext() shouldBe MqttMessage(topic1, ByteString("ohi"))
+      probe.requestNext(5.seconds) shouldBe msg
       Await.result(proxyKs2, timeout).shutdown()
     }
 

--- a/mqtt/src/test/travis/acl
+++ b/mqtt/src/test/travis/acl
@@ -8,9 +8,11 @@ topic sink-spec/topic1
 topic sink-spec/topic2
 topic source-test/topic1
 topic source-test/topic2
+topic source-test/will
 topic source-test/manualacks
 topic source-test/pendingacks
 
 user username1
 topic source-spec/secure-topic1
+topic source-spec/secure-topic2
 topic sink-spec/secure-topic1


### PR DESCRIPTION
Separate topics between tests better so they do not interfere.
As it turned out the for local tests the docker container had to be cleaned up between two runs, otherwise it would fail for old (unacknowledged) data popping up.
Made sure Java tests and Scala tests don't use the same topic names.