### PR TITLE
Csv: parsing two byte codes

### DIFF
--- a/csv/src/test/java/akka/stream/alpakka/csv/javadsl/CsvParsingTest.java
+++ b/csv/src/test/java/akka/stream/alpakka/csv/javadsl/CsvParsingTest.java
@@ -98,7 +98,7 @@ public class CsvParsingTest {
             assertThat(cause, is(instanceOf(MalformedCsvException.class)));
             MalformedCsvException csvException = (MalformedCsvException) cause;
             assertThat(csvException.getLineNo(), equalTo(2L));
-            assertThat(csvException.getBytePos(), equalTo(4));
+            assertThat(csvException.getBytePos(), equalTo(5));
         }
     }
 

--- a/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
@@ -181,6 +181,11 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
 
     "quoted values may contain CR, LF" in {
       expectInOut("one,\"two\r\ntwo\",three\n", List("one", "two\r\ntwo", "three"))
+      expectInOut("one,\"two\r\ntwo\",three", List("one", "two\r\ntwo", "three"))(requireLineEnd = false)
+    }
+
+    "quoted values may contain CR, LF in last field" in {
+      expectInOut("one,\"two\r\ntwo\"", List("one", "two\r\ntwo"))(requireLineEnd = false)
     }
 
     "handle escaping split over two inputs" in {


### PR DESCRIPTION
Parsing two-byte things on split `ByteString`s requires specialised states.

Fixes #880 