### PR TITLE
MQTT: use dynamic port for proxy in tests

### DIFF
--- a/docs/src/main/paradox/mqtt.md
+++ b/docs/src/main/paradox/mqtt.md
@@ -1,7 +1,6 @@
 # MQTT Connector
 
-The MQTT connector provides an Akka Stream source, sink and flow to connect to MQTT servers.
-
+The MQTT connector provides an Akka Stream source, sink and flow to connect to MQTT servers. It is based on [Eclipse Paho](https://www.eclipse.org/paho/clients/java/). 
 
 ### Reported issues
 
@@ -16,7 +15,7 @@ The MQTT connector provides an Akka Stream source, sink and flow to connect to M
   version=$version$
 }
 
-## Usage
+## Setup
 
 @@@ warning { title='Use delayed stream restarts' }
 Note that the following examples do not provide any connection management and are designed to get you going quickly. Consider empty client IDs to auto-generate unique identifiers and the use of [delayed stream restarts](https://doc.akka.io/docs/akka/current/stream/stream-error.html?language=scala#delayed-restarts-with-a-backoff-stage). The underlying Paho library's auto-reconnect feature [does not handle initial connections by design](https://github.com/eclipse/paho.mqtt.golang/issues/77).
@@ -32,6 +31,10 @@ Java
 
 Here we used @scaladoc[MqttConnectionSettings](akka.stream.alpakka.mqtt.MqttConnectionSettings$) factory to set the address of the server, client ID, which needs to be unique for every client, and client persistence implementation (@extref[MemoryPersistence](paho-api:org/eclipse/paho/client/mqttv3/persist/MemoryPersistence)) which allows to control reliability guarantees.
 
+Most settings are passed on to Paho's @extref[MqttConnectOptions](paho-api:org/eclipse/paho/client/mqttv3/MqttConnectOptions) and documented there. 
+
+
+## Reading from MQTT
 
 Then let's create a source that is going to connect to the MQTT server upon materialization and receive messages that are sent to the subscribed topics.
 
@@ -70,6 +73,8 @@ Scala
 Java
 : @@snip ($alpakka$/mqtt/src/test/java/akka/stream/alpakka/mqtt/javadsl/MqttSourceTest.java) { #run-source-with-manualacks }
 
+
+## Publishing to MQTT
 
 To publish messages to the MQTT server create a sink and run it.
 

--- a/mqtt/src/main/scala/akka/stream/alpakka/mqtt/Mqtt.scala
+++ b/mqtt/src/main/scala/akka/stream/alpakka/mqtt/Mqtt.scala
@@ -77,6 +77,10 @@ object MqttSourceSettings {
     MqttSourceSettings(connectionSettings)
 }
 
+/**
+ * Connection settings passed to the underlying Paho client.
+ * @see https://www.eclipse.org/paho/files/javadoc/org/eclipse/paho/client/mqttv3/MqttConnectOptions.html
+ */
 final case class MqttConnectionSettings(
     broker: String,
     clientId: String,

--- a/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala
+++ b/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala
@@ -287,9 +287,9 @@ class MqttSourceSpec
 
       val msg = MqttMessage(topic1, ByteString("ohi"))
 
-      // Create a proxy to RabbitMQ so it can be shutdown
-      val proxyPort = 1337 // make sure to keep it separate from ports used by other tests
-      val (proxyBinding, connection) = Tcp().bind("localhost", proxyPort).toMat(Sink.head)(Keep.both).run()
+      // Create a proxy on an available port so it can be shut down
+      val (proxyBinding, connection) = Tcp().bind("localhost", 0).toMat(Sink.head)(Keep.both).run()
+      val proxyPort = proxyBinding.futureValue.localAddress.getPort
       val proxyKs = connection.map(
         _.handleWith(
           Tcp()
@@ -311,6 +311,7 @@ class MqttSourceSpec
 
       // Ensure that the connection made it all the way to the server by waiting until it receives a message
       Await.ready(subscribed, timeout)
+
       Source.single(msg).runWith(MqttSink(sinkSettings, MqttQoS.AtLeastOnce))
       try {
         probe.requestNext()
@@ -347,9 +348,9 @@ class MqttSourceSpec
       val lastWill = MqttMessage(willTopic, ByteString("ohi"), Some(MqttQoS.AtLeastOnce), retained = true)
       //#will-message
 
-      // Create a proxy to RabbitMQ so it can be shutdown
-      val proxyPort = 1338 // make sure to keep it separate from ports used by other tests
-      val (proxyBinding, connection) = Tcp().bind("localhost", proxyPort).toMat(Sink.head)(Keep.both).run()
+      // Create a proxy on an available port so it can be shut down
+      val (proxyBinding, connection) = Tcp().bind("localhost", 0).toMat(Sink.head)(Keep.both).run()
+      val proxyPort = proxyBinding.futureValue.localAddress.getPort
       val proxyKs = connection.map(
         _.handleWith(
           Tcp()


### PR DESCRIPTION
Using a dynamic port hopefully clears #929.

Added some links to the Paho client lib, as well.