### PR TITLE
Publish snapshots after every merge

### DIFF
--- a/.jvmopts-travis
+++ b/.jvmopts-travis
@@ -1,0 +1,6 @@
+# This is used to configure the sbt instance that Travis launches
+
+-Xms1G
+-Xmx1G
+-Xss2M
+-XX:ReservedCodeCacheSize=128m

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot
-  timeout: 300
+  timeout: 900
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 # default script for jobs, that do not have any specified
 script:
   - ${PRE_CMD:=return 0} # do nothing if not set
-  - sbt -J-XX:ReservedCodeCacheSize=128m -J-Xmx800M -J-Xms800M -J-server "$CMD"
+  - sbt -jvm-opts .jvmopts-travis "$CMD"
 
 jobs:
   include:
@@ -74,49 +74,35 @@ jobs:
     - env: CMD=+unix-domain-socket/testChanged
     - env: CMD=+xml/testChanged
 
-    - stage: whitesource-master
-      script: sbt whitesourceCheckPolicies whitesourceUpdate
-
-    - stage: whitesource-release
+    - stage: whitesource
       script: sbt whitesourceCheckPolicies whitesourceUpdate
 
     - stage: publish
-      script: sbt -J-XX:ReservedCodeCacheSize=128m +publish
+      script: sbt -jvm-opts .jvmopts-travis +publish
 
     - stage: techhub-ping
       script: curl -I https://ci.lightbend.com/job/techhub-publisher/build?token=$TECH_HUB_TOKEN
 
-    - stage: publish-nightly
-      script: sbt -J-XX:ReservedCodeCacheSize=128m publish
-
 stages:
   # runs on master commits and PRs
   - name: check
-    if: NOT tag =~ ^v AND NOT type = cron
+    if: NOT tag =~ ^v
 
   # runs on master commits and PRs
   - name: test
-    if: NOT tag =~ ^v AND NOT type = cron
+    if: NOT tag =~ ^v
 
-  # runs on main repo master commits
-  - name: whitesource-master
-    if: repo = akka/alpakka AND branch = master AND type = push
+  # runs on main repo master commits or version-tagged commits
+  - name: whitesource
+    if: repo = akka/alpakka AND ( ( branch = master AND type = push ) OR tag =~ ^v )
 
-  # runs on main repo version-tagged commits
-  - name: whitesource-release
-    if: repo = akka/alpakka AND tag =~ ^v AND NOT type = cron
-
-  # runs on main repo version-tagged commits
+  # runs on main repo master commits or version-tagged commits
   - name: publish
-    if: repo = akka/alpakka AND tag =~ ^v AND NOT type = cron
+    if: repo = akka/alpakka AND ( ( branch = master AND type = push ) OR tag =~ ^v )
 
   # runs on main repo version-tagged commits
   - name: techhub-ping
-    if: repo = akka/alpakka AND tag =~ ^v AND NOT type = cron
-
-  # runs on main repo and from cron
-  - name: publish-nightly
-    if: repo = akka/alpakka AND type = cron
+    if: repo = akka/alpakka AND tag =~ ^v
 
 after_failure:
   - docker-compose logs
@@ -130,6 +116,7 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot
+  timeout: 300
 
 env:
   global:

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -18,7 +18,7 @@ The code in this documentation is compiled against
 
 Release notes are found at [Github releases](https://github.com/akka/alpakka/releases).
 
-If you want to try out a connector that has not yet been released, give @ref[snapshots](other-docs/snapshots.md) a spin which are published daily.
+If you want to try out a connector that has not yet been released, give @ref[snapshots](other-docs/snapshots.md) a spin which are published after every merged PR.
 
 ## Contributing
 

--- a/docs/src/main/paradox/other-docs/snapshots.md
+++ b/docs/src/main/paradox/other-docs/snapshots.md
@@ -3,7 +3,7 @@
 [bintray-badge]:  https://api.bintray.com/packages/akka/snapshots/alpakka/images/download.svg
 [bintray]:        https://bintray.com/akka/snapshots/alpakka/_latestVersion 
 
-Snapshots are published daily to a repository in bintray. Add the following to your project build definition to resolve Alpakka snapshots:
+Snapshots are published after every merged PR to a repository in bintray. Add the following to your project build definition to resolve Alpakka snapshots:
 
 sbt
 :   ```scala


### PR DESCRIPTION
instead of daily. Publishing daily is problematic due to artifact version clashes if there were no commits between snapshot releases.