### PR TITLE
AWS S3: Reimplementation of hex encoding to avoid depending on JAXB

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/auth/package.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/auth/package.scala
@@ -5,7 +5,6 @@
 package akka.stream.alpakka.s3
 
 import java.security.MessageDigest
-import javax.xml.bind.DatatypeConverter
 
 import akka.stream.scaladsl.{Flow, Keep, Sink}
 import akka.util.ByteString
@@ -13,7 +12,19 @@ import akka.util.ByteString
 import scala.concurrent.Future
 
 package object auth {
-  def encodeHex(bytes: Array[Byte]): String = DatatypeConverter.printHexBinary(bytes).toLowerCase
+
+  private val Digits = "0123456789abcdef".toCharArray()
+
+  def encodeHex(bytes: Array[Byte]): String = {
+    val length = bytes.length
+    val out = new Array[Char](length * 2)
+    for (i <- 0 to length - 1) {
+      val b = bytes(i)
+      out(i * 2) = Digits((b >> 4) & 0xF)
+      out(i * 2 + 1) = Digits(b & 0xF)
+    }
+    new String(out)
+  }
 
   def encodeHex(bytes: ByteString): String = encodeHex(bytes.toArray)
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/auth/authSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/auth/authSpec.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.s3.auth
+
+import org.scalatest.FlatSpec
+
+class authSpec extends FlatSpec {
+
+  "encodeHex" should "encode string to hex string" in {
+    assert(encodeHex("1234+abcd".getBytes()) == "313233342b61626364")
+  }
+
+}


### PR DESCRIPTION
I coundn't find hex encoding in current depending libraries, therefore I added own implementation to remove the future dependency to JAXB.

Closes #952.