### PR TITLE
FTP  Added `explicitSSL` parameter to `FtpsSettings` (#976).

### DIFF
--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -34,6 +34,8 @@ Java
 The configuration above will create an anonymous connection with a remote FTP server in passive mode. For both FTPs and SFTP servers, you will need to provide the specialized versions of these settings: @scaladoc[FtpsSettings](akka.stream.alpakka.ftp.RemoteFileSettings$$FtpsSettings) or @scaladoc[SftpSettings](akka.stream.alpakka.ftp.RemoteFileSettings$$SftpSettings)
 respectively.
 
+The example demonstrates optional use of `configureConnection` option available on FTP and FTPs clients. Use it to configure any custom parameters the server may require, such as explicit or implicit data transfer encryption.
+
 For non-anonymous connection, please provide an instance of @scaladoc[NonAnonFtpCredentials](akka.stream.alpakka.ftp.FtpCredentials$$NonAnonFtpCredentials) instead.
 
 For connection using a private key, please provide an instance of @scaladoc[SftpIdentity](akka.stream.alpakka.ftp.SftpIdentity) to @scaladoc[SftpSettings](akka.stream.alpakka.ftp.RemoteFileSettings$$SftpSettings).

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.ftp.impl
+
+import java.io.{IOException, InputStream, OutputStream}
+import java.nio.file.Paths
+import java.nio.file.attribute.PosixFilePermission
+
+import akka.stream.alpakka.ftp.FtpFile
+import org.apache.commons.net.ftp.{FTPClient, FTPFile}
+
+import scala.collection.immutable
+import scala.util.Try
+
+private[ftp] trait CommonFtpOperations {
+  type Handler = FTPClient
+
+  def listFiles(basePath: String, handler: Handler): immutable.Seq[FtpFile] = {
+    val path = if (!basePath.isEmpty && basePath.head != '/') s"/$basePath" else basePath
+    handler
+      .listFiles(path)
+      .collect {
+        case file: FTPFile if file.getName != "." && file.getName != ".." =>
+          FtpFile(
+            file.getName,
+            Paths.get(s"$path/${file.getName}").normalize.toString,
+            file.isDirectory,
+            file.getSize,
+            file.getTimestamp.getTimeInMillis,
+            getPosixFilePermissions(file)
+          )
+      }
+      .toVector
+  }
+
+  private def getPosixFilePermissions(file: FTPFile) =
+    Map(
+      PosixFilePermission.OWNER_READ → file.hasPermission(FTPFile.USER_ACCESS, FTPFile.READ_PERMISSION),
+      PosixFilePermission.OWNER_WRITE → file.hasPermission(FTPFile.USER_ACCESS, FTPFile.WRITE_PERMISSION),
+      PosixFilePermission.OWNER_EXECUTE → file.hasPermission(FTPFile.USER_ACCESS, FTPFile.EXECUTE_PERMISSION),
+      PosixFilePermission.GROUP_READ → file.hasPermission(FTPFile.GROUP_ACCESS, FTPFile.READ_PERMISSION),
+      PosixFilePermission.GROUP_WRITE → file.hasPermission(FTPFile.GROUP_ACCESS, FTPFile.WRITE_PERMISSION),
+      PosixFilePermission.GROUP_EXECUTE → file.hasPermission(FTPFile.GROUP_ACCESS, FTPFile.EXECUTE_PERMISSION),
+      PosixFilePermission.OTHERS_READ → file.hasPermission(FTPFile.WORLD_ACCESS, FTPFile.READ_PERMISSION),
+      PosixFilePermission.OTHERS_WRITE → file.hasPermission(FTPFile.WORLD_ACCESS, FTPFile.WRITE_PERMISSION),
+      PosixFilePermission.OTHERS_EXECUTE → file.hasPermission(FTPFile.WORLD_ACCESS, FTPFile.EXECUTE_PERMISSION)
+    ).collect {
+      case (perm, true) ⇒ perm
+    }.toSet
+
+  def listFiles(handler: Handler): immutable.Seq[FtpFile] = listFiles("", handler)
+
+  def retrieveFileInputStream(name: String, handler: Handler): Try[InputStream] = Try {
+    val is = handler.retrieveFileStream(name)
+    if (is != null) is else throw new IOException(s"$name: No such file or directory")
+  }
+
+  def storeFileOutputStream(name: String, handler: Handler, append: Boolean): Try[OutputStream] = Try {
+    val os = if (append) handler.appendFileStream(name) else handler.storeFileStream(name)
+    if (os != null) os else throw new IOException(s"Could not write to $name")
+  }
+
+  def move(fromPath: String, destinationPath: String, handler: Handler): Unit =
+    handler.rename(fromPath, destinationPath)
+
+  def remove(path: String, handler: Handler): Unit =
+    handler.deleteFile(path)
+}

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
@@ -6,7 +6,8 @@ package akka.stream.alpakka.ftp
 package impl
 
 import net.schmizz.sshj.SSHClient
-import org.apache.commons.net.ftp.FTPClient
+import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
+
 import scala.collection.immutable
 import scala.util.Try
 import java.io.{InputStream, OutputStream}
@@ -35,5 +36,6 @@ protected[ftp] trait FtpLike[FtpClient, S <: RemoteFileSettings] {
 object FtpLike {
   // type class instances
   implicit val ftpLikeInstance = new FtpLike[FTPClient, FtpFileSettings] with FtpOperations
+  implicit val ftpsLikeInstance = new FtpLike[FTPSClient, FtpsSettings] with FtpsOperations
   implicit val sFtpLikeInstance = new FtpLike[SSHClient, SftpSettings] with SftpOperations
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
@@ -35,7 +35,7 @@ protected[ftp] trait FtpLike[FtpClient, S <: RemoteFileSettings] {
 
 object FtpLike {
   // type class instances
-  implicit val ftpLikeInstance = new FtpLike[FTPClient, FtpFileSettings] with FtpOperations
+  implicit val ftpLikeInstance = new FtpLike[FTPClient, FtpSettings] with FtpOperations
   implicit val ftpsLikeInstance = new FtpLike[FTPSClient, FtpsSettings] with FtpsOperations
   implicit val sFtpLikeInstance = new FtpLike[SSHClient, SftpSettings] with SftpOperations
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
@@ -9,10 +9,12 @@ import org.apache.commons.net.ftp.{FTP, FTPClient}
 
 import scala.util.Try
 
-private[ftp] trait FtpOperations extends CommonFtpOperations { _: FtpLike[FTPClient, FtpFileSettings] =>
+private[ftp] trait FtpOperations extends CommonFtpOperations { _: FtpLike[FTPClient, FtpSettings] =>
 
-  def connect(connectionSettings: FtpFileSettings)(implicit ftpClient: FTPClient): Try[Handler] = Try {
+  def connect(connectionSettings: FtpSettings)(implicit ftpClient: FTPClient): Try[Handler] = Try {
     ftpClient.connect(connectionSettings.host, connectionSettings.port)
+
+    connectionSettings.configureConnection(ftpClient)
 
     ftpClient.login(
       connectionSettings.credentials.username,

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
@@ -103,11 +103,11 @@ private[ftp] trait FtpSource extends FtpSourceFactory[FTPClient] {
   protected val ftpIOSinkName: String = FtpIOSinkName
 }
 
-private[ftp] trait FtpsSource extends FtpSourceFactory[FTPClient] {
+private[ftp] trait FtpsSource extends FtpSourceFactory[FTPSClient] {
   protected final val FtpsBrowserSourceName = "FtpsBrowserSource"
   protected final val FtpsIOSourceName = "FtpsIOSource"
   protected final val FtpsIOSinkName = "FtpsIOSink"
-  protected val ftpClient: () => FTPClient = () => new FTPSClient
+  protected val ftpClient: () => FTPSClient = () => new FTPSClient
   protected val ftpBrowserSourceName: String = FtpsBrowserSourceName
   protected val ftpIOSourceName: String = FtpsIOSourceName
   protected val ftpIOSinkName: String = FtpsIOSinkName
@@ -178,8 +178,8 @@ private[ftp] trait FtpSourceParams extends FtpSource with FtpDefaultSettings {
 }
 
 private[ftp] trait FtpsSourceParams extends FtpsSource with FtpsDefaultSettings {
-  type S = FtpFileSettings
-  protected[this] val ftpLike: FtpLike[FTPClient, S] = FtpLike.ftpLikeInstance
+  type S = FtpsSettings
+  protected[this] val ftpLike: FtpLike[FTPSClient, S] = FtpLike.ftpsLikeInstance
 }
 
 private[ftp] trait SftpSourceParams extends SftpSource with SftpDefaultSettings {

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
@@ -173,7 +173,7 @@ private[ftp] trait SftpDefaultSettings {
 }
 
 private[ftp] trait FtpSourceParams extends FtpSource with FtpDefaultSettings {
-  type S = FtpFileSettings
+  type S = FtpSettings
   protected[this] val ftpLike: FtpLike[FTPClient, S] = FtpLike.ftpLikeInstance
 }
 

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
@@ -2,16 +2,16 @@
  * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.stream.alpakka.ftp
-package impl
+package akka.stream.alpakka.ftp.impl
 
-import org.apache.commons.net.ftp.{FTP, FTPClient}
+import akka.stream.alpakka.ftp.FtpsSettings
+import org.apache.commons.net.ftp.{FTP, FTPSClient}
 
 import scala.util.Try
 
-private[ftp] trait FtpOperations extends CommonFtpOperations { _: FtpLike[FTPClient, FtpFileSettings] =>
+private[ftp] trait FtpsOperations extends CommonFtpOperations { _: FtpLike[FTPSClient, FtpsSettings] =>
 
-  def connect(connectionSettings: FtpFileSettings)(implicit ftpClient: FTPClient): Try[Handler] = Try {
+  def connect(connectionSettings: FtpsSettings)(implicit ftpClient: FTPSClient): Try[Handler] = Try {
     ftpClient.connect(connectionSettings.host, connectionSettings.port)
 
     ftpClient.login(
@@ -27,10 +27,14 @@ private[ftp] trait FtpOperations extends CommonFtpOperations { _: FtpLike[FTPCli
       ftpClient.enterLocalPassiveMode()
     }
 
+    if (connectionSettings.explicitSSL) {
+      ftpClient.execPROT("P")
+    }
+
     ftpClient
   }
 
-  def disconnect(handler: Handler)(implicit ftpClient: FTPClient): Unit =
+  def disconnect(handler: Handler)(implicit ftpClient: FTPSClient): Unit =
     if (ftpClient.isConnected) {
       ftpClient.logout()
       ftpClient.disconnect()

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
@@ -14,6 +14,8 @@ private[ftp] trait FtpsOperations extends CommonFtpOperations { _: FtpLike[FTPSC
   def connect(connectionSettings: FtpsSettings)(implicit ftpClient: FTPSClient): Try[Handler] = Try {
     ftpClient.connect(connectionSettings.host, connectionSettings.port)
 
+    connectionSettings.configureConnection(ftpClient)
+
     ftpClient.login(
       connectionSettings.credentials.username,
       connectionSettings.credentials.password
@@ -25,10 +27,6 @@ private[ftp] trait FtpsOperations extends CommonFtpOperations { _: FtpLike[FTPSC
 
     if (connectionSettings.passiveMode) {
       ftpClient.enterLocalPassiveMode()
-    }
-
-    if (connectionSettings.explicitSSL) {
-      ftpClient.execPROT("P")
     }
 
     ftpClient

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -15,9 +15,10 @@ import akka.stream.scaladsl.{Source => ScalaSource}
 import akka.stream.scaladsl.{Sink => ScalaSink}
 import akka.util.ByteString
 import net.schmizz.sshj.SSHClient
-import org.apache.commons.net.ftp.FTPClient
+import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
 import java.util.concurrent.CompletionStage
 import java.util.function._
+
 import scala.compat.java8.FunctionConverters._
 
 sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
@@ -237,7 +238,7 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
 }
 class SftpApi extends FtpApi[SSHClient] with SftpSourceParams
 object Ftp extends FtpApi[FTPClient] with FtpSourceParams
-object Ftps extends FtpApi[FTPClient] with FtpsSourceParams
+object Ftps extends FtpApi[FTPSClient] with FtpsSourceParams
 object Sftp extends SftpApi {
 
   /**

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -94,13 +94,15 @@ object FtpSettings {
  * @param credentials credentials (username and password)
  * @param binary specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false)
  * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
+ * @param explicitSSL specifies whether to use ssl encryption for data connections. Default is no (false).
  */
 final case class FtpsSettings(
     host: InetAddress,
     port: Int = FtpsSettings.DefaultFtpsPort,
     credentials: FtpCredentials = AnonFtpCredentials,
     binary: Boolean = false,
-    passiveMode: Boolean = false
+    passiveMode: Boolean = false,
+    explicitSSL: Boolean = false
 ) extends FtpFileSettings {
   def withPort(port: Int): FtpsSettings =
     copy(port = port)
@@ -113,6 +115,9 @@ final case class FtpsSettings(
 
   def withPassiveMode(passiveMode: Boolean): FtpsSettings =
     copy(passiveMode = passiveMode)
+
+  def withExplicitSSL(explicitSSL: Boolean): FtpsSettings =
+    copy(explicitSSL = explicitSSL)
 }
 
 object FtpsSettings {

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -8,6 +8,8 @@ import akka.stream.alpakka.ftp.FtpCredentials.AnonFtpCredentials
 import java.net.InetAddress
 import java.nio.file.attribute.PosixFilePermission
 
+import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
+
 /**
  * FTP remote file descriptor.
  *
@@ -61,7 +63,8 @@ final case class FtpSettings(
     port: Int = FtpSettings.DefaultFtpPort,
     credentials: FtpCredentials = AnonFtpCredentials,
     binary: Boolean = false,
-    passiveMode: Boolean = false
+    passiveMode: Boolean = false,
+    configureConnection: FTPClient => Unit = _ => {}
 ) extends FtpFileSettings {
   def withPort(port: Int): FtpSettings =
     copy(port = port)
@@ -74,6 +77,9 @@ final case class FtpSettings(
 
   def withPassiveMode(passiveMode: Boolean): FtpSettings =
     copy(passiveMode = passiveMode)
+
+  def withConfigureConnection(configureConnection: FTPClient => Unit): FtpSettings =
+    copy(configureConnection = configureConnection)
 }
 
 object FtpSettings {
@@ -94,7 +100,8 @@ object FtpSettings {
  * @param credentials credentials (username and password)
  * @param binary specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false)
  * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
- * @param explicitSSL specifies whether to use ssl encryption for data connections. Default is no (false).
+ * @param configureConnection A function which will be called after connecting to the server. Use this for
+ *                            any custom configuration required by the server you're connecting to.
  */
 final case class FtpsSettings(
     host: InetAddress,
@@ -102,7 +109,7 @@ final case class FtpsSettings(
     credentials: FtpCredentials = AnonFtpCredentials,
     binary: Boolean = false,
     passiveMode: Boolean = false,
-    explicitSSL: Boolean = false
+    configureConnection: FTPSClient => Unit = _ => {}
 ) extends FtpFileSettings {
   def withPort(port: Int): FtpsSettings =
     copy(port = port)
@@ -116,8 +123,8 @@ final case class FtpsSettings(
   def withPassiveMode(passiveMode: Boolean): FtpsSettings =
     copy(passiveMode = passiveMode)
 
-  def withExplicitSSL(explicitSSL: Boolean): FtpsSettings =
-    copy(explicitSSL = explicitSSL)
+  def withConfigureConnection(configureConnection: FTPSClient => Unit): FtpsSettings =
+    copy(configureConnection = configureConnection)
 }
 
 object FtpsSettings {

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -82,6 +82,13 @@ final case class FtpSettings(
 
   def withConfigureConnection(configureConnection: FTPClient => Unit): FtpSettings =
     copy(configureConnection = configureConnection)
+
+  /**
+   * Java API:
+   * Sets the configure connection callback.
+   */
+  def withConfigureConnectionConsumer(configureConnection: java.util.function.Consumer[FTPClient]): FtpSettings =
+    copy(configureConnection = configureConnection.accept)
 }
 
 object FtpSettings {

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -57,6 +57,8 @@ sealed abstract class FtpFileSettings extends RemoteFileSettings {
  * @param credentials credentials (username and password)
  * @param binary specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false)
  * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
+ * @param configureConnection A function which will be called after connecting to the server. Use this for
+ *                            any custom configuration required by the server you are connecting to.
  */
 final case class FtpSettings(
     host: InetAddress,
@@ -101,7 +103,7 @@ object FtpSettings {
  * @param binary specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false)
  * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
  * @param configureConnection A function which will be called after connecting to the server. Use this for
- *                            any custom configuration required by the server you're connecting to.
+ *                            any custom configuration required by the server you are connecting to.
  */
 final case class FtpsSettings(
     host: InetAddress,

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -11,7 +11,8 @@ import akka.stream.alpakka.ftp.{FtpFile, RemoteFileSettings}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import net.schmizz.sshj.SSHClient
-import org.apache.commons.net.ftp.FTPClient
+import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
+
 import scala.concurrent.Future
 
 sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
@@ -169,7 +170,7 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
 
 class SftpApi extends FtpApi[SSHClient] with SftpSourceParams
 object Ftp extends FtpApi[FTPClient] with FtpSourceParams
-object Ftps extends FtpApi[FTPClient] with FtpsSourceParams
+object Ftps extends FtpApi[FTPSClient] with FtpsSourceParams
 
 object Sftp extends SftpApi {
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java
@@ -63,13 +63,12 @@ public class FtpStageTest extends PlainFtpSupportImpl implements CommonFtpStageT
   }
 
   private FtpSettings settings() throws Exception {
-    final FtpSettings settings = new FtpSettings(
-            InetAddress.getByName("localhost"),
-            getPort(),
-            FtpCredentials.createAnonCredentials(),
-            false, // binary
-            true   // passiveMode
-    );
+    final FtpSettings settings = FtpSettings.create(InetAddress.getByName("localhost"))
+            .withPort(getPort())
+            .withCredentials(FtpCredentials
+            .createAnonCredentials())
+            .withBinary(false)
+            .withPassiveMode(true);
     return settings;
   }
 }

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
@@ -74,7 +74,8 @@ public class FtpsStageTest extends FtpsSupportImpl implements CommonFtpStageTest
             getPort(),
             FtpCredentials.createAnonCredentials(),
             false, // binary
-            true   // passiveMode
+            true,  // passiveMode
+            false  // explicitSSL
     );
     //#create-settings
     return settings;

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
@@ -69,14 +69,12 @@ public class FtpsStageTest extends FtpsSupportImpl implements CommonFtpStageTest
 
   private FtpsSettings settings() throws Exception {
     //#create-settings
-    final FtpsSettings settings = new FtpsSettings(
-            InetAddress.getByName("localhost"),
-            getPort(),
-            FtpCredentials.createAnonCredentials(),
-            false, // binary
-            true,  // passiveMode
-            false  // explicitSSL
-    );
+    final FtpsSettings settings = FtpsSettings.create(
+            InetAddress.getByName("localhost"))
+            .withPort(getPort())
+            .withCredentials(FtpCredentials.createAnonCredentials())
+            .withBinary(false)
+            .withPassiveMode(false);
     //#create-settings
     return settings;
   }

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpSettingsExample.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpSettingsExample.java
@@ -7,6 +7,10 @@ package akka.stream.alpakka.ftp.examples;
 //#create-settings
 import akka.stream.alpakka.ftp.FtpCredentials;
 import akka.stream.alpakka.ftp.FtpSettings;
+import org.apache.commons.net.PrintCommandListener;
+import org.apache.commons.net.ftp.FTPClient;
+
+import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
@@ -15,13 +19,18 @@ public class FtpSettingsExample {
 
     public FtpSettingsExample() {
         try {
-            settings =  new FtpSettings(
-                    InetAddress.getByName("localhost"),
-                    FtpSettings.DefaultFtpPort(),
-                    FtpCredentials.createAnonCredentials(),
-                    false, // binary
-                    true // passiveMode
-            );
+            settings = FtpSettings.create(
+                InetAddress.getByName("localhost"))
+                .withPort(FtpSettings.DefaultFtpPort())
+                .withCredentials(FtpCredentials.createAnonCredentials())
+                .withBinary(false)
+                .withPassiveMode(false)
+                .withConfigureConnection((FTPClient ftpClient) -> {
+                    ftpClient.addProtocolCommandListener(
+                            new PrintCommandListener(new PrintWriter(System.out), true)
+                    );
+                    return null;
+                });
         } catch (UnknownHostException e) {
             e.printStackTrace();
         }

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpSettingsExample.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpSettingsExample.java
@@ -5,10 +5,11 @@
 package akka.stream.alpakka.ftp.examples;
 
 //#create-settings
-import akka.stream.alpakka.ftp.FtpCredentials;
-import akka.stream.alpakka.ftp.FtpSettings;
-import org.apache.commons.net.PrintCommandListener;
-import org.apache.commons.net.ftp.FTPClient;
+                import akka.stream.alpakka.ftp.FtpCredentials;
+                import akka.stream.alpakka.ftp.FtpSettings;
+                import org.apache.commons.net.PrintCommandListener;
+                import org.apache.commons.net.ftp.FTPClient;
+//#create-settings
 
 import java.io.PrintWriter;
 import java.net.InetAddress;
@@ -19,21 +20,23 @@ public class FtpSettingsExample {
 
     public FtpSettingsExample() {
         try {
-            settings = FtpSettings.create(
-                InetAddress.getByName("localhost"))
-                .withPort(FtpSettings.DefaultFtpPort())
-                .withCredentials(FtpCredentials.createAnonCredentials())
-                .withBinary(false)
-                .withPassiveMode(false)
-                .withConfigureConnection((FTPClient ftpClient) -> {
-                    ftpClient.addProtocolCommandListener(
-                            new PrintCommandListener(new PrintWriter(System.out), true)
-                    );
-                    return null;
-                });
+            settings =
+//#create-settings
+
+                FtpSettings
+                    .create(InetAddress.getByName("localhost"))
+                    .withPort(FtpSettings.DefaultFtpPort())
+                    .withCredentials(FtpCredentials.createAnonCredentials())
+                    .withBinary(false)
+                    .withPassiveMode(false)
+                    .withConfigureConnectionConsumer((FTPClient ftpClient) -> {
+                        ftpClient.addProtocolCommandListener(
+                                new PrintCommandListener(new PrintWriter(System.out), true)
+                        );
+                    });
+//#create-settings
         } catch (UnknownHostException e) {
             e.printStackTrace();
         }
     }
 }
-//#create-settings

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala
@@ -4,8 +4,12 @@
 
 package akka.stream.alpakka.ftp
 
-import akka.stream.alpakka.ftp.scaladsl.{FtpApi, Sftp, SftpApi}
+import java.io.PrintWriter
+
+import akka.stream.alpakka.ftp.scaladsl.{Sftp, SftpApi}
 import net.schmizz.sshj.DefaultConfig
+import org.apache.commons.net.PrintCommandListener
+import org.apache.commons.net.ftp.FTPClient
 
 object scalaExamples {
 
@@ -19,7 +23,10 @@ object scalaExamples {
       InetAddress.getByName("localhost"),
       credentials = AnonFtpCredentials,
       binary = true,
-      passiveMode = true
+      passiveMode = true,
+      configureConnection = (ftpClient: FTPClient) => {
+        ftpClient.addProtocolCommandListener(new PrintCommandListener(new PrintWriter(System.out), true))
+      }
     )
     //#create-settings
   }

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala
@@ -4,19 +4,16 @@
 
 package akka.stream.alpakka.ftp
 
-import java.io.PrintWriter
-
-import akka.stream.alpakka.ftp.scaladsl.{Sftp, SftpApi}
-import net.schmizz.sshj.DefaultConfig
-import org.apache.commons.net.PrintCommandListener
-import org.apache.commons.net.ftp.FTPClient
-
 object scalaExamples {
 
   // settings
   object settings {
     //#create-settings
+    import akka.stream.alpakka.ftp.FtpSettings
     import akka.stream.alpakka.ftp.FtpCredentials.AnonFtpCredentials
+    import org.apache.commons.net.PrintCommandListener
+    import org.apache.commons.net.ftp.FTPClient
+    import java.io.PrintWriter
     import java.net.InetAddress
 
     val settings = FtpSettings(
@@ -33,6 +30,8 @@ object scalaExamples {
 
   object sshConfigure {
     //#configure-custom-ssh-client
+    import akka.stream.alpakka.ftp.scaladsl.{Sftp, SftpApi}
+    import net.schmizz.sshj.DefaultConfig
     import net.schmizz.sshj.SSHClient
 
     val sshClient: SSHClient = new SSHClient(new DefaultConfig)


### PR DESCRIPTION
I've tested it agains the server, which requires encrypted data transfer and it works.

I'm not super sure how to add this case to the specs yet.