### PR TITLE
Fix exception thrown when AMQP can't connect to the server.

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnector.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnector.scala
@@ -75,8 +75,10 @@ private[amqp] trait AmqpConnectorLogic { this: GraphStageLogic =>
     if ((channel ne null) && channel.isOpen) channel.close()
     channel = null
 
-    connection.removeShutdownListener(shutdownListener)
-    settings.connectionProvider.release(connection)
-    connection = null
+    if (connection ne null) {
+      connection.removeShutdownListener(shutdownListener)
+      settings.connectionProvider.release(connection)
+      connection = null
+    }
   }
 }


### PR DESCRIPTION
I noticed that when the connection fails (wrong credentials or whatever) the connection is still null so there is a NullPointerException when trying to remove listeners.

However, the exception is not caught in the tests. Probably because it's thrown in a different thread?
Any advice on how to test or improve this is more than welcome :)