### PR TITLE
Non-static signing key for S3 MultiPartUpload (#996)

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -486,9 +486,6 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
                        sse.fold[Seq[HttpHeader]](Seq.empty) { _.headersFor(InitiateMultipartUpload) }
                      ))
 
-    // use the same key for all sub-requests (chunks)
-    val key: SigningKey = signingKey
-
     val headers: S3Headers = S3Headers(sse.fold[Seq[HttpHeader]](Seq.empty) { _.headersFor(CopyPart) })
 
     requestInfo
@@ -502,7 +499,7 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
       }
       .mapConcat(identity)
       .mapAsync(parallelism) {
-        case (req, info) => Signer.signedRequest(req, key).zip(Future.successful(info))
+        case (req, info) => Signer.signedRequest(req, signingKey).zip(Future.successful(info))
       }
   }
 

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -358,7 +358,7 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
             uploadPartRequest(uploadInfo, chunkIndex, chunkedPayload.data, chunkedPayload.size, headers)
           (partRequest, (uploadInfo, chunkIndex))
       }
-      .mapAsync(parallelism) { case (req, info) => Signer.signedRequest(req, SigningKey).zip(Future.successful(info)) }
+      .mapAsync(parallelism) { case (req, info) => Signer.signedRequest(req, signingKey).zip(Future.successful(info)) }
   }
 
   private def getChunkBuffer(chunkSize: Int) = settings.bufferType match {


### PR DESCRIPTION
Adjust S3 MultiPartUpload to use non-static signing key.  See issue: 
https://github.com/akka/alpakka/issues/996