### PR TITLE
AMQP - allow setting of autoAck on underlying channel.basicConsume call

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectorSettings.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectorSettings.scala
@@ -25,6 +25,7 @@ final case class NamedQueueSourceSettings(
     declarations: immutable.Seq[Declaration] = immutable.Seq.empty,
     noLocal: Boolean = false,
     exclusive: Boolean = false,
+    ackRequired: Boolean = true,
     consumerTag: String = "default",
     arguments: Map[String, AnyRef] = Map.empty
 ) extends AmqpSourceSettings {
@@ -34,6 +35,8 @@ final case class NamedQueueSourceSettings(
   def withNoLocal(noLocal: Boolean): NamedQueueSourceSettings = copy(noLocal = noLocal)
 
   def withExclusive(exclusive: Boolean): NamedQueueSourceSettings = copy(exclusive = exclusive)
+
+  def withAckRequired(ackRequired: Boolean): NamedQueueSourceSettings = copy(ackRequired = ackRequired)
 
   def withConsumerTag(consumerTag: String): NamedQueueSourceSettings = copy(consumerTag = consumerTag)
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpSourceStage.scala
@@ -114,7 +114,7 @@ private[amqp] final class AmqpSourceStage(settings: AmqpSourceSettings, bufferSi
         def setupNamedQueue(settings: NamedQueueSourceSettings): Unit =
           channel.basicConsume(
             settings.queue,
-            false, // never auto-ack
+            !settings.ackRequired,
             settings.consumerTag, // consumer tag
             settings.noLocal,
             settings.exclusive,

--- a/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
+++ b/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
@@ -228,7 +228,7 @@ public class AmqpDocsTest {
 
   @Test
   public void publishAndConsumeWithoutAutoAck() throws Exception {
-    final String queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis();
+    final String queueName = "amqp-conn-it-spec-no-auto-ack-" + System.currentTimeMillis();
     final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
 
     final Sink<ByteString, CompletionStage<Done>> amqpSink =
@@ -269,7 +269,7 @@ public class AmqpDocsTest {
 
   @Test
   public void republishMessageWithoutAutoAckIfNacked() throws Exception {
-    final String queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis();
+    final String queueName = "amqp-conn-it-spec-no-auto-ack-nacked-" + System.currentTimeMillis();
     final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
 
     final Sink<ByteString, CompletionStage<Done>> amqpSink =

--- a/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
+++ b/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
@@ -61,7 +61,7 @@ public class AmqpDocsTest {
   @Test
   public void publishAndConsume() throws Exception {
     // #queue-declaration
-    final String queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis();
+    final String queueName = "amqp-conn-it-test-simple-queue-" + System.currentTimeMillis();
     final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
     // #queue-declaration
 
@@ -110,7 +110,7 @@ public class AmqpDocsTest {
   @Test
   public void publishAndConsumeRpc() throws Exception {
 
-    final String queueName = "amqp-conn-it-spec-rpc-queue-" + System.currentTimeMillis();
+    final String queueName = "amqp-conn-it-test-rpc-queue-" + System.currentTimeMillis();
     final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
 
     // #create-rpc-flow
@@ -169,7 +169,7 @@ public class AmqpDocsTest {
   @Test
   public void publishFanoutAndConsume() throws Exception {
     // #exchange-declaration
-    final String exchangeName = "amqp-conn-it-spec-pub-sub" + System.currentTimeMillis();
+    final String exchangeName = "amqp-conn-it-test-pub-sub-" + System.currentTimeMillis();
     final ExchangeDeclaration exchangeDeclaration =
         ExchangeDeclaration.create(exchangeName, "fanout");
     // #exchange-declaration
@@ -228,7 +228,7 @@ public class AmqpDocsTest {
 
   @Test
   public void publishAndConsumeWithoutAutoAck() throws Exception {
-    final String queueName = "amqp-conn-it-spec-no-auto-ack-" + System.currentTimeMillis();
+    final String queueName = "amqp-conn-it-test-no-auto-ack-" + System.currentTimeMillis();
     final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
 
     final Sink<ByteString, CompletionStage<Done>> amqpSink =
@@ -269,7 +269,7 @@ public class AmqpDocsTest {
 
   @Test
   public void republishMessageWithoutAutoAckIfNacked() throws Exception {
-    final String queueName = "amqp-conn-it-spec-no-auto-ack-nacked-" + System.currentTimeMillis();
+    final String queueName = "amqp-conn-it-test-no-auto-ack-nacked-" + System.currentTimeMillis();
     final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
 
     final Sink<ByteString, CompletionStage<Done>> amqpSink =

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -373,30 +373,32 @@ class AmqpConnectorsSpec extends AmqpSpec {
     }
 
     "declare connection that does not require server acks" in {
-        val connectionProvider =
+      val connectionProvider =
         AmqpDetailsConnectionProvider("localhost", 5672)
 
-        val queueName = "amqp-conn-it-spec-fire-and-forget-" + System.currentTimeMillis()
-        val queueDeclaration = QueueDeclaration(queueName)
+      val queueName = "amqp-conn-it-spec-fire-and-forget-" + System.currentTimeMillis()
+      val queueDeclaration = QueueDeclaration(queueName)
 
-        val amqpSink = AmqpSink.simple(
-          AmqpSinkSettings(connectionProvider)
-            .withRoutingKey(queueName)
-            .withDeclarations(queueDeclaration)
-        )
+      val amqpSink = AmqpSink.simple(
+        AmqpSinkSettings(connectionProvider)
+          .withRoutingKey(queueName)
+          .withDeclarations(queueDeclaration)
+      )
 
-        //#create-source with ackRequired = false
-        val amqpSource = AmqpSource.atMostOnceSource(
-          NamedQueueSourceSettings(connectionProvider, queueName, ackRequired = false).withDeclarations(queueDeclaration),
+      val amqpSource = AmqpSource
+        .committableSource(
+          NamedQueueSourceSettings(connectionProvider, queueName, ackRequired = false)
+            .withDeclarations(queueDeclaration),
           bufferSize = 10
         )
+        .mapAsync(1)(cm => cm.ack().map(_ => cm))
 
-        val input = Vector("one", "two", "three", "four", "five")
-        Source(input).map(s => ByteString(s)).runWith(amqpSink).futureValue shouldEqual Done
+      val input = Vector("one", "two", "three", "four", "five")
+      Source(input).map(s => ByteString(s)).runWith(amqpSink).futureValue shouldEqual Done
 
-        val result = amqpSource.take(input.size).runWith(Sink.seq)
+      val result = amqpSource.take(input.size).runWith(Sink.seq)
 
-        result.futureValue.map(_.bytes.utf8String) shouldEqual input
-      }
+      result.futureValue.map(_.message.bytes.utf8String) shouldEqual input
+    }
   }
 }

--- a/amqp/src/test/scala/docs/scaladsl/AmqpDocsSpec.scala
+++ b/amqp/src/test/scala/docs/scaladsl/AmqpDocsSpec.scala
@@ -155,7 +155,7 @@ class AmqpDocsSpec extends AmqpSpec {
     }
 
     "publish and consume elements through a simple queue again in the same JVM without autoAck" in {
-      val queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis()
+      val queueName = "amqp-conn-it-spec-no-auto-ack-" + System.currentTimeMillis()
       val queueDeclaration = QueueDeclaration(queueName)
 
       val amqpSink = AmqpSink.simple(
@@ -186,7 +186,7 @@ class AmqpDocsSpec extends AmqpSpec {
 
     "republish message without autoAck if nack is sent" in {
 
-      val queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis()
+      val queueName = "amqp-conn-it-spec-no-auto-ack-nacked-" + System.currentTimeMillis()
       val queueDeclaration = QueueDeclaration(queueName)
 
       val amqpSink = AmqpSink.simple(


### PR DESCRIPTION
Fixes #1000 

The introduced field is `NamedQueueSourceSettings.ackRequired` rather than `autoAck` (being the name of the affected parameter in underlying amqp-client lib) to avoid confusion with the existing autoAck functionality (cc #97).

New integration test only tests that it isn't broken. Given the flag is merely passed to underlying library, I think we can assume that it works as intended.