### PR TITLE
Describe includeDocumentVersion property of ElasticsearchSourceSettings

### DIFF
--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -80,9 +80,10 @@ Java
 : @@snip ($alpakka$/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java) { #source-settings }
 
 
-| Parameter  | Default | Description                                                                                                              |
-| ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
-| bufferSize | 10      | `ElasticsearchSource` retrieves messages from Elasticsearch by scroll scan. This buffer size is used as the scroll size. | 
+| Parameter              | Default | Description                                                                                                              |
+| ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
+| bufferSize             | 10      | `ElasticsearchSource` retrieves messages from Elasticsearch by scroll scan. This buffer size is used as the scroll size. | 
+| includeDocumentVersion | false   | Tell Elasticsearch to return the documents `_version` property with the search results. See [Version](http://nocf-www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html) and [Optimistic Concurrenct Control](https://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html) to know about this property. |
 
 
 Also, we can configure the sink by `ElasticsearchSinkSettings`.


### PR DESCRIPTION
Add description about `includeDocumentVersion` property of `ElasticsearchSourceSettings` to the document.

This property is defined here:
https://github.com/akka/alpakka/blob/3902367aa8a9097d6f676adecb8fb475b76505af/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSourceSettings.scala#L17

and used in `ElasticsearchSourceStage`:
https://github.com/akka/alpakka/blob/3902367aa8a9097d6f676adecb8fb475b76505af/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSourceStage.scala#L80-L88