### PR TITLE
Docs: Use moved ElasticsearchSettings class

### DIFF
--- a/doc-examples/src/main/java/elastic/FetchUsingSlickAndStreamIntoElasticInJava.java
+++ b/doc-examples/src/main/java/elastic/FetchUsingSlickAndStreamIntoElasticInJava.java
@@ -10,9 +10,9 @@ package elastic;
         import akka.stream.ActorMaterializer;
         import akka.stream.Materializer;
 
+        import akka.stream.alpakka.elasticsearch.ElasticsearchSinkSettings;
         import akka.stream.alpakka.elasticsearch.IncomingMessage;
         import akka.stream.alpakka.elasticsearch.javadsl.ElasticsearchSink;
-        import akka.stream.alpakka.elasticsearch.javadsl.ElasticsearchSinkSettings;
         import org.apache.http.HttpHost;
         import org.elasticsearch.client.RestClient;
 
@@ -96,7 +96,7 @@ public class FetchUsingSlickAndStreamIntoElasticInJava {
                     .create(                                                             // (9)
                         "movie",
                         "boxoffice",
-                        new ElasticsearchSinkSettings(),
+                        ElasticsearchSinkSettings.Default(),
                         elasticSearchClient,
                         objectToJsonMapper
                     ), materializer);


### PR DESCRIPTION
The doc examples are not compiled for PRs. This change is necessary to make them compile after #1016 