### PR TITLE
Cassandra: avoiding isExhausted calls + prefetching results when buffer is half full

### DIFF
--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/CassandraSourceStage.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/CassandraSourceStage.scala
@@ -5,13 +5,11 @@
 package akka.stream.alpakka.cassandra
 
 import akka.stream._
-import akka.stream.stage.{AsyncCallback, GraphStage, GraphStageLogic, OutHandler}
+import akka.stream.stage.{GraphStage, GraphStageLogic, OutHandler}
 import com.datastax.driver.core.{ResultSet, Row, Session, Statement}
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
-
-import akka.stream.alpakka.cassandra.GuavaFutures._
 
 final class CassandraSourceStage(futStmt: Future[Statement], session: Session) extends GraphStage[SourceShape[Row]] {
   val out: Outlet[Row] = Outlet("CassandraSource.out")

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/GuavaFutures.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/GuavaFutures.scala
@@ -6,9 +6,24 @@ package akka.stream.alpakka.cassandra
 
 import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture}
 
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Failure, Success, Try}
 
 private[cassandra] object GuavaFutures {
+
+  def invokeTryCallback[T](
+      listenableFuture: ListenableFuture[T],
+      executor: java.util.concurrent.Executor = ExecutionContext.global
+  )(callback: Try[T] => Unit): Unit =
+    Futures.addCallback(
+      listenableFuture,
+      new FutureCallback[T] {
+        override def onSuccess(result: T): Unit = callback(Success(result))
+        override def onFailure(t: Throwable): Unit = callback(Failure(t))
+      },
+      executor
+    )
+
   implicit final class GuavaFutureOpts[A](val guavaFut: ListenableFuture[A]) extends AnyVal {
     def asScala(): Future[A] = {
       val p = Promise[A]()

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/GuavaFutures.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/GuavaFutures.scala
@@ -11,10 +11,8 @@ import scala.util.{Failure, Success, Try}
 
 private[cassandra] object GuavaFutures {
 
-  def invokeTryCallback[T](
-      listenableFuture: ListenableFuture[T],
-      executor: java.util.concurrent.Executor = ExecutionContext.global
-  )(callback: Try[T] => Unit): Unit =
+  def invokeTryCallback[T](listenableFuture: ListenableFuture[T],
+                           executor: java.util.concurrent.Executor)(callback: Try[T] => Unit): Unit =
     Futures.addCallback(
       listenableFuture,
       new FutureCallback[T] {


### PR DESCRIPTION
Fixes #1021 

* also using `Future.foreach` instead of `map`/`flatMap` for side effect
* not using redundant scala Future implicit class conversion (we are only interested in the side effect of `AsyncCallback` anyway…)
* not replacing boxed `ResultSet` on every fetch (`ResultSet` is reusable, no need to generate garbage for gc)
* general boyscouting