### PR TITLE
AWS S3: Remove Unexpected Download Limit

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -94,6 +94,7 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
     import mat.executionContext
     val s3Headers = S3Headers(sse.fold[Seq[HttpHeader]](Seq.empty) { _.headersFor(GetObject) })
     val future = request(s3Location, rangeOption = range, versionId = versionId, s3Headers = s3Headers)
+      .map(response => response.withEntity(response.entity.withoutSizeLimit))
     val source = Source
       .fromFuture(future.flatMap(entityForSuccess).map(_._1))
       .map(_.dataBytes)


### PR DESCRIPTION
Fixes #303 

Because S3 connector is using `akka-http`, it inherits the default 8Mb HttpRequest limit. There is no reason why an S3 download should be limited to just 8Mb, and throw an unexpected exception on large files.