### PR TITLE
HBase: Allow multiple mutations

### DIFF
--- a/docs/src/main/paradox/hbase.md
+++ b/docs/src/main/paradox/hbase.md
@@ -22,21 +22,50 @@ Build a converter and a tableSetting.
 
 Converter will map the domain object to list of HBase mutations (`Append`, `Delete`, `Increment`, `Put`).
 
-scala
-:   @@snip ($alpakka$/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala) { #create-converter }
+Here some examples:
 
-java
-:   @@snip ($alpakka$/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java) { #create-converter }
-
-Other mutations can also be returned:
+- A `Put` mutation:
 
 scala
-:   @@snip ($alpakka$/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala) { #create-converter-mutations }
+:   @@snip ($alpakka$/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala) { #create-converter-put }
 
 java
-:   @@snip ($alpakka$/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java) { #create-converter-mutations }
+:   @@snip ($alpakka$/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java) { #create-converter-put }
+
+- An `Append` mutation:
+
+scala
+:   @@snip ($alpakka$/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala) { #create-converter-append }
+
+java
+:   @@snip ($alpakka$/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java) { #create-converter-append }
+
+- A `Delete` mutation:
+
+scala
+:   @@snip ($alpakka$/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala) { #create-converter-delete }
+
+java
+:   @@snip ($alpakka$/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java) { #create-converter-delete }
+
+- An `Increment` mutation:
+
+scala
+:   @@snip ($alpakka$/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala) { #create-converter-increment }
+
+java
+:   @@snip ($alpakka$/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java) { #create-converter-increment }
+
 
 To ignore an object just return an empty `List`, this will have no effect on HBase.
+You can also combine mutations to perform complex business logic:
+
+scala
+:   @@snip ($alpakka$/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala) { #create-converter-complex }
+
+java
+:   @@snip ($alpakka$/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java) { #create-converter-complex }
+
 Remember that if you returns a list of mutations they will be applied in the same order.
 The list of Mutations are not applied in an transaction, each mutation is independent.
 

--- a/docs/src/main/paradox/hbase.md
+++ b/docs/src/main/paradox/hbase.md
@@ -20,13 +20,25 @@ HBase is a column family NoSQL Database backed by HDFS.
 
 Build a converter and a tableSetting.
 
-Converter will map the domain object to HBase column.
+Converter will map the domain object to list of HBase mutations (`Append`, `Delete`, `Increment`, `Put`).
 
 scala
 :   @@snip ($alpakka$/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala) { #create-converter }
 
 java
 :   @@snip ($alpakka$/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java) { #create-converter }
+
+Other mutations can also be returned:
+
+scala
+:   @@snip ($alpakka$/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala) { #create-converter-mutations }
+
+java
+:   @@snip ($alpakka$/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java) { #create-converter-mutations }
+
+To ignore an object just return an empty `List`, this will have no effect on HBase.
+Remember that if you returns a list of mutations they will be applied in the same order.
+The list of Mutations are not applied in an transaction, each mutation is independent.
 
 Table will be created on demand.
 

--- a/hbase/src/main/scala/akka/stream/alpakka/hbase/HBaseSettings.scala
+++ b/hbase/src/main/scala/akka/stream/alpakka/hbase/HBaseSettings.scala
@@ -6,22 +6,30 @@ package akka.stream.alpakka.hbase
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hbase.TableName
-import org.apache.hadoop.hbase.client.Put
+import org.apache.hadoop.hbase.client.Mutation
 
 import scala.collection.immutable
 
 final case class HTableSettings[T](conf: Configuration,
                                    tableName: TableName,
                                    columnFamilies: immutable.Seq[String],
-                                   converter: T => Put)
+                                   converter: T => immutable.Seq[Mutation])
 
 object HTableSettings {
+
   def create[T](conf: Configuration,
                 tableName: TableName,
                 columnFamilies: java.util.List[String],
-                converter: java.util.function.Function[T, Put]): HTableSettings[T] = {
+                converter: java.util.function.Function[T, java.util.List[Mutation]]): HTableSettings[T] = {
     import scala.compat.java8.FunctionConverters._
     import scala.collection.JavaConverters._
-    HTableSettings(conf, tableName, immutable.Seq(columnFamilies.asScala: _*), asScalaFromFunction(converter))
+
+    val mutationsFunc = (m: T) => {
+      val list = asScalaFromFunction(converter)(m)
+
+      immutable.Seq(list.asScala: _*)
+    }
+
+    HTableSettings(conf, tableName, immutable.Seq(columnFamilies.asScala: _*), mutationsFunc)
   }
 }

--- a/hbase/src/main/scala/akka/stream/alpakka/hbase/internal/HBaseFlowStage.scala
+++ b/hbase/src/main/scala/akka/stream/alpakka/hbase/internal/HBaseFlowStage.scala
@@ -35,25 +35,28 @@ private[hbase] class HBaseFlowStage[A](settings: HTableSettings[A]) extends Grap
           pull(in)
       })
 
-      setHandler(in, new InHandler {
-        override def onPush() = {
-          val msg = grab(in)
+      setHandler(
+        in,
+        new InHandler {
+          override def onPush() = {
+            val msg = grab(in)
 
-          val mutations = settings.converter(msg)
+            val mutations = settings.converter(msg)
 
-          for (mutation <- mutations) {
-            mutation match {
-              case x: Put => table.put(x)
-              case x: Delete => table.delete(x)
-              case x: Append => table.append(x)
-              case x: Increment => table.increment(x)
+            for (mutation <- mutations) {
+              mutation match {
+                case x: Put => table.put(x)
+                case x: Delete => table.delete(x)
+                case x: Append => table.append(x)
+                case x: Increment => table.increment(x)
+              }
             }
+
+            push(out, msg)
           }
 
-          push(out, msg)
         }
-
-      })
+      )
 
       override def postStop() = {
         log.debug("Stage completed")

--- a/hbase/src/main/scala/akka/stream/alpakka/hbase/javadsl/HTableStage.scala
+++ b/hbase/src/main/scala/akka/stream/alpakka/hbase/javadsl/HTableStage.scala
@@ -10,9 +10,8 @@ import akka.stream.scaladsl.{Flow, Keep, Sink}
 import akka.{Done, NotUsed}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hbase.TableName
-import org.apache.hadoop.hbase.client.Put
+import org.apache.hadoop.hbase.client.Mutation
 
-import scala.collection.immutable
 import scala.concurrent.Future
 
 object HTableStage {
@@ -20,10 +19,8 @@ object HTableStage {
   def table[T](conf: Configuration,
                tableName: TableName,
                columnFamilies: java.util.List[String],
-               converter: java.util.function.Function[T, Put]): HTableSettings[T] = {
-    import scala.compat.java8.FunctionConverters._
-    import scala.collection.JavaConverters._
-    HTableSettings(conf, tableName, immutable.Seq(columnFamilies.asScala: _*), asScalaFromFunction(converter))
+               converter: java.util.function.Function[T, java.util.List[Mutation]]): HTableSettings[T] = {
+    HTableSettings.create(conf, tableName, columnFamilies, converter)
   }
 
   def sink[A](config: HTableSettings[A]): akka.stream.javadsl.Sink[A, Future[Done]] =

--- a/hbase/src/main/scala/akka/stream/alpakka/hbase/javadsl/HTableStage.scala
+++ b/hbase/src/main/scala/akka/stream/alpakka/hbase/javadsl/HTableStage.scala
@@ -19,9 +19,8 @@ object HTableStage {
   def table[T](conf: Configuration,
                tableName: TableName,
                columnFamilies: java.util.List[String],
-               converter: java.util.function.Function[T, java.util.List[Mutation]]): HTableSettings[T] = {
+               converter: java.util.function.Function[T, java.util.List[Mutation]]): HTableSettings[T] =
     HTableSettings.create(conf, tableName, columnFamilies, converter)
-  }
 
   def sink[A](config: HTableSettings[A]): akka.stream.javadsl.Sink[A, Future[Done]] =
     Flow[A].via(flow(config)).toMat(Sink.ignore)(Keep.right).asJava

--- a/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java
+++ b/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java
@@ -56,7 +56,7 @@ public class HBaseStageTest {
   }
 
   // #create-converter
-  Function<Person, Put> hBaseConverter =
+  Function<Person, List<Mutation>> hBaseConverter =
       person -> {
         Put put = null;
         try {
@@ -66,7 +66,7 @@ public class HBaseStageTest {
         } catch (UnsupportedEncodingException e) {
           e.printStackTrace();
         }
-        return put;
+        return Arrays.asList(put);
       };
   // #create-converter
 

--- a/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java
+++ b/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java
@@ -18,6 +18,7 @@ import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java
+++ b/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java
@@ -18,8 +18,7 @@ import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.Mutation;
-import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.*;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -69,6 +68,31 @@ public class HBaseStageTest {
         return Arrays.asList(put);
       };
   // #create-converter
+
+  // #create-converter-mutations
+  Function<Person, List<Mutation>> mutationsHBaseConverter =
+      person -> {
+        try {
+          Put put = new Put(String.format("id_%d", person.id).getBytes("UTF-8"));
+          put.addColumn(
+              "info".getBytes("UTF-8"), "name".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
+
+          Append append = new Append(String.format("id_%d", person.id).getBytes("UTF-8"));
+          append.add(
+              "info".getBytes("UTF-8"), "aliases".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
+
+          Delete delete = new Delete(String.format("id_%d", person.id).getBytes("UTF-8"));
+
+          Increment increment = new Increment(String.format("id_%d", person.id).getBytes("UTF-8"));
+          increment.addColumn("info".getBytes("UTF-8"), "age".getBytes("UTF-8"), 1);
+
+          return Arrays.asList(append, put, delete, increment);
+        } catch (UnsupportedEncodingException e) {
+          e.printStackTrace();
+          return Arrays.asList();
+        }
+      };
+  // #create-converter-mutations
 
   @Test
   public void sink() throws ExecutionException, InterruptedException, TimeoutException {

--- a/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java
+++ b/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java
@@ -54,64 +54,114 @@ public class HBaseStageTest {
     TestKit.shutdownActorSystem(system);
   }
 
-  // #create-converter
+  // #create-converter-put
   Function<Person, List<Mutation>> hBaseConverter =
-      person -> {
-        Put put = null;
-        try {
-          put = new Put(String.format("id_%d", person.id).getBytes("UTF-8"));
-          put.addColumn(
-              "info".getBytes("UTF-8"), "name".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-          e.printStackTrace();
+    person -> {
+      try {
+        Put put = new Put(String.format("id_%d", person.id).getBytes("UTF-8"));
+        put.addColumn(
+          "info".getBytes("UTF-8"), "name".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
+
+        return Collections.singletonList(put);
+      } catch (UnsupportedEncodingException e) {
+        e.printStackTrace();
+        return Collections.emptyList();
+      }
+    };
+  // #create-converter-put
+
+  // #create-converter-append
+  Function<Person, List<Mutation>> appendHBaseConverter =
+    person -> {
+      try {
+        Append append = new Append(String.format("id_%d", person.id).getBytes("UTF-8"));
+        append.add(
+          "info".getBytes("UTF-8"), "aliases".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
+
+        return Collections.singletonList(append);
+      } catch (UnsupportedEncodingException e) {
+        e.printStackTrace();
+        return Collections.emptyList();
+      }
+    };
+  // #create-converter-append
+
+  // #create-converter-delete
+  Function<Person, List<Mutation>> deleteHBaseConverter =
+    person -> {
+      try {
+        Delete delete = new Delete(String.format("id_%d", person.id).getBytes("UTF-8"));
+
+        return Collections.singletonList(delete);
+      } catch (UnsupportedEncodingException e) {
+        e.printStackTrace();
+        return Collections.emptyList();
+      }
+    };
+  // #create-converter-delete
+
+  // #create-converter-increment
+  Function<Person, List<Mutation>> incrementHBaseConverter =
+    person -> {
+      try {
+        Increment increment = new Increment(String.format("id_%d", person.id).getBytes("UTF-8"));
+        increment.addColumn("info".getBytes("UTF-8"), "numberOfChanges".getBytes("UTF-8"), 1);
+
+        return Collections.singletonList(increment);
+      } catch (UnsupportedEncodingException e) {
+        e.printStackTrace();
+        return Collections.emptyList();
+      }
+    };
+  // #create-converter-increment
+
+  // #create-converter-complex
+  Function<Person, List<Mutation>> complexHBaseConverter =
+    person -> {
+      try {
+        byte[] id = String.format("id_%d", person.id).getBytes("UTF-8");
+        byte[] infoFamily = "info".getBytes("UTF-8");
+
+        if (person.id != 0 && person.name.isEmpty()) {
+          Delete delete = new Delete(id);
+          return Collections.singletonList(delete);
+        } else if (person.id != 0) {
+          Put put = new Put(id);
+          put.addColumn(infoFamily, "name".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
+
+          Increment increment = new Increment(id);
+          increment.addColumn(infoFamily, "numberOfChanges".getBytes("UTF-8"), 1);
+
+          return Arrays.asList(put, increment);
+        } else {
+          return Collections.emptyList();
         }
-        return Arrays.asList(put);
-      };
-  // #create-converter
+      } catch (UnsupportedEncodingException e) {
+        e.printStackTrace();
+        return Collections.emptyList();
+      }
+    };
+  // #create-converter-complex
 
-  // #create-converter-mutations
-  Function<Person, List<Mutation>> mutationsHBaseConverter =
-      person -> {
-        try {
-          Put put = new Put(String.format("id_%d", person.id).getBytes("UTF-8"));
-          put.addColumn(
-              "info".getBytes("UTF-8"), "name".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
-
-          Append append = new Append(String.format("id_%d", person.id).getBytes("UTF-8"));
-          append.add(
-              "info".getBytes("UTF-8"), "aliases".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
-
-          Delete delete = new Delete(String.format("id_%d", person.id).getBytes("UTF-8"));
-
-          Increment increment = new Increment(String.format("id_%d", person.id).getBytes("UTF-8"));
-          increment.addColumn("info".getBytes("UTF-8"), "age".getBytes("UTF-8"), 1);
-
-          return Arrays.asList(append, put, delete, increment);
-        } catch (UnsupportedEncodingException e) {
-          e.printStackTrace();
-          return Arrays.asList();
-        }
-      };
-  // #create-converter-mutations
 
   @Test
-  public void sink() throws ExecutionException, InterruptedException, TimeoutException {
+  public void sink() throws InterruptedException, TimeoutException {
 
     // #create-settings
     HTableSettings<Person> tableSettings =
-        HTableSettings.create(
-            HBaseConfiguration.create(),
-            TableName.valueOf("person1"),
-            Arrays.asList("info"),
-            hBaseConverter);
+      HTableSettings.create(
+        HBaseConfiguration.create(),
+        TableName.valueOf("person1"),
+        Collections.singletonList("info"),
+        hBaseConverter);
     // #create-settings
 
     // #sink
     final Sink<Person, scala.concurrent.Future<Done>> sink = HTableStage.sink(tableSettings);
     Future<Done> o =
-        Source.from(Arrays.asList(100, 101, 102, 103, 104))
-            .map((i) -> new Person(i, String.format("name %d", i)))
-            .runWith(sink, materializer);
+      Source.from(Arrays.asList(100, 101, 102, 103, 104))
+        .map((i) -> new Person(i, String.format("name %d", i)))
+        .runWith(sink, materializer);
     // #sink
 
     Await.ready(o, Duration.Inf());
@@ -121,20 +171,20 @@ public class HBaseStageTest {
   public void flow() throws ExecutionException, InterruptedException {
 
     HTableSettings<Person> tableSettings =
-        HTableSettings.create(
-            HBaseConfiguration.create(),
-            TableName.valueOf("person2"),
-            Collections.singletonList("info"),
-            hBaseConverter);
+      HTableSettings.create(
+        HBaseConfiguration.create(),
+        TableName.valueOf("person2"),
+        Collections.singletonList("info"),
+        hBaseConverter);
 
     // #flow
     Flow<Person, Person, NotUsed> flow = HTableStage.flow(tableSettings);
     Pair<NotUsed, CompletionStage<List<Person>>> run =
-        Source.from(Arrays.asList(200, 201, 202, 203, 204))
-            .map((i) -> new Person(i, String.format("name_%d", i)))
-            .via(flow)
-            .toMat(Sink.seq(), Keep.both())
-            .run(materializer);
+      Source.from(Arrays.asList(200, 201, 202, 203, 204))
+        .map((i) -> new Person(i, String.format("name_%d", i)))
+        .via(flow)
+        .toMat(Sink.seq(), Keep.both())
+        .run(materializer);
     // #flow
 
     run.second().toCompletableFuture().get();

--- a/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala
+++ b/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala
@@ -8,7 +8,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.hbase.HTableSettings
 import akka.stream.scaladsl.{Sink, Source}
-import org.apache.hadoop.hbase.client.{Mutation, Put}
+import org.apache.hadoop.hbase.client._
 import org.apache.hadoop.hbase.util.Bytes
 import org.apache.hadoop.hbase.{HBaseConfiguration, TableName}
 import org.scalatest.{Matchers, WordSpec}
@@ -34,6 +34,27 @@ class HBaseStageSpec extends WordSpec with Matchers {
     List(put)
   }
   //#create-converter
+
+  //#create-converter-mutations
+  val mutationsHBaseConverter: Person => immutable.Seq[Mutation] = { person =>
+    // Insert or update a row
+    val put = new Put(s"id_${person.id}")
+    put.addColumn("info", "name", person.name)
+
+    // Append to a cell
+    val append = new Append(s"id_${person.id}")
+    append.add("info", "aliases", person.name)
+
+    // Delete the specified row
+    val delete = new Delete(s"id_${person.id}")
+
+    // Increment a cell value
+    val increment = new Increment(s"id_${person.id}")
+    increment.addColumn("info", "age", 1)
+
+    List(append, put, delete, increment)
+  }
+  //#create-converter-mutations
 
   //#create-settings
   val tableSettings =

--- a/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala
+++ b/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala
@@ -8,7 +8,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.hbase.HTableSettings
 import akka.stream.scaladsl.{Sink, Source}
-import org.apache.hadoop.hbase.client.Put
+import org.apache.hadoop.hbase.client.{Mutation, Put}
 import org.apache.hadoop.hbase.util.Bytes
 import org.apache.hadoop.hbase.{HBaseConfiguration, TableName}
 import org.scalatest.{Matchers, WordSpec}
@@ -28,10 +28,10 @@ class HBaseStageSpec extends WordSpec with Matchers {
   implicit def toBytes(string: String): Array[Byte] = Bytes.toBytes(string)
   case class Person(id: Int, name: String)
 
-  val hBaseConverter: Person => Put = { person =>
+  val hBaseConverter: Person => immutable.Seq[Mutation] = { person =>
     val put = new Put(s"id_${person.id}")
     put.addColumn("info", "name", person.name)
-    put
+    List(put)
   }
   //#create-converter
 

--- a/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala
+++ b/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala
@@ -56,7 +56,7 @@ class HBaseStageSpec extends WordSpec with Matchers {
   val incrementHBaseConverter: Person => immutable.Seq[Mutation] = { person =>
     // Increment a cell value
     val increment = new Increment(s"id_${person.id}")
-    increment.addColumn("info", "age", 1)
+    increment.addColumn("info", "numberOfChanges", 1)
     List(increment)
   }
   //#create-converter-increment
@@ -72,7 +72,11 @@ class HBaseStageSpec extends WordSpec with Matchers {
         // Insert or update a row
         val put = new Put(s"id_${person.id}")
         put.addColumn("info", "name", person.name)
-        List(put)
+
+        val increment = new Increment(s"id_${person.id}")
+        increment.addColumn("info", "numberOfChanges", 1)
+
+        List(put, increment)
       }
     } else {
       List.empty


### PR DESCRIPTION
I need to perform different kind of mutations on HBase given an input message.
Until now  only `put` is supported. 

My idea is to return a list of `Mutation` from the `converter` function instead of a single `Put` instance.
Then I have changed:

```
table.put(settings.converter(msg))
```

with:

```
val mutations = settings.converter(msg)
for (mutation <- mutations) {
	mutation match {
		case x: Put => table.put(x)
		case x: Delete => table.delete(x)
		case x: Append => table.append(x)
		case x: Increment => table.increment(x)
    }
}
```
This should allow to perform different kind of mutations (delete, increment, append) and also perform no mutations (useful if you have some business logic to skip some records).

It can probably solve #328 and #326

What do you think?