### PR TITLE
Pin OrientDB version to 2.2.35

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "9042:9042"
   orientdb:
-    image: orientdb:latest
+    image: orientdb:2.2.35
     ports:
       - "2424:2424"
     environment:


### PR DESCRIPTION
OrientDB `latest` docker image has been updated to `3.0.2` and that started failing tests: #1046