### PR TITLE
Unix Domain Socket - ensure that interest in READ is removed upon EOF

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -312,7 +312,7 @@ object Dependencies {
 
   val UnixDomainSocket = Seq(
     libraryDependencies ++= Seq(
-      "com.github.jnr" % "jnr-unixsocket" % "0.18" // BSD/ApacheV2/CPL/MIT as per https://github.com/akka/alpakka/issues/620#issuecomment-348727265
+      "com.github.jnr" % "jnr-unixsocket" % "0.19" // BSD/ApacheV2/CPL/MIT as per https://github.com/akka/alpakka/issues/620#issuecomment-348727265
     )
   )
 

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -168,10 +168,12 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
                       val pendingResult = queue.offer(ByteString(buffer))
                       pendingResult.onComplete(_ => sel.wakeup())
                       sendReceiveContext.receive = PendingReceiveAck(queue, buffer, pendingResult)
-                      key.interestOps(key.interestOps() & ~SelectionKey.OP_READ)
                     } else {
                       queue.complete()
                     }
+
+                    key.interestOps(key.interestOps() & ~SelectionKey.OP_READ)
+
                   case PendingReceiveAck(receiveQueue, receiveBuffer, pendingResult) if pendingResult.isCompleted =>
                     pendingResult.value.get match {
                       case Success(QueueOfferResult.Enqueued) =>


### PR DESCRIPTION
Fixes an issue observed with unix domain socket connector where when the read side was closed, the NIO event loop would go into an infinite loop with `channel.read` returning `-1`.

We should have be deregistering interest in `READ` when completing the queue.

Related PR: https://github.com/akka/alpakka/pull/878

/cc @huntc