### PR TITLE
DynamoDB client interface rather than class

### DIFF
--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoClient.scala
@@ -13,22 +13,27 @@ import akka.stream.scaladsl.{Flow, Sink, Source}
 
 import scala.concurrent.Future
 
-object DynamoClient {
-  def apply(settings: DynamoSettings)(implicit system: ActorSystem, materializer: Materializer) =
-    new DynamoClient(settings)
+trait DynamoClient {
+  def flow[Op <: AwsOp]: Flow[Op, Op#B, NotUsed]
+  def source(op: AwsPagedOp): Source[op.B, NotUsed]
+  def source(op: AwsOp): Source[op.B, NotUsed]
+  def single(op: AwsOp): Future[op.B]
 }
 
-final class DynamoClient(settings: DynamoSettings)(implicit system: ActorSystem, materializer: Materializer) {
-  private val client = new DynamoClientImpl(settings, DynamoImplicits.errorResponseHandler)
+object DynamoClient {
+  def apply(settings: DynamoSettings)(implicit system: ActorSystem, materializer: Materializer): DynamoClient =
+    new DynamoClient {
+      private val client = new DynamoClientImpl(settings, DynamoImplicits.errorResponseHandler)
 
-  def flow[Op <: AwsOp]: Flow[Op, Op#B, NotUsed] = client.flow[Op]
+      def flow[Op <: AwsOp]: Flow[Op, Op#B, NotUsed] = client.flow[Op]
 
-  def source(op: AwsPagedOp): Source[op.B, NotUsed] =
-    Paginator.source(flow, op)
+      def source(op: AwsPagedOp): Source[op.B, NotUsed] =
+        Paginator.source(client.flow, op)
 
-  def source(op: AwsOp): Source[op.B, NotUsed] =
-    Source.single(op).via(client.flow).map(_.asInstanceOf[op.B])
+      def source(op: AwsOp): Source[op.B, NotUsed] =
+        Source.single(op).via(client.flow).map(_.asInstanceOf[op.B])
 
-  def single(op: AwsOp): Future[op.B] =
-    Source.single(op).via(client.flow).map(_.asInstanceOf[op.B]).runWith(Sink.head[op.B])
+      def single(op: AwsOp): Future[op.B] =
+        Source.single(op).via(client.flow).map(_.asInstanceOf[op.B]).runWith(Sink.head[op.B])
+    }
 }


### PR DESCRIPTION
Implementing `DynamoClient` as a class, and in particular a final class, means that it's not possible to mock for testing repositories that use it.

This change converts it to an interface and returns an anonymous class implementing it from the apply method, which will be source-compatible with `DynamoClient(settings)`, although not with `new DynamoClient(settings)`.

Removing the `final` modified from the class would be another option, which would keep source compatibility in either of the above cases, but this seems like a cleaner approach to me.