### PR TITLE
Cassandra: remove need for execution context

### DIFF
--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraFlow.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraFlow.scala
@@ -19,10 +19,19 @@ object CassandraFlow {
   def createWithPassThrough[T](parallelism: Int,
                                statement: PreparedStatement,
                                statementBinder: BiFunction[T, PreparedStatement, BoundStatement],
-                               session: Session,
-                               ec: ExecutionContext): Flow[T, T, NotUsed] =
+                               session: Session): Flow[T, T, NotUsed] =
     ScalaCFlow
-      .createWithPassThrough[T](parallelism, statement, (t, p) => statementBinder.apply(t, p))(session, ec)
+      .createWithPassThrough[T](parallelism, statement, (t, p) => statementBinder.apply(t, p))(session)
+      .asJava
+
+  @deprecated("use createWithPassThrough without ExecutionContext instead", "0.20")
+  def createWithPassThrough[T](parallelism: Int,
+                               statement: PreparedStatement,
+                               statementBinder: BiFunction[T, PreparedStatement, BoundStatement],
+                               session: Session,
+                               ignored: ExecutionContext): Flow[T, T, NotUsed] =
+    ScalaCFlow
+      .createWithPassThrough[T](parallelism, statement, (t, p) => statementBinder.apply(t, p))(session)
       .asJava
 
   /**
@@ -36,14 +45,36 @@ object CassandraFlow {
                                                statement: PreparedStatement,
                                                statementBinder: BiFunction[T, PreparedStatement, BoundStatement],
                                                partitionKey: Function[T, K],
-                                               settings: CassandraBatchSettings = CassandraBatchSettings.Defaults,
-                                               session: Session,
-                                               ec: ExecutionContext): Flow[T, T, NotUsed] =
+                                               settings: CassandraBatchSettings,
+                                               session: Session): Flow[T, T, NotUsed] =
     ScalaCFlow
       .createUnloggedBatchWithPassThrough[T, K](parallelism,
                                                 statement,
                                                 (t, p) => statementBinder.apply(t, p),
                                                 t => partitionKey.apply(t),
-                                                settings)(session, ec)
+                                                settings)(session)
+      .asJava
+
+  /**
+   * Creates a flow that batches using an unlogged batch. Use this when most of the elements in the stream
+   * share the same partition key. Cassandra unlogged batches that share the same partition key will only
+   * resolve to one write internally in Cassandra, boosting write performance.
+   *
+   * Be aware that this stage does not preserve the upstream order.
+   */
+  @deprecated("use createUnloggedBatchWithPassThrough without ExecutionContext instead", "0.20")
+  def createUnloggedBatchWithPassThrough[T, K](parallelism: Int,
+                                               statement: PreparedStatement,
+                                               statementBinder: BiFunction[T, PreparedStatement, BoundStatement],
+                                               partitionKey: Function[T, K],
+                                               settings: CassandraBatchSettings,
+                                               session: Session,
+                                               ignored: ExecutionContext): Flow[T, T, NotUsed] =
+    ScalaCFlow
+      .createUnloggedBatchWithPassThrough[T, K](parallelism,
+                                                statement,
+                                                (t, p) => statementBinder.apply(t, p),
+                                                t => partitionKey.apply(t),
+                                                settings)(session)
       .asJava
 }

--- a/cassandra/src/test/java/akka/stream/alpakka/cassandra/javadsl/CassandraSourceTest.java
+++ b/cassandra/src/test/java/akka/stream/alpakka/cassandra/javadsl/CassandraSourceTest.java
@@ -23,7 +23,6 @@ import akka.japi.Pair;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
-import scala.concurrent.ExecutionContextExecutor;
 
 import java.util.List;
 import java.util.Set;
@@ -50,8 +49,6 @@ public class CassandraSourceTest {
 
   private static ActorSystem system;
   private static Materializer materializer;
-  private static ExecutionContextExecutor ec;
-
   private static Session session;
 
   private static Session setupSession() {
@@ -70,16 +67,11 @@ public class CassandraSourceTest {
     return Pair.create(system, materializer);
   }
 
-  private static ExecutionContextExecutor setupExecutionContext() {
-    return system.dispatcher();
-  }
-
   @BeforeClass
   public static void setup() {
     final Pair<ActorSystem, Materializer> sysmat = setupMaterializer();
     system = sysmat.first();
     materializer = sysmat.second();
-    ec = setupExecutionContext();
 
     session = setupSession();
 
@@ -145,7 +137,7 @@ public class CassandraSourceTest {
 
     // #run-flow
     final Flow<Integer, Integer, NotUsed> flow =
-        CassandraFlow.createWithPassThrough(2, preparedStatement, statementBinder, session, ec);
+        CassandraFlow.createWithPassThrough(2, preparedStatement, statementBinder, session);
 
     CompletionStage<List<Integer>> result = source.via(flow).runWith(Sink.seq(), materializer);
     // #run-flow
@@ -189,7 +181,7 @@ public class CassandraSourceTest {
     // #run-batching-flow
     final Flow<ToInsert, ToInsert, NotUsed> flow =
         CassandraFlow.createUnloggedBatchWithPassThrough(
-            2, preparedStatement, statementBinder, (ti) -> ti.id, defaultSettings, session, ec);
+            2, preparedStatement, statementBinder, (ti) -> ti.id, defaultSettings, session);
 
     CompletionStage<List<ToInsert>> result = source.via(flow).runWith(Sink.seq(), materializer);
     // #run-batching-flow


### PR DESCRIPTION
The pass through-functionality for Cassandra flows relies on a `map` on the future to just push in the pass through-value, by using Akkas `ExecutionContexts.sameThreadExecutionContext` this does not require an execution context to be passed in.

Fixes #1035 