### PR TITLE
Fix settings for projects that do not need to be published

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -149,7 +149,8 @@ lazy val orientdb = alpakkaProject("orientdb",
                                    fork in Test := true,
                                    parallelExecution in Test := false)
 
-lazy val reference = alpakkaProject("reference", "reference", Dependencies.Reference).enablePlugins(NoPublish)
+lazy val reference = alpakkaProject("reference", "reference", Dependencies.Reference, publish / skip := true)
+  .disablePlugins(BintrayPlugin)
 
 lazy val s3 = alpakkaProject("s3", "aws.s3", Dependencies.S3)
 
@@ -184,10 +185,11 @@ lazy val unixdomainsocket = alpakkaProject("unix-domain-socket", "unixdomainsock
 lazy val xml = alpakkaProject("xml", "xml", Dependencies.Xml)
 
 lazy val docs = project
-  .enablePlugins(ParadoxPlugin, NoPublish)
+  .enablePlugins(ParadoxPlugin)
   .disablePlugins(BintrayPlugin, MimaPlugin)
   .settings(
     name := "Alpakka",
+    publish / skip := true,
     paradoxTheme := Some(builtinParadoxTheme("generic")),
     paradoxProperties ++= Map(
       "version" -> version.value,
@@ -219,13 +221,14 @@ lazy val docs = project
   )
 
 lazy val `doc-examples` = project
-  .enablePlugins(NoPublish, AutomateHeaderPlugin)
+  .enablePlugins(AutomateHeaderPlugin)
   .disablePlugins(BintrayPlugin, MimaPlugin)
   .dependsOn(
     modules.map(p => classpathDependency(p)): _*
   )
   .settings(
     name := s"akka-stream-alpakka-doc-examples",
+    publish / skip := true,
     Dependencies.`Doc-examples`
   )
 

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -1,18 +1,5 @@
 import sbt._, Keys._
 
-/**
- * For projects that are not to be published.
- */
-object NoPublish extends AutoPlugin {
-  override def requires = plugins.JvmPlugin
-
-  override def projectSettings = Seq(
-    publishArtifact := false,
-    publish := {},
-    publishLocal := {}
-  )
-}
-
 object Publish extends AutoPlugin {
   import bintray.BintrayPlugin
   import bintray.BintrayPlugin.autoImport._


### PR DESCRIPTION
Also changed from the folklore of settings to disable publishing to the one setting that rules them all: `publish / skip := true`.