### PR TITLE
Fix warning in Elasticsearch test

### DIFF
--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
@@ -83,7 +83,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
            |    "book": {
            |      "dynamic": "strict",
            |      "properties": {
-           |        "title": { "type": "string"}
+           |        "title": { "type": "text"}
            |      }
            |    }
            |  }


### PR DESCRIPTION
Field type `string` is deprecated in the recent versions of Elasticsearch. We should use `text` or `keyword` instead.