### PR TITLE
Fixed visualization glitch in IBM MQ JmsConsumer doc section

### DIFF
--- a/docs/src/main/paradox/jms.md
+++ b/docs/src/main/paradox/jms.md
@@ -533,7 +533,6 @@ Scala
       JmsConsumerSettings(queueConnectionFactory)
         .withDestination(CustomDestination(TestQueueName, createMqQueue(TestQueueName)))
     )
-     
     ```
 
 Java
@@ -566,7 +565,6 @@ Java
         .create(queueConnectionFactory)
         .withDestination(new CustomDestination(testQueueName,createMqQueue(testQueueName)))
     );
-    
     ```
 
 ### Create a JmsProducer to an IBM MQ Topic


### PR DESCRIPTION
In the JMS documentation, the source code in the 'Create a JmsConsumer to an IBM MQ Queue' section doesn't display properly. This should fix it (by simply removing two newline characters).