### PR TITLE
Elasticsearch: Support update and delete by incoming message types

### DIFF
--- a/doc-examples/src/main/java/elastic/FetchUsingSlickAndStreamIntoElasticInJava.java
+++ b/doc-examples/src/main/java/elastic/FetchUsingSlickAndStreamIntoElasticInJava.java
@@ -11,7 +11,7 @@ import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 
 import akka.stream.alpakka.elasticsearch.ElasticsearchSinkSettings;
-import akka.stream.alpakka.elasticsearch.IncomingMessage;
+import akka.stream.alpakka.elasticsearch.IncomingIndexMessage;
 import akka.stream.alpakka.elasticsearch.javadsl.ElasticsearchSink;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
@@ -89,7 +89,7 @@ public class FetchUsingSlickAndStreamIntoElasticInJava {
                 "SELECT * FROM MOVIE",
                 (SlickRow row) ->
                     new Movie(row.nextInt(), row.nextString(), row.nextString(), row.nextDouble()))
-            .map(movie -> IncomingMessage.create(String.valueOf(movie.id), movie)) // (8)
+            .map(movie -> IncomingIndexMessage.create(String.valueOf(movie.id), movie)) // (8)
             .runWith(
                 ElasticsearchSink.create( // (9)
                     "movie",

--- a/doc-examples/src/main/scala/elastic/FetchUsingSlickAndStreamIntoElastic.scala
+++ b/doc-examples/src/main/scala/elastic/FetchUsingSlickAndStreamIntoElastic.scala
@@ -65,7 +65,7 @@ object FetchUsingSlickAndStreamIntoElastic extends ActorSystemAvailable with App
       .map {                                                                            // (7)
         case (id, genre, title, gross) => Movie(id, genre, title, gross)
       }
-      .map(movie => IncomingIndexMessage(Option(movie.id).map(_.toString), movie))      // (8)
+      .map(movie => IncomingIndexMessage(movie.id.toString, movie))                     // (8)
       .runWith(ElasticsearchSink.create[Movie]("movie", "boxoffice"))                   // (9)
 
   done.onComplete {

--- a/doc-examples/src/main/scala/elastic/FetchUsingSlickAndStreamIntoElastic.scala
+++ b/doc-examples/src/main/scala/elastic/FetchUsingSlickAndStreamIntoElastic.scala
@@ -8,7 +8,7 @@ package elastic
 // #sample
   import akka.Done
 
-  import akka.stream.alpakka.elasticsearch.IncomingMessage
+  import akka.stream.alpakka.elasticsearch.IncomingIndexMessage
   import akka.stream.alpakka.elasticsearch.scaladsl.ElasticsearchSink
   import org.apache.http.HttpHost
   import org.elasticsearch.client.RestClient
@@ -65,7 +65,7 @@ object FetchUsingSlickAndStreamIntoElastic extends ActorSystemAvailable with App
       .map {                                                                            // (7)
         case (id, genre, title, gross) => Movie(id, genre, title, gross)
       }
-      .map(movie => IncomingMessage(Option(movie.id).map(_.toString), movie))           // (8)
+      .map(movie => IncomingIndexMessage(Option(movie.id).map(_.toString), movie))      // (8)
       .runWith(ElasticsearchSink.create[Movie]("movie", "boxoffice"))                   // (9)
 
   done.onComplete {

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
@@ -306,7 +306,6 @@ class ElasticsearchFlowStage[T, C](
         val successMsgs = messageResults.filter(_.error.isEmpty)
         if (successMsgs.nonEmpty) {
           // push the messages that DID succeed
-          //val resultForSucceededMsgs = successMsgs.map(_.r)
           emit(out, Future.successful(successMsgs))
         }
       }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
@@ -415,9 +415,9 @@ class ElasticsearchFlowStage[T, C](
             ).toString
           case x: IncomingUpdateMessage[T, C] =>
             "\n" + JsObject(
-              "doc" -> writer.convert(x.source).parseJson,
+              "doc" -> writer.convert(x.source).parseJson
             ).toString
-          case x: IncomingDeleteMessage[T, C] =>
+          case _: IncomingDeleteMessage[T, C] =>
             ""
         }
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
@@ -22,64 +22,191 @@ import akka.NotUsed
 import org.apache.http.message.BasicHeader
 import org.apache.http.util.EntityUtils
 
-object IncomingMessage {
+object IncomingIndexMessage {
   // Apply method to use when not using passThrough
   def apply[T](id: Option[String], source: T): IncomingMessage[T, NotUsed] =
-    IncomingMessage(id, source, NotUsed)
+    IncomingIndexMessage(id, source, NotUsed)
 
   // Apply method to use when not using passThrough
   def apply[T](id: Option[String], source: T, version: Long): IncomingMessage[T, NotUsed] =
-    IncomingMessage(id, source, NotUsed, Option(version))
+    IncomingIndexMessage(id, source, NotUsed, Option(version))
 
   // Java-api - without passThrough
   def create[T](id: String, source: T): IncomingMessage[T, NotUsed] =
-    IncomingMessage(Option(id), source)
+    IncomingIndexMessage(Option(id), source)
 
   // Java-api - without passThrough
   def create[T](id: String, source: T, version: Long): IncomingMessage[T, NotUsed] =
-    IncomingMessage(Option(id), source, version)
+    IncomingIndexMessage(Option(id), source, version)
 
   // Java-api - without passThrough
   def create[T](source: T): IncomingMessage[T, NotUsed] =
-    IncomingMessage(None, source)
+    IncomingIndexMessage(None, source)
 
   // Java-api - with passThrough
   def create[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingMessage(Option(id), source, passThrough)
+    IncomingIndexMessage(Option(id), source, passThrough)
 
   // Java-api - with passThrough
   def create[T, C](id: String, source: T, passThrough: C, version: Long): IncomingMessage[T, C] =
-    IncomingMessage(Option(id), source, passThrough, Option(version))
+    IncomingIndexMessage(Option(id), source, passThrough, Option(version))
 
   // Java-api - with passThrough
   def create[T, C](id: String, source: T, passThrough: C, version: Long, indexName: String): IncomingMessage[T, C] =
-    IncomingMessage(Option(id), source, passThrough, Option(version), Option(indexName))
+    IncomingIndexMessage(Option(id), source, passThrough, Option(version), Option(indexName))
 
   // Java-api - with passThrough
   def create[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingMessage(None, source, passThrough)
+    IncomingIndexMessage(None, source, passThrough)
 }
 
-final case class IncomingMessage[T, C](id: Option[String],
-                                       source: T,
-                                       passThrough: C,
-                                       version: Option[Long] = None,
-                                       indexName: Option[String] = None) {
+object IncomingUpdateMessage {
+  // Apply method to use when not using passThrough
+  def apply[T](id: String, source: T): IncomingMessage[T, NotUsed] =
+    IncomingUpdateMessage(id, source, NotUsed)
 
-  def withVersion(version: Long): IncomingMessage[T, C] =
+  // Apply method to use when not using passThrough
+  def apply[T](id: String, source: T, upsert: Boolean): IncomingMessage[T, NotUsed] =
+    IncomingUpdateMessage(id, source, NotUsed, upsert)
+
+  // Apply method to use when not using passThrough
+  def apply[T](id: String, source: T, version: Long): IncomingMessage[T, NotUsed] =
+    IncomingUpdateMessage(id, source, NotUsed, false, Option(version))
+
+  // Apply method to use when not using passThrough
+  def apply[T](id: String, source: T, upsert: Boolean, version: Long): IncomingMessage[T, NotUsed] =
+    IncomingUpdateMessage(id, source, NotUsed, upsert, Option(version))
+
+  // Java-api - without passThrough
+  def create[T](id: String, source: T): IncomingMessage[T, NotUsed] =
+    IncomingUpdateMessage(id, source, NotUsed)
+
+  // Java-api - without passThrough
+  def create[T](id: String, source: T, upsert: Boolean): IncomingMessage[T, NotUsed] =
+    IncomingUpdateMessage(id, source, NotUsed, upsert)
+
+  // Java-api - without passThrough
+  def create[T](id: String, source: T, version: Long): IncomingMessage[T, NotUsed] =
+    IncomingUpdateMessage(id, source, NotUsed, false, Some(version))
+
+  // Java-api - without passThrough
+  def create[T](id: String, source: T, upsert: Boolean, version: Long): IncomingMessage[T, NotUsed] =
+    IncomingUpdateMessage(id, source, NotUsed, upsert, Some(version))
+
+  // Java-api - with passThrough
+  def create[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
+    IncomingUpdateMessage(id, source, passThrough)
+
+  // Java-api - with passThrough
+  def create[T, C](id: String, source: T, passThrough: C, upsert: Boolean): IncomingMessage[T, C] =
+    IncomingUpdateMessage(id, source, passThrough, upsert)
+
+  // Java-api - with passThrough
+  def create[T, C](id: String, source: T, passThrough: C, version: Long): IncomingMessage[T, C] =
+    IncomingUpdateMessage(id, source, passThrough, false, Option(version))
+
+  // Java-api - with passThrough
+  def create[T, C](id: String, source: T, passThrough: C, upsert: Boolean, version: Long): IncomingMessage[T, C] =
+    IncomingUpdateMessage(id, source, passThrough, upsert, Option(version))
+
+  // Java-api - with passThrough
+  def create[T, C](id: String, source: T, passThrough: C, version: Long, indexName: String): IncomingMessage[T, C] =
+    IncomingUpdateMessage(id, source, passThrough, false, Option(version), Option(indexName))
+
+  // Java-api - with passThrough
+  def create[T, C](id: String,
+                   source: T,
+                   passThrough: C,
+                   upsert: Boolean,
+                   version: Long,
+                   indexName: String): IncomingMessage[T, C] =
+    IncomingUpdateMessage(id, source, passThrough, upsert, Option(version), Option(indexName))
+
+}
+
+object IncomingDeleteMessage {
+  // Apply method to use when not using passThrough
+  def apply[T](id: String): IncomingDeleteMessage[T, NotUsed] =
+    IncomingDeleteMessage(id, NotUsed)
+
+  // Apply method to use when not using passThrough
+  def apply[T](id: String, version: Long): IncomingDeleteMessage[T, NotUsed] =
+    IncomingDeleteMessage(id, NotUsed, Option(version))
+
+  // Java-api - without passThrough
+  def create[T](id: String): IncomingDeleteMessage[T, NotUsed] =
+    IncomingDeleteMessage(id)
+
+  // Java-api - without passThrough
+  def create[T](id: String, version: Long): IncomingDeleteMessage[T, NotUsed] =
+    IncomingDeleteMessage(id, version)
+
+  // Java-api - with passThrough
+  def create[T, C](id: String, passThrough: C): IncomingDeleteMessage[T, C] =
+    IncomingDeleteMessage(id, passThrough)
+
+  // Java-api - with passThrough
+  def create[T, C](id: String, passThrough: C, version: Long): IncomingDeleteMessage[T, C] =
+    IncomingDeleteMessage(id, passThrough, Option(version))
+
+  // Java-api - with passThrough
+  def create[T, C](id: String, passThrough: C, version: Long, indexName: String): IncomingDeleteMessage[T, C] =
+    IncomingDeleteMessage(id, passThrough, Option(version), Option(indexName))
+}
+
+sealed trait IncomingMessage[T, C] {
+  val passThrough: C
+  val version: Option[Long]
+  val indexName: Option[String]
+  def withVersion(version: Long): IncomingMessage[T, C]
+  def withIndexName(indexName: String): IncomingMessage[T, C]
+}
+
+final case class IncomingDeleteMessage[T, C](id: String,
+                                             passThrough: C,
+                                             version: Option[Long] = None,
+                                             indexName: Option[String] = None)
+    extends IncomingMessage[T, C] {
+
+  def withVersion(version: Long): IncomingDeleteMessage[T, C] =
     this.copy(version = Option(version))
 
-  def withIndexName(indexName: String): IncomingMessage[T, C] =
+  def withIndexName(indexName: String): IncomingDeleteMessage[T, C] =
     this.copy(indexName = Option(indexName))
 }
 
-object IncomingMessageResult {
-  // Apply method to use when not using passThrough
-  def apply[T](source: T, success: Boolean, errorMsg: Option[String]): IncomingMessageResult[T, NotUsed] =
-    IncomingMessageResult(source, NotUsed, success, errorMsg)
+final case class IncomingIndexMessage[T, C](id: Option[String],
+                                            source: T,
+                                            passThrough: C,
+                                            version: Option[Long] = None,
+                                            indexName: Option[String] = None)
+    extends IncomingMessage[T, C] {
+
+  def withVersion(version: Long): IncomingIndexMessage[T, C] =
+    this.copy(version = Option(version))
+
+  def withIndexName(indexName: String): IncomingIndexMessage[T, C] =
+    this.copy(indexName = Option(indexName))
 }
 
-final case class IncomingMessageResult[T, C](source: T, passThrough: C, success: Boolean, errorMsg: Option[String])
+final case class IncomingUpdateMessage[T, C](id: String,
+                                             source: T,
+                                             passThrough: C,
+                                             upsert: Boolean = false,
+                                             version: Option[Long] = None,
+                                             indexName: Option[String] = None)
+    extends IncomingMessage[T, C] {
+
+  def withVersion(version: Long): IncomingUpdateMessage[T, C] =
+    this.copy(version = Option(version))
+
+  def withIndexName(indexName: String): IncomingUpdateMessage[T, C] =
+    this.copy(indexName = Option(indexName))
+}
+
+case class IncomingMessageResult[T2, C2](message: IncomingMessage[T2, C2], error: Option[String]) {
+  val success = error.isEmpty
+}
 
 trait MessageWriter[T] {
   def convert(message: T): String
@@ -106,7 +233,6 @@ class ElasticsearchFlowStage[T, C](
       private val responseHandler = getAsyncCallback[(Seq[IncomingMessage[T, C]], Response)](handleResponse)
       private var failedMessages: Seq[IncomingMessage[T, C]] = Nil
       private var retryCount: Int = 0
-      private val insertKeyword: String = if (!settings.docAsUpsert) "index" else "update"
 
       override def preStart(): Unit =
         pull(in)
@@ -139,25 +265,25 @@ class ElasticsearchFlowStage[T, C](
       private def handleSuccess(): Unit =
         completeStage()
 
-      private case class MessageWithResult[T2, C2](m: IncomingMessage[T2, C2], r: IncomingMessageResult[T2, C2])
-
       private def handleResponse(args: (Seq[IncomingMessage[T, C]], Response)): Unit = {
         val (messages, response) = args
         val responseJson = EntityUtils.toString(response.getEntity).parseJson
 
         // If some commands in bulk request failed, pass failed messages to follows.
         val items = responseJson.asJsObject.fields("items").asInstanceOf[JsArray]
-        val messageResults: Seq[MessageWithResult[T, C]] = items.elements.zip(messages).map {
+        val messageResults: Seq[IncomingMessageResult[T, C]] = items.elements.zip(messages).map {
           case (item, message) =>
-            val res = item.asJsObject.fields(insertKeyword).asJsObject
+            val command = message match {
+              case _: IncomingIndexMessage[_, _] => "index"
+              case _: IncomingUpdateMessage[_, _] => "update"
+              case _: IncomingDeleteMessage[_, _] => "delete"
+            }
+            val res = item.asJsObject.fields(command).asJsObject
             val error: Option[String] = res.fields.get("error").map(_.toString())
-            MessageWithResult(
-              message,
-              IncomingMessageResult(message.source, message.passThrough, error.isEmpty, error)
-            )
+            IncomingMessageResult(message, error)
         }
 
-        val failedMsgs = messageResults.filterNot(_.r.success)
+        val failedMsgs = messageResults.filterNot(_.error.isEmpty)
 
         if (failedMsgs.nonEmpty && settings.retryPartialFailure && retryCount < settings.maxRetry) {
           retryPartialFailedMessages(messageResults, failedMsgs)
@@ -167,30 +293,30 @@ class ElasticsearchFlowStage[T, C](
       }
 
       private def retryPartialFailedMessages(
-          messageResults: Seq[MessageWithResult[T, C]],
-          failedMsgs: Seq[MessageWithResult[T, C]]
+          messageResults: Seq[IncomingMessageResult[T, C]],
+          failedMsgs: Seq[IncomingMessageResult[T, C]]
       ): Unit = {
         // Retry partial failed messages
         // NOTE: When we partially return message like this, message will arrive out of order downstream
         // and it can break commit-logic when using Kafka
         retryCount = retryCount + 1
-        failedMessages = failedMsgs.map(_.m) // These are the messages we're going to retry
+        failedMessages = failedMsgs.map(_.message) // These are the messages we're going to retry
         scheduleOnce(NotUsed, settings.retryInterval.millis)
 
-        val successMsgs = messageResults.filter(_.r.success)
+        val successMsgs = messageResults.filter(_.error.isEmpty)
         if (successMsgs.nonEmpty) {
           // push the messages that DID succeed
-          val resultForSucceededMsgs = successMsgs.map(_.r)
-          emit(out, Future.successful(resultForSucceededMsgs))
+          //val resultForSucceededMsgs = successMsgs.map(_.r)
+          emit(out, Future.successful(successMsgs))
         }
       }
 
-      private def forwardAllResults(messageResults: Seq[MessageWithResult[T, C]]): Unit = {
+      private def forwardAllResults(messageResults: Seq[IncomingMessageResult[T, C]]): Unit = {
         retryCount = 0 // Clear retryCount
 
         // Push result
-        val listOfResults = messageResults.map(_.r)
-        emit(out, Future.successful(listOfResults))
+        //val listOfResults = messageResults.map(_.r)
+        emit(out, Future.successful(messageResults))
 
         // Fetch next messages from queue and send them
         val nextMessages = (1 to settings.bufferSize).flatMap { _ =>
@@ -213,22 +339,53 @@ class ElasticsearchFlowStage[T, C](
             val indexNameToUse: String = message.indexName.getOrElse(indexName)
 
             JsObject(
-              insertKeyword -> JsObject(
-                Seq(
-                  Option("_index" -> JsString(indexNameToUse)),
-                  Option("_type" -> JsString(typeName)),
-                  message.version.map { version =>
-                    "_version" -> JsNumber(version)
-                  },
-                  settings.versionType.map { versionType =>
-                    "version_type" -> JsString(versionType)
-                  },
-                  message.id.map { id =>
-                    "_id" -> JsString(id)
-                  }
-                ).flatten: _*
-              )
-            ).toString + "\n" + messageToJsonString(message)
+              message match {
+                case x: IncomingIndexMessage[_, _] =>
+                  "index" -> JsObject(
+                    Seq(
+                      Option("_index" -> JsString(indexNameToUse)),
+                      Option("_type" -> JsString(typeName)),
+                      message.version.map { version =>
+                        "_version" -> JsNumber(version)
+                      },
+                      settings.versionType.map { versionType =>
+                        "version_type" -> JsString(versionType)
+                      },
+                      x.id.map { id =>
+                        "_id" -> JsString(id)
+                      }
+                    ).flatten: _*
+                  )
+                case x: IncomingUpdateMessage[_, _] =>
+                  "update" -> JsObject(
+                    Seq(
+                      Option("_index" -> JsString(indexNameToUse)),
+                      Option("_type" -> JsString(typeName)),
+                      message.version.map { version =>
+                        "_version" -> JsNumber(version)
+                      },
+                      settings.versionType.map { versionType =>
+                        "version_type" -> JsString(versionType)
+                      },
+                      Option("_id" -> JsString(x.id))
+                    ).flatten: _*
+                  )
+                case x: IncomingDeleteMessage[_, _] =>
+                  "delete" -> JsObject(
+                    Seq(
+                      Option("_index" -> JsString(indexNameToUse)),
+                      Option("_type" -> JsString(typeName)),
+                      message.version.map { version =>
+                        "_version" -> JsNumber(version)
+                      },
+                      settings.versionType.map { versionType =>
+                        "version_type" -> JsString(versionType)
+                      },
+                      Option("_id" -> JsString(x.id))
+                    ).flatten: _*
+                  )
+              }
+            ).toString + messageToJsonString(message)
           }
           .mkString("", "\n", "\n")
 
@@ -248,13 +405,20 @@ class ElasticsearchFlowStage[T, C](
       }
 
       private def messageToJsonString(message: IncomingMessage[T, C]): String =
-        if (!settings.docAsUpsert) {
-          writer.convert(message.source)
-        } else {
-          JsObject(
-            "doc" -> writer.convert(message.source).parseJson,
-            "doc_as_upsert" -> JsTrue
-          ).toString
+        message match {
+          case x: IncomingIndexMessage[T, C] =>
+            "\n" + writer.convert(x.source)
+          case x: IncomingUpdateMessage[T, C] if x.upsert =>
+            "\n" + JsObject(
+              "doc" -> writer.convert(x.source).parseJson,
+              "doc_as_upsert" -> JsTrue
+            ).toString
+          case x: IncomingUpdateMessage[T, C] =>
+            "\n" + JsObject(
+              "doc" -> writer.convert(x.source).parseJson,
+            ).toString
+          case x: IncomingDeleteMessage[T, C] =>
+            ""
         }
 
       setHandlers(in, out, this)

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
@@ -24,185 +24,112 @@ import org.apache.http.util.EntityUtils
 
 object IncomingIndexMessage {
   // Apply method to use when not using passThrough
-  def apply[T](id: Option[String], source: T): IncomingMessage[T, NotUsed] =
-    IncomingIndexMessage(id, source, NotUsed)
+  def apply[T](source: T): IncomingMessage[T, NotUsed] =
+    IncomingMessage(id = None, source = Some(source), passThrough = NotUsed, operation = Index)
 
   // Apply method to use when not using passThrough
-  def apply[T](id: Option[String], source: T, version: Long): IncomingMessage[T, NotUsed] =
-    IncomingIndexMessage(id, source, NotUsed, Option(version))
+  def apply[T](id: String, source: T): IncomingMessage[T, NotUsed] =
+    IncomingMessage(id = Some(id), source = Some(source), passThrough = NotUsed, operation = Index)
 
-  // Java-api - without passThrough
-  def create[T](id: String, source: T): IncomingMessage[T, NotUsed] =
-    IncomingIndexMessage(Option(id), source)
+  // Apply method to use when using passThrough
+  def apply[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
+    IncomingMessage(id = None, source = Some(source), passThrough = passThrough, Index, None, None)
 
-  // Java-api - without passThrough
-  def create[T](id: String, source: T, version: Long): IncomingMessage[T, NotUsed] =
-    IncomingIndexMessage(Option(id), source, version)
+  // Apply method to use when using passThrough
+  def apply[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
+    IncomingMessage(Some(id), Some(source), passThrough, Index, None, None)
 
   // Java-api - without passThrough
   def create[T](source: T): IncomingMessage[T, NotUsed] =
-    IncomingIndexMessage(None, source)
+    IncomingIndexMessage(source)
 
-  // Java-api - with passThrough
-  def create[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingIndexMessage(Option(id), source, passThrough)
-
-  // Java-api - with passThrough
-  def create[T, C](id: String, source: T, passThrough: C, version: Long): IncomingMessage[T, C] =
-    IncomingIndexMessage(Option(id), source, passThrough, Option(version))
-
-  // Java-api - with passThrough
-  def create[T, C](id: String, source: T, passThrough: C, version: Long, indexName: String): IncomingMessage[T, C] =
-    IncomingIndexMessage(Option(id), source, passThrough, Option(version), Option(indexName))
+  // Java-api - without passThrough
+  def create[T](id: String, source: T): IncomingMessage[T, NotUsed] =
+    IncomingIndexMessage(id, source)
 
   // Java-api - with passThrough
   def create[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingIndexMessage(None, source, passThrough)
+    IncomingIndexMessage(source, passThrough)
+
+  // Java-api - with passThrough
+  def create[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
+    IncomingIndexMessage(id, source, passThrough)
 }
 
 object IncomingUpdateMessage {
   // Apply method to use when not using passThrough
   def apply[T](id: String, source: T): IncomingMessage[T, NotUsed] =
-    IncomingUpdateMessage(id, source, NotUsed)
+    IncomingMessage(Some(id), Some(source), NotUsed, Update, None, None)
 
-  // Apply method to use when not using passThrough
-  def apply[T](id: String, source: T, upsert: Boolean): IncomingMessage[T, NotUsed] =
-    IncomingUpdateMessage(id, source, NotUsed, upsert)
-
-  // Apply method to use when not using passThrough
-  def apply[T](id: String, source: T, version: Long): IncomingMessage[T, NotUsed] =
-    IncomingUpdateMessage(id, source, NotUsed, false, Option(version))
-
-  // Apply method to use when not using passThrough
-  def apply[T](id: String, source: T, upsert: Boolean, version: Long): IncomingMessage[T, NotUsed] =
-    IncomingUpdateMessage(id, source, NotUsed, upsert, Option(version))
+  // Apply method to use when using passThrough
+  def apply[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
+    IncomingMessage(Some(id), Some(source), passThrough, Update, None, None)
 
   // Java-api - without passThrough
   def create[T](id: String, source: T): IncomingMessage[T, NotUsed] =
-    IncomingUpdateMessage(id, source, NotUsed)
-
-  // Java-api - without passThrough
-  def create[T](id: String, source: T, upsert: Boolean): IncomingMessage[T, NotUsed] =
-    IncomingUpdateMessage(id, source, NotUsed, upsert)
-
-  // Java-api - without passThrough
-  def create[T](id: String, source: T, version: Long): IncomingMessage[T, NotUsed] =
-    IncomingUpdateMessage(id, source, NotUsed, false, Some(version))
-
-  // Java-api - without passThrough
-  def create[T](id: String, source: T, upsert: Boolean, version: Long): IncomingMessage[T, NotUsed] =
-    IncomingUpdateMessage(id, source, NotUsed, upsert, Some(version))
+    IncomingUpdateMessage(id, source)
 
   // Java-api - with passThrough
   def create[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
     IncomingUpdateMessage(id, source, passThrough)
+}
+
+object IncomingUpsertMessage {
+  // Apply method to use when not using passThrough
+  def apply[T](id: String, source: T): IncomingMessage[T, NotUsed] =
+    IncomingMessage(Some(id), Some(source), NotUsed, Upsert, None, None)
+
+  // Apply method to use when using passThrough
+  def apply[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
+    IncomingMessage(Some(id), Some(source), passThrough, Upsert, None, None)
+
+  // Java-api - without passThrough
+  def create[T](id: String, source: T): IncomingMessage[T, NotUsed] =
+    IncomingUpdateMessage(id, source)
 
   // Java-api - with passThrough
-  def create[T, C](id: String, source: T, passThrough: C, upsert: Boolean): IncomingMessage[T, C] =
-    IncomingUpdateMessage(id, source, passThrough, upsert)
-
-  // Java-api - with passThrough
-  def create[T, C](id: String, source: T, passThrough: C, version: Long): IncomingMessage[T, C] =
-    IncomingUpdateMessage(id, source, passThrough, false, Option(version))
-
-  // Java-api - with passThrough
-  def create[T, C](id: String, source: T, passThrough: C, upsert: Boolean, version: Long): IncomingMessage[T, C] =
-    IncomingUpdateMessage(id, source, passThrough, upsert, Option(version))
-
-  // Java-api - with passThrough
-  def create[T, C](id: String, source: T, passThrough: C, version: Long, indexName: String): IncomingMessage[T, C] =
-    IncomingUpdateMessage(id, source, passThrough, false, Option(version), Option(indexName))
-
-  // Java-api - with passThrough
-  def create[T, C](id: String,
-                   source: T,
-                   passThrough: C,
-                   upsert: Boolean,
-                   version: Long,
-                   indexName: String): IncomingMessage[T, C] =
-    IncomingUpdateMessage(id, source, passThrough, upsert, Option(version), Option(indexName))
-
+  def create[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
+    IncomingUpdateMessage(id, source, passThrough)
 }
 
 object IncomingDeleteMessage {
   // Apply method to use when not using passThrough
-  def apply[T](id: String): IncomingDeleteMessage[T, NotUsed] =
-    IncomingDeleteMessage(id, NotUsed)
+  def apply[T](id: String): IncomingMessage[T, NotUsed] =
+    IncomingMessage(Some(id), None, NotUsed, Delete, None, None)
 
-  // Apply method to use when not using passThrough
-  def apply[T](id: String, version: Long): IncomingDeleteMessage[T, NotUsed] =
-    IncomingDeleteMessage(id, NotUsed, Option(version))
+  // Apply method to use when using passThrough
+  def apply[T, C](id: String, passThrough: C): IncomingMessage[T, C] =
+    IncomingMessage(Some(id), None, passThrough, Delete, None, None)
 
   // Java-api - without passThrough
-  def create[T](id: String): IncomingDeleteMessage[T, NotUsed] =
+  def create[T](id: String): IncomingMessage[T, NotUsed] =
     IncomingDeleteMessage(id)
 
-  // Java-api - without passThrough
-  def create[T](id: String, version: Long): IncomingDeleteMessage[T, NotUsed] =
-    IncomingDeleteMessage(id, version)
-
   // Java-api - with passThrough
-  def create[T, C](id: String, passThrough: C): IncomingDeleteMessage[T, C] =
+  def create[T, C](id: String, passThrough: C): IncomingMessage[T, C] =
     IncomingDeleteMessage(id, passThrough)
-
-  // Java-api - with passThrough
-  def create[T, C](id: String, passThrough: C, version: Long): IncomingDeleteMessage[T, C] =
-    IncomingDeleteMessage(id, passThrough, Option(version))
-
-  // Java-api - with passThrough
-  def create[T, C](id: String, passThrough: C, version: Long, indexName: String): IncomingDeleteMessage[T, C] =
-    IncomingDeleteMessage(id, passThrough, Option(version), Option(indexName))
 }
 
-sealed trait IncomingMessage[T, C] {
-  val passThrough: C
-  val version: Option[Long]
-  val indexName: Option[String]
-  def withVersion(version: Long): IncomingMessage[T, C]
-  def withIndexName(indexName: String): IncomingMessage[T, C]
-}
-
-final case class IncomingDeleteMessage[T, C](id: String,
-                                             passThrough: C,
-                                             version: Option[Long] = None,
-                                             indexName: Option[String] = None)
-    extends IncomingMessage[T, C] {
-
-  def withVersion(version: Long): IncomingDeleteMessage[T, C] =
+case class IncomingMessage[T, C] private (
+    id: Option[String],
+    source: Option[T],
+    passThrough: C,
+    operation: Operation,
+    version: Option[Long] = None,
+    indexName: Option[String] = None
+) {
+  def withVersion(version: Long): IncomingMessage[T, C] =
     this.copy(version = Option(version))
 
-  def withIndexName(indexName: String): IncomingDeleteMessage[T, C] =
+  def withIndexName(indexName: String): IncomingMessage[T, C] =
     this.copy(indexName = Option(indexName))
 }
 
-final case class IncomingIndexMessage[T, C](id: Option[String],
-                                            source: T,
-                                            passThrough: C,
-                                            version: Option[Long] = None,
-                                            indexName: Option[String] = None)
-    extends IncomingMessage[T, C] {
-
-  def withVersion(version: Long): IncomingIndexMessage[T, C] =
-    this.copy(version = Option(version))
-
-  def withIndexName(indexName: String): IncomingIndexMessage[T, C] =
-    this.copy(indexName = Option(indexName))
-}
-
-final case class IncomingUpdateMessage[T, C](id: String,
-                                             source: T,
-                                             passThrough: C,
-                                             upsert: Boolean = false,
-                                             version: Option[Long] = None,
-                                             indexName: Option[String] = None)
-    extends IncomingMessage[T, C] {
-
-  def withVersion(version: Long): IncomingUpdateMessage[T, C] =
-    this.copy(version = Option(version))
-
-  def withIndexName(indexName: String): IncomingUpdateMessage[T, C] =
-    this.copy(indexName = Option(indexName))
-}
+sealed trait Operation
+final object Index extends Operation
+final object Update extends Operation
+final object Upsert extends Operation
+final object Delete extends Operation
 
 case class IncomingMessageResult[T2, C2](message: IncomingMessage[T2, C2], error: Option[String]) {
   val success = error.isEmpty
@@ -273,10 +200,10 @@ class ElasticsearchFlowStage[T, C](
         val items = responseJson.asJsObject.fields("items").asInstanceOf[JsArray]
         val messageResults: Seq[IncomingMessageResult[T, C]] = items.elements.zip(messages).map {
           case (item, message) =>
-            val command = message match {
-              case _: IncomingIndexMessage[_, _] => "index"
-              case _: IncomingUpdateMessage[_, _] => "update"
-              case _: IncomingDeleteMessage[_, _] => "delete"
+            val command = message.operation match {
+              case Index => "index"
+              case Update | Upsert => "update"
+              case Delete => "delete"
             }
             val res = item.asJsObject.fields(command).asJsObject
             val error: Option[String] = res.fields.get("error").map(_.toString())
@@ -337,8 +264,8 @@ class ElasticsearchFlowStage[T, C](
             val indexNameToUse: String = message.indexName.getOrElse(indexName)
 
             JsObject(
-              message match {
-                case x: IncomingIndexMessage[_, _] =>
+              message.operation match {
+                case Index =>
                   "index" -> JsObject(
                     Seq(
                       Option("_index" -> JsString(indexNameToUse)),
@@ -349,12 +276,12 @@ class ElasticsearchFlowStage[T, C](
                       settings.versionType.map { versionType =>
                         "version_type" -> JsString(versionType)
                       },
-                      x.id.map { id =>
+                      message.id.map { id =>
                         "_id" -> JsString(id)
                       }
                     ).flatten: _*
                   )
-                case x: IncomingUpdateMessage[_, _] =>
+                case Update | Upsert =>
                   "update" -> JsObject(
                     Seq(
                       Option("_index" -> JsString(indexNameToUse)),
@@ -365,10 +292,10 @@ class ElasticsearchFlowStage[T, C](
                       settings.versionType.map { versionType =>
                         "version_type" -> JsString(versionType)
                       },
-                      Option("_id" -> JsString(x.id))
+                      Option("_id" -> JsString(message.id.get))
                     ).flatten: _*
                   )
-                case x: IncomingDeleteMessage[_, _] =>
+                case Delete =>
                   "delete" -> JsObject(
                     Seq(
                       Option("_index" -> JsString(indexNameToUse)),
@@ -379,7 +306,7 @@ class ElasticsearchFlowStage[T, C](
                       settings.versionType.map { versionType =>
                         "version_type" -> JsString(versionType)
                       },
-                      Option("_id" -> JsString(x.id))
+                      Option("_id" -> JsString(message.id.get))
                     ).flatten: _*
                   )
               }
@@ -403,19 +330,19 @@ class ElasticsearchFlowStage[T, C](
       }
 
       private def messageToJsonString(message: IncomingMessage[T, C]): String =
-        message match {
-          case x: IncomingIndexMessage[T, C] =>
-            "\n" + writer.convert(x.source)
-          case x: IncomingUpdateMessage[T, C] if x.upsert =>
+        message.operation match {
+          case Index =>
+            "\n" + writer.convert(message.source.get)
+          case Upsert =>
             "\n" + JsObject(
-              "doc" -> writer.convert(x.source).parseJson,
+              "doc" -> writer.convert(message.source.get).parseJson,
               "doc_as_upsert" -> JsTrue
             ).toString
-          case x: IncomingUpdateMessage[T, C] =>
+          case Update =>
             "\n" + JsObject(
-              "doc" -> writer.convert(x.source).parseJson
+              "doc" -> writer.convert(message.source.get).parseJson
             ).toString
-          case _: IncomingDeleteMessage[T, C] =>
+          case Delete =>
             ""
         }
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
@@ -25,19 +25,11 @@ import org.apache.http.util.EntityUtils
 object IncomingIndexMessage {
   // Apply method to use when not using passThrough
   def apply[T](source: T): IncomingMessage[T, NotUsed] =
-    IncomingMessage(id = None, source = Some(source), passThrough = NotUsed, operation = Index)
+    IncomingMessage(Index, None, Some(source))
 
   // Apply method to use when not using passThrough
   def apply[T](id: String, source: T): IncomingMessage[T, NotUsed] =
-    IncomingMessage(id = Some(id), source = Some(source), passThrough = NotUsed, operation = Index)
-
-  // Apply method to use when using passThrough
-  def apply[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingMessage(id = None, source = Some(source), passThrough = passThrough, Index, None, None)
-
-  // Apply method to use when using passThrough
-  def apply[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingMessage(Some(id), Some(source), passThrough, Index, None, None)
+    IncomingMessage(Index, Some(id), Some(source))
 
   // Java-api - without passThrough
   def create[T](source: T): IncomingMessage[T, NotUsed] =
@@ -46,78 +38,49 @@ object IncomingIndexMessage {
   // Java-api - without passThrough
   def create[T](id: String, source: T): IncomingMessage[T, NotUsed] =
     IncomingIndexMessage(id, source)
-
-  // Java-api - with passThrough
-  def create[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingIndexMessage(source, passThrough)
-
-  // Java-api - with passThrough
-  def create[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingIndexMessage(id, source, passThrough)
 }
 
 object IncomingUpdateMessage {
   // Apply method to use when not using passThrough
   def apply[T](id: String, source: T): IncomingMessage[T, NotUsed] =
-    IncomingMessage(Some(id), Some(source), NotUsed, Update, None, None)
-
-  // Apply method to use when using passThrough
-  def apply[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingMessage(Some(id), Some(source), passThrough, Update, None, None)
+    IncomingMessage(Update, Some(id), Some(source))
 
   // Java-api - without passThrough
   def create[T](id: String, source: T): IncomingMessage[T, NotUsed] =
     IncomingUpdateMessage(id, source)
-
-  // Java-api - with passThrough
-  def create[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingUpdateMessage(id, source, passThrough)
 }
 
 object IncomingUpsertMessage {
   // Apply method to use when not using passThrough
   def apply[T](id: String, source: T): IncomingMessage[T, NotUsed] =
-    IncomingMessage(Some(id), Some(source), NotUsed, Upsert, None, None)
-
-  // Apply method to use when using passThrough
-  def apply[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingMessage(Some(id), Some(source), passThrough, Upsert, None, None)
+    IncomingMessage(Upsert, Some(id), Some(source))
 
   // Java-api - without passThrough
   def create[T](id: String, source: T): IncomingMessage[T, NotUsed] =
     IncomingUpdateMessage(id, source)
-
-  // Java-api - with passThrough
-  def create[T, C](id: String, source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingUpdateMessage(id, source, passThrough)
 }
 
 object IncomingDeleteMessage {
   // Apply method to use when not using passThrough
   def apply[T](id: String): IncomingMessage[T, NotUsed] =
-    IncomingMessage(Some(id), None, NotUsed, Delete, None, None)
-
-  // Apply method to use when using passThrough
-  def apply[T, C](id: String, passThrough: C): IncomingMessage[T, C] =
-    IncomingMessage(Some(id), None, passThrough, Delete, None, None)
+    IncomingMessage(Delete, Some(id), None)
 
   // Java-api - without passThrough
   def create[T](id: String): IncomingMessage[T, NotUsed] =
     IncomingDeleteMessage(id)
-
-  // Java-api - with passThrough
-  def create[T, C](id: String, passThrough: C): IncomingMessage[T, C] =
-    IncomingDeleteMessage(id, passThrough)
 }
 
 case class IncomingMessage[T, C] private (
+    operation: Operation,
     id: Option[String],
     source: Option[T],
-    passThrough: C,
-    operation: Operation,
+    passThrough: C = NotUsed,
     version: Option[Long] = None,
     indexName: Option[String] = None
 ) {
+  def withPassThrough[P](passThrough: P): IncomingMessage[T, P] =
+    this.copy(passThrough = passThrough)
+
   def withVersion(version: Long): IncomingMessage[T, C] =
     this.copy(version = Option(version))
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchFlowStage.scala
@@ -315,7 +315,6 @@ class ElasticsearchFlowStage[T, C](
         retryCount = 0 // Clear retryCount
 
         // Push result
-        //val listOfResults = messageResults.map(_.r)
         emit(out, Future.successful(messageResults))
 
         // Fetch next messages from queue and send them

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSinkSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSinkSettings.scala
@@ -20,7 +20,7 @@ final case class ElasticsearchSinkSettings(bufferSize: Int = 10,
                                            retryInterval: Int = 5000,
                                            maxRetry: Int = 100,
                                            retryPartialFailure: Boolean = false,
-                                           docAsUpsert: Boolean = false,
+                                           //docAsUpsert: Boolean = false,
                                            versionType: Option[String] = None) {
   def withBufferSize(bufferSize: Int): ElasticsearchSinkSettings =
     copy(bufferSize = bufferSize)
@@ -34,8 +34,8 @@ final case class ElasticsearchSinkSettings(bufferSize: Int = 10,
   def withRetryPartialFailure(retryPartialFailure: Boolean): ElasticsearchSinkSettings =
     copy(retryPartialFailure = retryPartialFailure)
 
-  def withDocAsUpsert(docAsUpsert: Boolean): ElasticsearchSinkSettings =
-    copy(docAsUpsert = docAsUpsert)
+//  def withDocAsUpsert(docAsUpsert: Boolean): ElasticsearchSinkSettings =
+//    copy(docAsUpsert = docAsUpsert)
 
   def withVersionType(versionType: String): ElasticsearchSinkSettings =
     copy(versionType = Some(versionType))

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSinkSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSinkSettings.scala
@@ -20,7 +20,6 @@ final case class ElasticsearchSinkSettings(bufferSize: Int = 10,
                                            retryInterval: Int = 5000,
                                            maxRetry: Int = 100,
                                            retryPartialFailure: Boolean = false,
-                                           //docAsUpsert: Boolean = false,
                                            versionType: Option[String] = None) {
   def withBufferSize(bufferSize: Int): ElasticsearchSinkSettings =
     copy(bufferSize = bufferSize)
@@ -33,9 +32,6 @@ final case class ElasticsearchSinkSettings(bufferSize: Int = 10,
 
   def withRetryPartialFailure(retryPartialFailure: Boolean): ElasticsearchSinkSettings =
     copy(retryPartialFailure = retryPartialFailure)
-
-//  def withDocAsUpsert(docAsUpsert: Boolean): ElasticsearchSinkSettings =
-//    copy(docAsUpsert = docAsUpsert)
 
   def withVersionType(versionType: String): ElasticsearchSinkSettings =
     copy(versionType = Some(versionType))

--- a/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
+++ b/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
@@ -388,7 +388,7 @@ public class ElasticsearchTest {
     flush(indexName);
 
     // Update document to version 2
-    Source.single(IncomingIndexMessage.create("1", book, 1L))
+    Source.single(IncomingIndexMessage.create("1", book).withVersion(1L))
         .via(
             ElasticsearchFlow.create(
                 indexName,
@@ -405,7 +405,7 @@ public class ElasticsearchTest {
     // Try to update document with wrong version to assert that we can send it
     long oldVersion = 1;
     boolean success =
-        Source.single(IncomingIndexMessage.create("1", book, oldVersion))
+        Source.single(IncomingIndexMessage.create("1", book).withVersion(oldVersion))
             .via(
                 ElasticsearchFlow.create(
                     indexName,
@@ -433,7 +433,7 @@ public class ElasticsearchTest {
     long externalVersion = 5;
 
     // Insert new document using external version
-    Source.single(IncomingIndexMessage.create("1", book, externalVersion))
+    Source.single(IncomingIndexMessage.create("1", book).withVersion(externalVersion))
         .via(
             ElasticsearchFlow.create(
                 indexName,

--- a/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
+++ b/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
@@ -295,7 +295,7 @@ public class ElasticsearchTest {
               String id = book.title;
 
               // Transform message so that we can write to elastic
-              return IncomingIndexMessage.create(id, book, kafkaMessage.offset);
+              return IncomingIndexMessage.create(id, book).withPassThrough(kafkaMessage.offset);
             })
         .via( // write to elastic
             ElasticsearchFlow.createWithPassThrough(

--- a/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
+++ b/elasticsearch/src/test/java/akka/stream/alpakka/elasticsearch/ElasticsearchTest.java
@@ -128,7 +128,7 @@ public class ElasticsearchTest {
         ElasticsearchSource.create("source", "book", "{\"match_all\": {}}", sourceSettings, client);
     CompletionStage<Done> f1 =
         source
-            .map(m -> IncomingMessage.create(m.id(), m.source()))
+            .map(m -> IncomingIndexMessage.create(m.id(), m.source()))
             .runWith(
                 ElasticsearchSink.create("sink1", "book", sinkSettings, client, new ObjectMapper()),
                 materializer);
@@ -177,7 +177,7 @@ public class ElasticsearchTest {
             "source", "book", "{\"match_all\": {}}", sourceSettings, client, Book.class);
     CompletionStage<Done> f1 =
         source
-            .map(m -> IncomingMessage.create(m.id(), m.source()))
+            .map(m -> IncomingIndexMessage.create(m.id(), m.source()))
             .runWith(
                 ElasticsearchSink.create("sink2", "book", sinkSettings, client, new ObjectMapper()),
                 materializer);
@@ -227,7 +227,7 @@ public class ElasticsearchTest {
                 ElasticsearchSourceSettings.Default().withBufferSize(5),
                 client,
                 Book.class)
-            .map(m -> IncomingMessage.create(m.id(), m.source()))
+            .map(m -> IncomingIndexMessage.create(m.id(), m.source()))
             .via(
                 ElasticsearchFlow.create(
                     "sink3",
@@ -295,7 +295,7 @@ public class ElasticsearchTest {
               String id = book.title;
 
               // Transform message so that we can write to elastic
-              return IncomingMessage.create(id, book, kafkaMessage.offset);
+              return IncomingIndexMessage.create(id, book, kafkaMessage.offset);
             })
         .via( // write to elastic
             ElasticsearchFlow.createWithPassThrough(
@@ -313,7 +313,7 @@ public class ElasticsearchTest {
                         if (!result.success())
                           throw new RuntimeException("Failed to write message to elastic");
                         // Commit to kafka
-                        kafkaCommitter.commit(result.passThrough());
+                        kafkaCommitter.commit(result.message().passThrough());
                       });
               return NotUsed.getInstance();
             })
@@ -356,7 +356,7 @@ public class ElasticsearchTest {
 
     // Insert document
     Book book = new Book("b");
-    Source.single(IncomingMessage.create("1", book))
+    Source.single(IncomingIndexMessage.create("1", book))
         .via(
             ElasticsearchFlow.create(
                 indexName,
@@ -388,7 +388,7 @@ public class ElasticsearchTest {
     flush(indexName);
 
     // Update document to version 2
-    Source.single(IncomingMessage.create("1", book, 1L))
+    Source.single(IncomingIndexMessage.create("1", book, 1L))
         .via(
             ElasticsearchFlow.create(
                 indexName,
@@ -405,7 +405,7 @@ public class ElasticsearchTest {
     // Try to update document with wrong version to assert that we can send it
     long oldVersion = 1;
     boolean success =
-        Source.single(IncomingMessage.create("1", book, oldVersion))
+        Source.single(IncomingIndexMessage.create("1", book, oldVersion))
             .via(
                 ElasticsearchFlow.create(
                     indexName,
@@ -433,7 +433,7 @@ public class ElasticsearchTest {
     long externalVersion = 5;
 
     // Insert new document using external version
-    Source.single(IncomingMessage.create("1", book, externalVersion))
+    Source.single(IncomingIndexMessage.create("1", book, externalVersion))
         .via(
             ElasticsearchFlow.create(
                 indexName,
@@ -500,7 +500,7 @@ public class ElasticsearchTest {
 
     // Insert document
     Source.from(docs)
-        .map((TestDoc d) -> IncomingMessage.create(d.id, d))
+        .map((TestDoc d) -> IncomingIndexMessage.create(d.id, d))
         .via(
             ElasticsearchFlow.create(
                 indexName,

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSpec.scala
@@ -409,7 +409,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
           println("title: " + book.title)
 
           // Transform message so that we can write to elastic
-          IncomingIndexMessage(id, book, kafkaMessage.offset)
+          IncomingIndexMessage(id, book).withPassThrough(kafkaMessage.offset)
         }
         .via( // write to elastic
           ElasticsearchFlow.createWithPassThrough[Book, KafkaOffset](


### PR DESCRIPTION
Currently, `ElasticsearchFlow` supports only **insert** and **upsert**. We can configure a flow as either one of them.

This pull request adds support for **update** and **delete** by message types by introducing following incoming message types:

- `IncomingIndexMessage`
- `IncomingUpdateMessage`
- `IncomingUpsertMessage`
- `IncomingDeleteMessage`

This also means it makes possible to handle all request types in single flow.

I'm not sure whether I should modify existing `ElasticsearchFlow` interfaces to support this functionality. I think it doesn't need so much effort to update existing code which uses `ElasticsearchFlow` to this version, but breaking source code compatibility is a fact.

If keeping source code compatibility is critical in Alpakka connectors, I would like to add new flow which has this functionality.