### PR TITLE
XML: Add ignoreInvalidChars option to XmlParsing.parser

### DIFF
--- a/xml/src/main/scala/akka/stream/alpakka/xml/javadsl/XmlParsing.scala
+++ b/xml/src/main/scala/akka/stream/alpakka/xml/javadsl/XmlParsing.scala
@@ -18,7 +18,13 @@ object XmlParsing {
    * Parser Flow that takes a stream of ByteStrings and parses them to XML events similar to SAX.
    */
   def parser(): akka.stream.javadsl.Flow[ByteString, ParseEvent, NotUsed] =
-    xml.scaladsl.XmlParsing.parser.asJava
+    xml.scaladsl.XmlParsing.parser(false).asJava
+
+  /**
+   * Parser Flow that takes a stream of ByteStrings and parses them to XML events similar to SAX.
+   */
+  def parser(ignoreInvalidChars: Boolean): akka.stream.javadsl.Flow[ByteString, ParseEvent, NotUsed] =
+    xml.scaladsl.XmlParsing.parser(ignoreInvalidChars).asJava
 
   /**
    * A Flow that transforms a stream of XML ParseEvents. This stage coalesces consequitive CData and Characters

--- a/xml/src/main/scala/akka/stream/alpakka/xml/scaladsl/XmlParsing.scala
+++ b/xml/src/main/scala/akka/stream/alpakka/xml/scaladsl/XmlParsing.scala
@@ -18,8 +18,13 @@ object XmlParsing {
   /**
    * Parser Flow that takes a stream of ByteStrings and parses them to XML events similar to SAX.
    */
-  val parser: Flow[ByteString, ParseEvent, NotUsed] =
-    Flow.fromGraph(new StreamingXmlParser)
+  val parser: Flow[ByteString, ParseEvent, NotUsed] = parser(false)
+
+  /**
+   * Parser Flow that takes a stream of ByteStrings and parses them to XML events similar to SAX.
+   */
+  def parser(ignoreInvalidChars: Boolean = false): Flow[ByteString, ParseEvent, NotUsed] =
+    Flow.fromGraph(new StreamingXmlParser(ignoreInvalidChars))
 
   /**
    * A Flow that transforms a stream of XML ParseEvents. This stage coalesces consequitive CData and Characters


### PR DESCRIPTION
When there are invalid bytes in XML, aalto-xml parser throws an exception like below:
```
[ERROR] [07/12/2018 17:57:02.332] [default-akka.actor.default-dispatcher-2] [akka://default/system/StreamSupervisor-0/flow-0-0-ignoreSink] Error in stage [akka.stream.alpakka.xml.Xml$StreamingXmlParser@110ba553]: Illegal XML character ((CTRL-CHAR, code 8))
 at [row,col {unknown-source}]: [10895,11]
com.fasterxml.aalto.WFCException: Illegal XML character ((CTRL-CHAR, code 8))
 at [row,col {unknown-source}]: [10895,11]
	at com.fasterxml.aalto.in.XmlScanner.reportInputProblem(XmlScanner.java:1333)
	at com.fasterxml.aalto.in.XmlScanner.handleInvalidXmlChar(XmlScanner.java:1526)
	at com.fasterxml.aalto.async.AsyncByteArrayScanner.parseCDataContents(AsyncByteArrayScanner.java:638)
	at com.fasterxml.aalto.async.AsyncByteArrayScanner.handleCDataStartMarker(AsyncByteArrayScanner.java:2061)
	at com.fasterxml.aalto.async.AsyncByteArrayScanner.handleCData(AsyncByteArrayScanner.java:1996)
	at com.fasterxml.aalto.async.AsyncByteArrayScanner.nextFromTree(AsyncByteArrayScanner.java:1218)
	at com.fasterxml.aalto.stax.StreamReaderImpl.next(StreamReaderImpl.java:760)
	at akka.stream.alpakka.xml.Xml$StreamingXmlParser$$anon$1.advanceParser(Xml.scala:236)
	at akka.stream.alpakka.xml.Xml$StreamingXmlParser$$anon$1.onPull(Xml.scala:226)
	at akka.stream.impl.fusing.GraphInterpreter.processPull(GraphInterpreter.scala:526)
	at akka.stream.impl.fusing.GraphInterpreter.execute(GraphInterpreter.scala:422)
	at akka.stream.impl.fusing.GraphInterpreterShell.runBatch(ActorGraphInterpreter.scala:588)
	at akka.stream.impl.fusing.ActorGraphInterpreter$SimpleBoundaryEvent.execute(ActorGraphInterpreter.scala:45)
	at akka.stream.impl.fusing.ActorGraphInterpreter$SimpleBoundaryEvent.execute$(ActorGraphInterpreter.scala:41)
	at akka.stream.impl.fusing.ActorGraphInterpreter$BatchingActorInputBoundary$OnNext.execute(ActorGraphInterpreter.scala:78)
	at akka.stream.impl.fusing.GraphInterpreterShell.processEvent(ActorGraphInterpreter.scala:563)
	at akka.stream.impl.fusing.ActorGraphInterpreter.akka$stream$impl$fusing$ActorGraphInterpreter$$processEvent(ActorGraphInterpreter.scala:745)
	at akka.stream.impl.fusing.ActorGraphInterpreter$$anonfun$receive$1.applyOrElse(ActorGraphInterpreter.scala:760)
	at akka.actor.Actor.aroundReceive(Actor.scala:517)
	at akka.actor.Actor.aroundReceive$(Actor.scala:515)
	at akka.stream.impl.fusing.ActorGraphInterpreter.aroundReceive(ActorGraphInterpreter.scala:670)
	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:588)
	at akka.actor.ActorCell.invoke(ActorCell.scala:557)
	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:258)
	at akka.dispatch.Mailbox.run(Mailbox.scala:225)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:235)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```

To handle invalid bytes, aalto-xml parser offers `IllegalCharHandler`. This pull request makes possible to ignore invalid bytes using `IllegalCharHandler` mechanism.