### PR TITLE
AWS Kinesis: Allow passing a user context object with each message.

### DIFF
--- a/docs/src/main/paradox/kinesis.md
+++ b/docs/src/main/paradox/kinesis.md
@@ -101,6 +101,8 @@ Batching has a drawback: message order cannot be guaranteed, as some records wit
 More information can be found [here](http://docs.aws.amazon.com/streams/latest/dev/developing-producers-with-sdk.html#kinesis-using-sdk-java-putrecords) and [here](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html).
 @@@
 
+In order to correlate the results with the original message, an optional user context object of arbitrary type can be associated with every message and will be returned with the corresponding result. This allows keeping track of which messages have been successfully sent to Kinesis even if the message order gets mixed up.
+
 Publishing to a Kinesis stream requires an instance of `KinesisFlowSettings`, although a default instance with sane values and a method that returns settings based on the stream shard number are also available:
 
 Scala

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisErrors.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisErrors.scala
@@ -17,8 +17,10 @@ object KinesisErrors {
 
   sealed trait KinesisFlowErrors extends NoStackTrace
   case class FailurePublishingRecords(e: Exception) extends RuntimeException(e) with KinesisFlowErrors
-  case class ErrorPublishingRecords(attempts: Int, records: Seq[PutRecordsResultEntry])
+  case class ErrorPublishingRecords[T](attempts: Int, recordsWithContext: Seq[(PutRecordsResultEntry, T)])
       extends RuntimeException(s"Unable to publish records after $attempts attempts")
-      with KinesisFlowErrors
+      with KinesisFlowErrors {
+    val records = recordsWithContext.map(_._1)
+  }
 
 }

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/javadsl/KinesisFlow.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/javadsl/KinesisFlow.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.kinesis.javadsl
 
 import akka.NotUsed
+import akka.japi.Pair
 import akka.stream.alpakka.kinesis.{scaladsl, KinesisFlowSettings}
 import akka.stream.javadsl.Flow
 import com.amazonaws.services.kinesis.AmazonKinesisAsync
@@ -21,4 +22,21 @@ object KinesisFlow {
             kinesisClient: AmazonKinesisAsync): Flow[PutRecordsRequestEntry, PutRecordsResultEntry, NotUsed] =
     (scaladsl.KinesisFlow.apply(streamName, settings)(kinesisClient)).asJava
 
+  def withUserContext[T](
+      streamName: String,
+      kinesisClient: AmazonKinesisAsync
+  ): Flow[Pair[PutRecordsRequestEntry, T], Pair[PutRecordsResultEntry, T], NotUsed] =
+    withUserContext(streamName, KinesisFlowSettings.defaultInstance, kinesisClient)
+
+  def withUserContext[T](
+      streamName: String,
+      settings: KinesisFlowSettings,
+      kinesisClient: AmazonKinesisAsync
+  ): Flow[Pair[PutRecordsRequestEntry, T], Pair[PutRecordsResultEntry, T], NotUsed] =
+    akka.stream.scaladsl
+      .Flow[Pair[PutRecordsRequestEntry, T]]
+      .map(_.toScala)
+      .via(scaladsl.KinesisFlow.withUserContext[T](streamName, settings)(kinesisClient))
+      .map({ case (res, ctx) => Pair.create(res, ctx) })
+      .asJava
 }

--- a/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/Examples.java
+++ b/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/Examples.java
@@ -6,6 +6,7 @@ package akka.stream.alpakka.kinesis.javadsl;
 
 import akka.NotUsed;
 import akka.actor.ActorSystem;
+import akka.japi.Pair;
 import akka.stream.ActorMaterializer;
 import akka.stream.alpakka.kinesis.KinesisFlowSettings;
 import akka.stream.alpakka.kinesis.ShardSettings;
@@ -80,6 +81,12 @@ public class Examples {
 
   final Flow<PutRecordsRequestEntry, PutRecordsResultEntry, NotUsed> defaultSettingsFlow =
       KinesisFlow.apply("streamName", amazonKinesisAsync);
+
+  final Flow<Pair<PutRecordsRequestEntry, String>, Pair<PutRecordsResultEntry, String>, NotUsed> flowWithStringContext =
+      KinesisFlow.withUserContext("streamName", flowSettings, amazonKinesisAsync);
+
+  final Flow<Pair<PutRecordsRequestEntry, String>, Pair<PutRecordsResultEntry, String>, NotUsed> defaultSettingsFlowWithStringContext =
+      KinesisFlow.withUserContext("streamName", flowSettings, amazonKinesisAsync);
 
   final Sink<PutRecordsRequestEntry, NotUsed> sink =
       KinesisSink.apply("streamName", flowSettings, amazonKinesisAsync);

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/scaladsl/Examples.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/scaladsl/Examples.scala
@@ -83,10 +83,16 @@ object Examples {
 
   val flow2: Flow[PutRecordsRequestEntry, PutRecordsResultEntry, NotUsed] = KinesisFlow("myStreamName", flowSettings)
 
-  val flow3: Flow[(String, ByteString), PutRecordsResultEntry, NotUsed] =
+  val flow3: Flow[(PutRecordsRequestEntry, String), (PutRecordsResultEntry, String), NotUsed] =
+    KinesisFlow.withUserContext("myStreamName")
+
+  val flow4: Flow[(PutRecordsRequestEntry, String), (PutRecordsResultEntry, String), NotUsed] =
+    KinesisFlow.withUserContext("myStreamName", flowSettings)
+
+  val flow5: Flow[(String, ByteString), PutRecordsResultEntry, NotUsed] =
     KinesisFlow.byPartitionAndBytes("myStreamName")
 
-  val flow4: Flow[(String, ByteBuffer), PutRecordsResultEntry, NotUsed] =
+  val flow6: Flow[(String, ByteBuffer), PutRecordsResultEntry, NotUsed] =
     KinesisFlow.byPartitionAndData("myStreamName")
 
   val sink1: Sink[PutRecordsRequestEntry, NotUsed] = KinesisSink("myStreamName")


### PR DESCRIPTION
* KinesisFlowStage now receives pairs of (PutRecordsRequestEntry, T)
* KinesisFlowStage outputs pairs of (PutRecordsResultEntry, T)
* Object of type T is passed through without modifications
* Can use T as a context to correlate input and output messages
* Changes are hidden behind the existing public API
* New method KinesisFlow.withUserContext enables using the context

Rationale: In our project, we were faced with the problem of mirroring a Kafka topic to a Kinesis stream. In order to ensure at-least-once semantics, we need to be careful to commit Kafka message offsets back only when they were successfully written to Kinesis. However, due to the async nature of Kinesis put requests, the message order to Kinesis is not guaranteed. So we need to manually track which messages have already been put to Kinesis to decide what and when to commit back to Kafka. 

The current Kinesis flow takes as input PutRecordRequests and returns PutRecordResults. Unfortunately, these objects contain no information that would allow us to correlate a result with the initial request, making it impossible to track which messages have already been successfully written to Kinesis. Therefore, in this pull request I implemented the possibility to pass an additional user context object with each PutRecordRequest, which is returned with the corresponding PutRecordResult. This context object allows correlationg request and result. The approach was inspired by akka http.

The previous public API was left unchanged; the additional functionality is hidden in the internal implementation and only exposed via new functions KinesisFlow.withUserContext.