### PR TITLE
Remove "//#upload" comments to avoid duplicate codes in the document

### DIFF
--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SinkSpec.scala
@@ -45,9 +45,7 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
 
     mockUpload()
 
-    //#upload
     val s3Sink: Sink[ByteString, Future[MultipartUploadResult]] = s3Client.multipartUpload(bucket, bucketKey)
-    //#upload
 
     val result: Future[MultipartUploadResult] = Source.single(ByteString(body)).runWith(s3Sink)
 


### PR DESCRIPTION
Thank you very much for your wonderful project! 

I found duplicate codes in the following document.

<img width="1051" alt="screen shot 2018-07-22 at 0 05 27" src="https://user-images.githubusercontent.com/10933561/43036907-03290e4c-8d43-11e8-91c9-7763deb452a7.png">  

(from: <https://developer.lightbend.com/docs/alpakka/current/s3.html>)

I'm not sure a mechanism to how the document created. But I guess that "//#upload" comments created a part of documents, so I removed one of them.