### PR TITLE
Add names to Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ script:
 jobs:
   include:
     - stage: check
-      script: sbt scalafmtCheck || { echo "[error] Unformatted code found. Please run 'test:compile' and commit the reformatted code."; false; }
-      env: SCALAFMT_CHECK
+      script: sbt scalafmtCheck || { echo "[error] Unformatted code found. Please run 'Test/compile' and commit the reformatted code."; false; }
+      name: "Code style check"
     - script: sbt scalafmtSbtCheck || { echo "[error] Unformatted sbt code found. Please run 'scalafmtSbt' and commit the reformatted code."; false; }
-      env: SCALAFMT_SBT_CHECK
+      name: "Build code style check"
     - env: CMD="Test/compile"
     - env: CMD="unidoc"
     - env: CMD="docs/paradox"

--- a/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java
+++ b/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java
@@ -56,112 +56,111 @@ public class HBaseStageTest {
 
   // #create-converter-put
   Function<Person, List<Mutation>> hBaseConverter =
-    person -> {
-      try {
-        Put put = new Put(String.format("id_%d", person.id).getBytes("UTF-8"));
-        put.addColumn(
-          "info".getBytes("UTF-8"), "name".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
+      person -> {
+        try {
+          Put put = new Put(String.format("id_%d", person.id).getBytes("UTF-8"));
+          put.addColumn(
+              "info".getBytes("UTF-8"), "name".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
 
-        return Collections.singletonList(put);
-      } catch (UnsupportedEncodingException e) {
-        e.printStackTrace();
-        return Collections.emptyList();
-      }
-    };
+          return Collections.singletonList(put);
+        } catch (UnsupportedEncodingException e) {
+          e.printStackTrace();
+          return Collections.emptyList();
+        }
+      };
   // #create-converter-put
 
   // #create-converter-append
   Function<Person, List<Mutation>> appendHBaseConverter =
-    person -> {
-      try {
-        Append append = new Append(String.format("id_%d", person.id).getBytes("UTF-8"));
-        append.add(
-          "info".getBytes("UTF-8"), "aliases".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
+      person -> {
+        try {
+          Append append = new Append(String.format("id_%d", person.id).getBytes("UTF-8"));
+          append.add(
+              "info".getBytes("UTF-8"), "aliases".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
 
-        return Collections.singletonList(append);
-      } catch (UnsupportedEncodingException e) {
-        e.printStackTrace();
-        return Collections.emptyList();
-      }
-    };
+          return Collections.singletonList(append);
+        } catch (UnsupportedEncodingException e) {
+          e.printStackTrace();
+          return Collections.emptyList();
+        }
+      };
   // #create-converter-append
 
   // #create-converter-delete
   Function<Person, List<Mutation>> deleteHBaseConverter =
-    person -> {
-      try {
-        Delete delete = new Delete(String.format("id_%d", person.id).getBytes("UTF-8"));
+      person -> {
+        try {
+          Delete delete = new Delete(String.format("id_%d", person.id).getBytes("UTF-8"));
 
-        return Collections.singletonList(delete);
-      } catch (UnsupportedEncodingException e) {
-        e.printStackTrace();
-        return Collections.emptyList();
-      }
-    };
+          return Collections.singletonList(delete);
+        } catch (UnsupportedEncodingException e) {
+          e.printStackTrace();
+          return Collections.emptyList();
+        }
+      };
   // #create-converter-delete
 
   // #create-converter-increment
   Function<Person, List<Mutation>> incrementHBaseConverter =
-    person -> {
-      try {
-        Increment increment = new Increment(String.format("id_%d", person.id).getBytes("UTF-8"));
-        increment.addColumn("info".getBytes("UTF-8"), "numberOfChanges".getBytes("UTF-8"), 1);
+      person -> {
+        try {
+          Increment increment = new Increment(String.format("id_%d", person.id).getBytes("UTF-8"));
+          increment.addColumn("info".getBytes("UTF-8"), "numberOfChanges".getBytes("UTF-8"), 1);
 
-        return Collections.singletonList(increment);
-      } catch (UnsupportedEncodingException e) {
-        e.printStackTrace();
-        return Collections.emptyList();
-      }
-    };
+          return Collections.singletonList(increment);
+        } catch (UnsupportedEncodingException e) {
+          e.printStackTrace();
+          return Collections.emptyList();
+        }
+      };
   // #create-converter-increment
 
   // #create-converter-complex
   Function<Person, List<Mutation>> complexHBaseConverter =
-    person -> {
-      try {
-        byte[] id = String.format("id_%d", person.id).getBytes("UTF-8");
-        byte[] infoFamily = "info".getBytes("UTF-8");
+      person -> {
+        try {
+          byte[] id = String.format("id_%d", person.id).getBytes("UTF-8");
+          byte[] infoFamily = "info".getBytes("UTF-8");
 
-        if (person.id != 0 && person.name.isEmpty()) {
-          Delete delete = new Delete(id);
-          return Collections.singletonList(delete);
-        } else if (person.id != 0) {
-          Put put = new Put(id);
-          put.addColumn(infoFamily, "name".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
+          if (person.id != 0 && person.name.isEmpty()) {
+            Delete delete = new Delete(id);
+            return Collections.singletonList(delete);
+          } else if (person.id != 0) {
+            Put put = new Put(id);
+            put.addColumn(infoFamily, "name".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
 
-          Increment increment = new Increment(id);
-          increment.addColumn(infoFamily, "numberOfChanges".getBytes("UTF-8"), 1);
+            Increment increment = new Increment(id);
+            increment.addColumn(infoFamily, "numberOfChanges".getBytes("UTF-8"), 1);
 
-          return Arrays.asList(put, increment);
-        } else {
+            return Arrays.asList(put, increment);
+          } else {
+            return Collections.emptyList();
+          }
+        } catch (UnsupportedEncodingException e) {
+          e.printStackTrace();
           return Collections.emptyList();
         }
-      } catch (UnsupportedEncodingException e) {
-        e.printStackTrace();
-        return Collections.emptyList();
-      }
-    };
+      };
   // #create-converter-complex
-
 
   @Test
   public void sink() throws InterruptedException, TimeoutException {
 
     // #create-settings
     HTableSettings<Person> tableSettings =
-      HTableSettings.create(
-        HBaseConfiguration.create(),
-        TableName.valueOf("person1"),
-        Collections.singletonList("info"),
-        hBaseConverter);
+        HTableSettings.create(
+            HBaseConfiguration.create(),
+            TableName.valueOf("person1"),
+            Collections.singletonList("info"),
+            hBaseConverter);
     // #create-settings
 
     // #sink
     final Sink<Person, scala.concurrent.Future<Done>> sink = HTableStage.sink(tableSettings);
     Future<Done> o =
-      Source.from(Arrays.asList(100, 101, 102, 103, 104))
-        .map((i) -> new Person(i, String.format("name %d", i)))
-        .runWith(sink, materializer);
+        Source.from(Arrays.asList(100, 101, 102, 103, 104))
+            .map((i) -> new Person(i, String.format("name %d", i)))
+            .runWith(sink, materializer);
     // #sink
 
     Await.ready(o, Duration.Inf());
@@ -171,20 +170,20 @@ public class HBaseStageTest {
   public void flow() throws ExecutionException, InterruptedException {
 
     HTableSettings<Person> tableSettings =
-      HTableSettings.create(
-        HBaseConfiguration.create(),
-        TableName.valueOf("person2"),
-        Collections.singletonList("info"),
-        hBaseConverter);
+        HTableSettings.create(
+            HBaseConfiguration.create(),
+            TableName.valueOf("person2"),
+            Collections.singletonList("info"),
+            hBaseConverter);
 
     // #flow
     Flow<Person, Person, NotUsed> flow = HTableStage.flow(tableSettings);
     Pair<NotUsed, CompletionStage<List<Person>>> run =
-      Source.from(Arrays.asList(200, 201, 202, 203, 204))
-        .map((i) -> new Person(i, String.format("name_%d", i)))
-        .via(flow)
-        .toMat(Sink.seq(), Keep.both())
-        .run(materializer);
+        Source.from(Arrays.asList(200, 201, 202, 203, 204))
+            .map((i) -> new Person(i, String.format("name_%d", i)))
+            .via(flow)
+            .toMat(Sink.seq(), Keep.both())
+            .run(materializer);
     // #flow
 
     run.second().toCompletableFuture().get();

--- a/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala
+++ b/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala
@@ -101,8 +101,7 @@ class HBaseStageSpec extends WordSpec with Matchers {
         val f = Source(1 to 10).map(i => Person(i, s"zozo_$i")).runWith(sink)
         //#sink
 
-        f.onComplete(e =>
-          actorSystem.terminate())
+        f.onComplete(e => actorSystem.terminate())
 
         Await.ready(f, Duration.Inf)
 

--- a/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/Examples.java
+++ b/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/Examples.java
@@ -82,11 +82,13 @@ public class Examples {
   final Flow<PutRecordsRequestEntry, PutRecordsResultEntry, NotUsed> defaultSettingsFlow =
       KinesisFlow.apply("streamName", amazonKinesisAsync);
 
-  final Flow<Pair<PutRecordsRequestEntry, String>, Pair<PutRecordsResultEntry, String>, NotUsed> flowWithStringContext =
-      KinesisFlow.withUserContext("streamName", flowSettings, amazonKinesisAsync);
+  final Flow<Pair<PutRecordsRequestEntry, String>, Pair<PutRecordsResultEntry, String>, NotUsed>
+      flowWithStringContext =
+          KinesisFlow.withUserContext("streamName", flowSettings, amazonKinesisAsync);
 
-  final Flow<Pair<PutRecordsRequestEntry, String>, Pair<PutRecordsResultEntry, String>, NotUsed> defaultSettingsFlowWithStringContext =
-      KinesisFlow.withUserContext("streamName", flowSettings, amazonKinesisAsync);
+  final Flow<Pair<PutRecordsRequestEntry, String>, Pair<PutRecordsResultEntry, String>, NotUsed>
+      defaultSettingsFlowWithStringContext =
+          KinesisFlow.withUserContext("streamName", flowSettings, amazonKinesisAsync);
 
   final Sink<PutRecordsRequestEntry, NotUsed> sink =
       KinesisSink.apply("streamName", flowSettings, amazonKinesisAsync);

--- a/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetFlowWithPassThrough.java
+++ b/slick/src/test/java/akka/stream/alpakka/slick/javadsl/DocSnippetFlowWithPassThrough.java
@@ -90,7 +90,7 @@ public class DocSnippetFlowWithPassThrough {
                                 new Pair(
                                     user,
                                     insertCount)) // allows to keep the kafka message offset so it
-                                                  // can be committed in a next stage
+                    // can be committed in a next stage
                     ))
             .log("nr-of-updated-rows")
             .mapAsync(

--- a/udp/src/test/java/docs/javadsl/UdpTest.java
+++ b/udp/src/test/java/docs/javadsl/UdpTest.java
@@ -49,14 +49,17 @@ public class UdpTest {
 
     // #bind-flow
     final Flow<Datagram, Datagram, CompletionStage<InetSocketAddress>> bindFlow =
-      Udp.bindFlow(bindToLocal, system);
+        Udp.bindFlow(bindToLocal, system);
     // #bind-flow
 
-    final Pair<Pair<TestPublisher.Probe<Datagram>, CompletionStage<InetSocketAddress>>, TestSubscriber.Probe<Datagram>> materialized =
-      TestSource.<Datagram>probe(system)
-        .viaMat(bindFlow, Keep.both())
-        .toMat(TestSink.probe(system), Keep.both())
-        .run(materializer);
+    final Pair<
+            Pair<TestPublisher.Probe<Datagram>, CompletionStage<InetSocketAddress>>,
+            TestSubscriber.Probe<Datagram>>
+        materialized =
+            TestSource.<Datagram>probe(system)
+                .viaMat(bindFlow, Keep.both())
+                .toMat(TestSink.probe(system), Keep.both())
+                .run(materializer);
 
     {
       // #send-datagrams


### PR DESCRIPTION
Before we used environment variable as a name, because that showed up in the Travis UI. However since stages went out of beta, support for job names has been added.

This also reformats some Java test code, which was left unformatted after the Java formatter change.