### PR TITLE
Unix Domain Socket - Improve halfClose handling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -180,7 +180,12 @@ lazy val text = alpakkaProject("text", "text")
 
 lazy val udp = alpakkaProject("udp", "udp")
 
-lazy val unixdomainsocket = alpakkaProject("unix-domain-socket", "unixdomainsocket", Dependencies.UnixDomainSocket)
+// FIXME: The exclude filter can be removed once we use JNR with 
+// https://github.com/jnr/jnr-enxio/pull/28 merged in.
+lazy val unixdomainsocket = alpakkaProject("unix-domain-socket", 
+                                           "unixdomainsocket", 
+                                           Dependencies.UnixDomainSocket,
+                                           excludeFilter.in(unmanagedSources.in(headerCreate)) := HiddenFileFilter || "KQSelector.java")
 
 lazy val xml = alpakkaProject("xml", "xml", Dependencies.Xml)
 

--- a/build.sbt
+++ b/build.sbt
@@ -180,12 +180,14 @@ lazy val text = alpakkaProject("text", "text")
 
 lazy val udp = alpakkaProject("udp", "udp")
 
-// FIXME: The exclude filter can be removed once we use JNR with 
+// FIXME: The exclude filter can be removed once we use JNR with
 // https://github.com/jnr/jnr-enxio/pull/28 merged in.
-lazy val unixdomainsocket = alpakkaProject("unix-domain-socket", 
-                                           "unixdomainsocket", 
-                                           Dependencies.UnixDomainSocket,
-                                           excludeFilter.in(unmanagedSources.in(headerCreate)) := HiddenFileFilter || "KQSelector.java")
+lazy val unixdomainsocket = alpakkaProject(
+  "unix-domain-socket",
+  "unixdomainsocket",
+  Dependencies.UnixDomainSocket,
+  excludeFilter.in(unmanagedSources.in(headerCreate)) := HiddenFileFilter || "KQSelector.java"
+)
 
 lazy val xml = alpakkaProject("xml", "xml", Dependencies.Xml)
 

--- a/unix-domain-socket/src/main/java/jnr/enxio/channels/KQSelector.java
+++ b/unix-domain-socket/src/main/java/jnr/enxio/channels/KQSelector.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (C) 2008 Wayne Meissner
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// FIXME: This file can be removed once https://github.com/jnr/jnr-enxio/pull/28 is in.
+
+package jnr.enxio.channels;
+
+import jnr.constants.platform.Errno;
+import jnr.ffi.Memory;
+import jnr.ffi.Pointer;
+import jnr.ffi.StructLayout;
+import jnr.ffi.TypeAlias;
+import jnr.ffi.provider.jffi.NativeRuntime;
+
+import java.io.IOException;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.spi.AbstractSelectableChannel;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An implementation of a {@link java.nio.channels.Selector} that uses the BSD (including MacOS)
+ * kqueue(2) mechanism
+ */
+class KQSelector extends java.nio.channels.spi.AbstractSelector {
+  private static final boolean DEBUG = false;
+  private static final int MAX_EVENTS = 100;
+  private static final int EVFILT_READ = -1;
+  private static final int EVFILT_WRITE = -2;
+  private static final int EV_ADD = 0x0001;
+  private static final int EV_DELETE = 0x0002;
+  private static final int EV_ENABLE = 0x0004;
+  private static final int EV_DISABLE = 0x0008;
+  private static final int EV_CLEAR = 0x0020;
+
+  private int kqfd = -1;
+  private final jnr.ffi.Runtime runtime = NativeRuntime.getSystemRuntime();
+  private final Pointer changebuf;
+  private final Pointer eventbuf;
+  private final EventIO io = EventIO.getInstance();
+  private final int[] pipefd = {-1, -1};
+  private final Object regLock = new Object();
+  private final Map<Integer, Descriptor> descriptors = new ConcurrentHashMap<Integer, Descriptor>();
+  private final Set<SelectionKey> selected = new LinkedHashSet<SelectionKey>();
+  private final Native.Timespec ZERO_TIMESPEC = new Native.Timespec(0, 0);
+
+  public KQSelector(NativeSelectorProvider provider) {
+    super(provider);
+    changebuf = Memory.allocateDirect(runtime, MAX_EVENTS * io.size());
+    eventbuf = Memory.allocateDirect(runtime, MAX_EVENTS * io.size());
+
+    Native.libc().pipe(pipefd);
+
+    kqfd = Native.libc().kqueue();
+    io.put(changebuf, 0, pipefd[0], EVFILT_READ, EV_ADD);
+    Native.libc().kevent(kqfd, changebuf, 1, null, 0, ZERO_TIMESPEC);
+  }
+
+  private static class Descriptor {
+    private final int fd;
+    private final Set<KQSelectionKey> keys = new HashSet<KQSelectionKey>();
+    private boolean write = false, read = false;
+
+    public Descriptor(int fd) {
+      this.fd = fd;
+    }
+  }
+
+  @Override
+  protected void implCloseSelector() throws IOException {
+    if (kqfd != -1) {
+      Native.close(kqfd);
+    }
+    if (pipefd[0] != -1) {
+      Native.close(pipefd[0]);
+    }
+    if (pipefd[1] != -1) {
+      Native.close(pipefd[1]);
+    }
+    pipefd[0] = pipefd[1] = kqfd = -1;
+
+    // deregister all keys
+    for (Map.Entry<Integer, Descriptor> entry : descriptors.entrySet()) {
+      for (KQSelectionKey k : entry.getValue().keys) {
+        deregister(k);
+      }
+    }
+  }
+
+  @Override
+  protected SelectionKey register(AbstractSelectableChannel ch, int ops, Object att) {
+    KQSelectionKey k = new KQSelectionKey(this, (NativeSelectableChannel) ch, ops);
+    synchronized (regLock) {
+      Descriptor d = new Descriptor(k.getFD());
+      descriptors.put(k.getFD(), d);
+      d.keys.add(k);
+      handleChangedKey(d);
+    }
+    k.attach(att);
+    return k;
+  }
+
+  @Override
+  public Set<SelectionKey> keys() {
+    Set<SelectionKey> keys = new HashSet<SelectionKey>();
+    for (Descriptor fd : descriptors.values()) {
+      keys.addAll(fd.keys);
+    }
+    return Collections.unmodifiableSet(keys);
+  }
+
+  @Override
+  public Set<SelectionKey> selectedKeys() {
+    return selected;
+  }
+
+  @Override
+  public int selectNow() throws IOException {
+    return poll(0);
+  }
+
+  @Override
+  public int select(long timeout) throws IOException {
+    return poll(timeout);
+  }
+
+  @Override
+  public int select() throws IOException {
+    return poll(-1);
+  }
+
+  private int poll(long timeout) {
+
+    int nchanged = handleCancelledKeys();
+
+    Native.Timespec ts = null;
+    if (timeout >= 0) {
+      long sec = TimeUnit.MILLISECONDS.toSeconds(timeout);
+      long nsec = TimeUnit.MILLISECONDS.toNanos(timeout % 1000);
+      ts = new Native.Timespec(sec, nsec);
+    }
+
+    if (DEBUG) System.out.printf("nchanged=%d\n", nchanged);
+    int nready = 0;
+    try {
+      begin();
+      do {
+
+        nready = Native.libc().kevent(kqfd, changebuf, nchanged, eventbuf, MAX_EVENTS, ts);
+
+      } while (nready < 0 && Errno.EINTR.equals(Errno.valueOf(Native.getRuntime().getLastError())));
+
+      if (DEBUG) System.out.println("kevent returned " + nready + " events ready");
+
+    } finally {
+      end();
+    }
+
+    int updatedKeyCount = 0;
+    synchronized (regLock) {
+      for (int i = 0; i < nready; ++i) {
+        int fd = io.getFD(eventbuf, i);
+        Descriptor d = descriptors.get(fd);
+
+        if (d != null) {
+          int filt = io.getFilter(eventbuf, i);
+          if (DEBUG) System.out.printf("fd=%d filt=0x%x\n", d.fd, filt);
+          for (KQSelectionKey k : d.keys) {
+            int iops = k.interestOps();
+            int ops = 0;
+
+            if (filt == EVFILT_READ) {
+              ops |= iops & (SelectionKey.OP_ACCEPT | SelectionKey.OP_READ);
+            }
+            if (filt == EVFILT_WRITE) {
+              ops |= iops & (SelectionKey.OP_CONNECT | SelectionKey.OP_WRITE);
+            }
+            ++updatedKeyCount;
+            k.readyOps(ops);
+            if (!selected.contains(k)) {
+              selected.add(k);
+            }
+          }
+
+        } else if (fd == pipefd[0]) {
+          if (DEBUG) System.out.println("Waking up");
+          wakeupReceived();
+        }
+      }
+    }
+    return updatedKeyCount;
+  }
+
+  private int handleCancelledKeys() {
+    Set<SelectionKey> cancelled = cancelledKeys();
+    synchronized (cancelled) {
+      int nchanged = 0;
+      synchronized (regLock) {
+        for (SelectionKey k : cancelled) {
+          KQSelectionKey kqs = (KQSelectionKey) k;
+          Descriptor d = descriptors.get(kqs.getFD());
+          deregister(kqs);
+          synchronized (selected) {
+            selected.remove(kqs);
+          }
+          d.keys.remove(kqs);
+          if (d.keys.isEmpty()) {
+            io.put(changebuf, nchanged++, kqs.getFD(), EVFILT_READ, EV_DELETE);
+            io.put(changebuf, nchanged++, kqs.getFD(), EVFILT_WRITE, EV_DELETE);
+            descriptors.remove(kqs.getFD());
+          }
+          if (nchanged >= MAX_EVENTS) {
+            Native.libc().kevent(kqfd, changebuf, nchanged, null, 0, ZERO_TIMESPEC);
+            nchanged = 0;
+          }
+        }
+      }
+      cancelled.clear();
+      return nchanged;
+    }
+  }
+
+  private void handleChangedKey(Descriptor changed) {
+    synchronized (regLock) {
+      int _nchanged = 0;
+      int writers = 0, readers = 0;
+      for (KQSelectionKey k : changed.keys) {
+        if ((k.interestOps() & (SelectionKey.OP_ACCEPT | SelectionKey.OP_READ)) != 0) {
+          ++readers;
+        }
+        if ((k.interestOps() & (SelectionKey.OP_CONNECT | SelectionKey.OP_WRITE)) != 0) {
+          ++writers;
+        }
+      }
+      for (Integer filt : new Integer[] {EVFILT_READ, EVFILT_WRITE}) {
+        int flags = 0;
+        //
+        // If no one is interested in events on the fd, disable it
+        //
+        if (filt == EVFILT_READ) {
+          if (readers > 0 && !changed.read) {
+            flags = EV_ADD | EV_ENABLE | EV_CLEAR;
+            changed.read = true;
+          } else if (readers == 0 && changed.read) {
+            flags = EV_DISABLE;
+            changed.read = false;
+          }
+        }
+        if (filt == EVFILT_WRITE) {
+          if (writers > 0 && !changed.write) {
+            flags = EV_ADD | EV_ENABLE | EV_CLEAR;
+            changed.write = true;
+          } else if (writers == 0 && changed.write) {
+            flags = EV_DISABLE;
+            changed.write = false;
+          }
+        }
+        if (DEBUG)
+          System.out.printf("Updating fd %d filt=0x%x flags=0x%x\n", changed.fd, filt, flags);
+        if (flags != 0) {
+          io.put(changebuf, _nchanged++, changed.fd, filt, flags);
+        }
+      }
+
+      Native.libc().kevent(kqfd, changebuf, _nchanged, null, 0, ZERO_TIMESPEC);
+    }
+  }
+
+  private void wakeupReceived() {
+    Native.libc().read(pipefd[0], new byte[1], 1);
+  }
+
+  @Override
+  public Selector wakeup() {
+    Native.libc().write(pipefd[1], new byte[1], 1);
+    return this;
+  }
+
+  void interestOps(KQSelectionKey k, int ops) {
+    synchronized (regLock) {
+      handleChangedKey(descriptors.get(k.getFD()));
+    }
+  }
+
+  private static final class EventIO {
+    private static final EventIO INSTANCE = new EventIO();
+    private final EventLayout layout = new EventLayout(NativeRuntime.getSystemRuntime());
+    private final jnr.ffi.Type uintptr_t = layout.getRuntime().findType(TypeAlias.uintptr_t);
+
+    public static EventIO getInstance() {
+      return EventIO.INSTANCE;
+    }
+
+    public final void put(Pointer buf, int index, int fd, int filt, int flags) {
+      buf.putInt(uintptr_t, (index * layout.size()) + layout.ident.offset(), fd);
+      buf.putShort((index * layout.size()) + layout.filter.offset(), (short) filt);
+      buf.putInt((index * layout.size()) + layout.flags.offset(), flags);
+    }
+
+    public final int size() {
+      return layout.size();
+    }
+
+    int getFD(Pointer ptr, int index) {
+      return (int) ptr.getInt(uintptr_t, (index * layout.size()) + layout.ident.offset());
+    }
+
+    public final void putFilter(Pointer buf, int index, int filter) {
+      buf.putShort((index * layout.size()) + layout.filter.offset(), (short) filter);
+    }
+
+    public final int getFilter(Pointer buf, int index) {
+      return buf.getShort((index * layout.size()) + layout.filter.offset());
+    }
+
+    public final void putFlags(Pointer buf, int index, int flags) {
+      buf.putShort((index * layout.size()) + layout.flags.offset(), (short) flags);
+    }
+  }
+
+  private static class EventLayout extends StructLayout {
+    private EventLayout(jnr.ffi.Runtime runtime) {
+      super(runtime);
+    }
+
+    public final uintptr_t ident = new uintptr_t();
+    public final int16_t filter = new int16_t();
+    public final u_int16_t flags = new u_int16_t();
+    public final u_int32_t fflags = new u_int32_t();
+    public final intptr_t data = new intptr_t();
+    public final Pointer udata = new Pointer();
+  }
+}

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -298,7 +298,7 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
               sendReceiveContext.send = if (halfClose) ShutdownRequested else CloseRequested
               sel.wakeup()
             }
-            (m, done)
+            Keep.left
         }
         .to(Sink.ignore)
     )

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -97,7 +97,9 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
 
   private class SendReceiveContext(
       @volatile var send: SendContext,
-      @volatile var receive: ReceiveContext
+      @volatile var sendClosed: Boolean,
+      @volatile var receive: ReceiveContext,
+      @volatile var receiveClosed: Boolean
   )
 
   /*
@@ -148,9 +150,15 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
                   case CloseRequested =>
                     key.cancel()
                     key.channel.close()
+                    sendReceiveContext.receiveClosed = true
+                    sendReceiveContext.sendClosed = true
                   case ShutdownRequested =>
                     try {
                       key.channel().asInstanceOf[UnixSocketChannel].shutdownOutput()
+                      sendReceiveContext.sendClosed = true
+                      if (sendReceiveContext.receiveClosed && sendReceiveContext.sendClosed) {
+                        key.channel().close()
+                      }
                     } catch {
                       // socket could have been closed in the meantime, so shutdownOutput will throw this
                       case _: IOException =>
@@ -180,6 +188,7 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
                       queue.complete()
                       try {
                         channel.shutdownInput()
+                        sendReceiveContext.receiveClosed = true
                       } catch {
                         // socket could have been closed in the meantime, so shutdownInput will throw this
                         case _: IOException =>
@@ -194,6 +203,8 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
                         sendReceiveContext.receive = ReceiveAvailable(receiveQueue, receiveBuffer)
                         key.interestOps(key.interestOps() | SelectionKey.OP_READ)
                       case _ =>
+                        sendReceiveContext.receiveClosed = true
+                        sendReceiveContext.sendClosed = true
                         receiveQueue.complete()
                         key.cancel()
                         key.channel.close()
@@ -264,7 +275,9 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
     val sendReceiveContext =
       new SendReceiveContext(
         SendAvailable(ByteBuffer.allocate(sendBufferSize)),
-        ReceiveAvailable(receiveQueue, ByteBuffer.allocate(receiveBufferSize))
+        false,
+        ReceiveAvailable(receiveQueue, ByteBuffer.allocate(receiveBufferSize)),
+        false
       ) // FIXME: No need for the costly allocation of direct buffers yet given https://github.com/jnr/jnr-unixsocket/pull/49
 
     val sendSink = Sink.fromGraph(

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -524,7 +524,7 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends Extension {
       channel
         .register(sel, SelectionKey.OP_CONNECT, connectKey(remoteAddress, connectionFinished, cancellable, context) _)
     val connection = Try(channel.connect(remoteAddress))
-    connection.failed.foreach(e => connectionFinished.failure(e))
+    connection.failed.foreach(e => connectionFinished.tryFailure(e))
 
     connectionFlow
       .merge(Source.fromFuture(connectionFinished.future.map(_ => ByteString.empty)))

--- a/unix-domain-socket/src/test/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocketSpec.scala
+++ b/unix-domain-socket/src/test/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocketSpec.scala
@@ -12,7 +12,10 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.testkit._
 import akka.util.ByteString
+import jnr.unixsocket.UnixSocketAddress
 import org.scalatest._
+
+import scala.concurrent.duration._
 
 class UnixDomainSocketSpec
     extends TestKit(ActorSystem("UnixDomainSocketSpec"))
@@ -54,6 +57,56 @@ class UnixDomainSocketSpec
       //#outgoingConnection
       }
       //#outgoingConnection
+    }
+
+    "allow the client to close the connection" in {
+      val file = Files.createTempFile("UnixDomainSocketSpec2", ".sock").toFile
+      file.delete()
+      file.deleteOnExit()
+
+      val sendBytes = ByteString("Hello")
+
+      val binding =
+        UnixDomainSocket().bindAndHandle(Flow[ByteString]
+                                           .delay(5.seconds)
+                                           .map(identity),
+                                         file)
+
+      binding.flatMap { connection =>
+        Source
+          .single(sendBytes)
+          .via(UnixDomainSocket().outgoingConnection(new UnixSocketAddress(file), halfClose = false))
+          .runWith(Sink.headOption)
+          .flatMap {
+            case e if e.isEmpty => connection.unbind().map(_ => succeed)
+          }
+      }
+    }
+
+    "close the server once the client is also closed" in {
+      val file = Files.createTempFile("UnixDomainSocketSpec3", ".sock").toFile
+      file.delete()
+      file.deleteOnExit()
+
+      val sendBytes = ByteString("Hello")
+
+      val binding =
+        UnixDomainSocket().bindAndHandle(
+          Flow
+            .fromSinkAndSource(Sink.ignore, Source.single(sendBytes).delay(1.second)),
+          file,
+          halfClose = true
+        )
+
+      binding.flatMap { connection =>
+        Source
+          .empty[ByteString]
+          .via(UnixDomainSocket().outgoingConnection(file))
+          .runWith(Sink.headOption)
+          .flatMap {
+            case e if e.nonEmpty => connection.unbind().map(_ => succeed)
+          }
+      }
     }
 
     "not be able to bind to a non-existent file" in {

--- a/unix-domain-socket/src/test/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocketSpec.scala
+++ b/unix-domain-socket/src/test/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocketSpec.scala
@@ -31,15 +31,9 @@ class UnixDomainSocketSpec
       file.delete()
       file.deleteOnExit()
 
-      //#handler
-      val handler = Flow[ByteString]
-        .fold(ByteString.empty)(_ ++ _)
-        .flatMapConcat(bytes => Source.single(bytes ++ bytes))
-      //#handler
-
       //#binding
       val binding =
-        UnixDomainSocket().bindAndHandle(handler, file)
+        UnixDomainSocket().bindAndHandle(Flow.fromFunction(identity), file)
       //#binding
 
       //#outgoingConnection
@@ -52,7 +46,7 @@ class UnixDomainSocketSpec
             .runWith(Sink.head)
         //#outgoingConnection
         result
-          .map(receiveBytes => assert(receiveBytes == sendBytes ++ sendBytes))
+          .map(receiveBytes => assert(receiveBytes == sendBytes))
           .flatMap {
             case `succeed` => connection.unbind().map(_ => succeed)
             case failedAssertion => failedAssertion


### PR DESCRIPTION
This PR includes a number of improvements to the `halfClose` handling of the Unix Domain Socket. `halfClose` is particularly relevant for clients (and enabled by default), as they will close their write side to signal end of input, but will still wish to read data from the server.

The main changes here are to call `shutdownOutput` and `shutdownInput` where appropriate, instead of closing the channel. Additionally, a bug in JNR is worked around which was causing some NIO events to be lost.

Fixes https://github.com/akka/alpakka/issues/1139