### PR TITLE
Reference flow that needs a resource

### DIFF
--- a/reference/src/main/scala/akka/stream/alpakka/reference/Resource.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/Resource.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.reference
+import akka.actor.{ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import akka.stream.scaladsl.Flow
+import akka.util.ByteString
+
+final class Resource {
+  // a resource that is to be kept once instance per ActorSystem
+  val connection = Flow[ByteString]
+}
+
+final class ResourceExt private (sys: ExtendedActorSystem) extends Extension {
+  implicit val resource = new Resource()
+}
+
+object ResourceExt extends ExtensionId[ResourceExt] with ExtensionIdProvider {
+  override def lookup = ResourceExt
+  override def createExtension(system: ExtendedActorSystem) = new ResourceExt(system)
+
+  /**
+   * Access to extension.
+   */
+  def apply()(implicit system: ActorSystem): ResourceExt = super.apply(system)
+
+  /**
+   * Java API
+   *
+   * Access to extension.
+   */
+  override def get(system: ActorSystem): ResourceExt = super.get(system)
+}

--- a/reference/src/main/scala/akka/stream/alpakka/reference/impl/ReferenceWithResourceFlow.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/impl/ReferenceWithResourceFlow.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.reference.impl
+
+import akka.annotation.InternalApi
+import akka.event.Logging
+import akka.stream.alpakka.reference.{ReferenceWriteMessage, Resource}
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+
+/**
+ * INTERNAL API
+ *
+ * Private package hides the class from the API in Scala. However it is still
+ * visible in Java. Use "InternalApi" annotation and "INTERNAL API" as the first
+ * line in scaladoc to communicate to Java developers that this is private API.
+ */
+@InternalApi private[reference] final class ReferenceWithResourceFlowStageLogic(
+    val resource: Resource,
+    val shape: FlowShape[ReferenceWriteMessage, ReferenceWriteMessage]
+) extends GraphStageLogic(shape) {
+
+  private def in = shape.in
+  private def out = shape.out
+
+  /**
+   * Initialization logic
+   */
+  override def preStart(): Unit = {}
+
+  setHandler(
+    in,
+    new InHandler {
+      override def onPush(): Unit =
+        push(out, grab(in))
+    }
+  )
+
+  setHandler(out, new OutHandler {
+    override def onPull(): Unit = pull(in)
+  })
+
+  /**
+   * Cleanup logic
+   */
+  override def postStop(): Unit = {}
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[reference] final class ReferenceWithResourceFlow(resource: Resource)
+    extends GraphStage[FlowShape[ReferenceWriteMessage, ReferenceWriteMessage]] {
+  val in: Inlet[ReferenceWriteMessage] = Inlet(Logging.simpleName(this) + ".in")
+  val out: Outlet[ReferenceWriteMessage] = Outlet(Logging.simpleName(this) + ".out")
+
+  override def initialAttributes: Attributes =
+    Attributes.name(Logging.simpleName(this))
+
+  override val shape: FlowShape[ReferenceWriteMessage, ReferenceWriteMessage] = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new ReferenceWithResourceFlowStageLogic(resource, shape)
+}

--- a/reference/src/main/scala/akka/stream/alpakka/reference/javadsl/ReferenceWithResource.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/javadsl/ReferenceWithResource.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.reference.javadsl
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.alpakka.reference.{scaladsl, ReferenceWriteMessage, Resource}
+import akka.stream.javadsl.Flow
+
+object ReferenceWithResource {
+  def flow(sys: ActorSystem): Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+    scaladsl.ReferenceWithResource.flow()(sys).asJava
+}
+
+object ReferenceWithExternalResource {
+  def flow(r: Resource): Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+    scaladsl.ReferenceWithExternalResource.flow()(r).asJava
+}

--- a/reference/src/main/scala/akka/stream/alpakka/reference/scaladsl/ReferenceWithResource.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/scaladsl/ReferenceWithResource.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.reference.scaladsl
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.alpakka.reference.impl.ReferenceWithResourceFlow
+import akka.stream.alpakka.reference.{ReferenceWriteMessage, Resource, ResourceExt}
+import akka.stream.scaladsl.Flow
+
+object ReferenceWithResource {
+  def flow()(implicit sys: ActorSystem): Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+    ReferenceWithExternalResource.flow()(ResourceExt().resource)
+}
+
+object ReferenceWithExternalResource {
+  def flow()(implicit r: Resource): Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+    Flow.fromGraph(new ReferenceWithResourceFlow(r))
+}

--- a/reference/src/test/java/docs/javadsl/ReferenceWithResourceTest.java
+++ b/reference/src/test/java/docs/javadsl/ReferenceWithResourceTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.javadsl;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.alpakka.reference.ReferenceWriteMessage;
+import akka.stream.alpakka.reference.Resource;
+import akka.stream.alpakka.reference.ResourceExt;
+import akka.stream.alpakka.reference.javadsl.ReferenceWithExternalResource;
+import akka.stream.alpakka.reference.javadsl.ReferenceWithResource;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.testkit.javadsl.TestKit;
+import org.junit.*;
+
+/** Append "Test" to every Java test suite. */
+public class ReferenceWithResourceTest {
+
+  static ActorSystem sys;
+  static Materializer mat;
+
+  static final String clientId = "test-client-id";
+
+  /** Called before test suite. */
+  @BeforeClass
+  public static void setUpBeforeClass() {
+    sys = ActorSystem.create("ReferenceTest");
+    mat = ActorMaterializer.create(sys);
+  }
+
+  /** Called before every test. */
+  @Before
+  public void setUp() {}
+
+  @Test
+  public void useGlobalResource() {
+    final Flow<ReferenceWriteMessage, ReferenceWriteMessage, NotUsed> flow =
+        ReferenceWithResource.flow(sys);
+
+    Source.single(ReferenceWriteMessage.create()).via(flow).to(Sink.seq()).run(mat);
+  }
+
+  @Test
+  public void useExternalResource() {
+    final Resource resource = ResourceExt.get(sys).resource();
+    final Flow<ReferenceWriteMessage, ReferenceWriteMessage, NotUsed> flow =
+        ReferenceWithExternalResource.flow(resource);
+
+    Source.single(ReferenceWriteMessage.create()).via(flow).to(Sink.seq()).run(mat);
+  }
+
+  /** Called after every test. */
+  @After
+  public void tearDown() {}
+
+  /** Called after test suite. */
+  @AfterClass
+  public static void tearDownAfterClass() {
+    TestKit.shutdownActorSystem(sys);
+  }
+}

--- a/reference/src/test/scala/docs/scaladsl/ReferenceWithResourceSpec.scala
+++ b/reference/src/test/scala/docs/scaladsl/ReferenceWithResourceSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.scaladsl
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.reference.{ReferenceWriteMessage, ResourceExt}
+import akka.stream.alpakka.reference.scaladsl.{ReferenceWithExternalResource, ReferenceWithResource}
+import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.testkit.TestKit
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.concurrent.ScalaFutures
+
+/**
+ * Append "Spec" to every Scala test suite.
+ */
+class ReferenceWithResourceSpec extends WordSpec with BeforeAndAfterAll with ScalaFutures with Matchers {
+
+  implicit val sys = ActorSystem("ReferenceSpec")
+  implicit val mat = ActorMaterializer()
+
+  final val ClientId = "test-client-id"
+
+  "reference with resource connector" should {
+
+    "use global resource" in {
+      val flow: Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+        ReferenceWithResource.flow()
+
+      Source
+        .single(ReferenceWriteMessage())
+        .via(flow)
+        .to(Sink.seq)
+        .run()
+    }
+
+    "use external resource" in {
+      implicit val resource = ResourceExt().resource
+      val flow = ReferenceWithExternalResource.flow()
+
+      Source
+        .single(ReferenceWriteMessage())
+        .via(flow)
+        .to(Sink.seq)
+        .run()
+    }
+  }
+
+  override def afterAll() =
+    TestKit.shutdownActorSystem(sys)
+}


### PR DESCRIPTION
Introduces an extension that is used to hold a resource per ActorSystem. One of the usecases for such pattern is the DynamoDB connector.