### PR TITLE
JMS producer multi session

### DIFF
--- a/docs/src/main/paradox/jms.md
+++ b/docs/src/main/paradox/jms.md
@@ -192,6 +192,24 @@ Scala
 Java
 : @@snip [snip](/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #run-flow-producer }
 
+### Configuring the Producer
+
+Scala
+: @@snip [snip](/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsSettingsSpec.scala) { #producer-settings }
+
+Java
+: @@snip [snip](/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsSettingsTest.java) { #producer-settings }
+
+The producer can be configured with the following settings.
+
+* `connectionFactory` (mandatory) the factory to use for creating Jms connections.
+* `destination` (mandatory) the destination (queue or topic) to send Jms messgages to.
+* `credentials` (optional) username and password to use for authentication to the Jms broker .
+* `sessionCount` (defaults to 1) the number of parallel sessions to use for sending Jms messages. Increasing the 
+  number of parallel sessions increases throughput at the cost of message ordering. While the messages may arrive
+  out of order at the Jms broker, the producer flow outputs messages in the order they are received.
+* `timeToLive`  (optional) the time messages should be kept on the Jms broker. This setting can be overridden on 
+  individual messages. If not set, messages will never expire.
 
 ## Receiving messages from a JMS provider
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/Exceptions.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Exceptions.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.jms
+
+trait RecoverableException extends Exception
+
+trait NonRecoverableException extends Exception
+
+case class UnsupportedMessagePropertyType(propertyName: String, propertyValue: Any, message: JmsMessage)
+    extends Exception(
+      s"Jms property '$propertyName' has unknown type '${propertyValue.getClass.getName}'. " +
+      "Only primitive types and String are supported as property values."
+    )
+    with NonRecoverableException
+
+case class NullMessageProperty(propertyName: String, message: JmsMessage)
+    extends Exception(
+      s"null value was given for Jms property '$propertyName'."
+    )
+    with NonRecoverableException
+
+case class UnsupportedMapMessageEntryType(entryName: String, entryValue: Any, message: JmsMapMessage)
+    extends Exception(
+      s"Jms MapMessage entry '$entryName' has unknown type '${entryValue.getClass.getName}'. " +
+      "Only primitive types, String, and Byte array are supported as entry values."
+    )
+    with NonRecoverableException
+
+case class NullMapMessageEntry(entryName: String, message: JmsMapMessage)
+    extends Exception(
+      s"null value was given for Jms MapMessage entry '$entryName'."
+    )
+    with NonRecoverableException

--- a/jms/src/main/scala/akka/stream/alpakka/jms/Exceptions.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Exceptions.scala
@@ -4,32 +4,38 @@
 
 package akka.stream.alpakka.jms
 
-trait RecoverableException extends Exception
+/**
+ * Marker trait indicating that the exception thrown is intermittent. The failed operation might succeed if tried again.
+ */
+trait RetriableException extends Exception
 
-trait NonRecoverableException extends Exception
+/**
+ * Marker trait indicating that the exception thrown is persistent. The operation will always fail when retried.
+ */
+trait NonRetriableException extends Exception
 
 case class UnsupportedMessagePropertyType(propertyName: String, propertyValue: Any, message: JmsMessage)
     extends Exception(
       s"Jms property '$propertyName' has unknown type '${propertyValue.getClass.getName}'. " +
       "Only primitive types and String are supported as property values."
     )
-    with NonRecoverableException
+    with NonRetriableException
 
 case class NullMessageProperty(propertyName: String, message: JmsMessage)
     extends Exception(
       s"null value was given for Jms property '$propertyName'."
     )
-    with NonRecoverableException
+    with NonRetriableException
 
 case class UnsupportedMapMessageEntryType(entryName: String, entryValue: Any, message: JmsMapMessage)
     extends Exception(
       s"Jms MapMessage entry '$entryName' has unknown type '${entryValue.getClass.getName}'. " +
       "Only primitive types, String, and Byte array are supported as entry values."
     )
-    with NonRecoverableException
+    with NonRetriableException
 
 case class NullMapMessageEntry(entryName: String, message: JmsMapMessage)
     extends Exception(
       s"null value was given for Jms MapMessage entry '$entryName'."
     )
-    with NonRecoverableException
+    with NonRetriableException

--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -88,10 +88,12 @@ object JmsProducerSettings {
 final case class JmsProducerSettings(connectionFactory: ConnectionFactory,
                                      destination: Option[Destination] = None,
                                      credentials: Option[Credentials] = None,
+                                     sessionCount: Int = 1,
                                      timeToLive: Option[Duration] = None,
                                      acknowledgeMode: Option[AcknowledgeMode] = None)
     extends JmsSettings {
   def withCredential(credentials: Credentials): JmsProducerSettings = copy(credentials = Some(credentials))
+  def withSessionCount(count: Int): JmsProducerSettings = copy(sessionCount = count)
   def withQueue(name: String): JmsProducerSettings = copy(destination = Some(Queue(name)))
   def withTopic(name: String): JmsProducerSettings = copy(destination = Some(Topic(name)))
   def withDestination(destination: Destination): JmsProducerSettings = copy(destination = Some(destination))

--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -30,6 +30,7 @@ sealed trait JmsSettings {
   def destination: Option[Destination]
   def credentials: Option[Credentials]
   def acknowledgeMode: Option[AcknowledgeMode]
+  def sessionCount: Int
 }
 
 sealed trait Destination {
@@ -116,6 +117,7 @@ final case class JmsBrowseSettings(connectionFactory: ConnectionFactory,
                                    selector: Option[String] = None,
                                    acknowledgeMode: Option[AcknowledgeMode] = None)
     extends JmsSettings {
+  override val sessionCount = 1
   def withCredential(credentials: Credentials): JmsBrowseSettings = copy(credentials = Some(credentials))
   def withQueue(name: String): JmsBrowseSettings = copy(destination = Some(Queue(name)))
   def withDestination(destination: Destination): JmsBrowseSettings = copy(destination = Some(destination))

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -40,7 +40,7 @@ private[jms] trait JmsConnector { this: GraphStageLogic =>
       onSessionOpened(session)
     }
 
-  private[jms] def executionContext(attributes: Attributes): ExecutionContext = {
+  protected def executionContext(attributes: Attributes): ExecutionContext = {
     val dispatcher = attributes.get[ActorAttributes.Dispatcher](
       ActorAttributes.Dispatcher("akka.stream.default-blocking-io-dispatcher")
     ) match {
@@ -55,7 +55,7 @@ private[jms] trait JmsConnector { this: GraphStageLogic =>
     }
   }
 
-  private[jms] def initSessionAsync(executionContext: ExecutionContext): Future[Unit] = {
+  protected def initSessionAsync(executionContext: ExecutionContext): Future[Unit] = {
     ec = executionContext
     val future = Future {
       val sessions = openSessions()
@@ -136,7 +136,7 @@ private[jms] class JmsMessageProducer(jmsProducer: MessageProducer, jmsSession: 
   private def findHeader[T](headersDuringSend: Set[JmsHeader])(f: PartialFunction[JmsHeader, T]): Option[T] =
     headersDuringSend.collectFirst(f)
 
-  private def createMessage(element: JmsMessage): Message =
+  private[jms] def createMessage(element: JmsMessage): Message =
     element match {
 
       case textMessage: JmsTextMessage => jmsSession.session.createTextMessage(textMessage.body)
@@ -155,7 +155,7 @@ private[jms] class JmsMessageProducer(jmsProducer: MessageProducer, jmsSession: 
 
     }
 
-  private def populateMessageProperties(message: javax.jms.Message, jmsMessage: JmsMessage): Unit =
+  private[jms] def populateMessageProperties(message: javax.jms.Message, jmsMessage: JmsMessage): Unit =
     jmsMessage.properties().foreach {
       case (key, v) =>
         v match {

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -91,8 +91,8 @@ private[jms] trait JmsConnector { this: GraphStageLogic =>
     }
 
     val sessionCount = jmsSettings match {
-      case settings: JmsConsumerSettings =>
-        settings.sessionCount
+      case settings: JmsConsumerSettings => settings.sessionCount
+      case settings: JmsProducerSettings => settings.sessionCount
       case _ => 1
     }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -5,12 +5,12 @@
 package akka.stream.alpakka.jms
 
 import java.util.concurrent.ArrayBlockingQueue
+
 import javax.jms
 import javax.jms._
-
-import akka.stream.ActorAttributes.Dispatcher
-import akka.stream.ActorMaterializer
+import akka.stream.{ActorAttributes, ActorMaterializer, Attributes}
 import akka.stream.stage.GraphStageLogic
+
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -40,11 +40,23 @@ private[jms] trait JmsConnector { this: GraphStageLogic =>
       onSessionOpened(session)
     }
 
-  private[jms] def initSessionAsync(dispatcher: Dispatcher): Future[Unit] = {
-    ec = materializer match {
+  private[jms] def executionContext(attributes: Attributes): ExecutionContext = {
+    val dispatcher = attributes.get[ActorAttributes.Dispatcher](
+      ActorAttributes.Dispatcher("akka.stream.default-blocking-io-dispatcher")
+    ) match {
+      case ActorAttributes.Dispatcher("") =>
+        ActorAttributes.Dispatcher("akka.stream.default-blocking-io-dispatcher")
+      case d => d
+    }
+
+    materializer match {
       case m: ActorMaterializer => m.system.dispatchers.lookup(dispatcher.dispatcher)
       case x => throw new IllegalArgumentException(s"Stage only works with the ActorMaterializer, was: $x")
     }
+  }
+
+  private[jms] def initSessionAsync(executionContext: ExecutionContext): Future[Unit] = {
+    ec = executionContext
     val future = Future {
       val sessions = openSessions()
       sessions foreach { session =>
@@ -88,6 +100,96 @@ private[jms] trait JmsConnector { this: GraphStageLogic =>
       createSession(connection, createDestination)
     }
   }
+}
+
+private[jms] object JmsMessageProducer {
+  def apply(jmsSession: JmsSession, settings: JmsProducerSettings): JmsMessageProducer = {
+    val producer = jmsSession.session.createProducer(jmsSession.destination)
+    if (settings.timeToLive.nonEmpty) {
+      producer.setTimeToLive(settings.timeToLive.get.toMillis)
+    }
+    new JmsMessageProducer(producer, jmsSession)
+  }
+}
+
+private[jms] class JmsMessageProducer(jmsProducer: MessageProducer, jmsSession: JmsSession) {
+
+  def send(elem: JmsMessage): Unit = {
+    val message: Message = createMessage(elem)
+    populateMessageProperties(message, elem.properties())
+
+    val (sendHeaders, headersBeforeSend: Set[JmsHeader]) = elem.headers.partition(_.usedDuringSend)
+    populateMessageHeader(message, headersBeforeSend)
+
+    val deliveryModeOption = findHeader(sendHeaders) { case x: JmsDeliveryMode => x.deliveryMode }
+    val priorityOption = findHeader(sendHeaders) { case x: JmsPriority => x.priority }
+    val timeToLiveInMillisOption = findHeader(sendHeaders) { case x: JmsTimeToLive => x.timeInMillis }
+
+    jmsProducer.send(
+      message,
+      deliveryModeOption.getOrElse(jmsProducer.getDeliveryMode),
+      priorityOption.getOrElse(jmsProducer.getPriority),
+      timeToLiveInMillisOption.getOrElse(jmsProducer.getTimeToLive)
+    )
+  }
+
+  private def findHeader[T](headersDuringSend: Set[JmsHeader])(f: PartialFunction[JmsHeader, T]): Option[T] =
+    headersDuringSend.collectFirst(f)
+
+  private def createMessage(element: JmsMessage): Message =
+    element match {
+
+      case textMessage: JmsTextMessage => jmsSession.session.createTextMessage(textMessage.body)
+
+      case byteMessage: JmsByteMessage =>
+        val newMessage = jmsSession.session.createBytesMessage()
+        newMessage.writeBytes(byteMessage.bytes)
+        newMessage
+
+      case mapMessage: JmsMapMessage =>
+        val newMessage = jmsSession.session.createMapMessage()
+        populateMapMessage(newMessage, mapMessage.body)
+        newMessage
+
+      case objectMessage: JmsObjectMessage => jmsSession.session.createObjectMessage(objectMessage.serializable)
+
+    }
+
+  private def populateMessageProperties(message: javax.jms.Message, properties: Map[String, Any]): Unit =
+    properties.foreach {
+      case (key, v) =>
+        v match {
+          case v: String => message.setStringProperty(key, v)
+          case v: Int => message.setIntProperty(key, v)
+          case v: Boolean => message.setBooleanProperty(key, v)
+          case v: Byte => message.setByteProperty(key, v)
+          case v: Short => message.setShortProperty(key, v)
+          case v: Long => message.setLongProperty(key, v)
+          case v: Double => message.setDoubleProperty(key, v)
+        }
+    }
+
+  private def populateMapMessage(message: javax.jms.MapMessage, map: Map[String, Any]): Unit =
+    map.foreach {
+      case (key, v) =>
+        v match {
+          case v: String => message.setString(key, v)
+          case v: Int => message.setInt(key, v)
+          case v: Boolean => message.setBoolean(key, v)
+          case v: Byte => message.setByte(key, v)
+          case v: Short => message.setShort(key, v)
+          case v: Long => message.setLong(key, v)
+          case v: Double => message.setDouble(key, v)
+          case v: Array[Byte] => message.setBytes(key, v)
+        }
+    }
+
+  private def populateMessageHeader(message: javax.jms.Message, headers: Set[JmsHeader]): Unit =
+    headers.foreach {
+      case JmsType(jmsType) => message.setJMSType(jmsType)
+      case JmsReplyTo(destination) => message.setJMSReplyTo(destination.create(jmsSession.session))
+      case JmsCorrelationId(jmsCorrelationId) => message.setJMSCorrelationID(jmsCorrelationId)
+    }
 }
 
 private[jms] class JmsSession(val connection: jms.Connection,

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -90,13 +90,7 @@ private[jms] trait JmsConnector { this: GraphStageLogic =>
       case _ => throw new IllegalArgumentException("Destination is missing")
     }
 
-    val sessionCount = jmsSettings match {
-      case settings: JmsConsumerSettings => settings.sessionCount
-      case settings: JmsProducerSettings => settings.sessionCount
-      case _ => 1
-    }
-
-    0 until sessionCount map { _ =>
+    0 until jmsSettings.sessionCount map { _ =>
       createSession(connection, createDestination)
     }
   }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
@@ -222,20 +222,11 @@ abstract class SourceStageLogic[T](shape: SourceShape[T],
     failStage(ex)
   }
 
-  private[jms] def getDispatcher =
-    attributes.get[ActorAttributes.Dispatcher](
-      ActorAttributes.Dispatcher("akka.stream.default-blocking-io-dispatcher")
-    ) match {
-      case ActorAttributes.Dispatcher("") =>
-        ActorAttributes.Dispatcher("akka.stream.default-blocking-io-dispatcher")
-      case d => d
-    }
-
   private[jms] val handleError = getAsyncCallback[Throwable] { e =>
     fail(out, e)
   }
 
-  override def preStart(): Unit = initSessionAsync(getDispatcher)
+  override def preStart(): Unit = initSessionAsync(executionContext(attributes))
 
   private[jms] val handleMessage = getAsyncCallback[T] { msg =>
     if (isAvailable(out)) {

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
@@ -33,18 +33,19 @@ private[jms] final class JmsConsumerStage(settings: JmsConsumerSettings)
 
       private val backpressure = new Semaphore(bufferSize)
 
-      private[jms] def createSession(connection: Connection, createDestination: Session => javax.jms.Destination) = {
+      protected def createSession(connection: Connection,
+                                  createDestination: Session => javax.jms.Destination): JmsSession = {
         val session =
           connection.createSession(false, settings.acknowledgeMode.getOrElse(AcknowledgeMode.AutoAcknowledge).mode)
         new JmsSession(connection, session, createDestination(session))
       }
 
-      private[jms] def pushMessage(msg: Message): Unit = {
+      protected def pushMessage(msg: Message): Unit = {
         push(out, msg)
         backpressure.release()
       }
 
-      override private[jms] def onSessionOpened(jmsSession: JmsSession): Unit =
+      override protected def onSessionOpened(jmsSession: JmsSession): Unit =
         jmsSession
           .createConsumer(settings.selector)
           .onComplete {
@@ -76,15 +77,16 @@ final class JmsAckSourceStage(settings: JmsConsumerSettings)
     val logic = new SourceStageLogic[AckEnvelope](shape, out, settings, inheritedAttributes) {
       private val maxPendingAck = settings.bufferSize
 
-      private[jms] def createSession(connection: Connection, createDestination: Session => javax.jms.Destination) = {
+      protected def createSession(connection: Connection,
+                                  createDestination: Session => javax.jms.Destination): JmsAckSession = {
         val session =
           connection.createSession(false, settings.acknowledgeMode.getOrElse(AcknowledgeMode.ClientAcknowledge).mode)
         new JmsAckSession(connection, session, createDestination(session), settings.bufferSize)
       }
 
-      private[jms] def pushMessage(msg: AckEnvelope): Unit = push(out, msg)
+      protected def pushMessage(msg: AckEnvelope): Unit = push(out, msg)
 
-      override private[jms] def onSessionOpened(jmsSession: JmsSession): Unit =
+      override protected def onSessionOpened(jmsSession: JmsSession): Unit =
         jmsSession match {
           case session: JmsAckSession =>
             session.createConsumer(settings.selector).onComplete {
@@ -153,15 +155,15 @@ final class JmsTxSourceStage(settings: JmsConsumerSettings)
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, KillSwitch) = {
     val logic = new SourceStageLogic[TxEnvelope](shape, out, settings, inheritedAttributes) {
-      private[jms] def createSession(connection: Connection, createDestination: Session => javax.jms.Destination) = {
+      protected def createSession(connection: Connection, createDestination: Session => javax.jms.Destination) = {
         val session =
           connection.createSession(true, settings.acknowledgeMode.getOrElse(AcknowledgeMode.SessionTransacted).mode)
         new JmsTxSession(connection, session, createDestination(session))
       }
 
-      private[jms] def pushMessage(msg: TxEnvelope): Unit = push(out, msg)
+      protected def pushMessage(msg: TxEnvelope): Unit = push(out, msg)
 
-      override private[jms] def onSessionOpened(jmsSession: JmsSession): Unit =
+      override protected def onSessionOpened(jmsSession: JmsSession): Unit =
         jmsSession match {
           case session: JmsTxSession =>
             session.createConsumer(settings.selector).onComplete {
@@ -207,7 +209,7 @@ abstract class SourceStageLogic[T](shape: SourceShape[T],
     with JmsConnector
     with StageLogging {
 
-  override private[jms] def jmsSettings = settings
+  override protected def jmsSettings: JmsConsumerSettings = settings
   private val queue = mutable.Queue[T]()
   private val stopping = new AtomicBoolean(false)
   private var stopped = false
@@ -241,7 +243,7 @@ abstract class SourceStageLogic[T](shape: SourceShape[T],
     }
   }
 
-  private[jms] def pushMessage(msg: T): Unit
+  protected def pushMessage(msg: T): Unit
 
   setHandler(out, new OutHandler {
     override def onPull(): Unit = {

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsExceptions.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsExceptions.scala
@@ -5,37 +5,32 @@
 package akka.stream.alpakka.jms
 
 /**
- * Marker trait indicating that the exception thrown is intermittent. The failed operation might succeed if tried again.
- */
-trait RetriableException extends Exception
-
-/**
  * Marker trait indicating that the exception thrown is persistent. The operation will always fail when retried.
  */
-trait NonRetriableException extends Exception
+trait NonRetriableJmsException extends Exception
 
 case class UnsupportedMessagePropertyType(propertyName: String, propertyValue: Any, message: JmsMessage)
     extends Exception(
       s"Jms property '$propertyName' has unknown type '${propertyValue.getClass.getName}'. " +
       "Only primitive types and String are supported as property values."
     )
-    with NonRetriableException
+    with NonRetriableJmsException
 
 case class NullMessageProperty(propertyName: String, message: JmsMessage)
     extends Exception(
       s"null value was given for Jms property '$propertyName'."
     )
-    with NonRetriableException
+    with NonRetriableJmsException
 
 case class UnsupportedMapMessageEntryType(entryName: String, entryValue: Any, message: JmsMapMessage)
     extends Exception(
       s"Jms MapMessage entry '$entryName' has unknown type '${entryValue.getClass.getName}'. " +
       "Only primitive types, String, and Byte array are supported as entry values."
     )
-    with NonRetriableException
+    with NonRetriableJmsException
 
 case class NullMapMessageEntry(entryName: String, message: JmsMapMessage)
     extends Exception(
       s"null value was given for Jms MapMessage entry '$entryName'."
     )
-    with NonRetriableException
+    with NonRetriableJmsException

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -31,11 +31,20 @@ private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducer
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with JmsConnector {
 
+      /*
+       * NOTE: the following code is heavily inspired by akka.stream.impl.fusing.MapAsync
+       *
+       * To get a condensed view of what the buffers and handler behavior is about, have a look there too.
+       */
+
       private lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
 
+      // available producers for sending messages. Initially full, but might contain less elements if
+      // messages are currently in-flight.
       private val jmsProducers: Buffer[JmsMessageProducer] = Buffer(settings.sessionCount, settings.sessionCount)
 
-      private val buffer: Buffer[Holder[A]] = Buffer(settings.sessionCount, settings.sessionCount)
+      // in-flight messages with the producers that were used to send them.
+      private val inFlightMessagesWithProducer: Buffer[Holder[A]] = Buffer(settings.sessionCount, settings.sessionCount)
 
       private[jms] def jmsSettings = settings
 
@@ -59,17 +68,22 @@ private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducer
         in,
         new InHandler {
 
-          override def onUpstreamFinish(): Unit = if (buffer.isEmpty) completeStage()
+          override def onUpstreamFinish(): Unit = if (inFlightMessagesWithProducer.isEmpty) completeStage()
 
           override def onPush(): Unit = {
             val elem: A = grab(in)
-            val jmsProducer = jmsProducers.dequeue() // fetch jms producer from the pool.
+            // fetch a jms producer from the pool, and create a holder object to capture the in-flight message.
+            val jmsProducer = jmsProducers.dequeue()
             val holder = new Holder(NotYetThere, futureCB, jmsProducer)
-            buffer.enqueue(holder)
+            inFlightMessagesWithProducer.enqueue(holder)
+
+            // send the element asynchronously, notifying the holder of (successful or failed) completion.
             Future {
               jmsProducer.send(elem)
               elem
             }.onComplete(holder)(akka.dispatch.ExecutionContexts.sameThreadExecutionContext)
+
+            // immediately ask for the next element if producers are available.
             pullIfNeeded()
           }
         }
@@ -83,7 +97,7 @@ private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducer
       private val futureCB = getAsyncCallback[Holder[A]](
         holder =>
           holder.elem match {
-            case Success(_) => pushNextIfPossible()
+            case Success(_) => pushNextIfPossible() // on success, try to push out the new element.
             case Failure(ex) => handleFailure(ex, holder)
         }
       )
@@ -91,19 +105,20 @@ private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducer
       private def pullIfNeeded(): Unit =
         if (jmsProducers.nonEmpty && !hasBeenPulled(in)) tryPull(in) // only pull if a producer is available in the pool.
 
-      // heavily inspired by akka.stream.impl.fusing.MapAsync
       private def pushNextIfPossible(): Unit =
-        if (buffer.isEmpty) {
+        if (inFlightMessagesWithProducer.isEmpty) {
+          // no messages in flight, are we about to complete?
           if (isClosed(in)) completeStage() else pullIfNeeded()
-        } else if (buffer.peek().elem eq NotYetThere) {
-          pullIfNeeded() // ahead of line blocking to keep order
+        } else if (inFlightMessagesWithProducer.peek().elem eq NotYetThere) {
+          // next message to be produced is still not there, we need to wait.
+          pullIfNeeded()
         } else if (isAvailable(out)) {
-          val holder = buffer.dequeue()
+          val holder = inFlightMessagesWithProducer.dequeue()
           holder.elem match {
             case Success(elem) =>
               push(out, elem)
               jmsProducers.enqueue(holder.jmsProducer) // put back jms producer to the pool.
-              pullIfNeeded()
+              pullIfNeeded() // Ask for the next element.
 
             case Failure(NonFatal(ex)) => handleFailure(ex, holder)
           }
@@ -111,7 +126,7 @@ private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducer
 
       private def handleFailure(ex: Throwable, holder: Holder[A]): Unit =
         holder.supervisionDirectiveFor(decider, ex) match {
-          case Supervision.Stop => failStage(ex)
+          case Supervision.Stop => failStage(ex) // fail only if supervision asks for it.
           case _ => pushNextIfPossible()
         }
     }
@@ -121,16 +136,22 @@ private[jms] object JmsProducerStage {
 
   val NotYetThere = Failure(new Exception with NoStackTrace)
 
-  // heavily inspired by akka.stream.impl.fusing.MapAsync
+  /*
+   * NOTE: the following code is heavily inspired by akka.stream.impl.fusing.MapAsync
+   *
+   * To get a condensed view of what the Holder is about, have a look there too.
+   */
   class Holder[A <: JmsMessage](var elem: Try[A], val cb: AsyncCallback[Holder[A]], val jmsProducer: JmsMessageProducer)
       extends (Try[A] => Unit) {
 
+    // To support both fail-fast when the supervision directive is Stop
+    // and not calling the decider multiple times, we need to cache the decider result and re-use that
     private var cachedSupervisionDirective: OptionVal[Supervision.Directive] = OptionVal.None
 
     def supervisionDirectiveFor(decider: Supervision.Decider, ex: Throwable): Supervision.Directive =
       cachedSupervisionDirective match {
-        case OptionVal.Some(d) ⇒ d
-        case OptionVal.None ⇒
+        case OptionVal.Some(d) => d
+        case OptionVal.None =>
           val d = decider(ex)
           cachedSupervisionDirective = OptionVal.Some(d)
           d
@@ -138,11 +159,12 @@ private[jms] object JmsProducerStage {
 
     def setElem(t: Try[A]): Unit =
       elem = t match {
-        case Success(null) ⇒ Failure[A](ReactiveStreamsCompliance.elementMustNotBeNullException)
-        case other ⇒ other
+        case Success(null) => Failure[A](ReactiveStreamsCompliance.elementMustNotBeNullException)
+        case other => other
       }
 
     override def apply(t: Try[A]): Unit = {
+      // invoked on future completion: set the element, and call the stage's completion callback.
       setElem(t)
       cb.invoke(this)
     }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -46,9 +46,9 @@ private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducer
       // in-flight messages with the producers that were used to send them.
       private val inFlightMessagesWithProducer: Buffer[Holder[A]] = Buffer(settings.sessionCount, settings.sessionCount)
 
-      private[jms] def jmsSettings = settings
+      protected def jmsSettings: JmsProducerSettings = settings
 
-      private[jms] def createSession(connection: Connection, createDestination: Session => jms.Destination) = {
+      protected def createSession(connection: Connection, createDestination: Session => jms.Destination): JmsSession = {
         val session =
           connection.createSession(false, settings.acknowledgeMode.getOrElse(AcknowledgeMode.AutoAcknowledge).mode)
         new JmsSession(connection, session, createDestination(session))

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -4,10 +4,18 @@
 
 package akka.stream.alpakka.jms
 
+import akka.stream.ActorAttributes.SupervisionStrategy
 import akka.stream._
+import akka.stream.alpakka.jms.JmsProducerStage._
+import akka.stream.impl.{Buffer, ReactiveStreamsCompliance}
 import akka.stream.stage._
+import akka.util.OptionVal
 import javax.jms
 import javax.jms.{Connection, Session}
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
+import scala.util.control.{NoStackTrace, NonFatal}
 
 private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducerSettings)
     extends GraphStage[FlowShape[A, A]] {
@@ -23,8 +31,11 @@ private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducer
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with JmsConnector {
 
-      private var jmsProducer: JmsMessageProducer = _
-      private var jmsSession: JmsSession = _
+      private lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
+
+      private val jmsProducers: Buffer[JmsMessageProducer] = Buffer(settings.sessionCount, settings.sessionCount)
+
+      private val buffer: Buffer[Holder[A]] = Buffer(settings.sessionCount, settings.sessionCount)
 
       private[jms] def jmsSettings = settings
 
@@ -36,23 +47,30 @@ private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducer
 
       override def preStart(): Unit = {
         jmsSessions = openSessions()
-        // TODO: Remove hack to limit publisher to single session.
-        jmsSession = jmsSessions.head
-        jmsProducer = JmsMessageProducer(jmsSession, settings)
+        jmsSessions.foreach(jmsSession => jmsProducers.enqueue(JmsMessageProducer(jmsSession, settings)))
+        ec = executionContext(inheritedAttributes)
       }
 
       setHandler(out, new OutHandler {
-        override def onPull(): Unit =
-          tryPull(in)
+        override def onPull(): Unit = pushNextIfPossible()
       })
 
       setHandler(
         in,
         new InHandler {
+
+          override def onUpstreamFinish(): Unit = if (buffer.isEmpty) completeStage()
+
           override def onPush(): Unit = {
             val elem: A = grab(in)
-            jmsProducer.send(elem)
-            push(out, elem)
+            val jmsProducer = jmsProducers.dequeue() // fetch jms producer from the pool.
+            val holder = new Holder(NotYetThere, futureCB, jmsProducer)
+            buffer.enqueue(holder)
+            Future {
+              jmsProducer.send(elem)
+              elem
+            }.onComplete(holder)(akka.dispatch.ExecutionContexts.sameThreadExecutionContext)
+            pullIfNeeded()
           }
         }
       )
@@ -61,6 +79,72 @@ private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducer
         jmsSessions.foreach(_.closeSession())
         jmsConnection.foreach(_.close)
       }
-    }
 
+      private val futureCB = getAsyncCallback[Holder[A]](
+        holder =>
+          holder.elem match {
+            case Success(_) => pushNextIfPossible()
+            case Failure(ex) => handleFailure(ex, holder)
+        }
+      )
+
+      private def pullIfNeeded(): Unit =
+        if (jmsProducers.nonEmpty && !hasBeenPulled(in)) tryPull(in) // only pull if a producer is available in the pool.
+
+      // heavily inspired by akka.stream.impl.fusing.MapAsync
+      private def pushNextIfPossible(): Unit =
+        if (buffer.isEmpty) {
+          if (isClosed(in)) completeStage() else pullIfNeeded()
+        } else if (buffer.peek().elem eq NotYetThere) {
+          pullIfNeeded() // ahead of line blocking to keep order
+        } else if (isAvailable(out)) {
+          val holder = buffer.dequeue()
+          holder.elem match {
+            case Success(elem) =>
+              push(out, elem)
+              jmsProducers.enqueue(holder.jmsProducer) // put back jms producer to the pool.
+              pullIfNeeded()
+
+            case Failure(NonFatal(ex)) => handleFailure(ex, holder)
+          }
+        }
+
+      private def handleFailure(ex: Throwable, holder: Holder[A]): Unit =
+        holder.supervisionDirectiveFor(decider, ex) match {
+          case Supervision.Stop => failStage(ex)
+          case _ => pushNextIfPossible()
+        }
+    }
+}
+
+private[jms] object JmsProducerStage {
+
+  val NotYetThere = Failure(new Exception with NoStackTrace)
+
+  // heavily inspired by akka.stream.impl.fusing.MapAsync
+  class Holder[A <: JmsMessage](var elem: Try[A], val cb: AsyncCallback[Holder[A]], val jmsProducer: JmsMessageProducer)
+      extends (Try[A] => Unit) {
+
+    private var cachedSupervisionDirective: OptionVal[Supervision.Directive] = OptionVal.None
+
+    def supervisionDirectiveFor(decider: Supervision.Decider, ex: Throwable): Supervision.Directive =
+      cachedSupervisionDirective match {
+        case OptionVal.Some(d) ⇒ d
+        case OptionVal.None ⇒
+          val d = decider(ex)
+          cachedSupervisionDirective = OptionVal.Some(d)
+          d
+      }
+
+    def setElem(t: Try[A]): Unit =
+      elem = t match {
+        case Success(null) ⇒ Failure[A](ReactiveStreamsCompliance.elementMustNotBeNullException)
+        case other ⇒ other
+      }
+
+    override def apply(t: Try[A]): Unit = {
+      setElem(t)
+      cb.invoke(this)
+    }
+  }
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -4,11 +4,10 @@
 
 package akka.stream.alpakka.jms
 
-import javax.jms
-import javax.jms.{Connection, Message, MessageProducer, Session}
-
 import akka.stream._
 import akka.stream.stage._
+import javax.jms
+import javax.jms.{Connection, Session}
 
 private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducerSettings)
     extends GraphStage[FlowShape[A, A]] {
@@ -21,10 +20,10 @@ private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducer
   override protected def initialAttributes: Attributes =
     ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher")
 
-  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with JmsConnector {
 
-      private var jmsProducer: MessageProducer = _
+      private var jmsProducer: JmsMessageProducer = _
       private var jmsSession: JmsSession = _
 
       private[jms] def jmsSettings = settings
@@ -39,10 +38,7 @@ private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducer
         jmsSessions = openSessions()
         // TODO: Remove hack to limit publisher to single session.
         jmsSession = jmsSessions.head
-        jmsProducer = jmsSession.session.createProducer(jmsSession.destination)
-        if (settings.timeToLive.nonEmpty) {
-          jmsProducer.setTimeToLive(settings.timeToLive.get.toMillis)
-        }
+        jmsProducer = JmsMessageProducer(jmsSession, settings)
       }
 
       setHandler(out, new OutHandler {
@@ -54,94 +50,17 @@ private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducer
         in,
         new InHandler {
           override def onPush(): Unit = {
-
             val elem: A = grab(in)
-
-            val message: Message = createMessage(jmsSession, elem)
-            populateMessageProperties(message, elem.properties)
-
-            val (sendHeaders, headersBeforeSend: Set[JmsHeader]) = elem.headers.partition(_.usedDuringSend)
-            populateMessageHeader(message, headersBeforeSend)
-
-            val deliveryModeOption = findHeader(sendHeaders) { case x: JmsDeliveryMode => x.deliveryMode }
-            val priorityOption = findHeader(sendHeaders) { case x: JmsPriority => x.priority }
-            val timeToLiveInMillisOption = findHeader(sendHeaders) { case x: JmsTimeToLive => x.timeInMillis }
-
-            jmsProducer.send(
-              message,
-              deliveryModeOption.getOrElse(jmsProducer.getDeliveryMode),
-              priorityOption.getOrElse(jmsProducer.getPriority),
-              timeToLiveInMillisOption.getOrElse(jmsProducer.getTimeToLive)
-            )
-
+            jmsProducer.send(elem)
             push(out, elem)
           }
         }
       )
-
-      private def findHeader[T](headersDuringSend: Set[JmsHeader])(f: PartialFunction[JmsHeader, T]): Option[T] =
-        headersDuringSend.collectFirst(f)
-
-      private def createMessage(jmsSession: JmsSession, element: JmsMessage): Message =
-        element match {
-
-          case textMessage: JmsTextMessage => jmsSession.session.createTextMessage(textMessage.body)
-
-          case byteMessage: JmsByteMessage =>
-            val newMessage = jmsSession.session.createBytesMessage()
-            newMessage.writeBytes(byteMessage.bytes)
-            newMessage
-
-          case mapMessage: JmsMapMessage =>
-            val newMessage = jmsSession.session.createMapMessage()
-            populateMapMessage(newMessage, mapMessage.body)
-            newMessage
-
-          case objectMessage: JmsObjectMessage => jmsSession.session.createObjectMessage(objectMessage.serializable)
-
-        }
-
-      private def populateMessageProperties(message: javax.jms.Message, properties: Map[String, Any]): Unit =
-        properties.foreach {
-          case (key, v) =>
-            v match {
-              case v: String => message.setStringProperty(key, v)
-              case v: Int => message.setIntProperty(key, v)
-              case v: Boolean => message.setBooleanProperty(key, v)
-              case v: Byte => message.setByteProperty(key, v)
-              case v: Short => message.setShortProperty(key, v)
-              case v: Long => message.setLongProperty(key, v)
-              case v: Double => message.setDoubleProperty(key, v)
-            }
-        }
-
-      private def populateMapMessage(message: javax.jms.MapMessage, map: Map[String, Any]): Unit =
-        map.foreach {
-          case (key, v) =>
-            v match {
-              case v: String => message.setString(key, v)
-              case v: Int => message.setInt(key, v)
-              case v: Boolean => message.setBoolean(key, v)
-              case v: Byte => message.setByte(key, v)
-              case v: Short => message.setShort(key, v)
-              case v: Long => message.setLong(key, v)
-              case v: Double => message.setDouble(key, v)
-              case v: Array[Byte] => message.setBytes(key, v)
-            }
-        }
-
-      private def populateMessageHeader(message: javax.jms.Message, headers: Set[JmsHeader]): Unit =
-        headers.foreach {
-          case JmsType(jmsType) => message.setJMSType(jmsType)
-          case JmsReplyTo(destination) => message.setJMSReplyTo(destination.create(jmsSession.session))
-          case JmsCorrelationId(jmsCorrelationId) => message.setJMSCorrelationID(jmsCorrelationId)
-        }
 
       override def postStop(): Unit = {
         jmsSessions.foreach(_.closeSession())
         jmsConnection.foreach(_.close)
       }
     }
-  }
 
 }

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsSettingsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsSettingsTest.java
@@ -1,0 +1,23 @@
+package akka.stream.alpakka.jms.javadsl;
+
+import akka.stream.alpakka.jms.Credentials;
+import akka.stream.alpakka.jms.JmsProducerSettings;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.junit.Test;
+
+import java.time.Duration;
+
+public class JmsSettingsTest {
+
+    @Test
+    public void settings() throws Exception {
+        //#producer-settings
+        JmsProducerSettings settings = JmsProducerSettings
+                .create(new ActiveMQConnectionFactory("broker-url"))
+                .withTopic("target-topic")
+                .withCredential(new Credentials("username", "password"))
+                .withSessionCount(10)
+                .withTimeToLive(Duration.ofHours(1));
+        //#producer-settings
+    }
+}

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsSettingsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsSettingsTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
 package akka.stream.alpakka.jms.javadsl;
 
 import akka.stream.alpakka.jms.Credentials;
@@ -9,15 +13,15 @@ import java.time.Duration;
 
 public class JmsSettingsTest {
 
-    @Test
-    public void settings() throws Exception {
-        //#producer-settings
-        JmsProducerSettings settings = JmsProducerSettings
-                .create(new ActiveMQConnectionFactory("broker-url"))
-                .withTopic("target-topic")
-                .withCredential(new Credentials("username", "password"))
-                .withSessionCount(10)
-                .withTimeToLive(Duration.ofHours(1));
-        //#producer-settings
-    }
+  @Test
+  public void settings() throws Exception {
+    // #producer-settings
+    JmsProducerSettings settings =
+        JmsProducerSettings.create(new ActiveMQConnectionFactory("broker-url"))
+            .withTopic("target-topic")
+            .withCredential(new Credentials("username", "password"))
+            .withSessionCount(10)
+            .withTimeToLive(Duration.ofHours(1));
+    // #producer-settings
+  }
 }

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsMessageProducerSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsMessageProducerSpec.scala
@@ -1,0 +1,105 @@
+package akka.stream.alpakka.jms
+import javax.jms._
+import javax.jms.{Destination => JmsDestination}
+import org.mockito.ArgumentMatchers.{any, anyBoolean, anyInt, anyString}
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+
+class JmsMessageProducerSpec extends JmsSpec with MockitoSugar {
+
+  trait Setup {
+    val factory: ConnectionFactory = mock[ConnectionFactory]
+    val connection: Connection = mock[Connection]
+    val session: Session = mock[Session]
+    val destination: JmsDestination = mock[JmsDestination]
+    val producer: MessageProducer = mock[MessageProducer]
+    val textMessage: TextMessage = mock[TextMessage]
+    val mapMessage: MapMessage = mock[MapMessage]
+
+    when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session)
+    when(session.createProducer(any[javax.jms.Destination])).thenReturn(producer)
+    when(session.createTextMessage(anyString())).thenReturn(textMessage)
+    when(session.createMapMessage()).thenReturn(mapMessage)
+
+    val settings = JmsProducerSettings(factory)
+    val jmsSession = new JmsSession(connection, session, destination)
+
+    val jmsProducer = JmsMessageProducer(jmsSession, settings)
+  }
+
+  "populating Jms message properties" should {
+    "succeed if properties are set to supported types" in new Setup {
+      jmsProducer.populateMessageProperties(
+        textMessage,
+        JmsTextMessage("test",
+                       Set.empty,
+                       Map("string" -> "string",
+                           "int" -> 1,
+                           "boolean" -> true,
+                           "byte" -> 2.toByte,
+                           "short" -> 3.toShort,
+                           "long" -> 4L,
+                           "double" -> 5.0))
+      )
+
+      verify(textMessage).setStringProperty("string", "string")
+      verify(textMessage).setIntProperty("int", 1)
+      verify(textMessage).setBooleanProperty("boolean", true)
+      verify(textMessage).setByteProperty("byte", 2.toByte)
+      verify(textMessage).setShortProperty("short", 3.toByte)
+      verify(textMessage).setLongProperty("long", 4L)
+      verify(textMessage).setDoubleProperty("double", 5.0)
+    }
+
+    "fail if a property is set to an unsupported type" in new Setup {
+      assertThrows[UnsupportedMessagePropertyType] {
+        val wrongProperties: Map[String, Any] = Map("object" -> this)
+        jmsProducer.populateMessageProperties(textMessage, JmsTextMessage("test", Set.empty, wrongProperties))
+      }
+    }
+
+    "fail if a property is set to a null value" in new Setup {
+      assertThrows[NullMessageProperty] {
+        val wrongProperties: Map[String, Any] = Map("object" -> null)
+        jmsProducer.populateMessageProperties(textMessage, JmsTextMessage("test", Set.empty, wrongProperties))
+      }
+    }
+  }
+
+  "creating a Jms Map message" should {
+    "succeed if map values are supported types" in new Setup {
+      jmsProducer.createMessage(
+        JmsMapMessage(
+          Map("string" -> "string",
+              "int" -> 1,
+              "boolean" -> true,
+              "byte" -> 2.toByte,
+              "short" -> 3.toShort,
+              "long" -> 4L,
+              "double" -> 5.0)
+        )
+      )
+      verify(mapMessage).setString("string", "string")
+      verify(mapMessage).setInt("int", 1)
+      verify(mapMessage).setBoolean("boolean", true)
+      verify(mapMessage).setByte("byte", 2.toByte)
+      verify(mapMessage).setShort("short", 3.toByte)
+      verify(mapMessage).setLong("long", 4L)
+      verify(mapMessage).setDouble("double", 5.0)
+    }
+
+    "fail if a map value is set to an unsupported type" in new Setup {
+      assertThrows[UnsupportedMapMessageEntryType] {
+        val wrongMap: Map[String, Any] = Map("object" -> this)
+        jmsProducer.createMessage(JmsMapMessage(wrongMap))
+      }
+    }
+
+    "fail if a map value is set to null" in new Setup {
+      assertThrows[NullMapMessageEntry] {
+        val wrongMap: Map[String, Any] = Map("object" -> null)
+        jmsProducer.createMessage(JmsMapMessage(wrongMap))
+      }
+    }
+  }
+}

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsMessageProducerSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsMessageProducerSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
 package akka.stream.alpakka.jms
 import javax.jms._
 import javax.jms.{Destination => JmsDestination}

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
@@ -787,30 +787,20 @@ class JmsConnectorsSpec extends JmsSpec with MockitoSugar {
     }
 
     "publish and consume strings through a queue with multiple sessions" in withServer() { ctx =>
-      //#connection-factory
       val connectionFactory: javax.jms.ConnectionFactory = new ActiveMQConnectionFactory(ctx.url)
-      //#connection-factory
 
-      //#create-text-sink
       val jmsSink: Sink[String, Future[Done]] = JmsProducer.textSink(
         JmsProducerSettings(connectionFactory).withQueue("test").withSessionCount(5)
       )
-      //#create-text-sink
 
-      //#run-text-sink
       val in = List("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")
       val sinkOut = Source(in).runWith(jmsSink)
-      //#run-text-sink
 
-      //#create-text-source
       val jmsSource: Source[String, KillSwitch] = JmsConsumer.textSource(
         JmsConsumerSettings(connectionFactory).withSessionCount(5).withBufferSize(10).withQueue("test")
       )
-      //#create-text-source
 
-      //#run-text-source
       val result = jmsSource.take(in.size).runWith(Sink.seq)
-      //#run-text-source
 
       result.futureValue should contain allElementsOf in
     }

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsSettingsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsSettingsSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
 package akka.stream.alpakka.jms.scaladsl
 import java.time.Duration
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsSettingsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsSettingsSpec.scala
@@ -1,0 +1,22 @@
+package akka.stream.alpakka.jms.scaladsl
+import java.time.Duration
+
+import akka.stream.alpakka.jms.{Credentials, JmsProducerSettings, JmsSpec, Topic}
+import org.apache.activemq.ActiveMQConnectionFactory
+
+class JmsSettingsSpec extends JmsSpec {
+
+  "Jms producer" should {
+    "have producer settings" in {
+      //#producer-settings
+      val settings = JmsProducerSettings(
+        new ActiveMQConnectionFactory("broker-url"),
+        destination = Some(Topic("target-topic")),
+        credentials = Some(Credentials("username", "password")),
+        sessionCount = 10,
+        timeToLive = Some(Duration.ofHours(1))
+      )
+      //#producer-settings
+    }
+  }
+}

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsSettingsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsSettingsSpec.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.jms.scaladsl
 import java.time.Duration
 
-import akka.stream.alpakka.jms.{Credentials, JmsProducerSettings, JmsSpec, Topic}
+import akka.stream.alpakka.jms.{Credentials, JmsProducerSettings, JmsSpec}
 import org.apache.activemq.ActiveMQConnectionFactory
 
 class JmsSettingsSpec extends JmsSpec {
@@ -13,13 +13,11 @@ class JmsSettingsSpec extends JmsSpec {
   "Jms producer" should {
     "have producer settings" in {
       //#producer-settings
-      val settings = JmsProducerSettings(
-        new ActiveMQConnectionFactory("broker-url"),
-        destination = Some(Topic("target-topic")),
-        credentials = Some(Credentials("username", "password")),
-        sessionCount = 10,
-        timeToLive = Some(Duration.ofHours(1))
-      )
+      val settings = JmsProducerSettings(new ActiveMQConnectionFactory("broker-url"))
+        .withTopic("target-topic")
+        .withCredential(Credentials("username", "password"))
+        .withSessionCount(10)
+        .withTimeToLive(Duration.ofHours(1))
       //#producer-settings
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -189,7 +189,8 @@ object Dependencies {
     libraryDependencies ++= Seq(
       "javax.jms" % "jms" % "1.1" % Provided, // CDDL + GPLv2
       "org.apache.activemq" % "activemq-broker" % "5.15.4" % Test, // ApacheV2
-      "org.apache.activemq" % "activemq-client" % "5.15.4" % Test // ApacheV2
+      "org.apache.activemq" % "activemq-client" % "5.15.4" % Test, // ApacheV2
+      "org.mockito" % "mockito-core" % "2.21.0" % Test // MIT
     ),
     resolvers += ("jboss" at "https://repository.jboss.org/nexus/content/groups/public")
   )


### PR DESCRIPTION
- JmsProducerStage now supports multiple sessions by behaving
  similarly to MapAsync
- Producers are pooled and parallelism is controlled by how producers
  are returned to the pool.
- Created a separate JmsMessageProducer class to keep the stage logic
  more focussed on coordinating elements within the stage.
- Grouped the logic for creating the execution context to use in the
  producer stage as well as in the consumer stage.

Fixes #1144