### PR TITLE
Solr: support update/delete/atomic update operations and batch those

### DIFF
--- a/docs/src/main/paradox/solr.md
+++ b/docs/src/main/paradox/solr.md
@@ -119,10 +119,47 @@ Java
 
 | Parameter           | Default | Description                                                                                            |
 | ------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| bufferSize          | 10      | `SolrSink` puts messages by one bulk request per messages of this buffer size.                |
 | retryInterval       | 5000    | When a request is failed, `SolrSink` retries that request after this interval (milliseconds). |
 | maxRetry            | 100     | `SolrSink` give up and fails the stage if it gets this number of consective failures.         | 
 | commitWithin        | -1      | Max time (in ms) before a commit will happen, -1 for manual committing |
+
+### Update atomically documents
+
+We can update atomically documents.
+
+Scala
+: @@snip [snip](/solr/src/test/scala/akka/stream/alpakka/solr/SolrSpec.scala) { #update-atomically-documents }
+
+Java
+: @@snip [snip](/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java) { #update-atomically-documents }
+
+We can use typed and bean to update atomically.
+
+### Delete documents by ids
+
+We can delete documents by ids.
+
+Scala
+: @@snip [snip](/solr/src/test/scala/akka/stream/alpakka/solr/SolrSpec.scala) { #delete-documents }
+
+Java
+: @@snip [snip](/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java) { #delete-documents }
+
+We can use typed and bean to delete.
+
+### Delete documents by query
+
+We can delete documents by query.
+
+Scala
+: @@snip [snip](/solr/src/test/scala/akka/stream/alpakka/solr/SolrSpec.scala) { #delete-documents-query }
+
+Java
+: @@snip [snip](/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java) { #delete-documents-query }
+
+We can use typed and bean to delete.
+
+
 
 ## Flow Usage
 

--- a/docs/src/main/paradox/solr.md
+++ b/docs/src/main/paradox/solr.md
@@ -118,9 +118,7 @@ Java
 
 
 | Parameter           | Default | Description                                                                                            |
-| ------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| retryInterval       | 5000    | When a request is failed, `SolrSink` retries that request after this interval (milliseconds). |
-| maxRetry            | 100     | `SolrSink` give up and fails the stage if it gets this number of consective failures.         | 
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------ | 
 | commitWithin        | -1      | Max time (in ms) before a commit will happen, -1 for manual committing |
 
 ### Update atomically documents

--- a/solr/src/main/scala/akka/stream/alpakka/solr/SolrFlowStage.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/SolrFlowStage.scala
@@ -17,45 +17,131 @@ import org.apache.solr.client.solrj.SolrClient
 import org.apache.solr.client.solrj.response.UpdateResponse
 import org.apache.solr.common.{SolrException, SolrInputDocument}
 
-import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
+import scala.collection.JavaConverters._
 
-object IncomingMessage {
-  // Apply method to use when not using passThrough
+private object IncomingMessage {
+  // Apply methods to use when not using passThrough
   def apply[T](source: T): IncomingMessage[T, NotUsed] =
-    IncomingMessage(Update, None, Some(source), NotUsed)
-
-  def apply[T](operation: Operation, source: T): IncomingMessage[T, NotUsed] =
-    IncomingMessage(operation, None, Some(source), NotUsed)
+    IncomingMessage(Update, None, None, Option(source), Map.empty, NotUsed)
 
   def apply(id: String): IncomingMessage[NotUsed, NotUsed] =
-    IncomingMessage(Delete, Some(id), None, NotUsed)
+    IncomingMessage(Delete, None, Option(id), None, Map.empty, NotUsed)
+
+  def apply(idField: String, id: String, field: String, updates: Map[String, Any]): IncomingMessage[NotUsed, NotUsed] =
+    IncomingMessage(AtomicUpdate, Option(idField), Option(id), None, Map(field -> updates), NotUsed)
+
+  // Apply methods to use with passThrough
+  def apply[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
+    IncomingMessage(Update, None, None, Option(source), Map.empty, passThrough)
+
+  def apply[C](id: String, passThrough: C): IncomingMessage[NotUsed, C] =
+    IncomingMessage(Delete, None, Option(id), None, Map.empty, passThrough)
+
+  def apply[C](idField: String,
+               id: String,
+               field: String,
+               updates: Map[String, Any],
+               passThrough: C): IncomingMessage[NotUsed, C] =
+    IncomingMessage(AtomicUpdate, Option(idField), Option(id), None, Map(field -> updates), passThrough)
 
   // Java-api - without passThrough
   def create[T](source: T): IncomingMessage[T, NotUsed] =
     IncomingMessage(source)
 
-  // Java-api - with passThrough
-  def create[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingMessage(Update, None, Some(source), passThrough)
-
   def create(id: String): IncomingMessage[NotUsed, NotUsed] =
     IncomingMessage(id)
 
+  def create(idField: String,
+             id: String,
+             field: String,
+             updates: java.util.Map[String, Object]): IncomingMessage[NotUsed, NotUsed] =
+    IncomingMessage(idField, id, field, updates.asScala.toMap)
+
   // Java-api - with passThrough
-  def create[T, C](operation: Operation,
-                   idOpt: Option[String],
-                   sourceOpt: Option[T],
-                   passThrough: C): IncomingMessage[T, C] =
-    IncomingMessage(operation, None, sourceOpt, passThrough)
+  def create[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
+    IncomingMessage(source, passThrough)
+
+  def create[C](id: String, passThrough: C): IncomingMessage[NotUsed, C] =
+    IncomingMessage(id, passThrough)
+
+  def create[C](idField: String,
+                id: String,
+                field: String,
+                updates: java.util.Map[String, Object],
+                passThrough: C): IncomingMessage[NotUsed, C] =
+    IncomingMessage(idField, id, field, updates.asScala.toMap, passThrough)
 
 }
 
+object IncomingUpdateMessage {
+  // Apply method to use when not using passThrough
+  def apply[T](source: T): IncomingMessage[T, NotUsed] =
+    IncomingMessage(source)
+
+  // Apply method to use when not using passThrough
+  def apply[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
+    IncomingMessage(source, passThrough)
+
+  // Java-api - without passThrough
+  def create[T](source: T): IncomingMessage[T, NotUsed] =
+    IncomingUpdateMessage(source)
+
+  // Java-api - without passThrough
+  def create[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
+    IncomingUpdateMessage(source, passThrough)
+}
+
+object IncomingDeleteMessage {
+  // Apply method to use when not using passThrough
+  def apply(id: String): IncomingMessage[NotUsed, NotUsed] =
+    IncomingMessage(id)
+
+  def apply[C](id: String, passThrough: C): IncomingMessage[NotUsed, C] =
+    IncomingMessage(id, passThrough)
+
+  // Java-api - without passThrough
+  def create(id: String): IncomingMessage[NotUsed, NotUsed] =
+    IncomingDeleteMessage(id)
+
+  def create[C](id: String, passThrough: C): IncomingMessage[NotUsed, C] =
+    IncomingDeleteMessage(id, passThrough)
+}
+
+object IncomingAtomicUpdateMessage {
+  // Apply method to use when not using passThrough
+  def apply(idField: String, id: String, field: String, updates: Map[String, Any]): IncomingMessage[NotUsed, NotUsed] =
+    IncomingMessage(idField, id, field, updates)
+
+  def apply[C](idField: String,
+               id: String,
+               field: String,
+               updates: Map[String, Any],
+               passThrough: C): IncomingMessage[NotUsed, C] =
+    IncomingMessage(idField, id, field, updates, passThrough)
+
+  // Java-api - without passThrough
+  def create(idField: String,
+             id: String,
+             field: String,
+             updates: java.util.Map[String, Object]): IncomingMessage[NotUsed, NotUsed] =
+    IncomingAtomicUpdateMessage(idField, id, field, updates.asScala.toMap)
+
+  def create[C](idField: String,
+                id: String,
+                field: String,
+                updates: java.util.Map[String, Object],
+                passThrough: C): IncomingMessage[NotUsed, C] =
+    IncomingAtomicUpdateMessage(idField, id, field, updates.asScala.toMap, passThrough)
+}
+
 final case class IncomingMessage[T, C](operation: Operation,
+                                       idFieldOpt: Option[String],
                                        idOpt: Option[String],
                                        sourceOpt: Option[T],
+                                       updates: Map[String, Any],
                                        passThrough: C = NotUsed)
 
 final case class IncomingMessageResult[T, C](id: Option[String], sourceOpt: Option[T], passThrough: C, status: Int)
@@ -78,6 +164,7 @@ private[solr] final class SolrFlowStage[T, C](
 sealed trait Operation
 final object Update extends Operation
 final object Delete extends Operation
+final object AtomicUpdate extends Operation
 
 private sealed trait SolrFlowState
 
@@ -198,22 +285,6 @@ private[solr] final class SolrFlowLogic[T, C](
   private def handleSuccess(): Unit =
     completeStage()
 
-  private def fDeleteBulkToSolr(messages: Seq[IncomingMessage[T, C]]): Future[UpdateResponse] = {
-    val docsIds = messages
-      .filter { message =>
-        message.operation == Delete && message.idOpt.isDefined
-      }
-      .map { message =>
-        message.idOpt.get
-      }
-    if (log.isDebugEnabled) log.debug(s"Delete the ids $docsIds")
-    Future {
-      blocking {
-        client.deleteById(collection, docsIds.asJava, settings.commitWithin)
-      }
-    }
-  }
-
   private[solr] def getDispatcher =
     attributes.get[ActorAttributes.Dispatcher](
       ActorAttributes.Dispatcher("akka.stream.default-blocking-io-dispatcher")
@@ -232,39 +303,84 @@ private[solr] final class SolrFlowLogic[T, C](
     }
   }
 
+  private def fAtomicUpdateBulkToSolr(messages: Seq[IncomingMessage[T, C]]): Future[UpdateResponse] = {
+    val docs = messages.map { message =>
+      val doc = new SolrInputDocument()
+      doc.addField(message.idFieldOpt.get, message.idOpt.get)
+      message.updates.foreach {
+        case (field, updates) => {
+          val jMap = updates.asInstanceOf[Map[String, Any]].asJava
+          doc.addField(field, jMap)
+        }
+      }
+      doc
+    }
+    Future {
+      blocking {
+        client.add(collection, docs.asJava, settings.commitWithin)
+      }
+    }
+  }
+
+  private def fDeleteBulkToSolr(messages: Seq[IncomingMessage[T, C]]): Future[UpdateResponse] = {
+    val docsIds = messages
+      .filter { message =>
+        message.operation == Delete && message.idOpt.isDefined
+      }
+      .map { message =>
+        message.idOpt.get
+      }
+    if (log.isDebugEnabled) log.debug(s"Delete the ids $docsIds")
+    Future {
+      blocking {
+        client.deleteById(collection, docsIds.asJava, settings.commitWithin)
+      }
+    }
+  }
+
   private def sendBulkToSolr(messages: Seq[IncomingMessage[T, C]]): Unit = {
-    val (updates, deletes) = messages.partition { m =>
-      m.operation == Update
+
+    def asyncSend(toSend: Seq[IncomingMessage[T, C]]): Future[UpdateResponse] = {
+      val operation = toSend.head.operation
+      //Just take a subset of this operation
+      val current = toSend.takeWhile { m =>
+        m.operation == operation
+      }
+      //send this subset
+      val response = operation match {
+        case Update => fUpdateBulkToSolr(current)
+        case AtomicUpdate => fAtomicUpdateBulkToSolr(current)
+        case Delete => fDeleteBulkToSolr(current)
+      }
+      //Now take the remaining
+      val remaining = toSend.dropWhile(m => m.operation == operation)
+      if (remaining.nonEmpty) {
+        response.flatMap { _ =>
+          asyncSend(remaining) //Important: Not really recursive, because the future breaks the recursion
+        }
+      } else {
+        response
+      }
     }
 
-    if (updates.isEmpty && deletes.isEmpty) {
-      //Nothing to do
-    } else {
-      val fBulkResult = if (updates.isEmpty) {
-        fDeleteBulkToSolr(deletes)
-      } else if (deletes.isEmpty) {
-        fUpdateBulkToSolr(updates)
-      } else {
-        fUpdateBulkToSolr(updates).flatMap(_ => fDeleteBulkToSolr(deletes))
-      }
-      fBulkResult.onComplete {
-        case Success(response) => responseHandler.invoke((messages, response.getStatus))
-        case Failure(exception) =>
-          log.error(exception, "Unable to send messages to SolR")
-          exception match {
-            case NonFatal(exc) =>
-              val rootCause = SolrException.getRootCause(exc)
-              if (shouldRetry(rootCause)) {
-                failureHandler.invoke((messages, exception))
-              } else {
-                val status = exc match {
-                  case e: SolrException => e.code()
-                  case _ => -1
-                }
-                responseHandler.invoke((messages, status))
+    val fBulkResult = asyncSend(messages)
+    fBulkResult.onComplete {
+      case Success(response) => responseHandler.invoke((messages, response.getStatus))
+      case Failure(exception) =>
+        log.error(exception, "Unable to send messages to SolR")
+        exception match {
+          case NonFatal(exc) =>
+            val rootCause = SolrException.getRootCause(exc)
+            if (shouldRetry(rootCause)) {
+              failureHandler.invoke((messages, exception))
+            } else {
+              val status = exc match {
+                case e: SolrException => e.code()
+                case _ => -1
               }
-          }
-      }
+              responseHandler.invoke((messages, status))
+            }
+        }
     }
   }
 

--- a/solr/src/main/scala/akka/stream/alpakka/solr/SolrFlowStage.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/SolrFlowStage.scala
@@ -87,11 +87,11 @@ object IncomingUpsertMessage {
 
   // Java-api - without passThrough
   def create[T](source: T): IncomingMessage[T, NotUsed] =
-    IncomingUpsertMessage(source)
+    IncomingUpsertMessage[T](source)
 
   // Java-api - without passThrough
   def create[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingUpsertMessage(source, passThrough)
+    IncomingUpsertMessage[T, C](source, passThrough)
 }
 
 object IncomingDeleteMessage {
@@ -104,10 +104,10 @@ object IncomingDeleteMessage {
 
   // Java-api - without passThrough
   def create[T](id: String): IncomingMessage[T, NotUsed] =
-    IncomingDeleteMessage(id)
+    IncomingDeleteMessage[T](id)
 
   def create[T, C](id: String, passThrough: C): IncomingMessage[T, C] =
-    IncomingDeleteMessage(id, passThrough)
+    IncomingDeleteMessage[T, C](id, passThrough)
 }
 
 object IncomingAtomicUpdateMessage {
@@ -127,14 +127,14 @@ object IncomingAtomicUpdateMessage {
                 id: String,
                 field: String,
                 updates: java.util.Map[String, Object]): IncomingMessage[T, NotUsed] =
-    IncomingAtomicUpdateMessage(idField, id, field, updates.asScala.toMap)
+    IncomingAtomicUpdateMessage[T](idField, id, field, updates.asScala.toMap)
 
   def create[T, C](idField: String,
                    id: String,
                    field: String,
                    updates: java.util.Map[String, Object],
                    passThrough: C): IncomingMessage[T, C] =
-    IncomingAtomicUpdateMessage(idField, id, field, updates.asScala.toMap, passThrough)
+    IncomingAtomicUpdateMessage[T, C](idField, id, field, updates.asScala.toMap, passThrough)
 }
 
 final case class IncomingMessage[T, C](operation: Operation,

--- a/solr/src/main/scala/akka/stream/alpakka/solr/SolrFlowStage.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/SolrFlowStage.scala
@@ -7,7 +7,6 @@ package akka.stream.alpakka.solr
 import java.net.{ConnectException, SocketException}
 
 import akka.NotUsed
-
 import akka.stream.alpakka.solr.SolrFlowStage.{Finished, Idle, Sending}
 import akka.stream.stage._
 import akka.stream._
@@ -25,51 +24,51 @@ private object IncomingMessage {
   def apply[T](source: T): IncomingMessage[T, NotUsed] =
     IncomingMessage(Update, None, None, Option(source), Map.empty, NotUsed)
 
-  def apply(id: String): IncomingMessage[NotUsed, NotUsed] =
+  def apply[T](id: String): IncomingMessage[T, NotUsed] =
     IncomingMessage(Delete, None, Option(id), None, Map.empty, NotUsed)
 
-  def apply(idField: String, id: String, field: String, updates: Map[String, Any]): IncomingMessage[NotUsed, NotUsed] =
+  def apply[T](idField: String, id: String, field: String, updates: Map[String, Any]): IncomingMessage[T, NotUsed] =
     IncomingMessage(AtomicUpdate, Option(idField), Option(id), None, Map(field -> updates), NotUsed)
 
   // Apply methods to use with passThrough
   def apply[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
     IncomingMessage(Update, None, None, Option(source), Map.empty, passThrough)
 
-  def apply[C](id: String, passThrough: C): IncomingMessage[NotUsed, C] =
+  def apply[T, C](id: String, passThrough: C): IncomingMessage[T, C] =
     IncomingMessage(Delete, None, Option(id), None, Map.empty, passThrough)
 
-  def apply[C](idField: String,
-               id: String,
-               field: String,
-               updates: Map[String, Any],
-               passThrough: C): IncomingMessage[NotUsed, C] =
+  def apply[T, C](idField: String,
+                  id: String,
+                  field: String,
+                  updates: Map[String, Any],
+                  passThrough: C): IncomingMessage[T, C] =
     IncomingMessage(AtomicUpdate, Option(idField), Option(id), None, Map(field -> updates), passThrough)
 
   // Java-api - without passThrough
   def create[T](source: T): IncomingMessage[T, NotUsed] =
     IncomingMessage(source)
 
-  def create(id: String): IncomingMessage[NotUsed, NotUsed] =
+  def create[T](id: String): IncomingMessage[T, NotUsed] =
     IncomingMessage(id)
 
-  def create(idField: String,
-             id: String,
-             field: String,
-             updates: java.util.Map[String, Object]): IncomingMessage[NotUsed, NotUsed] =
+  def create[T](idField: String,
+                id: String,
+                field: String,
+                updates: java.util.Map[String, Object]): IncomingMessage[T, NotUsed] =
     IncomingMessage(idField, id, field, updates.asScala.toMap)
 
   // Java-api - with passThrough
   def create[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
     IncomingMessage(source, passThrough)
 
-  def create[C](id: String, passThrough: C): IncomingMessage[NotUsed, C] =
+  def create[T, C](id: String, passThrough: C): IncomingMessage[T, C] =
     IncomingMessage(id, passThrough)
 
-  def create[C](idField: String,
-                id: String,
-                field: String,
-                updates: java.util.Map[String, Object],
-                passThrough: C): IncomingMessage[NotUsed, C] =
+  def create[T, C](idField: String,
+                   id: String,
+                   field: String,
+                   updates: java.util.Map[String, Object],
+                   passThrough: C): IncomingMessage[T, C] =
     IncomingMessage(idField, id, field, updates.asScala.toMap, passThrough)
 
 }
@@ -94,44 +93,44 @@ object IncomingUpdateMessage {
 
 object IncomingDeleteMessage {
   // Apply method to use when not using passThrough
-  def apply(id: String): IncomingMessage[NotUsed, NotUsed] =
+  def apply[T](id: String): IncomingMessage[T, NotUsed] =
     IncomingMessage(id)
 
-  def apply[C](id: String, passThrough: C): IncomingMessage[NotUsed, C] =
+  def apply[T, C](id: String, passThrough: C): IncomingMessage[T, C] =
     IncomingMessage(id, passThrough)
 
   // Java-api - without passThrough
-  def create(id: String): IncomingMessage[NotUsed, NotUsed] =
+  def create[T](id: String): IncomingMessage[T, NotUsed] =
     IncomingDeleteMessage(id)
 
-  def create[C](id: String, passThrough: C): IncomingMessage[NotUsed, C] =
+  def create[T, C](id: String, passThrough: C): IncomingMessage[T, C] =
     IncomingDeleteMessage(id, passThrough)
 }
 
 object IncomingAtomicUpdateMessage {
   // Apply method to use when not using passThrough
-  def apply(idField: String, id: String, field: String, updates: Map[String, Any]): IncomingMessage[NotUsed, NotUsed] =
+  def apply[T](idField: String, id: String, field: String, updates: Map[String, Any]): IncomingMessage[T, NotUsed] =
     IncomingMessage(idField, id, field, updates)
 
-  def apply[C](idField: String,
-               id: String,
-               field: String,
-               updates: Map[String, Any],
-               passThrough: C): IncomingMessage[NotUsed, C] =
+  def apply[T, C](idField: String,
+                  id: String,
+                  field: String,
+                  updates: Map[String, Any],
+                  passThrough: C): IncomingMessage[T, C] =
     IncomingMessage(idField, id, field, updates, passThrough)
 
   // Java-api - without passThrough
-  def create(idField: String,
-             id: String,
-             field: String,
-             updates: java.util.Map[String, Object]): IncomingMessage[NotUsed, NotUsed] =
-    IncomingAtomicUpdateMessage(idField, id, field, updates.asScala.toMap)
-
-  def create[C](idField: String,
+  def create[T](idField: String,
                 id: String,
                 field: String,
-                updates: java.util.Map[String, Object],
-                passThrough: C): IncomingMessage[NotUsed, C] =
+                updates: java.util.Map[String, Object]): IncomingMessage[T, NotUsed] =
+    IncomingAtomicUpdateMessage(idField, id, field, updates.asScala.toMap)
+
+  def create[T, C](idField: String,
+                   id: String,
+                   field: String,
+                   updates: java.util.Map[String, Object],
+                   passThrough: C): IncomingMessage[T, C] =
     IncomingAtomicUpdateMessage(idField, id, field, updates.asScala.toMap, passThrough)
 }
 
@@ -266,7 +265,16 @@ private[solr] final class SolrFlowLogic[T, C](
     completeStage()
 
   private def updateBulkToSolr(messages: Seq[IncomingMessage[T, C]]): UpdateResponse = {
-    val docs = messages.map(message => messageBinder.get(message.sourceOpt.get))
+    val binder = messageBinder.get
+    val docs = messages
+      .map(
+        message =>
+          message.sourceOpt.map { source: T =>
+            binder(source)
+        }
+      )
+      .flatten
+    if (log.isDebugEnabled) log.debug(s"Upsert $docs")
     client.add(collection, docs.asJava, settings.commitWithin)
   }
 
@@ -282,6 +290,7 @@ private[solr] final class SolrFlowLogic[T, C](
       }
       doc
     }
+    if (log.isDebugEnabled) log.debug(s"Update atomically $docs")
     client.add(collection, docs.asJava, settings.commitWithin)
   }
 
@@ -326,6 +335,7 @@ private[solr] final class SolrFlowLogic[T, C](
       handleResponse((messages, response.getStatus))
     } catch {
       case exception: Throwable =>
+        log.error(exception, s"Unable to treat messages $messages")
         exception match {
           case NonFatal(exc) =>
             val rootCause = SolrException.getRootCause(exc)

--- a/solr/src/main/scala/akka/stream/alpakka/solr/SolrFlowStage.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/SolrFlowStage.scala
@@ -8,10 +8,10 @@ import java.net.{ConnectException, SocketException}
 
 import akka.NotUsed
 
-import scala.concurrent.blocking
+import scala.concurrent.{blocking, ExecutionContext, Future}
 import akka.stream.alpakka.solr.SolrFlowStage.{Finished, Idle, Sending}
 import akka.stream.stage._
-import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream._
 import org.apache.http.NoHttpResponseException
 import org.apache.solr.client.solrj.SolrClient
 import org.apache.solr.client.solrj.response.UpdateResponse
@@ -19,15 +19,19 @@ import org.apache.solr.common.{SolrException, SolrInputDocument}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.concurrent.Future
 import scala.util.{Failure, Success}
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.control.NonFatal
 
 object IncomingMessage {
   // Apply method to use when not using passThrough
   def apply[T](source: T): IncomingMessage[T, NotUsed] =
-    IncomingMessage(source, NotUsed)
+    IncomingMessage(Update, None, Some(source), NotUsed)
+
+  def apply[T](operation: Operation, source: T): IncomingMessage[T, NotUsed] =
+    IncomingMessage(operation, None, Some(source), NotUsed)
+
+  def apply(id: String): IncomingMessage[NotUsed, NotUsed] =
+    IncomingMessage(Delete, Some(id), None, NotUsed)
 
   // Java-api - without passThrough
   def create[T](source: T): IncomingMessage[T, NotUsed] =
@@ -35,19 +39,32 @@ object IncomingMessage {
 
   // Java-api - with passThrough
   def create[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
-    IncomingMessage(source, passThrough)
+    IncomingMessage(Update, None, Some(source), passThrough)
+
+  def create(id: String): IncomingMessage[NotUsed, NotUsed] =
+    IncomingMessage(id)
+
+  // Java-api - with passThrough
+  def create[T, C](operation: Operation,
+                   idOpt: Option[String],
+                   sourceOpt: Option[T],
+                   passThrough: C): IncomingMessage[T, C] =
+    IncomingMessage(operation, None, sourceOpt, passThrough)
 
 }
 
-final case class IncomingMessage[T, C](source: T, passThrough: C)
+final case class IncomingMessage[T, C](operation: Operation,
+                                       idOpt: Option[String],
+                                       sourceOpt: Option[T],
+                                       passThrough: C = NotUsed)
 
-final case class IncomingMessageResult[T, C](source: T, passThrough: C, status: Int)
+final case class IncomingMessageResult[T, C](id: Option[String], sourceOpt: Option[T], passThrough: C, status: Int)
 
 private[solr] final class SolrFlowStage[T, C](
     collection: String,
     client: SolrClient,
     settings: SolrUpdateSettings,
-    messageBinder: T => SolrInputDocument
+    messageBinder: Option[T => SolrInputDocument]
 ) extends GraphStage[FlowShape[IncomingMessage[T, C], Future[Seq[IncomingMessageResult[T, C]]]]] {
 
   private val in = Inlet[IncomingMessage[T, C]]("messages")
@@ -57,6 +74,10 @@ private[solr] final class SolrFlowStage[T, C](
   override def createLogic(inheritedAttributes: Attributes): SolrFlowLogic[T, C] =
     new SolrFlowLogic[T, C](collection, client, in, out, shape, settings, messageBinder)
 }
+
+sealed trait Operation
+final object Update extends Operation
+final object Delete extends Operation
 
 private sealed trait SolrFlowState
 
@@ -73,7 +94,7 @@ private[solr] final class SolrFlowLogic[T, C](
     out: Outlet[Future[Seq[IncomingMessageResult[T, C]]]],
     shape: FlowShape[IncomingMessage[T, C], Future[Seq[IncomingMessageResult[T, C]]]],
     settings: SolrUpdateSettings,
-    messageBinder: T => SolrInputDocument
+    messageBinder: Option[T => SolrInputDocument]
 ) extends TimerGraphStageLogic(shape)
     with OutHandler
     with InHandler
@@ -85,6 +106,8 @@ private[solr] final class SolrFlowLogic[T, C](
   private var retryCount: Int = 0
   private val failureHandler = getAsyncCallback[(Seq[IncomingMessage[T, C]], Throwable)](handleFailure)
   private val responseHandler = getAsyncCallback[(Seq[IncomingMessage[T, C]], Int)](handleResponse)
+
+  implicit private var dispatcher: ExecutionContext = _
 
   setHandlers(in, out, this)
 
@@ -108,8 +131,10 @@ private[solr] final class SolrFlowLogic[T, C](
     tryPull()
   }
 
-  override def preStart(): Unit =
+  override def preStart(): Unit = {
+    dispatcher = materializer.asInstanceOf[ActorMaterializer].system.dispatchers.lookup(getDispatcher.dispatcher)
     pull(in)
+  }
 
   override def onTimer(timerKey: Any): Unit = {
     sendBulkToSolr(failedMessages)
@@ -149,7 +174,7 @@ private[solr] final class SolrFlowLogic[T, C](
     val (messages, status) = args
     log.debug(s"Handle the response with $status")
     retryCount = 0
-    val result = messages.map(m => IncomingMessageResult(m.source, m.passThrough, status))
+    val result = messages.map(m => IncomingMessageResult(m.idOpt, m.sourceOpt, m.passThrough, status))
 
     emit(out, Future.successful(result))
 
@@ -173,8 +198,33 @@ private[solr] final class SolrFlowLogic[T, C](
   private def handleSuccess(): Unit =
     completeStage()
 
-  private def fSendBulkToSolr(messages: Seq[IncomingMessage[T, C]]): Future[UpdateResponse] = {
-    val docs = messages.map(message => messageBinder(message.source))
+  private def fDeleteBulkToSolr(messages: Seq[IncomingMessage[T, C]]): Future[UpdateResponse] = {
+    val docsIds = messages
+      .filter { message =>
+        message.operation == Delete && message.idOpt.isDefined
+      }
+      .map { message =>
+        message.idOpt.get
+      }
+    if (log.isDebugEnabled) log.debug(s"Delete the ids $docsIds")
+    Future {
+      blocking {
+        client.deleteById(collection, docsIds.asJava, settings.commitWithin)
+      }
+    }
+  }
+
+  private[solr] def getDispatcher =
+    attributes.get[ActorAttributes.Dispatcher](
+      ActorAttributes.Dispatcher("akka.stream.default-blocking-io-dispatcher")
+    ) match {
+      case ActorAttributes.Dispatcher("") =>
+        ActorAttributes.Dispatcher("akka.stream.default-blocking-io-dispatcher")
+      case d => d
+    }
+
+  private def fUpdateBulkToSolr(messages: Seq[IncomingMessage[T, C]]): Future[UpdateResponse] = {
+    val docs = messages.map(message => messageBinder.get(message.sourceOpt.get))
     Future {
       blocking {
         client.add(collection, docs.asJava, settings.commitWithin)
@@ -182,24 +232,41 @@ private[solr] final class SolrFlowLogic[T, C](
     }
   }
 
-  private def sendBulkToSolr(messages: Seq[IncomingMessage[T, C]]): Unit =
-    fSendBulkToSolr(messages).onComplete {
-      case Success(response) => responseHandler.invoke((messages, response.getStatus))
-      case Failure(exception) =>
-        exception match {
-          case NonFatal(exc) =>
-            val rootCause = SolrException.getRootCause(exc)
-            if (shouldRetry(rootCause)) {
-              failureHandler.invoke((messages, exception))
-            } else {
-              val status = exc match {
-                case e: SolrException => e.code()
-                case _ => -1
-              }
-              responseHandler.invoke((messages, status))
-            }
-        }
+  private def sendBulkToSolr(messages: Seq[IncomingMessage[T, C]]): Unit = {
+    val (updates, deletes) = messages.partition { m =>
+      m.operation == Update
     }
+
+    if (updates.isEmpty && deletes.isEmpty) {
+      //Nothing to do
+    } else {
+      val fBulkResult = if (updates.isEmpty) {
+        fDeleteBulkToSolr(deletes)
+      } else if (deletes.isEmpty) {
+        fUpdateBulkToSolr(updates)
+      } else {
+        fUpdateBulkToSolr(updates).flatMap(_ => fDeleteBulkToSolr(deletes))
+      }
+      fBulkResult.onComplete {
+        case Success(response) => responseHandler.invoke((messages, response.getStatus))
+        case Failure(exception) =>
+          log.error(exception, "Unable to send messages to SolR")
+          exception match {
+            case NonFatal(exc) =>
+              val rootCause = SolrException.getRootCause(exc)
+              if (shouldRetry(rootCause)) {
+                failureHandler.invoke((messages, exception))
+              } else {
+                val status = exc match {
+                  case e: SolrException => e.code()
+                  case _ => -1
+                }
+                responseHandler.invoke((messages, status))
+              }
+          }
+      }
+    }
+  }
 
   private def shouldRetry(cause: Throwable): Boolean =
     cause match {

--- a/solr/src/main/scala/akka/stream/alpakka/solr/SolrUpdateSettings.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/SolrUpdateSettings.scala
@@ -8,16 +8,8 @@ import scala.concurrent.duration.{FiniteDuration, _}
 
 //#solr-update-settings
 final case class SolrUpdateSettings(
-    retryInterval: FiniteDuration = 5000.millis,
-    maxRetry: Int = 100,
     commitWithin: Int = -1
 ) {
-  def withRetryInterval(retryInterval: FiniteDuration): SolrUpdateSettings =
-    copy(retryInterval = retryInterval)
-
-  def withMaxRetry(maxRetry: Int): SolrUpdateSettings =
-    copy(maxRetry = maxRetry)
-
   def withCommitWithin(commitWithin: Int): SolrUpdateSettings =
     copy(commitWithin = commitWithin)
 }

--- a/solr/src/main/scala/akka/stream/alpakka/solr/SolrUpdateSettings.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/SolrUpdateSettings.scala
@@ -8,14 +8,10 @@ import scala.concurrent.duration.{FiniteDuration, _}
 
 //#solr-update-settings
 final case class SolrUpdateSettings(
-    bufferSize: Int = 10,
     retryInterval: FiniteDuration = 5000.millis,
     maxRetry: Int = 100,
     commitWithin: Int = -1
 ) {
-  def withBufferSize(bufferSize: Int): SolrUpdateSettings =
-    copy(bufferSize = bufferSize)
-
   def withRetryInterval(retryInterval: FiniteDuration): SolrUpdateSettings =
     copy(retryInterval = retryInterval)
 

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
@@ -79,6 +79,20 @@ object SolrFlow {
       .asJava
 
   /**
+   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for document to atomically update
+   * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]].
+   */
+  def update(
+      collection: String,
+      settings: SolrUpdateSettings,
+      client: SolrClient
+  ): javadsl.Flow[IncomingMessage[NotUsed, NotUsed], JavaList[IncomingMessageResult[NotUsed, NotUsed]], NotUsed] =
+    ScalaSolrFlow
+      .update(collection, settings)(client)
+      .map(_.asJava)
+      .asJava
+
+  /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for [[SolrInputDocument]] from [[IncomingMessage]]
    * to lists of [[IncomingMessageResult]] with `passThrough` of type `C`.
    */
@@ -135,6 +149,20 @@ object SolrFlow {
   ): javadsl.Flow[IncomingMessage[NotUsed, C], JavaList[IncomingMessageResult[NotUsed, C]], NotUsed] =
     ScalaSolrFlow
       .deleteWithPassThrough[C](collection, settings)(client)
+      .map(_.asJava)
+      .asJava
+
+  /**
+   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for document to atomically update
+   * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]] with `passThrough` of type `C`.
+   */
+  def updateWithPassThrough[C](
+      collection: String,
+      settings: SolrUpdateSettings,
+      client: SolrClient
+  ): javadsl.Flow[IncomingMessage[NotUsed, C], JavaList[IncomingMessageResult[NotUsed, C]], NotUsed] =
+    ScalaSolrFlow
+      .updateWithPassThrough[C](collection, settings)(client)
       .map(_.asJava)
       .asJava
 }

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
@@ -11,6 +11,7 @@ import akka.NotUsed
 import akka.stream.alpakka.solr.scaladsl.{SolrFlow => ScalaSolrFlow}
 import akka.stream.alpakka.solr.{IncomingMessage, IncomingMessageResult, SolrUpdateSettings}
 import akka.stream.javadsl
+import akka.stream.scaladsl.Flow
 import org.apache.solr.client.solrj.SolrClient
 import org.apache.solr.common.SolrInputDocument
 
@@ -22,14 +23,22 @@ object SolrFlow {
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for [[SolrInputDocument]]
    * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]].
    */
-  def document(
+  def documents(
       collection: String,
       settings: SolrUpdateSettings,
       client: SolrClient
-  ): javadsl.Flow[IncomingMessage[SolrInputDocument, NotUsed], JavaList[IncomingMessageResult[SolrInputDocument,
-                                                                                              NotUsed]], NotUsed] =
-    ScalaSolrFlow
-      .document(collection, settings)(client)
+  ): javadsl.Flow[JavaList[IncomingMessage[SolrInputDocument, NotUsed]], JavaList[
+    IncomingMessageResult[SolrInputDocument, NotUsed]
+  ], NotUsed] =
+    Flow
+      .fromFunction[JavaList[IncomingMessage[SolrInputDocument, NotUsed]], Seq[IncomingMessage[SolrInputDocument,
+                                                                                               NotUsed]]](
+        _.asScala.toSeq
+      )
+      .via(
+        ScalaSolrFlow
+          .documents(collection, settings)(client)
+      )
       .map(_.asJava)
       .asJava
 
@@ -37,14 +46,18 @@ object SolrFlow {
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
    */
-  def bean[T](
+  def beans[T](
       collection: String,
       settings: SolrUpdateSettings,
       client: SolrClient,
       clazz: Class[T]
-  ): javadsl.Flow[IncomingMessage[T, NotUsed], JavaList[IncomingMessageResult[T, NotUsed]], NotUsed] =
-    ScalaSolrFlow
-      .bean[T](collection, settings)(client)
+  ): javadsl.Flow[JavaList[IncomingMessage[T, NotUsed]], JavaList[IncomingMessageResult[T, NotUsed]], NotUsed] =
+    Flow
+      .fromFunction[JavaList[IncomingMessage[T, NotUsed]], Seq[IncomingMessage[T, NotUsed]]](_.asScala.toSeq)
+      .via(
+        ScalaSolrFlow
+          .beans[T](collection, settings)(client)
+      )
       .map(_.asJava)
       .asJava
 
@@ -58,9 +71,13 @@ object SolrFlow {
       binder: Function[T, SolrInputDocument],
       client: SolrClient,
       clazz: Class[T]
-  ): javadsl.Flow[IncomingMessage[T, NotUsed], JavaList[IncomingMessageResult[T, NotUsed]], NotUsed] =
-    ScalaSolrFlow
-      .typed[T](collection, settings, i => binder.apply(i))(client)
+  ): javadsl.Flow[JavaList[IncomingMessage[T, NotUsed]], JavaList[IncomingMessageResult[T, NotUsed]], NotUsed] =
+    Flow
+      .fromFunction[JavaList[IncomingMessage[T, NotUsed]], Seq[IncomingMessage[T, NotUsed]]](_.asScala.toSeq)
+      .via(
+        ScalaSolrFlow
+          .typed[T](collection, settings, i => binder.apply(i))(client)
+      )
       .map(_.asJava)
       .asJava
 
@@ -68,13 +85,19 @@ object SolrFlow {
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for document to delete
    * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]].
    */
-  def delete(
+  def deletes(
       collection: String,
       settings: SolrUpdateSettings,
       client: SolrClient
-  ): javadsl.Flow[IncomingMessage[NotUsed, NotUsed], JavaList[IncomingMessageResult[NotUsed, NotUsed]], NotUsed] =
-    ScalaSolrFlow
-      .delete(collection, settings)(client)
+  ): javadsl.Flow[JavaList[IncomingMessage[NotUsed, NotUsed]], JavaList[IncomingMessageResult[NotUsed, NotUsed]], NotUsed] =
+    Flow
+      .fromFunction[JavaList[IncomingMessage[NotUsed, NotUsed]], Seq[IncomingMessage[NotUsed, NotUsed]]](
+        _.asScala.toSeq
+      )
+      .via(
+        ScalaSolrFlow
+          .deletes(collection, settings)(client)
+      )
       .map(_.asJava)
       .asJava
 
@@ -82,13 +105,19 @@ object SolrFlow {
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for document to atomically update
    * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]].
    */
-  def update(
+  def updates(
       collection: String,
       settings: SolrUpdateSettings,
       client: SolrClient
-  ): javadsl.Flow[IncomingMessage[NotUsed, NotUsed], JavaList[IncomingMessageResult[NotUsed, NotUsed]], NotUsed] =
-    ScalaSolrFlow
-      .update(collection, settings)(client)
+  ): javadsl.Flow[JavaList[IncomingMessage[NotUsed, NotUsed]], JavaList[IncomingMessageResult[NotUsed, NotUsed]], NotUsed] =
+    Flow
+      .fromFunction[JavaList[IncomingMessage[NotUsed, NotUsed]], Seq[IncomingMessage[NotUsed, NotUsed]]](
+        _.asScala.toSeq
+      )
+      .via(
+        ScalaSolrFlow
+          .updates(collection, settings)(client)
+      )
       .map(_.asJava)
       .asJava
 
@@ -96,13 +125,20 @@ object SolrFlow {
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for [[SolrInputDocument]] from [[IncomingMessage]]
    * to lists of [[IncomingMessageResult]] with `passThrough` of type `C`.
    */
-  def documentWithPassThrough[C](
+  def documentsWithPassThrough[C](
       collection: String,
       settings: SolrUpdateSettings,
       client: SolrClient
-  ): javadsl.Flow[IncomingMessage[SolrInputDocument, C], JavaList[IncomingMessageResult[SolrInputDocument, C]], NotUsed] =
-    ScalaSolrFlow
-      .documentWithPassThrough[C](collection, settings)(client)
+  ): javadsl.Flow[JavaList[IncomingMessage[SolrInputDocument, C]], JavaList[IncomingMessageResult[SolrInputDocument,
+                                                                                                  C]], NotUsed] =
+    Flow
+      .fromFunction[JavaList[IncomingMessage[SolrInputDocument, C]], Seq[IncomingMessage[SolrInputDocument, C]]](
+        _.asScala.toSeq
+      )
+      .via(
+        ScalaSolrFlow
+          .documentsWithPassThrough(collection, settings)(client)
+      )
       .map(_.asJava)
       .asJava
 
@@ -111,14 +147,18 @@ object SolrFlow {
    * to lists of [[IncomingMessageResult]] with `passThrough` of type `C`
    * and [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]] for type 'T' .
    */
-  def beanWithPassThrough[T, C](
+  def beansWithPassThrough[T, C](
       collection: String,
       settings: SolrUpdateSettings,
       client: SolrClient,
       clazz: Class[T]
-  ): javadsl.Flow[IncomingMessage[T, C], JavaList[IncomingMessageResult[T, C]], NotUsed] =
-    ScalaSolrFlow
-      .beanWithPassThrough[T, C](collection, settings)(client)
+  ): javadsl.Flow[JavaList[IncomingMessage[T, C]], JavaList[IncomingMessageResult[T, C]], NotUsed] =
+    Flow
+      .fromFunction[JavaList[IncomingMessage[T, C]], Seq[IncomingMessage[T, C]]](_.asScala.toSeq)
+      .via(
+        ScalaSolrFlow
+          .beansWithPassThrough[T, C](collection, settings)(client)
+      )
       .map(_.asJava)
       .asJava
 
@@ -132,9 +172,13 @@ object SolrFlow {
       binder: Function[T, SolrInputDocument],
       client: SolrClient,
       clazz: Class[T]
-  ): javadsl.Flow[IncomingMessage[T, C], JavaList[IncomingMessageResult[T, C]], NotUsed] =
-    ScalaSolrFlow
-      .typedWithPassThrough[T, C](collection, settings, i => binder.apply(i))(client)
+  ): javadsl.Flow[JavaList[IncomingMessage[T, C]], JavaList[IncomingMessageResult[T, C]], NotUsed] =
+    Flow
+      .fromFunction[JavaList[IncomingMessage[T, C]], Seq[IncomingMessage[T, C]]](_.asScala.toSeq)
+      .via(
+        ScalaSolrFlow
+          .typedWithPassThrough[T, C](collection, settings, i => binder.apply(i))(client)
+      )
       .map(_.asJava)
       .asJava
 
@@ -146,9 +190,13 @@ object SolrFlow {
       collection: String,
       settings: SolrUpdateSettings,
       client: SolrClient
-  ): javadsl.Flow[IncomingMessage[NotUsed, C], JavaList[IncomingMessageResult[NotUsed, C]], NotUsed] =
-    ScalaSolrFlow
-      .deleteWithPassThrough[C](collection, settings)(client)
+  ): javadsl.Flow[JavaList[IncomingMessage[NotUsed, C]], JavaList[IncomingMessageResult[NotUsed, C]], NotUsed] =
+    Flow
+      .fromFunction[JavaList[IncomingMessage[NotUsed, C]], Seq[IncomingMessage[NotUsed, C]]](_.asScala.toSeq)
+      .via(
+        ScalaSolrFlow
+          .deletesWithPassThrough[C](collection, settings)(client)
+      )
       .map(_.asJava)
       .asJava
 
@@ -160,9 +208,13 @@ object SolrFlow {
       collection: String,
       settings: SolrUpdateSettings,
       client: SolrClient
-  ): javadsl.Flow[IncomingMessage[NotUsed, C], JavaList[IncomingMessageResult[NotUsed, C]], NotUsed] =
-    ScalaSolrFlow
-      .updateWithPassThrough[C](collection, settings)(client)
+  ): javadsl.Flow[JavaList[IncomingMessage[NotUsed, C]], JavaList[IncomingMessageResult[NotUsed, C]], NotUsed] =
+    Flow
+      .fromFunction[JavaList[IncomingMessage[NotUsed, C]], Seq[IncomingMessage[NotUsed, C]]](_.asScala.toSeq)
+      .via(
+        ScalaSolrFlow
+          .updatesWithPassThrough[C](collection, settings)(client)
+      )
       .map(_.asJava)
       .asJava
 }

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
@@ -22,7 +22,7 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for [[SolrInputDocument]]
    * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]].
-   * @deprecated ("use the method documents to batch operation")
+   * @deprecated ("use the method documents to batch operation","0.21")
    */
   def document(
       collection: String,
@@ -64,7 +64,7 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
-   * @deprecated ("use the method beans to batch operation")
+   * @deprecated ("use the method beans to batch operation","0.21")
    */
   def bean[T](
       collection: String,
@@ -101,7 +101,7 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with `binder` of type 'T'.
-   * @deprecated ("use the method typeds to batch operation")
+   * @deprecated ("use the method typeds to batch operation","0.21")
    */
   def typed[T](
       collection: String,
@@ -140,7 +140,7 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for [[SolrInputDocument]]
    * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]] with `passThrough` of type `C`.
-   * @deprecated ("use the method documentsWithPassThrough to batch operation")
+   * @deprecated ("use the method documentsWithPassThrough to batch operation","0.21")
    */
   def documentWithPassThrough[C](
       collection: String,
@@ -178,7 +178,7 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with `passThrough` of type `C` and [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
-   * @deprecated ("use the method beansWithPassThrough to batch operation")
+   * @deprecated ("use the method beansWithPassThrough to batch operation","0.21")
    */
   def beanWithPassThrough[T, C](
       collection: String,
@@ -216,7 +216,7 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with `binder` of type 'T'.
-   * @deprecated ("use the method typedsWithPassThrough to batch operation")
+   * @deprecated ("use the method typedsWithPassThrough to batch operation","0.21")
    */
   def typedWithPassThrough[T, C](
       collection: String,

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
@@ -22,6 +22,25 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for [[SolrInputDocument]]
    * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]].
+   * @deprecated ("use the method documents to batch operation")
+   */
+  def document(
+      collection: String,
+      settings: SolrUpdateSettings,
+      client: SolrClient
+  ): javadsl.Flow[IncomingMessage[SolrInputDocument, NotUsed], JavaList[
+    IncomingMessageResult[SolrInputDocument, NotUsed]
+  ], NotUsed] =
+    ScalaSolrFlow
+      .document(collection, settings)(client)
+      .map {
+        _.asJava
+      }
+      .asJava
+
+  /**
+   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for [[SolrInputDocument]]
+   * from sequence of [[IncomingMessage]] to sequences of [[IncomingMessageResult]].
    */
   def documents(
       collection: String,
@@ -45,6 +64,24 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
+   * @deprecated ("use the method beans to batch operation")
+   */
+  def bean[T](
+      collection: String,
+      settings: SolrUpdateSettings,
+      client: SolrClient,
+      clazz: Class[T]
+  ): javadsl.Flow[IncomingMessage[T, NotUsed], JavaList[IncomingMessageResult[T, NotUsed]], NotUsed] =
+    ScalaSolrFlow
+      .bean[T](collection, settings)(client)
+      .map {
+        _.asJava
+      }
+      .asJava
+
+  /**
+   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from sequence of [Seq[IncomingMessage]] to sequences
+   * of [[IncomingMessageResult]] with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
    */
   def beans[T](
       collection: String,
@@ -64,8 +101,27 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with `binder` of type 'T'.
+   * @deprecated ("use the method typeds to batch operation")
    */
   def typed[T](
+      collection: String,
+      settings: SolrUpdateSettings,
+      binder: Function[T, SolrInputDocument],
+      client: SolrClient,
+      clazz: Class[T]
+  ): javadsl.Flow[IncomingMessage[T, NotUsed], JavaList[IncomingMessageResult[T, NotUsed]], NotUsed] =
+    ScalaSolrFlow
+      .typed[T](collection, settings, i => binder.apply(i))(client)
+      .map {
+        _.asJava
+      }
+      .asJava
+
+  /**
+   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from sequence of [[IncomingMessage]] to sequences
+   * of [[IncomingMessageResult]] with `binder` of type 'T'.
+   */
+  def typeds[T](
       collection: String,
       settings: SolrUpdateSettings,
       binder: Function[T, SolrInputDocument],
@@ -76,9 +132,26 @@ object SolrFlow {
       .fromFunction[JavaList[IncomingMessage[T, NotUsed]], Seq[IncomingMessage[T, NotUsed]]](_.asScala.toSeq)
       .via(
         ScalaSolrFlow
-          .typed[T](collection, settings, i => binder.apply(i))(client)
+          .typeds[T](collection, settings, i => binder.apply(i))(client)
       )
       .map(_.asJava)
+      .asJava
+
+  /**
+   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for [[SolrInputDocument]]
+   * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]] with `passThrough` of type `C`.
+   * @deprecated ("use the method documentsWithPassThrough to batch operation")
+   */
+  def documentWithPassThrough[C](
+      collection: String,
+      settings: SolrUpdateSettings,
+      client: SolrClient
+  ): javadsl.Flow[IncomingMessage[SolrInputDocument, C], JavaList[IncomingMessageResult[SolrInputDocument, C]], NotUsed] =
+    ScalaSolrFlow
+      .documentWithPassThrough[C](collection, settings)(client)
+      .map {
+        _.asJava
+      }
       .asJava
 
   /**
@@ -103,7 +176,25 @@ object SolrFlow {
       .asJava
 
   /**
-   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type 'T' from [[IncomingMessage]]
+   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
+   * of [[IncomingMessageResult]] with `passThrough` of type `C` and [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
+   * @deprecated ("use the method beansWithPassThrough to batch operation")
+   */
+  def beanWithPassThrough[T, C](
+      collection: String,
+      settings: SolrUpdateSettings,
+      client: SolrClient,
+      clazz: Class[T]
+  ): javadsl.Flow[IncomingMessage[T, C], JavaList[IncomingMessageResult[T, C]], NotUsed] =
+    ScalaSolrFlow
+      .beanWithPassThrough[T, C](collection, settings)(client)
+      .map {
+        _.asJava
+      }
+      .asJava
+
+  /**
+   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type 'T' from sequence of [[IncomingMessage]]
    * to lists of [[IncomingMessageResult]] with `passThrough` of type `C`
    * and [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]] for type 'T' .
    */
@@ -123,10 +214,29 @@ object SolrFlow {
       .asJava
 
   /**
-   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type 'T' from [[IncomingMessage]]
-   * to lists of [[IncomingMessageResult]] with `passThrough` of type `C` and `binder` of type `T`.
+   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
+   * of [[IncomingMessageResult]] with `binder` of type 'T'.
+   * @deprecated ("use the method typedsWithPassThrough to batch operation")
    */
   def typedWithPassThrough[T, C](
+      collection: String,
+      settings: SolrUpdateSettings,
+      binder: Function[T, SolrInputDocument],
+      client: SolrClient,
+      clazz: Class[T]
+  ): javadsl.Flow[IncomingMessage[T, C], JavaList[IncomingMessageResult[T, C]], NotUsed] =
+    ScalaSolrFlow
+      .typedWithPassThrough[T, C](collection, settings, i => binder.apply(i))(client)
+      .map {
+        _.asJava
+      }
+      .asJava
+
+  /**
+   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type 'T' from sequence of [[IncomingMessage]]
+   * to lists of [[IncomingMessageResult]] with `passThrough` of type `C` and `binder` of type `T`.
+   */
+  def typedsWithPassThrough[T, C](
       collection: String,
       settings: SolrUpdateSettings,
       binder: Function[T, SolrInputDocument],
@@ -137,7 +247,7 @@ object SolrFlow {
       .fromFunction[JavaList[IncomingMessage[T, C]], Seq[IncomingMessage[T, C]]](_.asScala.toSeq)
       .via(
         ScalaSolrFlow
-          .typedWithPassThrough[T, C](collection, settings, i => binder.apply(i))(client)
+          .typedsWithPassThrough[T, C](collection, settings, i => binder.apply(i))(client)
       )
       .map(_.asJava)
       .asJava

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
@@ -82,46 +82,6 @@ object SolrFlow {
       .asJava
 
   /**
-   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for document to delete
-   * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]].
-   */
-  def deletes(
-      collection: String,
-      settings: SolrUpdateSettings,
-      client: SolrClient
-  ): javadsl.Flow[JavaList[IncomingMessage[NotUsed, NotUsed]], JavaList[IncomingMessageResult[NotUsed, NotUsed]], NotUsed] =
-    Flow
-      .fromFunction[JavaList[IncomingMessage[NotUsed, NotUsed]], Seq[IncomingMessage[NotUsed, NotUsed]]](
-        _.asScala.toSeq
-      )
-      .via(
-        ScalaSolrFlow
-          .deletes(collection, settings)(client)
-      )
-      .map(_.asJava)
-      .asJava
-
-  /**
-   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for document to atomically update
-   * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]].
-   */
-  def updates(
-      collection: String,
-      settings: SolrUpdateSettings,
-      client: SolrClient
-  ): javadsl.Flow[JavaList[IncomingMessage[NotUsed, NotUsed]], JavaList[IncomingMessageResult[NotUsed, NotUsed]], NotUsed] =
-    Flow
-      .fromFunction[JavaList[IncomingMessage[NotUsed, NotUsed]], Seq[IncomingMessage[NotUsed, NotUsed]]](
-        _.asScala.toSeq
-      )
-      .via(
-        ScalaSolrFlow
-          .updates(collection, settings)(client)
-      )
-      .map(_.asJava)
-      .asJava
-
-  /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for [[SolrInputDocument]] from [[IncomingMessage]]
    * to lists of [[IncomingMessageResult]] with `passThrough` of type `C`.
    */
@@ -182,39 +142,4 @@ object SolrFlow {
       .map(_.asJava)
       .asJava
 
-  /**
-   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for document to delete
-   * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]] with `passThrough` of type `C`.
-   */
-  def deleteWithPassThrough[C](
-      collection: String,
-      settings: SolrUpdateSettings,
-      client: SolrClient
-  ): javadsl.Flow[JavaList[IncomingMessage[NotUsed, C]], JavaList[IncomingMessageResult[NotUsed, C]], NotUsed] =
-    Flow
-      .fromFunction[JavaList[IncomingMessage[NotUsed, C]], Seq[IncomingMessage[NotUsed, C]]](_.asScala.toSeq)
-      .via(
-        ScalaSolrFlow
-          .deletesWithPassThrough[C](collection, settings)(client)
-      )
-      .map(_.asJava)
-      .asJava
-
-  /**
-   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for document to atomically update
-   * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]] with `passThrough` of type `C`.
-   */
-  def updateWithPassThrough[C](
-      collection: String,
-      settings: SolrUpdateSettings,
-      client: SolrClient
-  ): javadsl.Flow[JavaList[IncomingMessage[NotUsed, C]], JavaList[IncomingMessageResult[NotUsed, C]], NotUsed] =
-    Flow
-      .fromFunction[JavaList[IncomingMessage[NotUsed, C]], Seq[IncomingMessage[NotUsed, C]]](_.asScala.toSeq)
-      .via(
-        ScalaSolrFlow
-          .updatesWithPassThrough[C](collection, settings)(client)
-      )
-      .map(_.asJava)
-      .asJava
 }

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
@@ -65,6 +65,20 @@ object SolrFlow {
       .asJava
 
   /**
+   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for document to delete
+   * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]].
+   */
+  def delete(
+      collection: String,
+      settings: SolrUpdateSettings,
+      client: SolrClient
+  ): javadsl.Flow[IncomingMessage[NotUsed, NotUsed], JavaList[IncomingMessageResult[NotUsed, NotUsed]], NotUsed] =
+    ScalaSolrFlow
+      .delete(collection, settings)(client)
+      .map(_.asJava)
+      .asJava
+
+  /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for [[SolrInputDocument]] from [[IncomingMessage]]
    * to lists of [[IncomingMessageResult]] with `passThrough` of type `C`.
    */
@@ -110,4 +124,17 @@ object SolrFlow {
       .map(_.asJava)
       .asJava
 
+  /**
+   * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for document to delete
+   * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]] with `passThrough` of type `C`.
+   */
+  def deleteWithPassThrough[C](
+      collection: String,
+      settings: SolrUpdateSettings,
+      client: SolrClient
+  ): javadsl.Flow[IncomingMessage[NotUsed, C], JavaList[IncomingMessageResult[NotUsed, C]], NotUsed] =
+    ScalaSolrFlow
+      .deleteWithPassThrough[C](collection, settings)(client)
+      .map(_.asJava)
+      .asJava
 }

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
@@ -22,7 +22,7 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for [[SolrInputDocument]]
    * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]].
-   * @deprecated ("use the method documents to batch operation","0.21")
+   * @deprecated ("use the method documents to batch operation","0.20")
    */
   def document(
       collection: String,
@@ -64,7 +64,7 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
-   * @deprecated ("use the method beans to batch operation","0.21")
+   * @deprecated ("use the method beans to batch operation","0.20")
    */
   def bean[T](
       collection: String,
@@ -101,7 +101,7 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with `binder` of type 'T'.
-   * @deprecated ("use the method typeds to batch operation","0.21")
+   * @deprecated ("use the method typeds to batch operation","0.20")
    */
   def typed[T](
       collection: String,
@@ -140,7 +140,7 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for [[SolrInputDocument]]
    * from [[IncomingMessage]] to sequences of [[IncomingMessageResult]] with `passThrough` of type `C`.
-   * @deprecated ("use the method documentsWithPassThrough to batch operation","0.21")
+   * @deprecated ("use the method documentsWithPassThrough to batch operation","0.20")
    */
   def documentWithPassThrough[C](
       collection: String,
@@ -178,7 +178,7 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with `passThrough` of type `C` and [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
-   * @deprecated ("use the method beansWithPassThrough to batch operation","0.21")
+   * @deprecated ("use the method beansWithPassThrough to batch operation","0.20")
    */
   def beanWithPassThrough[T, C](
       collection: String,
@@ -216,7 +216,7 @@ object SolrFlow {
   /**
    * Java API: creates a [[akka.stream.alpakka.solr.SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with `binder` of type 'T'.
-   * @deprecated ("use the method typedsWithPassThrough to batch operation","0.21")
+   * @deprecated ("use the method typedsWithPassThrough to batch operation","0.20")
    */
   def typedWithPassThrough[T, C](
       collection: String,

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrSink.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrSink.scala
@@ -19,7 +19,7 @@ object SolrSink {
 
   /**
    * Java API: creates a [[SolrFlow]] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
-   * @deprecated ("use the method documents to batch operation","0.21")
+   * @deprecated ("use the method documents to batch operation","0.20")
    */
   def document(
       collection: String,
@@ -34,7 +34,7 @@ object SolrSink {
   /**
    * Java API: creates a [[SolrFlow]] to Solr for [[IncomingMessage]] containing type `T`
    * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
-   * @deprecated ("use the method beans to batch operation","0.21")
+   * @deprecated ("use the method beans to batch operation","0.20")
    */
   def bean[T](
       collection: String,
@@ -49,7 +49,7 @@ object SolrSink {
 
   /**
    * Java API: creates a [[SolrFlow]] to Solr for [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
-   * @deprecated ("use the method typeds to batch operation","0.21")
+   * @deprecated ("use the method typeds to batch operation","0.20")
    */
   def typed[T](
       collection: String,

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrSink.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrSink.scala
@@ -71,4 +71,17 @@ object SolrSink {
       .delete(collection, settings, client)
       .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[NotUsed, NotUsed]]],
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
+
+  /**
+   * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
+   */
+  def update(
+      collection: String,
+      settings: SolrUpdateSettings,
+      client: SolrClient
+  ): javadsl.Sink[IncomingMessage[NotUsed, NotUsed], CompletionStage[Done]] =
+    SolrFlow
+      .update(collection, settings, client)
+      .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[NotUsed, NotUsed]]],
+             javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 }

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrSink.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrSink.scala
@@ -14,18 +14,20 @@ import akka.{Done, NotUsed}
 import org.apache.solr.client.solrj.SolrClient
 import org.apache.solr.common.SolrInputDocument
 
+import java.util.{List => JavaList}
+
 object SolrSink {
 
   /**
    * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
    */
-  def document(
+  def documents(
       collection: String,
       settings: SolrUpdateSettings,
       client: SolrClient
-  ): javadsl.Sink[IncomingMessage[SolrInputDocument, NotUsed], CompletionStage[Done]] =
+  ): javadsl.Sink[JavaList[IncomingMessage[SolrInputDocument, NotUsed]], CompletionStage[Done]] =
     SolrFlow
-      .document(collection, settings, client)
+      .documents(collection, settings, client)
       .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[SolrInputDocument, NotUsed]]],
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 
@@ -33,14 +35,14 @@ object SolrSink {
    * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing type `T`
    * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
    */
-  def bean[T](
+  def beans[T](
       collection: String,
       settings: SolrUpdateSettings,
       client: SolrClient,
       clazz: Class[T]
-  ): Sink[IncomingMessage[T, NotUsed], CompletionStage[Done]] =
+  ): Sink[JavaList[IncomingMessage[T, NotUsed]], CompletionStage[Done]] =
     SolrFlow
-      .bean[T](collection, settings, client, clazz)
+      .beans[T](collection, settings, client, clazz)
       .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[T, NotUsed]]],
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 
@@ -53,7 +55,7 @@ object SolrSink {
       binder: Function[T, SolrInputDocument],
       client: SolrClient,
       clazz: Class[T]
-  ): javadsl.Sink[IncomingMessage[T, NotUsed], CompletionStage[Done]] =
+  ): javadsl.Sink[JavaList[IncomingMessage[T, NotUsed]], CompletionStage[Done]] =
     SolrFlow
       .typed[T](collection, settings, binder, client, clazz)
       .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[T, NotUsed]]],
@@ -62,26 +64,26 @@ object SolrSink {
   /**
    * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
    */
-  def delete(
+  def deletes(
       collection: String,
       settings: SolrUpdateSettings,
       client: SolrClient
-  ): javadsl.Sink[IncomingMessage[NotUsed, NotUsed], CompletionStage[Done]] =
+  ): javadsl.Sink[JavaList[IncomingMessage[NotUsed, NotUsed]], CompletionStage[Done]] =
     SolrFlow
-      .delete(collection, settings, client)
+      .deletes(collection, settings, client)
       .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[NotUsed, NotUsed]]],
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 
   /**
    * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
    */
-  def update(
+  def updates(
       collection: String,
       settings: SolrUpdateSettings,
       client: SolrClient
-  ): javadsl.Sink[IncomingMessage[NotUsed, NotUsed], CompletionStage[Done]] =
+  ): javadsl.Sink[JavaList[IncomingMessage[NotUsed, NotUsed]], CompletionStage[Done]] =
     SolrFlow
-      .update(collection, settings, client)
+      .updates(collection, settings, client)
       .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[NotUsed, NotUsed]]],
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 }

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrSink.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrSink.scala
@@ -13,7 +13,6 @@ import akka.stream.javadsl.Sink
 import akka.{Done, NotUsed}
 import org.apache.solr.client.solrj.SolrClient
 import org.apache.solr.common.SolrInputDocument
-
 import java.util.{List => JavaList}
 
 object SolrSink {
@@ -59,31 +58,5 @@ object SolrSink {
     SolrFlow
       .typed[T](collection, settings, binder, client, clazz)
       .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[T, NotUsed]]],
-             javadsl.Keep.right[NotUsed, CompletionStage[Done]])
-
-  /**
-   * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
-   */
-  def deletes(
-      collection: String,
-      settings: SolrUpdateSettings,
-      client: SolrClient
-  ): javadsl.Sink[JavaList[IncomingMessage[NotUsed, NotUsed]], CompletionStage[Done]] =
-    SolrFlow
-      .deletes(collection, settings, client)
-      .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[NotUsed, NotUsed]]],
-             javadsl.Keep.right[NotUsed, CompletionStage[Done]])
-
-  /**
-   * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
-   */
-  def updates(
-      collection: String,
-      settings: SolrUpdateSettings,
-      client: SolrClient
-  ): javadsl.Sink[JavaList[IncomingMessage[NotUsed, NotUsed]], CompletionStage[Done]] =
-    SolrFlow
-      .updates(collection, settings, client)
-      .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[NotUsed, NotUsed]]],
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 }

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrSink.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrSink.scala
@@ -19,6 +19,52 @@ object SolrSink {
 
   /**
    * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
+   * @deprecated ("use the method documents to batch operation")
+   */
+  def document(
+      collection: String,
+      settings: SolrUpdateSettings,
+      client: SolrClient
+  ): javadsl.Sink[IncomingMessage[SolrInputDocument, NotUsed], CompletionStage[Done]] =
+    SolrFlow
+      .document(collection, settings, client)
+      .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[SolrInputDocument, NotUsed]]],
+             javadsl.Keep.right[NotUsed, CompletionStage[Done]])
+
+  /**
+   * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing type `T`
+   * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
+   * @deprecated ("use the method beans to batch operation")
+   */
+  def bean[T](
+      collection: String,
+      settings: SolrUpdateSettings,
+      client: SolrClient,
+      clazz: Class[T]
+  ): Sink[IncomingMessage[T, NotUsed], CompletionStage[Done]] =
+    SolrFlow
+      .bean[T](collection, settings, client, clazz)
+      .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[T, NotUsed]]],
+             javadsl.Keep.right[NotUsed, CompletionStage[Done]])
+
+  /**
+   * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
+   * @deprecated ("use the method typeds to batch operation")
+   */
+  def typed[T](
+      collection: String,
+      settings: SolrUpdateSettings,
+      binder: Function[T, SolrInputDocument],
+      client: SolrClient,
+      clazz: Class[T]
+  ): javadsl.Sink[IncomingMessage[T, NotUsed], CompletionStage[Done]] =
+    SolrFlow
+      .typed[T](collection, settings, binder, client, clazz)
+      .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[T, NotUsed]]],
+             javadsl.Keep.right[NotUsed, CompletionStage[Done]])
+
+  /**
+   * Java API: creates a [[SolrFlow] to Solr for sequence of [[IncomingMessage]] containing [[SolrInputDocument]].
    */
   def documents(
       collection: String,
@@ -31,7 +77,7 @@ object SolrSink {
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 
   /**
-   * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing type `T`
+   * Java API: creates a [[SolrFlow] to Solr for sequence of [[IncomingMessage]] containing type `T`
    * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
    */
   def beans[T](
@@ -46,9 +92,9 @@ object SolrSink {
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 
   /**
-   * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
+   * Java API: creates a [[SolrFlow] to Solr for sequence of [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
    */
-  def typed[T](
+  def typeds[T](
       collection: String,
       settings: SolrUpdateSettings,
       binder: Function[T, SolrInputDocument],
@@ -56,7 +102,7 @@ object SolrSink {
       clazz: Class[T]
   ): javadsl.Sink[JavaList[IncomingMessage[T, NotUsed]], CompletionStage[Done]] =
     SolrFlow
-      .typed[T](collection, settings, binder, client, clazz)
+      .typeds[T](collection, settings, binder, client, clazz)
       .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[T, NotUsed]]],
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 }

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrSink.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrSink.scala
@@ -18,8 +18,8 @@ import java.util.{List => JavaList}
 object SolrSink {
 
   /**
-   * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
-   * @deprecated ("use the method documents to batch operation")
+   * Java API: creates a [[SolrFlow]] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
+   * @deprecated ("use the method documents to batch operation","0.21")
    */
   def document(
       collection: String,
@@ -32,9 +32,9 @@ object SolrSink {
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 
   /**
-   * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing type `T`
+   * Java API: creates a [[SolrFlow]] to Solr for [[IncomingMessage]] containing type `T`
    * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
-   * @deprecated ("use the method beans to batch operation")
+   * @deprecated ("use the method beans to batch operation","0.21")
    */
   def bean[T](
       collection: String,
@@ -48,8 +48,8 @@ object SolrSink {
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 
   /**
-   * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
-   * @deprecated ("use the method typeds to batch operation")
+   * Java API: creates a [[SolrFlow]] to Solr for [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
+   * @deprecated ("use the method typeds to batch operation","0.21")
    */
   def typed[T](
       collection: String,
@@ -64,7 +64,7 @@ object SolrSink {
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 
   /**
-   * Java API: creates a [[SolrFlow] to Solr for sequence of [[IncomingMessage]] containing [[SolrInputDocument]].
+   * Java API: creates a [[SolrFlow]] to Solr for sequence of [[IncomingMessage]] containing [[SolrInputDocument]].
    */
   def documents(
       collection: String,
@@ -77,7 +77,7 @@ object SolrSink {
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 
   /**
-   * Java API: creates a [[SolrFlow] to Solr for sequence of [[IncomingMessage]] containing type `T`
+   * Java API: creates a [[SolrFlow]] to Solr for sequence of [[IncomingMessage]] containing type `T`
    * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
    */
   def beans[T](
@@ -92,7 +92,7 @@ object SolrSink {
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 
   /**
-   * Java API: creates a [[SolrFlow] to Solr for sequence of [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
+   * Java API: creates a [[SolrFlow]] to Solr for sequence of [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
    */
   def typeds[T](
       collection: String,

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrSink.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrSink.scala
@@ -58,4 +58,17 @@ object SolrSink {
       .typed[T](collection, settings, binder, client, clazz)
       .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[T, NotUsed]]],
              javadsl.Keep.right[NotUsed, CompletionStage[Done]])
+
+  /**
+   * Java API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
+   */
+  def delete(
+      collection: String,
+      settings: SolrUpdateSettings,
+      client: SolrClient
+  ): javadsl.Sink[IncomingMessage[NotUsed, NotUsed], CompletionStage[Done]] =
+    SolrFlow
+      .delete(collection, settings, client)
+      .toMat(javadsl.Sink.ignore[java.util.List[IncomingMessageResult[NotUsed, NotUsed]]],
+             javadsl.Keep.right[NotUsed, CompletionStage[Done]])
 }

--- a/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrFlow.scala
@@ -74,44 +74,6 @@ object SolrFlow {
       )
 
   /**
-   * Scala API: creates a [[SolrFlowStage]] for message to delete from [[IncomingMessage]] to sequences
-   * of [[IncomingMessageResult]].
-   */
-  def deletes(collection: String, settings: SolrUpdateSettings)(
-      implicit client: SolrClient
-  ): Flow[Seq[IncomingMessage[NotUsed, NotUsed]], Seq[
-    IncomingMessageResult[NotUsed, NotUsed]
-  ], NotUsed] =
-    Flow
-      .fromGraph(
-        new SolrFlowStage[NotUsed, NotUsed](
-          collection,
-          client,
-          settings,
-          None
-        )
-      )
-
-  /**
-   * Scala API: creates a [[SolrFlowStage]] for message to atomically update from [[IncomingMessage]] to sequences
-   * of [[IncomingMessageResult]].
-   */
-  def updates(collection: String, settings: SolrUpdateSettings)(
-      implicit client: SolrClient
-  ): Flow[Seq[IncomingMessage[NotUsed, NotUsed]], Seq[
-    IncomingMessageResult[NotUsed, NotUsed]
-  ], NotUsed] =
-    Flow
-      .fromGraph(
-        new SolrFlowStage[NotUsed, NotUsed](
-          collection,
-          client,
-          settings,
-          None
-        )
-      )
-
-  /**
    * Scala API: creates a [[SolrFlowStage]] for [[SolrInputDocument]] from [[IncomingMessage]]
    * to lists of [[IncomingMessageResult]] with `passThrough` of type `C`.
    */
@@ -166,44 +128,6 @@ object SolrFlow {
           client,
           settings,
           Some(binder)
-        )
-      )
-
-  /**
-   * Scala API: creates a [[SolrFlowStage]] for message to delete from [[IncomingMessage]] to sequences
-   * of [[IncomingMessageResult]] with `passThrough` of type `C`.
-   */
-  def deletesWithPassThrough[C](collection: String, settings: SolrUpdateSettings)(
-      implicit client: SolrClient
-  ): Flow[Seq[IncomingMessage[NotUsed, C]], Seq[
-    IncomingMessageResult[NotUsed, C]
-  ], NotUsed] =
-    Flow
-      .fromGraph(
-        new SolrFlowStage[NotUsed, C](
-          collection,
-          client,
-          settings,
-          None
-        )
-      )
-
-  /**
-   * Scala API: creates a [[SolrFlowStage]] for message to atomically update from [[IncomingMessage]] to sequences
-   * of [[IncomingMessageResult]] with `passThrough` of type `C`.
-   */
-  def updatesWithPassThrough[C](collection: String, settings: SolrUpdateSettings)(
-      implicit client: SolrClient
-  ): Flow[Seq[IncomingMessage[NotUsed, C]], Seq[
-    IncomingMessageResult[NotUsed, C]
-  ], NotUsed] =
-    Flow
-      .fromGraph(
-        new SolrFlowStage[NotUsed, C](
-          collection,
-          client,
-          settings,
-          None
         )
       )
 

--- a/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrFlow.scala
@@ -92,6 +92,25 @@ object SolrFlow {
       .mapAsync(1)(identity)
 
   /**
+   * Scala API: creates a [[SolrFlowStage]] for message to atomically update from [[IncomingMessage]] to sequences
+   * of [[IncomingMessageResult]].
+   */
+  def update(collection: String,
+             settings: SolrUpdateSettings)(implicit client: SolrClient): Flow[IncomingMessage[NotUsed, NotUsed], Seq[
+    IncomingMessageResult[NotUsed, NotUsed]
+  ], NotUsed] =
+    Flow
+      .fromGraph(
+        new SolrFlowStage[NotUsed, NotUsed](
+          collection,
+          client,
+          settings,
+          None
+        )
+      )
+      .mapAsync(1)(identity)
+
+  /**
    * Scala API: creates a [[SolrFlowStage]] for [[SolrInputDocument]] from [[IncomingMessage]]
    * to lists of [[IncomingMessageResult]] with `passThrough` of type `C`.
    */
@@ -157,6 +176,26 @@ object SolrFlow {
    * of [[IncomingMessageResult]] with `passThrough` of type `C`.
    */
   def deleteWithPassThrough[C](collection: String, settings: SolrUpdateSettings)(
+      implicit client: SolrClient
+  ): Flow[IncomingMessage[NotUsed, C], Seq[
+    IncomingMessageResult[NotUsed, C]
+  ], NotUsed] =
+    Flow
+      .fromGraph(
+        new SolrFlowStage[NotUsed, C](
+          collection,
+          client,
+          settings,
+          None
+        )
+      )
+      .mapAsync(1)(identity)
+
+  /**
+   * Scala API: creates a [[SolrFlowStage]] for message to atomically update from [[IncomingMessage]] to sequences
+   * of [[IncomingMessageResult]] with `passThrough` of type `C`.
+   */
+  def updateWithPassThrough[C](collection: String, settings: SolrUpdateSettings)(
       implicit client: SolrClient
   ): Flow[IncomingMessage[NotUsed, C], Seq[
     IncomingMessageResult[NotUsed, C]

--- a/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrFlow.scala
@@ -15,6 +15,25 @@ object SolrFlow {
   /**
    * Scala API: creates a [[SolrFlowStage]] for [[SolrInputDocument]] from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]].
+   * @deprecated ("use the method documents to batch operation")
+   */
+  def document(
+      collection: String,
+      settings: SolrUpdateSettings
+  )(implicit client: SolrClient): Flow[IncomingMessage[SolrInputDocument, NotUsed], Seq[
+    IncomingMessageResult[SolrInputDocument, NotUsed]
+  ], NotUsed] =
+    Flow
+      .fromFunction[IncomingMessage[SolrInputDocument, NotUsed], Seq[IncomingMessage[SolrInputDocument, NotUsed]]](
+        t => Seq(t)
+      )
+      .via(
+        documents(collection, settings)(client)
+      )
+
+  /**
+   * Scala API: creates a [[SolrFlowStage]] for [[SolrInputDocument]] from sequences of [[IncomingMessage]] to sequences
+   * of [[IncomingMessageResult]].
    */
   def documents(
       collection: String,
@@ -28,12 +47,31 @@ object SolrFlow {
           collection,
           client,
           settings,
-          Some(identity)
+          identity
         )
       )
 
   /**
-   * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
+   * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequence
+   * of [[IncomingMessageResult]] with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
+   * @deprecated ("use the method beans to batch operation")
+   */
+  def bean[T](
+      collection: String,
+      settings: SolrUpdateSettings
+  )(
+      implicit client: SolrClient
+  ): Flow[IncomingMessage[T, NotUsed], Seq[IncomingMessageResult[T, NotUsed]], NotUsed] =
+    Flow
+      .fromFunction[IncomingMessage[T, NotUsed], Seq[IncomingMessage[T, NotUsed]]](
+        t => Seq(t)
+      )
+      .via(
+        beans[T](collection, settings)(client)
+      )
+
+  /**
+   * Scala API: creates a [[SolrFlowStage]] for type `T` from sequence of [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
    */
   def beans[T](
@@ -48,15 +86,35 @@ object SolrFlow {
           collection,
           client,
           settings,
-          Some(new DefaultSolrObjectBinder)
+          new DefaultSolrObjectBinder
         )
       )
 
   /**
-   * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
+   * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequence
    * of [[IncomingMessageResult]] with `binder` of type 'T'.
+   * @deprecated ("use the method typeds to batch operation")
    */
   def typed[T](
+      collection: String,
+      settings: SolrUpdateSettings,
+      binder: T => SolrInputDocument
+  )(
+      implicit client: SolrClient
+  ): Flow[IncomingMessage[T, NotUsed], Seq[IncomingMessageResult[T, NotUsed]], NotUsed] =
+    Flow
+      .fromFunction[IncomingMessage[T, NotUsed], Seq[IncomingMessage[T, NotUsed]]](
+        t => Seq(t)
+      )
+      .via(
+        typeds[T](collection, settings, binder)(client)
+      )
+
+  /**
+   * Scala API: creates a [[SolrFlowStage]] for type `T` from sequence of [[IncomingMessage]] to sequences
+   * of [[IncomingMessageResult]] with `binder` of type 'T'.
+   */
+  def typeds[T](
       collection: String,
       settings: SolrUpdateSettings,
       binder: T => SolrInputDocument
@@ -69,8 +127,27 @@ object SolrFlow {
           collection,
           client,
           settings,
-          Some(binder)
+          binder
         )
+      )
+
+  /**
+   * Scala API: creates a [[SolrFlowStage]] for [[SolrInputDocument]] from [[IncomingMessage]] to sequences
+   * of [[IncomingMessageResult]] with `passThrough` of type `C`.
+   * @deprecated ("use the method documentsWithPassThrough to batch operation")
+   */
+  def documentWithPassThrough[C](
+      collection: String,
+      settings: SolrUpdateSettings
+  )(
+      implicit client: SolrClient
+  ): Flow[IncomingMessage[SolrInputDocument, C], Seq[IncomingMessageResult[SolrInputDocument, C]], NotUsed] =
+    Flow
+      .fromFunction[IncomingMessage[SolrInputDocument, C], Seq[IncomingMessage[SolrInputDocument, C]]](
+        t => Seq(t)
+      )
+      .via(
+        documentsWithPassThrough[C](collection, settings)(client)
       )
 
   /**
@@ -89,8 +166,28 @@ object SolrFlow {
           collection,
           client,
           settings,
-          Some(identity)
+          identity
         )
+      )
+
+  /**
+   * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequence
+   * of [[IncomingMessageResult]] with `passThrough` of type `C`
+   * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
+   * @deprecated ("use the method beansWithPassThrough to batch operation")
+   */
+  def beanWithPassThrough[T, C](
+      collection: String,
+      settings: SolrUpdateSettings
+  )(
+      implicit client: SolrClient
+  ): Flow[IncomingMessage[T, C], Seq[IncomingMessageResult[T, C]], NotUsed] =
+    Flow
+      .fromFunction[IncomingMessage[T, C], Seq[IncomingMessage[T, C]]](
+        t => Seq(t)
+      )
+      .via(
+        beansWithPassThrough(collection, settings)(client)
       )
 
   /**
@@ -108,15 +205,35 @@ object SolrFlow {
           collection,
           client,
           settings,
-          Some(new DefaultSolrObjectBinder)
+          new DefaultSolrObjectBinder
         )
+      )
+
+  /**
+   * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequence
+   * of [[IncomingMessageResult]] with `passThrough` of type `C` and `binder` of type 'T'.
+   * @deprecated ("use the method typedsWithPassThrough to batch operation")
+   */
+  def typedWithPassThrough[T, C](
+      collection: String,
+      settings: SolrUpdateSettings,
+      binder: T => SolrInputDocument
+  )(
+      implicit client: SolrClient
+  ): Flow[IncomingMessage[T, C], Seq[IncomingMessageResult[T, C]], NotUsed] =
+    Flow
+      .fromFunction[IncomingMessage[T, C], Seq[IncomingMessage[T, C]]](
+        t => Seq(t)
+      )
+      .via(
+        typedsWithPassThrough(collection, settings, binder)(client)
       )
 
   /**
    * Scala API: creates a [[SolrFlowStage]] for type 'T' from [[IncomingMessage]]
    * to lists of [[IncomingMessageResult]] with `passThrough` of type `C` and `binder` of type `T`.
    */
-  def typedWithPassThrough[T, C](
+  def typedsWithPassThrough[T, C](
       collection: String,
       settings: SolrUpdateSettings,
       binder: T => SolrInputDocument
@@ -127,7 +244,7 @@ object SolrFlow {
           collection,
           client,
           settings,
-          Some(binder)
+          binder
         )
       )
 

--- a/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrFlow.scala
@@ -16,10 +16,10 @@ object SolrFlow {
    * Scala API: creates a [[SolrFlowStage]] for [[SolrInputDocument]] from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]].
    */
-  def document(
+  def documents(
       collection: String,
       settings: SolrUpdateSettings
-  )(implicit client: SolrClient): Flow[IncomingMessage[SolrInputDocument, NotUsed], Seq[
+  )(implicit client: SolrClient): Flow[Seq[IncomingMessage[SolrInputDocument, NotUsed]], Seq[
     IncomingMessageResult[SolrInputDocument, NotUsed]
   ], NotUsed] =
     Flow
@@ -31,16 +31,17 @@ object SolrFlow {
           Some(identity)
         )
       )
-      .mapAsync(1)(identity)
 
   /**
    * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
    */
-  def bean[T](
+  def beans[T](
       collection: String,
       settings: SolrUpdateSettings
-  )(implicit client: SolrClient): Flow[IncomingMessage[T, NotUsed], Seq[IncomingMessageResult[T, NotUsed]], NotUsed] =
+  )(
+      implicit client: SolrClient
+  ): Flow[Seq[IncomingMessage[T, NotUsed]], Seq[IncomingMessageResult[T, NotUsed]], NotUsed] =
     Flow
       .fromGraph(
         new SolrFlowStage[T, NotUsed](
@@ -50,7 +51,6 @@ object SolrFlow {
           Some(new DefaultSolrObjectBinder)
         )
       )
-      .mapAsync(1)(identity)
 
   /**
    * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequences
@@ -60,7 +60,9 @@ object SolrFlow {
       collection: String,
       settings: SolrUpdateSettings,
       binder: T => SolrInputDocument
-  )(implicit client: SolrClient): Flow[IncomingMessage[T, NotUsed], Seq[IncomingMessageResult[T, NotUsed]], NotUsed] =
+  )(
+      implicit client: SolrClient
+  ): Flow[Seq[IncomingMessage[T, NotUsed]], Seq[IncomingMessageResult[T, NotUsed]], NotUsed] =
     Flow
       .fromGraph(
         new SolrFlowStage[T, NotUsed](
@@ -70,14 +72,14 @@ object SolrFlow {
           Some(binder)
         )
       )
-      .mapAsync(1)(identity)
 
   /**
    * Scala API: creates a [[SolrFlowStage]] for message to delete from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]].
    */
-  def delete(collection: String,
-             settings: SolrUpdateSettings)(implicit client: SolrClient): Flow[IncomingMessage[NotUsed, NotUsed], Seq[
+  def deletes(collection: String, settings: SolrUpdateSettings)(
+      implicit client: SolrClient
+  ): Flow[Seq[IncomingMessage[NotUsed, NotUsed]], Seq[
     IncomingMessageResult[NotUsed, NotUsed]
   ], NotUsed] =
     Flow
@@ -89,14 +91,14 @@ object SolrFlow {
           None
         )
       )
-      .mapAsync(1)(identity)
 
   /**
    * Scala API: creates a [[SolrFlowStage]] for message to atomically update from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]].
    */
-  def update(collection: String,
-             settings: SolrUpdateSettings)(implicit client: SolrClient): Flow[IncomingMessage[NotUsed, NotUsed], Seq[
+  def updates(collection: String, settings: SolrUpdateSettings)(
+      implicit client: SolrClient
+  ): Flow[Seq[IncomingMessage[NotUsed, NotUsed]], Seq[
     IncomingMessageResult[NotUsed, NotUsed]
   ], NotUsed] =
     Flow
@@ -108,18 +110,17 @@ object SolrFlow {
           None
         )
       )
-      .mapAsync(1)(identity)
 
   /**
    * Scala API: creates a [[SolrFlowStage]] for [[SolrInputDocument]] from [[IncomingMessage]]
    * to lists of [[IncomingMessageResult]] with `passThrough` of type `C`.
    */
-  def documentWithPassThrough[C](
+  def documentsWithPassThrough[C](
       collection: String,
       settings: SolrUpdateSettings
   )(
       implicit client: SolrClient
-  ): Flow[IncomingMessage[SolrInputDocument, C], Seq[IncomingMessageResult[SolrInputDocument, C]], NotUsed] =
+  ): Flow[Seq[IncomingMessage[SolrInputDocument, C]], Seq[IncomingMessageResult[SolrInputDocument, C]], NotUsed] =
     Flow
       .fromGraph(
         new SolrFlowStage[SolrInputDocument, C](
@@ -129,17 +130,16 @@ object SolrFlow {
           Some(identity)
         )
       )
-      .mapAsync(1)(identity)
 
   /**
    * Scala API: creates a [[SolrFlowStage]] for type 'T' from [[IncomingMessage]]
    * to lists of [[IncomingMessageResult]] with `passThrough` of type `C`
    * and [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]] for type 'T' .
    */
-  def beanWithPassThrough[T, C](
+  def beansWithPassThrough[T, C](
       collection: String,
       settings: SolrUpdateSettings
-  )(implicit client: SolrClient): Flow[IncomingMessage[T, C], Seq[IncomingMessageResult[T, C]], NotUsed] =
+  )(implicit client: SolrClient): Flow[Seq[IncomingMessage[T, C]], Seq[IncomingMessageResult[T, C]], NotUsed] =
     Flow
       .fromGraph(
         new SolrFlowStage[T, C](
@@ -149,7 +149,6 @@ object SolrFlow {
           Some(new DefaultSolrObjectBinder)
         )
       )
-      .mapAsync(1)(identity)
 
   /**
    * Scala API: creates a [[SolrFlowStage]] for type 'T' from [[IncomingMessage]]
@@ -159,7 +158,7 @@ object SolrFlow {
       collection: String,
       settings: SolrUpdateSettings,
       binder: T => SolrInputDocument
-  )(implicit client: SolrClient): Flow[IncomingMessage[T, C], Seq[IncomingMessageResult[T, C]], NotUsed] =
+  )(implicit client: SolrClient): Flow[Seq[IncomingMessage[T, C]], Seq[IncomingMessageResult[T, C]], NotUsed] =
     Flow
       .fromGraph(
         new SolrFlowStage[T, C](
@@ -169,15 +168,14 @@ object SolrFlow {
           Some(binder)
         )
       )
-      .mapAsync(1)(identity)
 
   /**
    * Scala API: creates a [[SolrFlowStage]] for message to delete from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with `passThrough` of type `C`.
    */
-  def deleteWithPassThrough[C](collection: String, settings: SolrUpdateSettings)(
+  def deletesWithPassThrough[C](collection: String, settings: SolrUpdateSettings)(
       implicit client: SolrClient
-  ): Flow[IncomingMessage[NotUsed, C], Seq[
+  ): Flow[Seq[IncomingMessage[NotUsed, C]], Seq[
     IncomingMessageResult[NotUsed, C]
   ], NotUsed] =
     Flow
@@ -189,15 +187,14 @@ object SolrFlow {
           None
         )
       )
-      .mapAsync(1)(identity)
 
   /**
    * Scala API: creates a [[SolrFlowStage]] for message to atomically update from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with `passThrough` of type `C`.
    */
-  def updateWithPassThrough[C](collection: String, settings: SolrUpdateSettings)(
+  def updatesWithPassThrough[C](collection: String, settings: SolrUpdateSettings)(
       implicit client: SolrClient
-  ): Flow[IncomingMessage[NotUsed, C], Seq[
+  ): Flow[Seq[IncomingMessage[NotUsed, C]], Seq[
     IncomingMessageResult[NotUsed, C]
   ], NotUsed] =
     Flow
@@ -209,7 +206,6 @@ object SolrFlow {
           None
         )
       )
-      .mapAsync(1)(identity)
 
   private class DefaultSolrObjectBinder(implicit c: SolrClient) extends (Any => SolrInputDocument) {
     override def apply(v1: Any): SolrInputDocument =

--- a/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrFlow.scala
@@ -28,7 +28,7 @@ object SolrFlow {
           collection,
           client,
           settings,
-          identity
+          Some(identity)
         )
       )
       .mapAsync(1)(identity)
@@ -47,7 +47,7 @@ object SolrFlow {
           collection,
           client,
           settings,
-          new DefaultSolrObjectBinder
+          Some(new DefaultSolrObjectBinder)
         )
       )
       .mapAsync(1)(identity)
@@ -67,7 +67,26 @@ object SolrFlow {
           collection,
           client,
           settings,
-          binder
+          Some(binder)
+        )
+      )
+      .mapAsync(1)(identity)
+
+  /**
+   * Scala API: creates a [[SolrFlowStage]] for message to delete from [[IncomingMessage]] to sequences
+   * of [[IncomingMessageResult]].
+   */
+  def delete(collection: String,
+             settings: SolrUpdateSettings)(implicit client: SolrClient): Flow[IncomingMessage[NotUsed, NotUsed], Seq[
+    IncomingMessageResult[NotUsed, NotUsed]
+  ], NotUsed] =
+    Flow
+      .fromGraph(
+        new SolrFlowStage[NotUsed, NotUsed](
+          collection,
+          client,
+          settings,
+          None
         )
       )
       .mapAsync(1)(identity)
@@ -88,7 +107,7 @@ object SolrFlow {
           collection,
           client,
           settings,
-          identity
+          Some(identity)
         )
       )
       .mapAsync(1)(identity)
@@ -108,7 +127,7 @@ object SolrFlow {
           collection,
           client,
           settings,
-          new DefaultSolrObjectBinder
+          Some(new DefaultSolrObjectBinder)
         )
       )
       .mapAsync(1)(identity)
@@ -128,7 +147,27 @@ object SolrFlow {
           collection,
           client,
           settings,
-          binder
+          Some(binder)
+        )
+      )
+      .mapAsync(1)(identity)
+
+  /**
+   * Scala API: creates a [[SolrFlowStage]] for message to delete from [[IncomingMessage]] to sequences
+   * of [[IncomingMessageResult]] with `passThrough` of type `C`.
+   */
+  def deleteWithPassThrough[C](collection: String, settings: SolrUpdateSettings)(
+      implicit client: SolrClient
+  ): Flow[IncomingMessage[NotUsed, C], Seq[
+    IncomingMessageResult[NotUsed, C]
+  ], NotUsed] =
+    Flow
+      .fromGraph(
+        new SolrFlowStage[NotUsed, C](
+          collection,
+          client,
+          settings,
+          None
         )
       )
       .mapAsync(1)(identity)

--- a/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrFlow.scala
@@ -15,7 +15,7 @@ object SolrFlow {
   /**
    * Scala API: creates a [[SolrFlowStage]] for [[SolrInputDocument]] from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]].
-   * @deprecated ("use the method documents to batch operation","0.21")
+   * @deprecated ("use the method documents to batch operation","0.20")
    */
   def document(
       collection: String,
@@ -54,7 +54,7 @@ object SolrFlow {
   /**
    * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequence
    * of [[IncomingMessageResult]] with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
-   * @deprecated ("use the method beans to batch operation","0.21")
+   * @deprecated ("use the method beans to batch operation","0.20")
    */
   def bean[T](
       collection: String,
@@ -93,7 +93,7 @@ object SolrFlow {
   /**
    * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequence
    * of [[IncomingMessageResult]] with `binder` of type 'T'.
-   * @deprecated ("use the method typeds to batch operation","0.21")
+   * @deprecated ("use the method typeds to batch operation","0.20")
    */
   def typed[T](
       collection: String,
@@ -134,7 +134,7 @@ object SolrFlow {
   /**
    * Scala API: creates a [[SolrFlowStage]] for [[SolrInputDocument]] from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with `passThrough` of type `C`.
-   * @deprecated ("use the method documentsWithPassThrough to batch operation","0.21")
+   * @deprecated ("use the method documentsWithPassThrough to batch operation","0.20")
    */
   def documentWithPassThrough[C](
       collection: String,
@@ -174,7 +174,7 @@ object SolrFlow {
    * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequence
    * of [[IncomingMessageResult]] with `passThrough` of type `C`
    * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
-   * @deprecated ("use the method beansWithPassThrough to batch operation","0.21")
+   * @deprecated ("use the method beansWithPassThrough to batch operation","0.20")
    */
   def beanWithPassThrough[T, C](
       collection: String,
@@ -212,7 +212,7 @@ object SolrFlow {
   /**
    * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequence
    * of [[IncomingMessageResult]] with `passThrough` of type `C` and `binder` of type 'T'.
-   * @deprecated ("use the method typedsWithPassThrough to batch operation","0.21")
+   * @deprecated ("use the method typedsWithPassThrough to batch operation","0.20")
    */
   def typedWithPassThrough[T, C](
       collection: String,

--- a/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrFlow.scala
@@ -15,7 +15,7 @@ object SolrFlow {
   /**
    * Scala API: creates a [[SolrFlowStage]] for [[SolrInputDocument]] from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]].
-   * @deprecated ("use the method documents to batch operation")
+   * @deprecated ("use the method documents to batch operation","0.21")
    */
   def document(
       collection: String,
@@ -54,7 +54,7 @@ object SolrFlow {
   /**
    * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequence
    * of [[IncomingMessageResult]] with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
-   * @deprecated ("use the method beans to batch operation")
+   * @deprecated ("use the method beans to batch operation","0.21")
    */
   def bean[T](
       collection: String,
@@ -93,7 +93,7 @@ object SolrFlow {
   /**
    * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequence
    * of [[IncomingMessageResult]] with `binder` of type 'T'.
-   * @deprecated ("use the method typeds to batch operation")
+   * @deprecated ("use the method typeds to batch operation","0.21")
    */
   def typed[T](
       collection: String,
@@ -134,7 +134,7 @@ object SolrFlow {
   /**
    * Scala API: creates a [[SolrFlowStage]] for [[SolrInputDocument]] from [[IncomingMessage]] to sequences
    * of [[IncomingMessageResult]] with `passThrough` of type `C`.
-   * @deprecated ("use the method documentsWithPassThrough to batch operation")
+   * @deprecated ("use the method documentsWithPassThrough to batch operation","0.21")
    */
   def documentWithPassThrough[C](
       collection: String,
@@ -174,7 +174,7 @@ object SolrFlow {
    * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequence
    * of [[IncomingMessageResult]] with `passThrough` of type `C`
    * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
-   * @deprecated ("use the method beansWithPassThrough to batch operation")
+   * @deprecated ("use the method beansWithPassThrough to batch operation","0.21")
    */
   def beanWithPassThrough[T, C](
       collection: String,
@@ -212,7 +212,7 @@ object SolrFlow {
   /**
    * Scala API: creates a [[SolrFlowStage]] for type `T` from [[IncomingMessage]] to sequence
    * of [[IncomingMessageResult]] with `passThrough` of type `C` and `binder` of type 'T'.
-   * @deprecated ("use the method typedsWithPassThrough to batch operation")
+   * @deprecated ("use the method typedsWithPassThrough to batch operation","0.21")
    */
   def typedWithPassThrough[T, C](
       collection: String,

--- a/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrSink.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrSink.scala
@@ -28,7 +28,7 @@ object SolrSink {
   /**
    * Scala API: creates a [[SolrFlow]] to Solr for [[IncomingMessage]] containing type `T`
    * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
-   * @deprecated ("use the method beans to batch operation","0.21")
+   * @deprecated ("use the method beans to batch operation","0.20")
    */
   def bean[T](collection: String, settings: SolrUpdateSettings)(
       implicit client: SolrClient
@@ -39,7 +39,7 @@ object SolrSink {
 
   /**
    * Scala API: creates a [[SolrFlow]] to Solr for sequence of [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
-   * @deprecated ("use the method typeds to batch operation","0.21")
+   * @deprecated ("use the method typeds to batch operation","0.20")
    */
   def typed[T](
       collection: String,

--- a/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrSink.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrSink.scala
@@ -47,23 +47,4 @@ object SolrSink {
       .typed[T](collection, settings, binder)
       .toMat(Sink.ignore)(Keep.right)
 
-  /**
-   * Scala API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing ids to delete.
-   */
-  def deletes[T](collection: String, settings: SolrUpdateSettings)(
-      implicit client: SolrClient
-  ): Sink[Seq[IncomingMessage[NotUsed, NotUsed]], Future[Done]] =
-    SolrFlow
-      .deletes(collection, settings)
-      .toMat(Sink.ignore)(Keep.right)
-
-  /**
-   * Scala API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing ids to update.
-   */
-  def updates[T](collection: String, settings: SolrUpdateSettings)(
-      implicit client: SolrClient
-  ): Sink[Seq[IncomingMessage[NotUsed, NotUsed]], Future[Done]] =
-    SolrFlow
-      .updates(collection, settings)
-      .toMat(Sink.ignore)(Keep.right)
 }

--- a/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrSink.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrSink.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Future
 object SolrSink {
 
   /**
-   * Scala API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
+   * Scala API: creates a [[SolrFlow]] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
    * @deprecated ("use the method documents to batch operation")
    */
   def document[T](collection: String, settings: SolrUpdateSettings)(
@@ -26,9 +26,9 @@ object SolrSink {
       .toMat(Sink.ignore)(Keep.right)
 
   /**
-   * Scala API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing type `T`
+   * Scala API: creates a [[SolrFlow]] to Solr for [[IncomingMessage]] containing type `T`
    * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
-   * @deprecated ("use the method beans to batch operation")
+   * @deprecated ("use the method beans to batch operation","0.21")
    */
   def bean[T](collection: String, settings: SolrUpdateSettings)(
       implicit client: SolrClient
@@ -38,8 +38,8 @@ object SolrSink {
       .toMat(Sink.ignore)(Keep.right)
 
   /**
-   * Scala API: creates a [[SolrFlow] to Solr for sequence of [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
-   * @deprecated ("use the method typeds to batch operation")
+   * Scala API: creates a [[SolrFlow]] to Solr for sequence of [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
+   * @deprecated ("use the method typeds to batch operation","0.21")
    */
   def typed[T](
       collection: String,
@@ -51,7 +51,7 @@ object SolrSink {
       .toMat(Sink.ignore)(Keep.right)
 
   /**
-   * Scala API: creates a [[SolrFlow] to Solr for sequence of [[IncomingMessage]] containing [[SolrInputDocument]].
+   * Scala API: creates a [[SolrFlow]] to Solr for sequence of [[IncomingMessage]] containing [[SolrInputDocument]].
    */
   def documents[T](collection: String, settings: SolrUpdateSettings)(
       implicit client: SolrClient
@@ -61,7 +61,7 @@ object SolrSink {
       .toMat(Sink.ignore)(Keep.right)
 
   /**
-   * Scala API: creates a [[SolrFlow] to Solr for sequence of [[IncomingMessage]] containing type `T`
+   * Scala API: creates a [[SolrFlow]] to Solr for sequence of [[IncomingMessage]] containing type `T`
    * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
    */
   def beans[T](collection: String, settings: SolrUpdateSettings)(
@@ -72,7 +72,7 @@ object SolrSink {
       .toMat(Sink.ignore)(Keep.right)
 
   /**
-   * Scala API: creates a [[SolrFlow] to Solr for sequence of [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
+   * Scala API: creates a [[SolrFlow]] to Solr for sequence of [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
    */
   def typeds[T](
       collection: String,

--- a/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrSink.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrSink.scala
@@ -56,4 +56,14 @@ object SolrSink {
     SolrFlow
       .delete(collection, settings)
       .toMat(Sink.ignore)(Keep.right)
+
+  /**
+   * Scala API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing ids to update.
+   */
+  def update[T](collection: String, settings: SolrUpdateSettings)(
+      implicit client: SolrClient
+  ): Sink[IncomingMessage[NotUsed, NotUsed], Future[Done]] =
+    SolrFlow
+      .update(collection, settings)
+      .toMat(Sink.ignore)(Keep.right)
 }

--- a/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrSink.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrSink.scala
@@ -17,22 +17,22 @@ object SolrSink {
   /**
    * Scala API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
    */
-  def document[T](collection: String, settings: SolrUpdateSettings)(
+  def documents[T](collection: String, settings: SolrUpdateSettings)(
       implicit client: SolrClient
-  ): Sink[IncomingMessage[SolrInputDocument, NotUsed], Future[Done]] =
+  ): Sink[Seq[IncomingMessage[SolrInputDocument, NotUsed]], Future[Done]] =
     SolrFlow
-      .document(collection, settings)
+      .documents(collection, settings)
       .toMat(Sink.ignore)(Keep.right)
 
   /**
    * Scala API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing type `T`
    * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
    */
-  def bean[T](collection: String, settings: SolrUpdateSettings)(
+  def beans[T](collection: String, settings: SolrUpdateSettings)(
       implicit client: SolrClient
-  ): Sink[IncomingMessage[T, NotUsed], Future[Done]] =
+  ): Sink[Seq[IncomingMessage[T, NotUsed]], Future[Done]] =
     SolrFlow
-      .bean[T](collection, settings)
+      .beans[T](collection, settings)
       .toMat(Sink.ignore)(Keep.right)
 
   /**
@@ -42,7 +42,7 @@ object SolrSink {
       collection: String,
       settings: SolrUpdateSettings,
       binder: T => SolrInputDocument
-  )(implicit client: SolrClient): Sink[IncomingMessage[T, NotUsed], Future[Done]] =
+  )(implicit client: SolrClient): Sink[Seq[IncomingMessage[T, NotUsed]], Future[Done]] =
     SolrFlow
       .typed[T](collection, settings, binder)
       .toMat(Sink.ignore)(Keep.right)
@@ -50,20 +50,20 @@ object SolrSink {
   /**
    * Scala API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing ids to delete.
    */
-  def delete[T](collection: String, settings: SolrUpdateSettings)(
+  def deletes[T](collection: String, settings: SolrUpdateSettings)(
       implicit client: SolrClient
-  ): Sink[IncomingMessage[NotUsed, NotUsed], Future[Done]] =
+  ): Sink[Seq[IncomingMessage[NotUsed, NotUsed]], Future[Done]] =
     SolrFlow
-      .delete(collection, settings)
+      .deletes(collection, settings)
       .toMat(Sink.ignore)(Keep.right)
 
   /**
    * Scala API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing ids to update.
    */
-  def update[T](collection: String, settings: SolrUpdateSettings)(
+  def updates[T](collection: String, settings: SolrUpdateSettings)(
       implicit client: SolrClient
-  ): Sink[IncomingMessage[NotUsed, NotUsed], Future[Done]] =
+  ): Sink[Seq[IncomingMessage[NotUsed, NotUsed]], Future[Done]] =
     SolrFlow
-      .update(collection, settings)
+      .updates(collection, settings)
       .toMat(Sink.ignore)(Keep.right)
 }

--- a/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrSink.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrSink.scala
@@ -46,4 +46,14 @@ object SolrSink {
     SolrFlow
       .typed[T](collection, settings, binder)
       .toMat(Sink.ignore)(Keep.right)
+
+  /**
+   * Scala API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing ids to delete.
+   */
+  def delete[T](collection: String, settings: SolrUpdateSettings)(
+      implicit client: SolrClient
+  ): Sink[IncomingMessage[NotUsed, NotUsed], Future[Done]] =
+    SolrFlow
+      .delete(collection, settings)
+      .toMat(Sink.ignore)(Keep.right)
 }

--- a/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrSink.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/scaladsl/SolrSink.scala
@@ -16,6 +16,42 @@ object SolrSink {
 
   /**
    * Scala API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing [[SolrInputDocument]].
+   * @deprecated ("use the method documents to batch operation")
+   */
+  def document[T](collection: String, settings: SolrUpdateSettings)(
+      implicit client: SolrClient
+  ): Sink[IncomingMessage[SolrInputDocument, NotUsed], Future[Done]] =
+    SolrFlow
+      .document(collection, settings)
+      .toMat(Sink.ignore)(Keep.right)
+
+  /**
+   * Scala API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing type `T`
+   * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
+   * @deprecated ("use the method beans to batch operation")
+   */
+  def bean[T](collection: String, settings: SolrUpdateSettings)(
+      implicit client: SolrClient
+  ): Sink[IncomingMessage[T, NotUsed], Future[Done]] =
+    SolrFlow
+      .bean[T](collection, settings)
+      .toMat(Sink.ignore)(Keep.right)
+
+  /**
+   * Scala API: creates a [[SolrFlow] to Solr for sequence of [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
+   * @deprecated ("use the method typeds to batch operation")
+   */
+  def typed[T](
+      collection: String,
+      settings: SolrUpdateSettings,
+      binder: T => SolrInputDocument
+  )(implicit client: SolrClient): Sink[IncomingMessage[T, NotUsed], Future[Done]] =
+    SolrFlow
+      .typed[T](collection, settings, binder)
+      .toMat(Sink.ignore)(Keep.right)
+
+  /**
+   * Scala API: creates a [[SolrFlow] to Solr for sequence of [[IncomingMessage]] containing [[SolrInputDocument]].
    */
   def documents[T](collection: String, settings: SolrUpdateSettings)(
       implicit client: SolrClient
@@ -25,7 +61,7 @@ object SolrSink {
       .toMat(Sink.ignore)(Keep.right)
 
   /**
-   * Scala API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing type `T`
+   * Scala API: creates a [[SolrFlow] to Solr for sequence of [[IncomingMessage]] containing type `T`
    * with [[org.apache.solr.client.solrj.beans.DocumentObjectBinder]].
    */
   def beans[T](collection: String, settings: SolrUpdateSettings)(
@@ -36,15 +72,15 @@ object SolrSink {
       .toMat(Sink.ignore)(Keep.right)
 
   /**
-   * Scala API: creates a [[SolrFlow] to Solr for [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
+   * Scala API: creates a [[SolrFlow] to Solr for sequence of [[IncomingMessage]] containing type `T` with `binder` of type 'T'.
    */
-  def typed[T](
+  def typeds[T](
       collection: String,
       settings: SolrUpdateSettings,
       binder: T => SolrInputDocument
   )(implicit client: SolrClient): Sink[Seq[IncomingMessage[T, NotUsed]], Future[Done]] =
     SolrFlow
-      .typed[T](collection, settings, binder)
+      .typeds[T](collection, settings, binder)
       .toMat(Sink.ignore)(Keep.right)
 
 }

--- a/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java
+++ b/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java
@@ -14,11 +14,9 @@ import akka.stream.alpakka.solr.javadsl.SolrSource;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
-import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.beans.Field;
 import org.apache.solr.client.solrj.embedded.JettyConfig;
-import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.ZkClientClusterStateProvider;
 import org.apache.solr.client.solrj.io.SolrClientCache;
 import org.apache.solr.client.solrj.io.Tuple;
@@ -104,7 +102,7 @@ public class SolrTest {
                   Book book = tupleToBook.apply(tuple);
                   SolrInputDocument doc = bookToDoc.apply(book);
                   List<IncomingMessage<SolrInputDocument, NotUsed>> list = new ArrayList<>();
-                  list.add(IncomingUpdateMessage.create(doc));
+                  list.add(IncomingUpsertMessage.create(doc));
                   return list;
                 })
             .runWith(
@@ -160,7 +158,7 @@ public class SolrTest {
                 tuple -> {
                   String title = tuple.getString("title");
                   List<IncomingMessage<BookBean, NotUsed>> list = new ArrayList<>();
-                  list.add(IncomingUpdateMessage.create(new BookBean(title)));
+                  list.add(IncomingUpsertMessage.create(new BookBean(title)));
                   return list;
                 })
             .runWith(
@@ -205,11 +203,11 @@ public class SolrTest {
             .map(
                 tuple -> {
                   List<IncomingMessage<Book, NotUsed>> list = new ArrayList<>();
-                  list.add(IncomingUpdateMessage.create(tupleToBook.apply(tuple)));
+                  list.add(IncomingUpsertMessage.create(tupleToBook.apply(tuple)));
                   return list;
                 })
             .runWith(
-                SolrSink.typed(
+                SolrSink.typeds(
                     "collection4", settings, bookToDoc, cluster.getSolrClient(), Book.class),
                 materializer);
     // #run-typed
@@ -251,11 +249,11 @@ public class SolrTest {
             .map(
                 tuple -> {
                   List<IncomingMessage<Book, NotUsed>> list = new ArrayList<>();
-                  list.add(IncomingUpdateMessage.create(tupleToBook.apply(tuple)));
+                  list.add(IncomingUpsertMessage.create(tupleToBook.apply(tuple)));
                   return list;
                 })
             .via(
-                SolrFlow.typed(
+                SolrFlow.typeds(
                     "collection5", settings, bookToDoc, cluster.getSolrClient(), Book.class))
             .runWith(Sink.ignore(), materializer);
     // #run-flow
@@ -309,11 +307,11 @@ public class SolrTest {
               Book book = kafkaMessage.book;
               // Transform message so that we can write to elastic
               List<IncomingMessage<Book, KafkaOffset>> list = new ArrayList<>();
-              list.add(IncomingUpdateMessage.create(book, kafkaMessage.offset));
+              list.add(IncomingUpsertMessage.create(book, kafkaMessage.offset));
               return list;
             })
         .via(
-            SolrFlow.typedWithPassThrough(
+            SolrFlow.typedsWithPassThrough(
                 "collection6", settings, bookToDoc, cluster.getSolrClient(), Book.class))
         .map(
             messageResults -> {
@@ -366,7 +364,7 @@ public class SolrTest {
                   Book book = tupleToBook.apply(tuple);
                   SolrInputDocument doc = bookToDoc.apply(book);
                   List<IncomingMessage<SolrInputDocument, NotUsed>> list = new ArrayList<>();
-                  list.add(IncomingUpdateMessage.create(doc));
+                  list.add(IncomingUpsertMessage.create(doc));
                   return list;
                 })
             .runWith(
@@ -419,7 +417,7 @@ public class SolrTest {
                   Book book = new Book(tupleToBook.apply(tuple).title, "Written by good authors.");
                   SolrInputDocument doc = bookToDoc.apply(book);
                   List<IncomingMessage<SolrInputDocument, NotUsed>> list = new ArrayList<>();
-                  list.add(IncomingUpdateMessage.create(doc));
+                  list.add(IncomingUpsertMessage.create(doc));
                   return list;
                 })
             .runWith(

--- a/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java
+++ b/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java
@@ -632,11 +632,7 @@ public class SolrTest {
     Source<Tuple, NotUsed> source = SolrSource.fromTupleStream(stream);
     // #define-source
     // #solr-update-settings
-    SolrUpdateSettings settings =
-        SolrUpdateSettings.create()
-            .withRetryInterval(FiniteDuration.create(5000, TimeUnit.MILLISECONDS))
-            .withMaxRetry(100)
-            .withCommitWithin(-1);
+    SolrUpdateSettings settings = SolrUpdateSettings.create().withCommitWithin(-1);
     // #solr-update-settings
   }
 }

--- a/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java
+++ b/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java
@@ -364,7 +364,7 @@ public class SolrTest {
 
     TupleStream stream2 = getTupleStream("collection7");
 
-    //#delete-documents
+    // #delete-documents
     CompletionStage<Done> res2 =
         SolrSource.fromTupleStream(stream2)
             .map(
@@ -374,7 +374,7 @@ public class SolrTest {
             .groupedWithin(5, Duration.ofMillis(10))
             .runWith(
                 SolrSink.documents("collection7", settings, cluster.getSolrClient()), materializer);
-    //#delete-documents
+    // #delete-documents
 
     res2.toCompletableFuture().get();
 
@@ -417,7 +417,7 @@ public class SolrTest {
 
     TupleStream stream2 = getTupleStream("collection8");
 
-    //#update-atomically-documents
+    // #update-atomically-documents
     CompletionStage<Done> res2 =
         SolrSource.fromTupleStream(stream2)
             .map(
@@ -432,7 +432,7 @@ public class SolrTest {
             .groupedWithin(5, Duration.ofMillis(10))
             .runWith(
                 SolrSink.documents("collection8", settings, cluster.getSolrClient()), materializer);
-    //#update-atomically-documents
+    // #update-atomically-documents
 
     res2.toCompletableFuture().get();
 
@@ -489,7 +489,7 @@ public class SolrTest {
 
     TupleStream stream2 = getTupleStream("collection9");
 
-    //#delete-documents-query
+    // #delete-documents-query
     CompletionStage<Done> res2 =
         SolrSource.fromTupleStream(stream2)
             .map(
@@ -499,7 +499,7 @@ public class SolrTest {
             .groupedWithin(5, Duration.ofMillis(10))
             .runWith(
                 SolrSink.documents("collection9", settings, cluster.getSolrClient()), materializer);
-    //#delete-documents-query
+    // #delete-documents-query
 
     res2.toCompletableFuture().get();
 

--- a/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java
+++ b/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java
@@ -416,11 +416,12 @@ public class SolrTest {
         SolrSource.fromTupleStream(stream2)
             .map(
                 t -> {
-                  Map<String, Object> m = new HashMap<>();
-                  m.put("set", (t.fields.get("comment") + " It's is a good book!!!"));
-
+                  Map<String, Map<String, Object>> m1 = new HashMap<>();
+                  Map<String, Object> m2 = new HashMap<>();
+                  m2.put("set", (t.fields.get("comment") + " It's is a good book!!!"));
+                  m1.put("comment", m2);
                   return IncomingAtomicUpdateMessage.<SolrInputDocument>create(
-                      "title", t.fields.get("title").toString(), "comment", m);
+                      "title", t.fields.get("title").toString(), "comment", m1);
                 })
             .groupedWithin(5, Duration.ofMillis(10))
             .runWith(
@@ -538,6 +539,7 @@ public class SolrTest {
     ((ZkClientClusterStateProvider) cluster.getSolrClient().getClusterStateProvider())
         .uploadConfig(confDir.toPath(), "conf");
 
+    cluster.getSolrClient().setIdField("title");
     createCollection("collection1");
 
     assertTrue(

--- a/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java
+++ b/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java
@@ -381,12 +381,12 @@ public class SolrTest {
         SolrSource.fromTupleStream(stream2)
             .map(
                 t -> {
-                  List<IncomingMessage<NotUsed, NotUsed>> list = new ArrayList<>();
+                  List<IncomingMessage<SolrInputDocument, NotUsed>> list = new ArrayList<>();
                   list.add(IncomingDeleteMessage.create(tupleToBook.apply(t).title));
                   return list;
                 })
             .runWith(
-                SolrSink.deletes("collection7", settings, cluster.getSolrClient()), materializer);
+                SolrSink.documents("collection7", settings, cluster.getSolrClient()), materializer);
 
     res2.toCompletableFuture().get();
 
@@ -436,14 +436,14 @@ public class SolrTest {
                 t -> {
                   Map<String, Object> m = new HashMap<>();
                   m.put("set", (t.fields.get("comment") + " It's is a good book!!!"));
-                  List<IncomingMessage<NotUsed, NotUsed>> list = new ArrayList<>();
+                  List<IncomingMessage<SolrInputDocument, NotUsed>> list = new ArrayList<>();
                   list.add(
                       IncomingAtomicUpdateMessage.create(
                           "title", t.fields.get("title").toString(), "comment", m));
                   return list;
                 })
             .runWith(
-                SolrSink.updates("collection8", settings, cluster.getSolrClient()), materializer);
+                SolrSink.documents("collection8", settings, cluster.getSolrClient()), materializer);
 
     res2.toCompletableFuture().get();
 

--- a/solr/src/test/resources/conf/schema.xml
+++ b/solr/src/test/resources/conf/schema.xml
@@ -51,6 +51,7 @@
 
     <field name="_version_" type="long" indexed="true" stored="true"/>
     <field name="title" type="string" docValues="true" multiValued="false" indexed="true" stored="true"/>
+    <field name="comment" type="string" docValues="true" multiValued="false" indexed="false" stored="true"/>
 
     <uniqueKey>title</uniqueKey>
 </schema>

--- a/solr/src/test/resources/conf/schema.xml
+++ b/solr/src/test/resources/conf/schema.xml
@@ -51,4 +51,6 @@
 
     <field name="_version_" type="long" indexed="true" stored="true"/>
     <field name="title" type="string" docValues="true" multiValued="false" indexed="true" stored="true"/>
+
+    <uniqueKey>title</uniqueKey>
 </schema>

--- a/solr/src/test/scala/akka/stream/alpakka/solr/SolrSpec.scala
+++ b/solr/src/test/scala/akka/stream/alpakka/solr/SolrSpec.scala
@@ -747,7 +747,7 @@ class SolrSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
     import akka.stream.alpakka.solr.SolrUpdateSettings
 
     val settings =
-      SolrUpdateSettings(retryInterval = 5000.millis, maxRetry = 100, commitWithin = -1)
+      SolrUpdateSettings(commitWithin = -1)
     //#solr-update-settings
   }
 }

--- a/solr/src/test/scala/akka/stream/alpakka/solr/SolrSpec.scala
+++ b/solr/src/test/scala/akka/stream/alpakka/solr/SolrSpec.scala
@@ -430,7 +430,7 @@ class SolrSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
             "title",
             tuple.fields.get("title").toString,
             tuple.fields.get("title").toString,
-            Map("comment" -> Map("set" -> (tuple.fields.get("comment") + " It's is a good book!!!")))
+            Map("comment" -> Map("set" -> (tuple.fields.get("comment") + " It is a good book!!!")))
           )
         }
         .groupedWithin(5, new FiniteDuration(10, TimeUnit.MILLISECONDS))
@@ -459,13 +459,13 @@ class SolrSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
       val result = Await.result(res2, Duration.Inf)
 
       result shouldEqual Seq(
-        "Akka Concurrency. Written by good authors. It's is a good book!!!",
-        "Akka in Action. Written by good authors. It's is a good book!!!",
-        "Effective Akka. Written by good authors. It's is a good book!!!",
-        "Learning Scala. Written by good authors. It's is a good book!!!",
-        "Programming in Scala. Written by good authors. It's is a good book!!!",
-        "Scala Puzzlers. Written by good authors. It's is a good book!!!",
-        "Scala for Spark in Production. Written by good authors. It's is a good book!!!"
+        "Akka Concurrency. Written by good authors. It is a good book!!!",
+        "Akka in Action. Written by good authors. It is a good book!!!",
+        "Effective Akka. Written by good authors. It is a good book!!!",
+        "Learning Scala. Written by good authors. It is a good book!!!",
+        "Programming in Scala. Written by good authors. It is a good book!!!",
+        "Scala Puzzlers. Written by good authors. It is a good book!!!",
+        "Scala for Spark in Production. Written by good authors. It is a good book!!!"
       )
     }
 
@@ -565,7 +565,7 @@ class SolrSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
             "title",
             tuple.fields.get("title").toString,
             tuple.fields.get("title").toString,
-            Map("comment" -> Map("set" -> (tuple.fields.get("comment") + " It's is a good book!!!")))
+            Map("comment" -> Map("set" -> (tuple.fields.get("comment") + " It is a good book!!!")))
           )
         }
         .groupedWithin(5, new FiniteDuration(10, TimeUnit.MILLISECONDS))
@@ -594,13 +594,13 @@ class SolrSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
       val result = Await.result(res2, Duration.Inf)
 
       result shouldEqual Seq(
-        "Akka Concurrency. Written by good authors. It's is a good book!!!",
-        "Akka in Action. Written by good authors. It's is a good book!!!",
-        "Effective Akka. Written by good authors. It's is a good book!!!",
-        "Learning Scala. Written by good authors. It's is a good book!!!",
-        "Programming in Scala. Written by good authors. It's is a good book!!!",
-        "Scala Puzzlers. Written by good authors. It's is a good book!!!",
-        "Scala for Spark in Production. Written by good authors. It's is a good book!!!"
+        "Akka Concurrency. Written by good authors. It is a good book!!!",
+        "Akka in Action. Written by good authors. It is a good book!!!",
+        "Effective Akka. Written by good authors. It is a good book!!!",
+        "Learning Scala. Written by good authors. It is a good book!!!",
+        "Programming in Scala. Written by good authors. It is a good book!!!",
+        "Scala Puzzlers. Written by good authors. It is a good book!!!",
+        "Scala for Spark in Production. Written by good authors. It is a good book!!!"
       )
     }
 

--- a/solr/src/test/scala/akka/stream/alpakka/solr/SolrSpec.scala
+++ b/solr/src/test/scala/akka/stream/alpakka/solr/SolrSpec.scala
@@ -431,8 +431,8 @@ class SolrSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
           IncomingAtomicUpdateMessage[SolrInputDocument](
             "title",
             tuple.fields.get("title").toString,
-            "comment",
-            Map("set" -> (tuple.fields.get("comment") + " It's is a good book!!!"))
+            tuple.fields.get("title").toString,
+            Map("comment" -> Map("set" -> (tuple.fields.get("comment") + " It's is a good book!!!")))
           )
         }
         .groupedWithin(5, new FiniteDuration(10, TimeUnit.MILLISECONDS))
@@ -568,10 +568,12 @@ class SolrSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
       val f2 = SolrSource
         .fromTupleStream(ts = stream2)
         .map { tuple: Tuple =>
-          IncomingAtomicUpdateMessage[Book]("title",
-                                            tuple.fields.get("title").toString,
-                                            "comment",
-                                            Map("set" -> (tuple.fields.get("comment") + " It's is a good book!!!")))
+          IncomingAtomicUpdateMessage[Book](
+            "title",
+            tuple.fields.get("title").toString,
+            tuple.fields.get("title").toString,
+            Map("comment" -> Map("set" -> (tuple.fields.get("comment") + " It's is a good book!!!")))
+          )
         }
         .groupedWithin(5, new FiniteDuration(10, TimeUnit.MILLISECONDS))
         .runWith(
@@ -656,6 +658,7 @@ class SolrSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
     cluster.getSolrClient.getClusterStateProvider
       .asInstanceOf[ZkClientClusterStateProvider]
       .uploadConfig(confDir.toPath, "conf")
+    cluster.getSolrClient.setIdField("title")
 
     createCollection("collection1")
 


### PR DESCRIPTION
At this moment, there's a little problem of performance with SolR component because there's no asynchronous part in the code. So the batch size is always 1. 
I propose an alternative by keeping the inspiration from the Elastic Search component.
The solr update is now encapsulated in a future, and the async callbacks are used to make everything coherent (in failure and in success).
Still using the elastic search code, I will provide a notion of operation, to allow the removal of documents.
Please, have a look.
 