### PR TITLE
JMS: Support for durable subscriptions #966

### DIFF
--- a/docs/src/main/paradox/jms.md
+++ b/docs/src/main/paradox/jms.md
@@ -44,7 +44,7 @@ Gradle
 
 ## Usage
 
-The JMS message model supports several types of message body (see @javadoc[javax.jms.Message](javax.jms.Message)) and Alpakka currently supports messages with a body containing a @javadoc[String](java.lang.String), 
+The JMS message model supports several types of message body (see @javadoc[javax.jms.Message](javax.jms.Message)) and Alpakka currently supports messages with a body containing a @javadoc[String](java.lang.String),
 a @javadoc[Serializable](java.io.Serializable) object, a @javadoc[Map](java.util.Map) or a byte array.
 
 First define a @javadoc[javax.jms.ConnectionFactory](javax.jms.ConnectionFactory) depending on the implementation you're using. Here we're using Active MQ.
@@ -85,7 +85,7 @@ Java
 
 ### Sending byte messages to a JMS provider
 
-Create a sink, that accepts and forwards @scaladoc[JmsByteMessage](akka.stream.alpakka.jms.JmsByteMessage$)s to the JMS provider. 
+Create a sink, that accepts and forwards @scaladoc[JmsByteMessage](akka.stream.alpakka.jms.JmsByteMessage$)s to the JMS provider.
 
 Scala
 : @@snip [snip](/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #create-bytearray-sink }
@@ -162,7 +162,7 @@ Java
 : @@snip [snip](/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-messages-with-properties }
 
 ### Sending messages with header to a JMS provider
-For every @scaladoc[JmsMessage](akka.stream.alpakka.jms.JmsMessage$) you can set also jms headers. 
+For every @scaladoc[JmsMessage](akka.stream.alpakka.jms.JmsMessage$) you can set also jms headers.
 
 Scala
 : @@snip [snip](/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #create-messages-with-headers }
@@ -401,7 +401,7 @@ Java
 *  Using multiple sessions increases throughput, especially if a acknowledging message by message is desired.
 *  Messages may arrive out of order if `sessionCount` is larger than 1.
 *  Message-by-message acknowledgement can be achieved by setting `bufferSize` to 0, thus disabling buffering. The outstanding messages before backpressure will be the `sessionCount`.
-*  The default `AcknowledgeMode` is `ClientAcknowledge` but can be overridden to custom `AcknowledgeMode`s, even implementation-specific ones by setting the `AcknowledgeMode` in the `JmsConsumerSettings` when creating the stream. 
+*  The default `AcknowledgeMode` is `ClientAcknowledge` but can be overridden to custom `AcknowledgeMode`s, even implementation-specific ones by setting the `AcknowledgeMode` in the `JmsConsumerSettings` when creating the stream.
 
 ### Transactionally receiving @javadoc[javax.jms.Message](javax.jms.Message)s from a JMS provider
 
@@ -430,8 +430,8 @@ Java
 *  Higher throughput is achieved by increasing the `sessionCount`.
 *  Messages will arrive out of order if `sessionCount` is larger than 1.
 *  Buffering is not supported in transaction mode. The `bufferSize` is ignored.
-*  The default `AcknowledgeMode` is `SessionTransacted` but can be overridden to custom `AcknowledgeMode`s, even implementation-specific ones by setting the `AcknowledgeMode` in the `JmsConsumerSettings` when creating the stream. 
- 
+*  The default `AcknowledgeMode` is `SessionTransacted` but can be overridden to custom `AcknowledgeMode`s, even implementation-specific ones by setting the `AcknowledgeMode` in the `JmsConsumerSettings` when creating the stream.
+
 ### Browsing messages from a JMS provider
 
 The browse source will stream the messages in a queue without consuming them.
@@ -460,7 +460,6 @@ Java
 *  The JMS API does not require the content of an enumeration to be a static snapshot of queue content. Whether these changes are visible or not depends on the JMS provider.
 *  A message must not be returned by a QueueBrowser before its delivery time has been reached.
 
-
 ### Using Topic with an JMS provider
 
 You can use JMS topic in a very similar way.
@@ -488,6 +487,26 @@ Such sink and source can be started the same way as in the previous example.
 * Explicit acknowledgement sources and transactional sources work with topics the same way they work with queues.
 * **DO NOT** set the `sessionCount` greater than 1 for topics. Doing so will result in duplicate messages being delivered. Each topic message is delivered to each JMS session and all the messages feed to the same `Source`. JMS 2.0 created shared consumers to solve this problem and multiple sessions without duplication may be supported in the future.
 
+### Using a durable Topic subscription with a JMS provider
+
+Using a durable topic subscription works mostly like a normal topic source.
+
+You need to specify a client ID for the connection factory you use to create the consumer with, however:
+
+Scala
+: @@snip [snip](/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #create-connection-factory-with-client-id }
+
+Java
+: @@snip [snip](/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-connection-factory-with-client-id }
+
+In addition, use `withDurableTopic` and specify a name for the durable subscriber:
+
+Scala
+: @@snip [snip](/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #create-durable-topic-source }
+
+Java
+: @@snip [snip](/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-durable-topic-source }
+
 ### Running the example code
 
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
@@ -503,7 +522,7 @@ Java
     sbt
     > jms/testOnly *.JmsConnectorsTest
     ```
-    
+
 ### Stopping a JMS Source
 
 All JMS sources materialize to a `KillSwitch` to allow safely stopping consumption without message loss for transactional and acknowledged messages, and with minimal message loss for the simple JMS source.
@@ -587,7 +606,7 @@ Java
         .withQueue(testQueueName)
     );
 
-    // Option2: create Source using custom factory 
+    // Option2: create Source using custom factory
     private Function1<Session, Destination> createMqQueue(String destinationName) {
         return (session) -> {
             ...
@@ -665,7 +684,7 @@ Java
         .withTopic(testTopicName)
     );
 
-    // Option2: create Source using custom factory 
+    // Option2: create Source using custom factory
     private Function1<Session, Destination> createMqTopic(String destinationName) {
         return (session) -> {
             ...

--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -40,6 +40,9 @@ sealed trait Destination {
 final case class Topic(override val name: String) extends Destination {
   override val create: (jms.Session) => jms.Destination = session => session.createTopic(name)
 }
+final case class DurableTopic(name: String, subscriberName: String) extends Destination {
+  override val create: (jms.Session) => jms.Destination = session => session.createTopic(name)
+}
 final case class Queue(override val name: String) extends Destination {
   override val create: (jms.Session) => jms.Destination = session => session.createQueue(name)
 }
@@ -67,13 +70,16 @@ final case class JmsConsumerSettings(connectionFactory: ConnectionFactory,
                                      sessionCount: Int = 1,
                                      bufferSize: Int = 100,
                                      selector: Option[String] = None,
-                                     acknowledgeMode: Option[AcknowledgeMode] = None)
+                                     acknowledgeMode: Option[AcknowledgeMode] = None,
+                                     durableName: Option[String] = None)
     extends JmsSettings {
   def withCredential(credentials: Credentials): JmsConsumerSettings = copy(credentials = Some(credentials))
   def withSessionCount(count: Int): JmsConsumerSettings = copy(sessionCount = count)
   def withBufferSize(size: Int): JmsConsumerSettings = copy(bufferSize = size)
   def withQueue(name: String): JmsConsumerSettings = copy(destination = Some(Queue(name)))
   def withTopic(name: String): JmsConsumerSettings = copy(destination = Some(Topic(name)))
+  def withDurableTopic(name: String, subscriberName: String) =
+    copy(destination = Some(DurableTopic(name, subscriberName)))
   def withDestination(destination: Destination): JmsConsumerSettings = copy(destination = Some(destination))
   def withSelector(selector: String): JmsConsumerSettings = copy(selector = Some(selector))
   def withAcknowledgeMode(acknowledgeMode: AcknowledgeMode): JmsConsumerSettings =

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
@@ -37,7 +37,7 @@ private[jms] final class JmsConsumerStage(settings: JmsConsumerSettings)
                                   createDestination: Session => javax.jms.Destination): JmsSession = {
         val session =
           connection.createSession(false, settings.acknowledgeMode.getOrElse(AcknowledgeMode.AutoAcknowledge).mode)
-        new JmsSession(connection, session, createDestination(session))
+        new JmsSession(connection, session, createDestination(session), settings.destination.get)
       }
 
       protected def pushMessage(msg: Message): Unit = {
@@ -81,7 +81,11 @@ final class JmsAckSourceStage(settings: JmsConsumerSettings)
                                   createDestination: Session => javax.jms.Destination): JmsAckSession = {
         val session =
           connection.createSession(false, settings.acknowledgeMode.getOrElse(AcknowledgeMode.ClientAcknowledge).mode)
-        new JmsAckSession(connection, session, createDestination(session), settings.bufferSize)
+        new JmsAckSession(connection,
+                          session,
+                          createDestination(session),
+                          settings.destination.get,
+                          settings.bufferSize)
       }
 
       protected def pushMessage(msg: AckEnvelope): Unit = push(out, msg)
@@ -158,7 +162,7 @@ final class JmsTxSourceStage(settings: JmsConsumerSettings)
       protected def createSession(connection: Connection, createDestination: Session => javax.jms.Destination) = {
         val session =
           connection.createSession(true, settings.acknowledgeMode.getOrElse(AcknowledgeMode.SessionTransacted).mode)
-        new JmsTxSession(connection, session, createDestination(session))
+        new JmsTxSession(connection, session, createDestination(session), settings.destination.get)
       }
 
       protected def pushMessage(msg: TxEnvelope): Unit = push(out, msg)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -51,7 +51,7 @@ private[jms] final class JmsProducerStage[A <: JmsMessage](settings: JmsProducer
       protected def createSession(connection: Connection, createDestination: Session => jms.Destination): JmsSession = {
         val session =
           connection.createSession(false, settings.acknowledgeMode.getOrElse(AcknowledgeMode.AutoAcknowledge).mode)
-        new JmsSession(connection, session, createDestination(session))
+        new JmsSession(connection, session, createDestination(session), settings.destination.get)
       }
 
       override def preStart(): Unit = {

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsMessageProducerSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsMessageProducerSpec.scala
@@ -19,14 +19,15 @@ class JmsMessageProducerSpec extends JmsSpec with MockitoSugar {
     val producer: MessageProducer = mock[MessageProducer]
     val textMessage: TextMessage = mock[TextMessage]
     val mapMessage: MapMessage = mock[MapMessage]
+    val settingsDestination: Destination = mock[Destination]
 
     when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session)
     when(session.createProducer(any[javax.jms.Destination])).thenReturn(producer)
     when(session.createTextMessage(anyString())).thenReturn(textMessage)
     when(session.createMapMessage()).thenReturn(mapMessage)
 
-    val settings = JmsProducerSettings(factory)
-    val jmsSession = new JmsSession(connection, session, destination)
+    val settings = JmsProducerSettings(factory, destination = Option(settingsDestination))
+    val jmsSession = new JmsSession(connection, session, destination, settingsDestination)
 
     val jmsProducer = JmsMessageProducer(jmsSession, settings)
   }


### PR DESCRIPTION
- This is a shameless minor update of the changes done by @liff in #862 to make it work with the changes done by @russellyou  #867. More specifically, to be able to use the `create` API from `Destination`.