### PR TITLE
Reference: updates to message types

### DIFF
--- a/reference/src/main/scala/akka/stream/alpakka/reference/impl/ReferenceFlow.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/impl/ReferenceFlow.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.reference.impl
 import akka.annotation.InternalApi
 import akka.event.Logging
 import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
-import akka.stream.alpakka.reference.ReferenceWriteMessage
+import akka.stream.alpakka.reference.{ReferenceWriteMessage, ReferenceWriteResult}
 import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 
 /**
@@ -18,7 +18,7 @@ import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
  * line in scaladoc to communicate to Java developers that this is private API.
  */
 @InternalApi private[reference] final class ReferenceFlowStageLogic(
-    val shape: FlowShape[ReferenceWriteMessage, ReferenceWriteMessage]
+    val shape: FlowShape[ReferenceWriteMessage, ReferenceWriteResult]
 ) extends GraphStageLogic(shape) {
 
   private def in = shape.in
@@ -35,7 +35,7 @@ import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
       override def onPush(): Unit = {
         val msg = grab(in)
         val total = msg.metrics.values.sum
-        push(out, msg.withMetrics(msg.metrics + ("total" -> total)))
+        push(out, new ReferenceWriteResult(msg, msg.metrics + ("total" -> total), 400))
       }
     }
   )
@@ -54,14 +54,14 @@ import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
  * INTERNAL API
  */
 @InternalApi private[reference] final class ReferenceFlow()
-    extends GraphStage[FlowShape[ReferenceWriteMessage, ReferenceWriteMessage]] {
+    extends GraphStage[FlowShape[ReferenceWriteMessage, ReferenceWriteResult]] {
   val in: Inlet[ReferenceWriteMessage] = Inlet(Logging.simpleName(this) + ".in")
-  val out: Outlet[ReferenceWriteMessage] = Outlet(Logging.simpleName(this) + ".out")
+  val out: Outlet[ReferenceWriteResult] = Outlet(Logging.simpleName(this) + ".out")
 
   override def initialAttributes: Attributes =
     Attributes.name(Logging.simpleName(this))
 
-  override val shape: FlowShape[ReferenceWriteMessage, ReferenceWriteMessage] = FlowShape(in, out)
+  override val shape: FlowShape[ReferenceWriteMessage, ReferenceWriteResult] = FlowShape(in, out)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new ReferenceFlowStageLogic(shape)

--- a/reference/src/main/scala/akka/stream/alpakka/reference/impl/ReferenceSource.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/impl/ReferenceSource.scala
@@ -8,7 +8,7 @@ import akka.Done
 import akka.annotation.InternalApi
 import akka.event.Logging
 import akka.stream._
-import akka.stream.alpakka.reference.{ReferenceReadMessage, SourceSettings}
+import akka.stream.alpakka.reference.{ReferenceReadResult, SourceSettings}
 import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, OutHandler}
 import akka.util.ByteString
 
@@ -26,7 +26,7 @@ import scala.util.Success
 @InternalApi private[reference] final class ReferenceSourceStageLogic(
     val settings: SourceSettings,
     val startupPromise: Promise[Done],
-    val shape: SourceShape[ReferenceReadMessage]
+    val shape: SourceShape[ReferenceReadResult]
 ) extends GraphStageLogic(shape) {
 
   private def out = shape.out
@@ -40,9 +40,7 @@ import scala.util.Success
   setHandler(out, new OutHandler {
     override def onPull(): Unit = push(
       out,
-      ReferenceReadMessage()
-        .withData(immutable.Seq(ByteString("one")))
-        .withBytesRead(Success(100))
+      new ReferenceReadResult(immutable.Seq(ByteString("one")), Success(100))
     )
   })
 
@@ -56,13 +54,13 @@ import scala.util.Success
  * INTERNAL API
  */
 @InternalApi private[reference] final class ReferenceSource(settings: SourceSettings)
-    extends GraphStageWithMaterializedValue[SourceShape[ReferenceReadMessage], Future[Done]] {
-  val out: Outlet[ReferenceReadMessage] = Outlet(Logging.simpleName(this) + ".out")
+    extends GraphStageWithMaterializedValue[SourceShape[ReferenceReadResult], Future[Done]] {
+  val out: Outlet[ReferenceReadResult] = Outlet(Logging.simpleName(this) + ".out")
 
   override def initialAttributes: Attributes =
     Attributes.name(Logging.simpleName(this))
 
-  override val shape: SourceShape[ReferenceReadMessage] = SourceShape(out)
+  override val shape: SourceShape[ReferenceReadResult] = SourceShape(out)
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Done]) = {
     // materialized value created as a new instance on every materialization

--- a/reference/src/main/scala/akka/stream/alpakka/reference/javadsl/Reference.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/javadsl/Reference.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.{CompletionStage, Executor}
 
 import akka.{Done, NotUsed}
 import akka.stream.alpakka.reference
-import akka.stream.alpakka.reference.{ReferenceReadMessage, ReferenceWriteMessage, SourceSettings}
+import akka.stream.alpakka.reference.{ReferenceReadResult, ReferenceWriteMessage, ReferenceWriteResult, SourceSettings}
 import akka.stream.javadsl.{Flow, Source}
 
 import scala.concurrent.ExecutionContext
@@ -20,7 +20,7 @@ object Reference {
    *
    * Call Scala source factory and convert both: the source and materialized values to Java classes.
    */
-  def source(settings: SourceSettings): Source[ReferenceReadMessage, CompletionStage[Done]] = {
+  def source(settings: SourceSettings): Source[ReferenceReadResult, CompletionStage[Done]] = {
     import scala.compat.java8.FutureConverters._
     reference.scaladsl.Reference.source(settings).mapMaterializedValue(_.toJava).asJava
   }
@@ -28,13 +28,13 @@ object Reference {
   /**
    * Only convert the flow type, as the materialized value type is the same between Java and Scala.
    */
-  def flow(): Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+  def flow(): Flow[ReferenceWriteMessage, ReferenceWriteResult, NotUsed] =
     reference.scaladsl.Reference.flow().asJava
 
   /**
    * In Java API take Executor as parameter if the operator needs to perform asynchronous tasks.
    */
-  def flowAsyncMapped(ex: Executor): Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+  def flowAsyncMapped(ex: Executor): Flow[ReferenceWriteMessage, ReferenceWriteResult, NotUsed] =
     reference.scaladsl.Reference.flowAsyncMapped()(ExecutionContext.fromExecutor(ex)).asJava
 
 }

--- a/reference/src/main/scala/akka/stream/alpakka/reference/javadsl/ReferenceWithResource.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/javadsl/ReferenceWithResource.scala
@@ -6,14 +6,14 @@ package akka.stream.alpakka.reference.javadsl
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.stream.alpakka.reference.{scaladsl, ReferenceWriteMessage, Resource}
+import akka.stream.alpakka.reference.{scaladsl, ReferenceWriteMessage, ReferenceWriteResult, Resource}
 import akka.stream.javadsl.Flow
 
 /**
  * Akka Stream operator factories that use resource instance from the extension.
  */
 object ReferenceWithResource {
-  def flow(sys: ActorSystem): Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+  def flow(sys: ActorSystem): Flow[ReferenceWriteMessage, ReferenceWriteResult, NotUsed] =
     scaladsl.ReferenceWithResource.flow()(sys).asJava
 }
 
@@ -21,6 +21,6 @@ object ReferenceWithResource {
  * Akka Stream operator factories that take an external resource.
  */
 object ReferenceWithExternalResource {
-  def flow(r: Resource): Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+  def flow(r: Resource): Flow[ReferenceWriteMessage, ReferenceWriteResult, NotUsed] =
     scaladsl.ReferenceWithExternalResource.flow()(r).asJava
 }

--- a/reference/src/main/scala/akka/stream/alpakka/reference/scaladsl/Reference.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/scaladsl/Reference.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.reference.scaladsl
 
 import akka.{Done, NotUsed}
 import akka.stream.alpakka.reference.impl.{ReferenceFlow, ReferenceSource}
-import akka.stream.alpakka.reference.{ReferenceReadMessage, ReferenceWriteMessage, SourceSettings}
+import akka.stream.alpakka.reference.{ReferenceReadResult, ReferenceWriteMessage, ReferenceWriteResult, SourceSettings}
 import akka.stream.scaladsl.{Flow, Source}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -18,19 +18,19 @@ object Reference {
    *
    * Also describe the significance of the materialized value.
    */
-  def source(settings: SourceSettings): Source[ReferenceReadMessage, Future[Done]] =
+  def source(settings: SourceSettings): Source[ReferenceReadResult, Future[Done]] =
     Source.fromGraph(new ReferenceSource(settings))
 
   /**
    * API doc should describe what will be done to the incoming messages to the flow,
    * and what messages will be emitted by the flow.
    */
-  def flow(): Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+  def flow(): Flow[ReferenceWriteMessage, ReferenceWriteResult, NotUsed] =
     Flow.fromGraph(new ReferenceFlow())
 
   /**
    * If the operator needs an ExecutionContext, take it as an implicit parameter.
    */
-  def flowAsyncMapped()(implicit ec: ExecutionContext): Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+  def flowAsyncMapped()(implicit ec: ExecutionContext): Flow[ReferenceWriteMessage, ReferenceWriteResult, NotUsed] =
     flow().mapAsync(parallelism = 4)(m => Future { m })
 }

--- a/reference/src/main/scala/akka/stream/alpakka/reference/scaladsl/ReferenceWithResource.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/scaladsl/ReferenceWithResource.scala
@@ -6,14 +6,14 @@ package akka.stream.alpakka.reference.scaladsl
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.alpakka.reference.impl.ReferenceWithResourceFlow
-import akka.stream.alpakka.reference.{ReferenceWriteMessage, Resource, ResourceExt}
+import akka.stream.alpakka.reference.{ReferenceWriteMessage, ReferenceWriteResult, Resource, ResourceExt}
 import akka.stream.scaladsl.Flow
 
 /**
  * Akka Stream operator factories that use resource instance from the extension.
  */
 object ReferenceWithResource {
-  def flow()(implicit sys: ActorSystem): Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+  def flow()(implicit sys: ActorSystem): Flow[ReferenceWriteMessage, ReferenceWriteResult, NotUsed] =
     ReferenceWithExternalResource.flow()(ResourceExt().resource)
 }
 
@@ -21,6 +21,6 @@ object ReferenceWithResource {
  * Akka Stream operator factories that take an external resource.
  */
 object ReferenceWithExternalResource {
-  def flow()(implicit r: Resource): Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+  def flow()(implicit r: Resource): Flow[ReferenceWriteMessage, ReferenceWriteResult, NotUsed] =
     Flow.fromGraph(new ReferenceWithResourceFlow(r))
 }

--- a/reference/src/main/scala/akka/stream/alpakka/reference/testkit/MessageFactory.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/testkit/MessageFactory.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.reference.testkit
+import akka.annotation.ApiMayChange
+import akka.stream.alpakka.reference.{ReferenceReadResult, ReferenceWriteMessage, ReferenceWriteResult}
+import akka.util.ByteString
+
+import scala.collection.immutable
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
+
+@ApiMayChange
+object MessageFactory {
+
+  @ApiMayChange
+  def createReadResult(data: immutable.Seq[ByteString], bytesRead: Try[Int]): ReferenceReadResult =
+    new ReferenceReadResult(data, bytesRead)
+
+  /**
+   * Java API
+   */
+  @ApiMayChange
+  def createReadResultSuccess(data: java.util.List[ByteString], bytesRead: Int): ReferenceReadResult =
+    new ReferenceReadResult(data.asScala.toList, Success(bytesRead))
+
+  /**
+   * Java API
+   */
+  @ApiMayChange
+  def createReadResultFailure(data: java.util.List[ByteString], failure: Throwable): ReferenceReadResult =
+    new ReferenceReadResult(data.asScala.toList, Failure(failure))
+
+  @ApiMayChange
+  def createWriteResult(message: ReferenceWriteMessage, metrics: Map[String, Long], status: Int): ReferenceWriteResult =
+    new ReferenceWriteResult(message, metrics, status)
+
+  /**
+   * Java API
+   */
+  @ApiMayChange
+  def createWriteResult(message: ReferenceWriteMessage,
+                        metrics: java.util.Map[String, java.lang.Long],
+                        status: Int): ReferenceWriteResult =
+    new ReferenceWriteResult(message, metrics.asScala.mapValues(Long.unbox).toMap, status)
+
+}

--- a/reference/src/test/java/docs/javadsl/ReferenceWithResourceTest.java
+++ b/reference/src/test/java/docs/javadsl/ReferenceWithResourceTest.java
@@ -9,6 +9,7 @@ import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.reference.ReferenceWriteMessage;
+import akka.stream.alpakka.reference.ReferenceWriteResult;
 import akka.stream.alpakka.reference.Resource;
 import akka.stream.alpakka.reference.ResourceExt;
 import akka.stream.alpakka.reference.javadsl.ReferenceWithExternalResource;
@@ -40,7 +41,7 @@ public class ReferenceWithResourceTest {
 
   @Test
   public void useGlobalResource() {
-    final Flow<ReferenceWriteMessage, ReferenceWriteMessage, NotUsed> flow =
+    final Flow<ReferenceWriteMessage, ReferenceWriteResult, NotUsed> flow =
         ReferenceWithResource.flow(sys);
 
     Source.single(ReferenceWriteMessage.create()).via(flow).to(Sink.seq()).run(mat);
@@ -49,7 +50,7 @@ public class ReferenceWithResourceTest {
   @Test
   public void useExternalResource() {
     final Resource resource = ResourceExt.get(sys).resource();
-    final Flow<ReferenceWriteMessage, ReferenceWriteMessage, NotUsed> flow =
+    final Flow<ReferenceWriteMessage, ReferenceWriteResult, NotUsed> flow =
         ReferenceWithExternalResource.flow(resource);
 
     Source.single(ReferenceWriteMessage.create()).via(flow).to(Sink.seq()).run(mat);

--- a/reference/src/test/scala/docs/scaladsl/ReferenceSpec.scala
+++ b/reference/src/test/scala/docs/scaladsl/ReferenceSpec.scala
@@ -6,9 +6,9 @@ package docs.scaladsl
 
 import akka.{Done, NotUsed}
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.alpakka.reference.scaladsl.Reference
-import akka.stream.alpakka.reference.{Authentication, ReferenceReadMessage, ReferenceWriteMessage, SourceSettings}
+import akka.stream.alpakka.reference._
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.testkit.TestKit
 import akka.util.ByteString
@@ -24,7 +24,7 @@ import scala.concurrent.Future
 class ReferenceSpec extends WordSpec with BeforeAndAfterAll with ScalaFutures with Matchers {
 
   implicit val sys = ActorSystem("ReferenceSpec")
-  implicit val mat = ActorMaterializer()
+  implicit val mat: Materializer = ActorMaterializer()
 
   final val ClientId = "test-client-id"
 
@@ -51,19 +51,19 @@ class ReferenceSpec extends WordSpec with BeforeAndAfterAll with ScalaFutures wi
       // #source
       val settings: SourceSettings = SourceSettings(ClientId)
 
-      val source: Source[ReferenceReadMessage, Future[Done]] =
+      val source: Source[ReferenceReadResult, Future[Done]] =
         Reference.source(settings)
       // #source
     }
 
     "compile flow" in {
       // #flow
-      val flow: Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+      val flow: Flow[ReferenceWriteMessage, ReferenceWriteResult, NotUsed] =
         Reference.flow()
       // #flow
 
       implicit val ec = scala.concurrent.ExecutionContext.global
-      val flow2: Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+      val flow2: Flow[ReferenceWriteMessage, ReferenceWriteResult, NotUsed] =
         Reference.flow()
     }
 
@@ -100,7 +100,7 @@ class ReferenceSpec extends WordSpec with BeforeAndAfterAll with ScalaFutures wi
 
       val result = source.via(flow).runWith(Sink.seq).futureValue
 
-      result.flatMap(_.data) should contain theSameElementsAs Seq(
+      result.flatMap(_.message.data) should contain theSameElementsAs Seq(
         "one",
         "two",
         "three",

--- a/reference/src/test/scala/docs/scaladsl/ReferenceWithResourceSpec.scala
+++ b/reference/src/test/scala/docs/scaladsl/ReferenceWithResourceSpec.scala
@@ -5,8 +5,8 @@
 package docs.scaladsl
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.alpakka.reference.{ReferenceWriteMessage, ResourceExt}
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.alpakka.reference.{ReferenceWriteMessage, ReferenceWriteResult, Resource, ResourceExt}
 import akka.stream.alpakka.reference.scaladsl.{ReferenceWithExternalResource, ReferenceWithResource}
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.testkit.TestKit
@@ -19,14 +19,14 @@ import org.scalatest.concurrent.ScalaFutures
 class ReferenceWithResourceSpec extends WordSpec with BeforeAndAfterAll with ScalaFutures with Matchers {
 
   implicit val sys = ActorSystem("ReferenceSpec")
-  implicit val mat = ActorMaterializer()
+  implicit val mat: Materializer = ActorMaterializer()
 
   final val ClientId = "test-client-id"
 
   "reference with resource connector" should {
 
     "use global resource" in {
-      val flow: Flow[ReferenceWriteMessage, ReferenceWriteMessage, NotUsed] =
+      val flow: Flow[ReferenceWriteMessage, ReferenceWriteResult, NotUsed] =
         ReferenceWithResource.flow()
 
       Source
@@ -37,7 +37,7 @@ class ReferenceWithResourceSpec extends WordSpec with BeforeAndAfterAll with Sca
     }
 
     "use external resource" in {
-      implicit val resource = ResourceExt().resource
+      implicit val resource: Resource = ResourceExt().resource
       val flow = ReferenceWithExternalResource.flow()
 
       Source


### PR DESCRIPTION
* Exemplify WriteMessage => WriteResult
* Rename ReadMessage to ReadResult as it comes from the outside
* showcase testkit to allow constructing result instances
* use full package names for Java classes