### PR TITLE
Jms per message destination

### DIFF
--- a/docs/src/main/paradox/jms.md
+++ b/docs/src/main/paradox/jms.md
@@ -192,6 +192,26 @@ Scala
 Java
 : @@snip [snip](/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #run-flow-producer }
 
+### Sending messages with per-message destinations
+
+The producer supports also a message flow that allows to set per-message destinations. In the flow settings that
+are passed in, it is not allowed to provide a queue or topic:
+
+Scala
+: @@snip [snip](/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #create-directed-flow-producer }
+
+Java
+: @@snip [snip](/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #create-directed-flow-producer }
+
+The destination can then be defined per message:
+
+Scala
+: @@snip [snip](/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala) { #run-directed-flow-producer }
+
+Java
+: @@snip [snip](/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java) { #run-directed-flow-producer }
+
+
 ### Configuring the Producer
 
 Scala

--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -35,18 +35,18 @@ sealed trait JmsSettings {
 
 sealed trait Destination {
   val name: String
-  val create: (jms.Session) => jms.Destination
+  val create: jms.Session => jms.Destination
 }
 final case class Topic(override val name: String) extends Destination {
-  override val create: (jms.Session) => jms.Destination = session => session.createTopic(name)
+  override val create: jms.Session => jms.Destination = session => session.createTopic(name)
 }
 final case class DurableTopic(name: String, subscriberName: String) extends Destination {
-  override val create: (jms.Session) => jms.Destination = session => session.createTopic(name)
+  override val create: jms.Session => jms.Destination = session => session.createTopic(name)
 }
 final case class Queue(override val name: String) extends Destination {
-  override val create: (jms.Session) => jms.Destination = session => session.createQueue(name)
+  override val create: jms.Session => jms.Destination = session => session.createQueue(name)
 }
-final case class CustomDestination(override val name: String, override val create: (jms.Session) => jms.Destination)
+final case class CustomDestination(override val name: String, override val create: jms.Session => jms.Destination)
     extends Destination
 
 final class AcknowledgeMode(val mode: Int)
@@ -78,7 +78,7 @@ final case class JmsConsumerSettings(connectionFactory: ConnectionFactory,
   def withBufferSize(size: Int): JmsConsumerSettings = copy(bufferSize = size)
   def withQueue(name: String): JmsConsumerSettings = copy(destination = Some(Queue(name)))
   def withTopic(name: String): JmsConsumerSettings = copy(destination = Some(Topic(name)))
-  def withDurableTopic(name: String, subscriberName: String) =
+  def withDurableTopic(name: String, subscriberName: String): JmsConsumerSettings =
     copy(destination = Some(DurableTopic(name, subscriberName)))
   def withDestination(destination: Destination): JmsConsumerSettings = copy(destination = Some(destination))
   def withSelector(selector: String): JmsConsumerSettings = copy(selector = Some(selector))

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -150,7 +150,7 @@ private[jms] class JmsMessageProducer(jmsProducer: MessageProducer, jmsSession: 
     }
 
   private[jms] def populateMessageProperties(message: javax.jms.Message, jmsMessage: JmsMessage): Unit =
-    jmsMessage.properties().foreach {
+    jmsMessage.properties.foreach {
       case (key, v) =>
         v match {
           case v: String => message.setStringProperty(key, v)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -4,41 +4,46 @@
 
 package akka.stream.alpakka.jms
 
+import java.util
+import java.util.Collections
 import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.ConcurrentHashMap
 
+import akka.stream.alpakka.jms.JmsMessageProducer.{DestinationMode, MessageDefinedDestination}
 import javax.jms
 import javax.jms._
 import akka.stream.{ActorAttributes, ActorMaterializer, Attributes}
 import akka.stream.stage.{AsyncCallback, GraphStageLogic}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.ref.SoftReference
+import scala.collection.JavaConverters._
 
 /**
  * Internal API
  */
-private[jms] trait JmsConnector { this: GraphStageLogic =>
+private[jms] trait JmsConnector[S <: JmsSession] { this: GraphStageLogic =>
 
   implicit protected var ec: ExecutionContext = _
 
   protected var jmsConnection: Option[Connection] = None
 
-  protected var jmsSessions = Seq.empty[JmsSession]
+  protected var jmsSessions = Seq.empty[S]
 
   protected def jmsSettings: JmsSettings
 
-  protected def onSessionOpened(jmsSession: JmsSession): Unit = {}
+  protected def onSessionOpened(jmsSession: S): Unit = {}
 
-  protected def fail: AsyncCallback[Throwable] = getAsyncCallback[Throwable](e => failStage(e))
+  protected val fail: AsyncCallback[Throwable] = getAsyncCallback[Throwable](e => failStage(e))
 
-  private def onConnection = getAsyncCallback[Connection] { c =>
+  private val onConnection: AsyncCallback[Connection] = getAsyncCallback[Connection] { c =>
     jmsConnection = Some(c)
   }
 
-  private def onSession =
-    getAsyncCallback[JmsSession] { session =>
-      jmsSessions :+= session
-      onSessionOpened(session)
-    }
+  private val onSession: AsyncCallback[S] = getAsyncCallback[S] { session =>
+    jmsSessions :+= session
+    onSessionOpened(session)
+  }
 
   protected def executionContext(attributes: Attributes): ExecutionContext = {
     val dispatcher = attributes.get[ActorAttributes.Dispatcher](
@@ -63,50 +68,88 @@ private[jms] trait JmsConnector { this: GraphStageLogic =>
         onSession.invoke(session)
       }
     }
-    future.onFailure {
-      case e: Exception => fail.invoke(e)
-    }
+    future.failed.foreach(e => fail.invoke(e))
     future
   }
 
-  protected def createSession(connection: Connection, createDestination: jms.Session => jms.Destination): JmsSession
+  def openSessions(): Seq[S]
 
-  protected def openSessions(): Seq[JmsSession] = {
+  def openConnection(): Connection = {
     val factory = jmsSettings.connectionFactory
     val connection = jmsSettings.credentials match {
       case Some(Credentials(username, password)) => factory.createConnection(username, password)
       case _ => factory.createConnection()
     }
     connection.setExceptionListener(new ExceptionListener {
-      override def onException(exception: JMSException) =
+      override def onException(exception: JMSException): Unit =
         fail.invoke(exception)
     })
-    connection.start()
     onConnection.invoke(connection)
+    connection
+  }
+}
+
+private[jms] trait JmsConsumerConnector extends JmsConnector[JmsConsumerSession] { this: GraphStageLogic =>
+
+  protected def createSession(connection: Connection,
+                              createDestination: jms.Session => jms.Destination): JmsConsumerSession
+
+  def openSessions(): Seq[JmsConsumerSession] = {
+    val connection = openConnection()
+    connection.start()
 
     val createDestination = jmsSettings.destination match {
-      case Some(destination) =>
-        destination.create
+      case Some(destination) => destination.create
       case _ => throw new IllegalArgumentException("Destination is missing")
     }
 
-    0 until jmsSettings.sessionCount map { _ =>
-      createSession(connection, createDestination)
-    }
+    for (_ <- 0 until jmsSettings.sessionCount)
+      yield createSession(connection, createDestination)
+  }
+}
+
+private[jms] trait JmsProducerConnector extends JmsConnector[JmsProducerSession] { this: GraphStageLogic =>
+
+  def openSessions(): Seq[JmsProducerSession] = {
+    val connection = openConnection()
+
+    val maybeDestinationFactory = jmsSettings.destination.map(_.create)
+
+    for (_ <- 0 until jmsSettings.sessionCount)
+      yield {
+        val session = connection.createSession(false, AcknowledgeMode.AutoAcknowledge.mode)
+        new JmsProducerSession(connection, session, maybeDestinationFactory.map(_.apply(session)))
+      }
   }
 }
 
 private[jms] object JmsMessageProducer {
-  def apply(jmsSession: JmsSession, settings: JmsProducerSettings): JmsMessageProducer = {
-    val producer = jmsSession.session.createProducer(jmsSession.jmsDestination)
+  def apply(jmsSession: JmsProducerSession, settings: JmsProducerSettings): JmsMessageProducer = {
+    val producer = jmsSession.session.createProducer(jmsSession.jmsDestination.orNull)
     if (settings.timeToLive.nonEmpty) {
       producer.setTimeToLive(settings.timeToLive.get.toMillis)
     }
-    new JmsMessageProducer(producer, jmsSession)
+    new JmsMessageProducer(producer, jmsSession, destinationMode(settings))
   }
+
+  def destinationMode(settings: JmsProducerSettings): DestinationMode =
+    if (settings.destination.isDefined) ProducerDefinedDestination else MessageDefinedDestination
+
+  sealed trait DestinationMode
+  object ProducerDefinedDestination extends DestinationMode
+  object MessageDefinedDestination extends DestinationMode
+
 }
 
-private[jms] class JmsMessageProducer(jmsProducer: MessageProducer, jmsSession: JmsSession) {
+private[jms] class JmsMessageProducer(jmsProducer: MessageProducer,
+                                      jmsSession: JmsProducerSession,
+                                      mode: DestinationMode) {
+
+  // Using a synchronized map (and not ConcurrentHashMap) for the cache since:
+  // - we run on our on execution context and cannot piggy-back on Akka's synchronization
+  // - we run send()s with one thread at a time, so there will be no lock contention.
+  private val destinationCache =
+    Collections.synchronizedMap(new util.HashMap[Destination, SoftReference[jms.Destination]]()).asScala
 
   def send(elem: JmsMessage): Unit = {
     val message: Message = createMessage(elem)
@@ -115,37 +158,53 @@ private[jms] class JmsMessageProducer(jmsProducer: MessageProducer, jmsSession: 
     val (sendHeaders, headersBeforeSend: Set[JmsHeader]) = elem.headers.partition(_.usedDuringSend)
     populateMessageHeader(message, headersBeforeSend)
 
-    val deliveryModeOption = findHeader(sendHeaders) { case x: JmsDeliveryMode => x.deliveryMode }
-    val priorityOption = findHeader(sendHeaders) { case x: JmsPriority => x.priority }
-    val timeToLiveInMillisOption = findHeader(sendHeaders) { case x: JmsTimeToLive => x.timeInMillis }
+    val deliveryMode = sendHeaders
+      .collectFirst { case x: JmsDeliveryMode => x.deliveryMode }
+      .getOrElse(jmsProducer.getDeliveryMode)
 
-    jmsProducer.send(
-      message,
-      deliveryModeOption.getOrElse(jmsProducer.getDeliveryMode),
-      priorityOption.getOrElse(jmsProducer.getPriority),
-      timeToLiveInMillisOption.getOrElse(jmsProducer.getTimeToLive)
-    )
+    val priority = sendHeaders
+      .collectFirst { case x: JmsPriority => x.priority }
+      .getOrElse(jmsProducer.getPriority)
+
+    val timeToLive = sendHeaders
+      .collectFirst { case x: JmsTimeToLive => x.timeInMillis }
+      .getOrElse(jmsProducer.getTimeToLive)
+
+    elem match {
+      case directed: JmsDirectedMessage if mode == MessageDefinedDestination =>
+        val jmsDestination = lookup(directed.destination)
+        jmsProducer.send(jmsDestination, message, deliveryMode, priority, timeToLive)
+      case _ =>
+        jmsProducer.send(message, deliveryMode, priority, timeToLive)
+    }
   }
 
-  private def findHeader[T](headersDuringSend: Set[JmsHeader])(f: PartialFunction[JmsHeader, T]): Option[T] =
-    headersDuringSend.collectFirst(f)
+  def lookup(destination: Destination): jms.Destination =
+    destinationCache.get(destination) match {
+      case Some(SoftReference(jmsDestination)) =>
+        jmsDestination
+      case _ =>
+        val jmsDestination = destination.create(jmsSession.session)
+        destinationCache.put(destination, SoftReference(jmsDestination))
+        jmsDestination
+    }
 
   private[jms] def createMessage(element: JmsMessage): Message =
     element match {
 
-      case textMessage: JmsTextMessage => jmsSession.session.createTextMessage(textMessage.body)
+      case textMessage: JmsAbstractTextMessage => jmsSession.session.createTextMessage(textMessage.body)
 
-      case byteMessage: JmsByteMessage =>
+      case byteMessage: JmsAbstractByteMessage =>
         val newMessage = jmsSession.session.createBytesMessage()
         newMessage.writeBytes(byteMessage.bytes)
         newMessage
 
-      case mapMessage: JmsMapMessage =>
+      case mapMessage: JmsAbstractMapMessage =>
         val newMessage = jmsSession.session.createMapMessage()
         populateMapMessage(newMessage, mapMessage)
         newMessage
 
-      case objectMessage: JmsObjectMessage => jmsSession.session.createObjectMessage(objectMessage.serializable)
+      case objectMessage: JmsAbstractObjectMessage => jmsSession.session.createObjectMessage(objectMessage.serializable)
 
     }
 
@@ -165,7 +224,7 @@ private[jms] class JmsMessageProducer(jmsProducer: MessageProducer, jmsSession: 
         }
     }
 
-  private def populateMapMessage(message: javax.jms.MapMessage, jmsMessage: JmsMapMessage): Unit =
+  private def populateMapMessage(message: javax.jms.MapMessage, jmsMessage: JmsAbstractMapMessage): Unit =
     jmsMessage.body.foreach {
       case (key, v) =>
         v match {
@@ -190,10 +249,11 @@ private[jms] class JmsMessageProducer(jmsProducer: MessageProducer, jmsSession: 
     }
 }
 
-private[jms] class JmsSession(val connection: jms.Connection,
-                              val session: jms.Session,
-                              val jmsDestination: jms.Destination,
-                              val settingsDestination: Destination) {
+private[jms] trait JmsSession {
+
+  def connection: jms.Connection
+
+  def session: jms.Session
 
   private[jms] def closeSessionAsync()(implicit ec: ExecutionContext): Future[Unit] = Future { closeSession() }
 
@@ -202,11 +262,18 @@ private[jms] class JmsSession(val connection: jms.Connection,
   private[jms] def abortSessionAsync()(implicit ec: ExecutionContext): Future[Unit] = Future { abortSession() }
 
   private[jms] def abortSession(): Unit = closeSession()
+}
 
-  private[jms] def createProducer()(implicit ec: ExecutionContext): Future[jms.MessageProducer] =
-    Future {
-      session.createProducer(jmsDestination)
-    }
+private[jms] class JmsProducerSession(val connection: jms.Connection,
+                                      val session: jms.Session,
+                                      val jmsDestination: Option[jms.Destination])
+    extends JmsSession
+
+private[jms] class JmsConsumerSession(val connection: jms.Connection,
+                                      val session: jms.Session,
+                                      val jmsDestination: jms.Destination,
+                                      val settingsDestination: Destination)
+    extends JmsSession {
 
   private[jms] def createConsumer(
       selector: Option[String]
@@ -233,7 +300,7 @@ private[jms] class JmsAckSession(override val connection: jms.Connection,
                                  override val jmsDestination: jms.Destination,
                                  override val settingsDestination: Destination,
                                  val maxPendingAcks: Int)
-    extends JmsSession(connection, session, jmsDestination, settingsDestination) {
+    extends JmsConsumerSession(connection, session, jmsDestination, settingsDestination) {
 
   private[jms] var pendingAck = 0
   private[jms] val ackQueue = new ArrayBlockingQueue[() => Unit](maxPendingAcks + 1)
@@ -254,7 +321,7 @@ private[jms] class JmsTxSession(override val connection: jms.Connection,
                                 override val session: jms.Session,
                                 override val jmsDestination: jms.Destination,
                                 override val settingsDestination: Destination)
-    extends JmsSession(connection, session, jmsDestination, settingsDestination) {
+    extends JmsConsumerSession(connection, session, jmsDestination, settingsDestination) {
 
   private[jms] val commitQueue = new ArrayBlockingQueue[TxEnvelope => Unit](1)
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerStage.scala
@@ -34,10 +34,10 @@ private[jms] final class JmsConsumerStage(settings: JmsConsumerSettings)
       private val backpressure = new Semaphore(bufferSize)
 
       protected def createSession(connection: Connection,
-                                  createDestination: Session => javax.jms.Destination): JmsSession = {
+                                  createDestination: Session => javax.jms.Destination): JmsConsumerSession = {
         val session =
           connection.createSession(false, settings.acknowledgeMode.getOrElse(AcknowledgeMode.AutoAcknowledge).mode)
-        new JmsSession(connection, session, createDestination(session), settings.destination.get)
+        new JmsConsumerSession(connection, session, createDestination(session), settings.destination.get)
       }
 
       protected def pushMessage(msg: Message): Unit = {
@@ -45,7 +45,7 @@ private[jms] final class JmsConsumerStage(settings: JmsConsumerSettings)
         backpressure.release()
       }
 
-      override protected def onSessionOpened(jmsSession: JmsSession): Unit =
+      override protected def onSessionOpened(jmsSession: JmsConsumerSession): Unit =
         jmsSession
           .createConsumer(settings.selector)
           .onComplete {
@@ -90,7 +90,7 @@ final class JmsAckSourceStage(settings: JmsConsumerSettings)
 
       protected def pushMessage(msg: AckEnvelope): Unit = push(out, msg)
 
-      override protected def onSessionOpened(jmsSession: JmsSession): Unit =
+      override protected def onSessionOpened(jmsSession: JmsConsumerSession): Unit =
         jmsSession match {
           case session: JmsAckSession =>
             session.createConsumer(settings.selector).onComplete {
@@ -167,7 +167,7 @@ final class JmsTxSourceStage(settings: JmsConsumerSettings)
 
       protected def pushMessage(msg: TxEnvelope): Unit = push(out, msg)
 
-      override protected def onSessionOpened(jmsSession: JmsSession): Unit =
+      override protected def onSessionOpened(jmsSession: JmsConsumerSession): Unit =
         jmsSession match {
           case session: JmsTxSession =>
             session.createConsumer(settings.selector).onComplete {
@@ -210,7 +210,7 @@ abstract class SourceStageLogic[T](shape: SourceShape[T],
                                    settings: JmsConsumerSettings,
                                    attributes: Attributes)
     extends GraphStageLogic(shape)
-    with JmsConnector
+    with JmsConsumerConnector
     with StageLogging {
 
   override protected def jmsSettings: JmsConsumerSettings = settings

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsExceptions.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsExceptions.scala
@@ -22,14 +22,14 @@ case class NullMessageProperty(propertyName: String, message: JmsMessage)
     )
     with NonRetriableJmsException
 
-case class UnsupportedMapMessageEntryType(entryName: String, entryValue: Any, message: JmsMapMessage)
+case class UnsupportedMapMessageEntryType(entryName: String, entryValue: Any, message: JmsAbstractMapMessage)
     extends Exception(
       s"Jms MapMessage entry '$entryName' has unknown type '${entryValue.getClass.getName}'. " +
       "Only primitive types, String, and Byte array are supported as entry values."
     )
     with NonRetriableJmsException
 
-case class NullMapMessageEntry(entryName: String, message: JmsMapMessage)
+case class NullMapMessageEntry(entryName: String, message: JmsAbstractMapMessage)
     extends Exception(
       s"null value was given for Jms MapMessage entry '$entryName'."
     )

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsProducer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsProducer.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.jms.javadsl
 import java.util.concurrent.CompletionStage
 
 import akka.{Done, NotUsed}
-import akka.stream.alpakka.jms.{JmsMessage, JmsProducerSettings, JmsProducerStage}
+import akka.stream.alpakka.jms.{JmsDirectedMessage, JmsMessage, JmsProducerSettings}
 import akka.stream.scaladsl.{Flow, Keep}
 
 import scala.collection.JavaConversions
@@ -22,6 +22,14 @@ object JmsProducer {
       settings: JmsProducerSettings
   ): akka.stream.javadsl.Flow[R, R, NotUsed] =
     akka.stream.alpakka.jms.scaladsl.JmsProducer.flow(settings).asJava
+
+  /**
+   * Java API: Creates an [[JmsProducer]] for [[JmsDirectedMessage]]s
+   */
+  def directedMessageFlow[R <: JmsDirectedMessage](
+      settings: JmsProducerSettings
+  ): akka.stream.javadsl.Flow[R, R, NotUsed] =
+    akka.stream.alpakka.jms.scaladsl.JmsProducer.directedMessageFlow(settings).asJava
 
   /**
    * Java API: Creates an [[JmsProducer]] for [[JmsMessage]]s

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsProducer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsProducer.scala
@@ -15,8 +15,18 @@ object JmsProducer {
   /**
    * Scala API: Creates an [[JmsProducer]] for [[JmsMessage]]s
    */
-  def flow[T <: JmsMessage](settings: JmsProducerSettings): Flow[T, T, NotUsed] =
+  def flow[T <: JmsMessage](settings: JmsProducerSettings): Flow[T, T, NotUsed] = {
+    require(settings.destination.isDefined, "Producer destination must be defined in regular producer flow")
     Flow.fromGraph(new JmsProducerStage(settings))
+  }
+
+  /**
+   * Scala API: Creates an [[JmsProducer]] for [[JmsDirectedMessage]]s
+   */
+  def directedMessageFlow[T <: JmsDirectedMessage](settings: JmsProducerSettings): Flow[T, T, NotUsed] = {
+    require(settings.destination.isEmpty, "Producer destination must be undefined in directed producer flow")
+    Flow.fromGraph(new JmsProducerStage(settings))
+  }
 
   /**
    * Scala API: Creates an [[JmsProducer]] for [[JmsMessage]]s

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
@@ -690,6 +690,44 @@ public class JmsConnectorsTest {
         });
   }
 
+    @Test
+    public void directedProducerFlow() throws Exception {
+    withServer(
+        ctx -> {
+          ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
+
+          // #create-directed-flow-producer
+          Flow<JmsDirectedTextMessage, JmsDirectedTextMessage, NotUsed> flowSink =
+              JmsProducer.directedMessageFlow(JmsProducerSettings.create(connectionFactory));
+          // #create-directed-flow-producer
+
+          // #run-directed-flow-producer
+          List<JmsDirectedTextMessage> input = new ArrayList<>();
+          for (Integer n : Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) {
+            String queueName = (n % 2 == 0) ? "even" : "odd";
+            input.add(JmsTextMessage.create(n.toString()).toQueue(queueName));
+          }
+
+          Source.from(input).via(flowSink).runWith(Sink.seq(), materializer);
+          // #run-directed-flow-producer
+
+          CompletionStage<List<Integer>> even = JmsConsumer.textSource(
+            JmsConsumerSettings.create(connectionFactory).withBufferSize(10).withQueue("even"))
+            .take(5)
+            .map(Integer::parseInt)
+            .runWith(Sink.seq(), materializer);
+
+          CompletionStage<List<Integer>> odd = JmsConsumer.textSource(
+            JmsConsumerSettings.create(connectionFactory).withBufferSize(10).withQueue("odd"))
+            .take(5)
+            .map(Integer::parseInt)
+            .runWith(Sink.seq(), materializer);
+
+          assertEquals(Arrays.asList(1, 3, 5, 7, 9), odd.toCompletableFuture().get());
+          assertEquals(Arrays.asList(2, 4, 6, 8, 10), even.toCompletableFuture().get());
+        });
+    }
+
   private static ActorSystem system;
   private static Materializer materializer;
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsMessageProducerSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsMessageProducerSpec.scala
@@ -26,8 +26,8 @@ class JmsMessageProducerSpec extends JmsSpec with MockitoSugar {
     when(session.createTextMessage(anyString())).thenReturn(textMessage)
     when(session.createMapMessage()).thenReturn(mapMessage)
 
-    val settings = JmsProducerSettings(factory, destination = Option(settingsDestination))
-    val jmsSession = new JmsSession(connection, session, destination, settingsDestination)
+    val settings = JmsProducerSettings(factory, destination = Some(settingsDestination))
+    val jmsSession = new JmsProducerSession(connection, session, Some(destination))
 
     val jmsProducer = JmsMessageProducer(jmsSession, settings)
   }

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
@@ -31,7 +31,7 @@ final case class DummyObject(payload: String)
 
 class JmsConnectorsSpec extends JmsSpec with MockitoSugar {
 
-  override implicit val patienceConfig = PatienceConfig(2.minutes)
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(2.minutes)
 
   "The JMS Connectors" should {
     "publish and consume strings through a queue" in withServer() { ctx =>
@@ -787,6 +787,73 @@ class JmsConnectorsSpec extends JmsSpec with MockitoSugar {
       //#run-flow-producer
 
       result.futureValue should ===(input)
+    }
+
+    "accept message-defined destinations in directed flow" in withServer() { ctx =>
+      val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
+
+      //#create-directed-flow-producer
+      val directedFlowSink: Flow[JmsDirectedMessage, JmsDirectedMessage, NotUsed] =
+        JmsProducer.directedMessageFlow(
+          JmsProducerSettings(connectionFactory) // no destination configured
+        )
+      //#create-directed-flow-producer
+
+      //#run-directed-flow-producer
+      val input = (1 to 100).map { i =>
+        val queueName = if (i % 2 == 0) "even" else "odd"
+        JmsTextMessage(i.toString).toQueue(queueName)
+      }
+      Source(input)
+        .via(directedFlowSink)
+        .runWith(Sink.ignore)
+      //#run-directed-flow-producer
+
+      val jmsEvenSource: Source[String, KillSwitch] = JmsConsumer.textSource(
+        JmsConsumerSettings(connectionFactory).withBufferSize(10).withQueue("even")
+      )
+      val jmsOddSource: Source[String, KillSwitch] = JmsConsumer.textSource(
+        JmsConsumerSettings(connectionFactory).withBufferSize(10).withQueue("odd")
+      )
+
+      jmsEvenSource.take(input.size / 2).map(_.toInt).runWith(Sink.seq).futureValue shouldBe (2 to 100 by 2)
+      jmsOddSource.take(input.size / 2).map(_.toInt).runWith(Sink.seq).futureValue shouldBe (1 to 99 by 2)
+    }
+
+    "ignore message destination in regular flow" in withServer() { ctx =>
+      val connectionFactory = new ActiveMQConnectionFactory(ctx.url)
+      val jmsSink: Sink[JmsDirectedMessage, Future[Done]] = JmsProducer
+        .flow(JmsProducerSettings(connectionFactory).withQueue("test"))
+        .toMat(Sink.ignore)(Keep.right)
+
+      val in = List("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")
+      val input = in.map(c => JmsTextMessage(c).toQueue("doesNotExist"))
+
+      Source(input).runWith(jmsSink)
+
+      val jmsSource: Source[String, KillSwitch] = JmsConsumer.textSource(
+        JmsConsumerSettings(connectionFactory).withBufferSize(10).withQueue("test")
+      )
+
+      val result = jmsSource.take(in.size).runWith(Sink.seq)
+
+      result.futureValue shouldEqual in
+    }
+
+    "fail if message destination is not defined when using regular flow" in {
+      val connectionFactory = new ActiveMQConnectionFactory("localhost:1234")
+
+      an[IllegalArgumentException] shouldBe thrownBy {
+        JmsProducer.flow(JmsProducerSettings(connectionFactory))
+      }
+    }
+
+    "fail if message destination is defined when using a directed message flow" in {
+      val connectionFactory = new ActiveMQConnectionFactory("localhost:1234")
+
+      an[IllegalArgumentException] shouldBe thrownBy {
+        JmsProducer.directedMessageFlow(JmsProducerSettings(connectionFactory).withQueue("test"))
+      }
     }
 
     "publish and consume strings through a queue with multiple sessions" in withServer() { ctx =>


### PR DESCRIPTION
Extends the Jms message model with messages having destinations, and implement a flow (`directedMessageFlow`) that consumes messages with destinations only.