### PR TITLE
SSE: Allow provision of custom EventStreamUnmarshalling in EventSource

### DIFF
--- a/sse/src/main/scala/akka/stream/alpakka/sse/scaladsl/EventSource.scala
+++ b/sse/src/main/scala/akka/stream/alpakka/sse/scaladsl/EventSource.scala
@@ -17,6 +17,7 @@ import akka.http.scaladsl.model.sse.ServerSentEvent.heartbeat
 import akka.http.scaladsl.model.MediaTypes.`text/event-stream`
 import akka.http.scaladsl.model.headers.`Last-Event-ID`
 import akka.http.scaladsl.unmarshalling.sse.EventStreamUnmarshalling
+
 import scala.concurrent.Future
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
@@ -76,16 +77,18 @@ object EventSource {
    * @param send function to send a HTTP request
    * @param initialLastEventId initial value for Last-Evend-ID header, `None` by default
    * @param retryDelay delay for retrying after completion, `0` by default
-   * @param mat implicit `Materializer`, needed to obtain server-sent events
+   * @param unmarshaller converts event-stream responses to a Source of `ServerSentEvent`s.
+   * @param mat implicit Materializer`, needed to obtain server-sent events
    * @return continuous source of server-sent events
    */
   def apply(uri: Uri,
             send: HttpRequest => Future[HttpResponse],
             initialLastEventId: Option[String] = None,
-            retryDelay: FiniteDuration = Duration.Zero)(
+            retryDelay: FiniteDuration = Duration.Zero,
+            unmarshaller: EventStreamUnmarshalling = EventStreamUnmarshalling)(
       implicit mat: Materializer
   ): EventSource = {
-    import EventStreamUnmarshalling._
+    import unmarshaller._
     import mat.executionContext
 
     val continuousEvents = {

--- a/sse/src/main/scala/akka/stream/alpakka/sse/scaladsl/EventSource.scala
+++ b/sse/src/main/scala/akka/stream/alpakka/sse/scaladsl/EventSource.scala
@@ -78,7 +78,7 @@ object EventSource {
    * @param initialLastEventId initial value for Last-Evend-ID header, `None` by default
    * @param retryDelay delay for retrying after completion, `0` by default
    * @param unmarshaller converts event-stream responses to a Source of `ServerSentEvent`s.
-   * @param mat implicit Materializer`, needed to obtain server-sent events
+   * @param mat implicit `Materializer`, needed to obtain server-sent events
    * @return continuous source of server-sent events
    */
   def apply(uri: Uri,


### PR DESCRIPTION
#1183 describes how events that exceed line length of 4096 bytes silently fail, leading to a retry loop.

This PR allows the user to provide their own `EventStreamUnmarshalling` instance, thereby overriding the default values for `maxEventSize` and `maxLineSize`.

It does not fix the silent failure, but allows users to avoid it.