### PR TITLE
FTP: towards 1.0

### DIFF
--- a/doc-examples/src/main/scala/ftpsamples/FtpToFile.scala
+++ b/doc-examples/src/main/scala/ftpsamples/FtpToFile.scala
@@ -34,7 +34,7 @@ object FtpToFile extends ActorSystemAvailable with App {
   ftpFileSystem.putFileOnFtp("/home/anonymous", "hello2.txt")
 
   // #sample
-  val ftpSettings = FtpSettings(InetAddress.getByName("localhost"), port)
+  val ftpSettings = FtpSettings(InetAddress.getByName("localhost")).withPort(port)
 
   // #sample
 

--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -24,10 +24,10 @@ The FTP connector provides Akka Stream sources to connect to FTP, FTPs and SFTP 
 In order to establish a connection with the remote server, you need to provide a specialized version of a @scaladoc[RemoteFileSettings](akka.stream.alpakka.ftp.RemoteFileSettings) instance. It's specialized as it depends on the kind of server you're connecting to: FTP, FTPs or SFTP.
 
 Scala
-: @@snip [snip](/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #create-settings }
+: @@snip [snip](/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala) { #create-settings }
 
 Java
-: @@snip [snip](/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpSettingsExample.java) { #create-settings }
+: @@snip [snip](/ftp/src/test/java/docs/javadsl/FtpSettingsExample.java) { #create-settings }
 
 The configuration above will create an anonymous connection with a remote FTP server in passive mode. For both FTPs and SFTP servers, you will need to provide the specialized versions of these settings: @scaladoc[FtpsSettings](akka.stream.alpakka.ftp.RemoteFileSettings$$FtpsSettings) or @scaladoc[SftpSettings](akka.stream.alpakka.ftp.RemoteFileSettings$$SftpSettings)
 respectively.
@@ -41,20 +41,20 @@ For connection using a private key, please provide an instance of @scaladoc[Sftp
 In order to use a custom SSH client for SFTP please provide an instance of @scaladoc[SSHClient](net.schmizz.sshj.SSHClient).
 
 Scala
-: @@snip [snip](/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #configure-custom-ssh-client }
+: @@snip [snip](/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala) { #configure-custom-ssh-client }
 
 Java
-: @@snip [snip](/ftp/src/test/java/akka/stream/alpakka/ftp/examples/ConfigureCustomSSHClient.java) { #configure-custom-ssh-client }
+: @@snip [snip](/ftp/src/test/java/docs/javadsl/ConfigureCustomSSHClient.java) { #configure-custom-ssh-client }
 
 ### Traversing a remote FTP folder recursively
 
 In order to traverse a remote folder recursively, you need to use the `ls` method in the FTP API:
 
 Scala
-: @@snip [snip](/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #traversing }
+: @@snip [snip](/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala) { #traversing }
 
 Java
-: @@snip [snip](/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpTraversingExample.java) { #traversing }
+: @@snip [snip](/ftp/src/test/java/docs/javadsl/FtpTraversingExample.java) { #traversing }
 
 This source will emit @scaladoc[FtpFile](akka.stream.alpakka.ftp.FtpFile) elements with no significant materialization.
 
@@ -65,10 +65,10 @@ For both FTPs and SFTP servers, you will need to use the `FTPs` and `SFTP` API r
 In order to retrieve a remote file as a stream of bytes, you need to use the `fromPath` method in the FTP API:
 
 Scala
-: @@snip [snip](/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #retrieving }
+: @@snip [snip](/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala) { #retrieving }
 
 Java
-: @@snip [snip](/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpRetrievingExample.java) { #retrieving }
+: @@snip [snip](/ftp/src/test/java/docs/javadsl/FtpRetrievingExample.java) { #retrieving }
 
 This source will emit @scaladoc[ByteString](akka.util.ByteString) elements and materializes to @scaladoc[Future](scala.concurrent.Future) in Scala API and @javadoc[CompletionStage](java/util/concurrent/CompletionStage) in Java API of @scaladoc[IOResult](akka.stream.IOResult) when the stream finishes.
 
@@ -79,10 +79,10 @@ For both FTPs and SFTP servers, you will need to use the `FTPs` and `SFTP` API r
 In order to store a remote file from a stream of bytes, you need to use the `toPath` method in the FTP API:
 
 Scala
-: @@snip [snip](/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #storing }
+: @@snip [snip](/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala) { #storing }
 
 Java
-: @@snip [snip](/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpWritingExample.java) { #storing }
+: @@snip [snip](/ftp/src/test/java/docs/javadsl/FtpWritingExample.java) { #storing }
 
 This sink will consume @scaladoc[ByteString](akka.util.ByteString) elements and materializes to @scaladoc[Future](scala.concurrent.Future) in Scala API and @javadoc[CompletionStage](java/util/concurrent/CompletionStage) in Java API of @scaladoc[IOResult](akka.stream.IOResult) when the stream finishes.
 
@@ -93,10 +93,10 @@ For both FTPs and SFTP servers, you will need to use the `FTPs` and `SFTP` API r
 In order to remove a remote file, you need to use the `remove` method in the FTP API:
 
 Scala
-: @@snip [snip](/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #removing }
+: @@snip [snip](/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala) { #removing }
 
 Java
-: @@snip [snip](/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpRemovingExample.java) { #removing }
+: @@snip [snip](/ftp/src/test/java/docs/javadsl/FtpRemovingExample.java) { #removing }
 
 This sink will consume @scaladoc[FtpFile](akka.stream.alpakka.ftp.FtpFile) elements and materializes to @scaladoc[Future](scala.concurrent.Future) in Scala API and @javadoc[CompletionStage](java/util/concurrent/CompletionStage) in Java API of @scaladoc[IOResult](akka.stream.IOResult) when the stream finishes.
 
@@ -105,10 +105,10 @@ This sink will consume @scaladoc[FtpFile](akka.stream.alpakka.ftp.FtpFile) eleme
 In order to move a remote file, you need to use the `move` method in the FTP API. The `move` method takes a function to calculate the path to which the file should be moved based on the consumed @scaladoc[FtpFile](akka.stream.alpakka.ftp.FtpFile).   
 
 Scala
-: @@snip [snip](/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #moving }
+: @@snip [snip](/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala) { #moving }
 
 Java
-: @@snip [snip](/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpMovingExample.java) { #moving }
+: @@snip [snip](/ftp/src/test/java/docs/javadsl/FtpMovingExample.java) { #moving }
 
 This sink will consume @scaladoc[FtpFile](akka.stream.alpakka.ftp.FtpFile) elements and materializes to @scaladoc[Future](scala.concurrent.Future) in Scala API and @javadoc[CompletionStage](java/util/concurrent/CompletionStage) in Java API of @scaladoc[IOResult](akka.stream.IOResult) when the stream finishes.
 
@@ -117,10 +117,10 @@ Typical use-case for this would be listing files from a ftp location, do some pr
 ### Example: downloading files from an FTP location and move the original files  
 
 Scala
-: @@snip [snip](/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala) { #processAndMove }
+: @@snip [snip](/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala) { #processAndMove }
 
 Java
-: @@snip [snip](/ftp/src/test/java/akka/stream/alpakka/ftp/examples/FtpProcessAndMoveExample.java) { #processAndMove }
+: @@snip [snip](/ftp/src/test/java/docs/javadsl/FtpProcessAndMoveExample.java) { #processAndMove }
 
 ### Running the example code
 

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
@@ -8,12 +8,17 @@ import java.io.{IOException, InputStream, OutputStream}
 import java.nio.file.Paths
 import java.nio.file.attribute.PosixFilePermission
 
+import akka.annotation.InternalApi
 import akka.stream.alpakka.ftp.FtpFile
 import org.apache.commons.net.ftp.{FTPClient, FTPFile}
 
 import scala.collection.immutable
 import scala.util.Try
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait CommonFtpOperations {
   type Handler = FTPClient
 

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpBrowserGraphStage.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpBrowserGraphStage.scala
@@ -5,10 +5,15 @@
 package akka.stream.alpakka.ftp
 package impl
 
+import akka.annotation.InternalApi
 import akka.stream.stage.{GraphStage, OutHandler}
 import akka.stream.{Attributes, Outlet, SourceShape}
 import akka.stream.impl.Stages.DefaultAttributes.IODispatcher
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpBrowserGraphStage[FtpClient, S <: RemoteFileSettings] extends GraphStage[SourceShape[FtpFile]] {
 
   def name: String

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpGraphStageLogic.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpGraphStageLogic.scala
@@ -7,11 +7,16 @@ package impl
 
 import java.io.IOException
 
+import akka.annotation.InternalApi
 import akka.stream.Shape
 import akka.stream.stage.GraphStageLogic
 
 import scala.util.control.NonFatal
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] abstract class FtpGraphStageLogic[T, FtpClient, S <: RemoteFileSettings](
     val shape: Shape,
     val ftpLike: FtpLike[FtpClient, S],

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpIOGraphStage.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpIOGraphStage.scala
@@ -14,8 +14,14 @@ import akka.util.ByteString.ByteString1C
 import scala.concurrent.{Future, Promise}
 import java.io.{IOException, InputStream, OutputStream}
 
+import akka.annotation.InternalApi
+
 import scala.util.control.NonFatal
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpIOGraphStage[FtpClient, S <: RemoteFileSettings, Sh <: Shape]
     extends GraphStageWithMaterializedValue[Sh, Future[IOResult]] {
 
@@ -35,6 +41,10 @@ private[ftp] trait FtpIOGraphStage[FtpClient, S <: RemoteFileSettings, Sh <: Sha
   override def shape: Sh
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpIOSourceStage[FtpClient, S <: RemoteFileSettings]
     extends FtpIOGraphStage[FtpClient, S, SourceShape[ByteString]] {
 
@@ -126,6 +136,10 @@ private[ftp] trait FtpIOSourceStage[FtpClient, S <: RemoteFileSettings]
 
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpIOSinkStage[FtpClient, S <: RemoteFileSettings]
     extends FtpIOGraphStage[FtpClient, S, SinkShape[ByteString]] {
 
@@ -210,6 +224,10 @@ private[ftp] trait FtpIOSinkStage[FtpClient, S <: RemoteFileSettings]
 
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpMoveSink[FtpClient, S <: RemoteFileSettings]
     extends GraphStageWithMaterializedValue[SinkShape[FtpFile], Future[IOResult]] {
   val connectionSettings: S
@@ -250,6 +268,10 @@ private[ftp] trait FtpMoveSink[FtpClient, S <: RemoteFileSettings]
   }
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpRemoveSink[FtpClient, S <: RemoteFileSettings]
     extends GraphStageWithMaterializedValue[SinkShape[FtpFile], Future[IOResult]] {
   val connectionSettings: S

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
@@ -12,6 +12,12 @@ import scala.collection.immutable
 import scala.util.Try
 import java.io.{InputStream, OutputStream}
 
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
 protected[ftp] trait FtpLike[FtpClient, S <: RemoteFileSettings] {
 
   type Handler
@@ -33,6 +39,10 @@ protected[ftp] trait FtpLike[FtpClient, S <: RemoteFileSettings] {
   def remove(path: String, handler: Handler): Unit
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 object FtpLike {
   // type class instances
   implicit val ftpLikeInstance = new FtpLike[FTPClient, FtpSettings] with FtpOperations

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
@@ -5,10 +5,15 @@
 package akka.stream.alpakka.ftp
 package impl
 
+import akka.annotation.InternalApi
 import org.apache.commons.net.ftp.{FTP, FTPClient}
 
 import scala.util.Try
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpOperations extends CommonFtpOperations { _: FtpLike[FTPClient, FtpSettings] =>
 
   def connect(connectionSettings: FtpSettings)(implicit ftpClient: FTPClient): Try[Handler] = Try {

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.ftp.impl
 import java.net.InetAddress
 
 import akka.annotation.InternalApi
-import akka.stream.alpakka.ftp.FtpCredentials.{AnonFtpCredentials, NonAnonFtpCredentials}
+import akka.stream.alpakka.ftp.FtpCredentials
 import akka.stream.alpakka.ftp._
 import net.schmizz.sshj.SSHClient
 import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
@@ -156,9 +156,9 @@ private[ftp] trait FtpDefaultSettings {
       InetAddress.getByName(hostname)
     ).withCredentials(
       if (username.isDefined)
-        NonAnonFtpCredentials(username.get, password.getOrElse(""))
+        FtpCredentials.create(username.get, password.getOrElse(""))
       else
-        AnonFtpCredentials
+        FtpCredentials.anonymous
     )
 }
 
@@ -176,9 +176,9 @@ private[ftp] trait FtpsDefaultSettings {
       InetAddress.getByName(hostname)
     ).withCredentials(
       if (username.isDefined)
-        NonAnonFtpCredentials(username.get, password.getOrElse(""))
+        FtpCredentials.create(username.get, password.getOrElse(""))
       else
-        AnonFtpCredentials
+        FtpCredentials.anonymous
     )
 }
 
@@ -196,9 +196,9 @@ private[ftp] trait SftpDefaultSettings {
       InetAddress.getByName(hostname)
     ).withCredentials(
       if (username.isDefined)
-        NonAnonFtpCredentials(username.get, password.getOrElse(""))
+        FtpCredentials.create(username.get, password.getOrElse(""))
       else
-        AnonFtpCredentials
+        FtpCredentials.anonymous
     )
 }
 

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
@@ -6,11 +6,16 @@ package akka.stream.alpakka.ftp.impl
 
 import java.net.InetAddress
 
+import akka.annotation.InternalApi
 import akka.stream.alpakka.ftp.FtpCredentials.{AnonFtpCredentials, NonAnonFtpCredentials}
 import akka.stream.alpakka.ftp._
 import net.schmizz.sshj.SSHClient
 import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpSourceFactory[FtpClient] { self =>
 
   type S <: RemoteFileSettings
@@ -94,6 +99,10 @@ private[ftp] trait FtpSourceFactory[FtpClient] { self =>
   ): S
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpSource extends FtpSourceFactory[FTPClient] {
   protected final val FtpBrowserSourceName = "FtpBrowserSource"
   protected final val FtpIOSourceName = "FtpIOSource"
@@ -104,6 +113,10 @@ private[ftp] trait FtpSource extends FtpSourceFactory[FTPClient] {
   protected val ftpIOSinkName: String = FtpIOSinkName
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpsSource extends FtpSourceFactory[FTPSClient] {
   protected final val FtpsBrowserSourceName = "FtpsBrowserSource"
   protected final val FtpsIOSourceName = "FtpsIOSource"
@@ -114,6 +127,10 @@ private[ftp] trait FtpsSource extends FtpSourceFactory[FTPSClient] {
   protected val ftpIOSinkName: String = FtpsIOSinkName
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait SftpSource extends FtpSourceFactory[SSHClient] {
   protected final val sFtpBrowserSourceName = "sFtpBrowserSource"
   protected final val sFtpIOSourceName = "sFtpIOSource"
@@ -125,6 +142,10 @@ private[ftp] trait SftpSource extends FtpSourceFactory[SSHClient] {
   protected val ftpIOSinkName: String = sFtpIOSinkName
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpDefaultSettings {
   protected def defaultSettings(
       hostname: String,
@@ -141,6 +162,10 @@ private[ftp] trait FtpDefaultSettings {
     )
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpsDefaultSettings {
   protected def defaultSettings(
       hostname: String,
@@ -157,6 +182,10 @@ private[ftp] trait FtpsDefaultSettings {
     )
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait SftpDefaultSettings {
   protected def defaultSettings(
       hostname: String,
@@ -173,16 +202,28 @@ private[ftp] trait SftpDefaultSettings {
     )
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpSourceParams extends FtpSource with FtpDefaultSettings {
   type S = FtpSettings
   protected[this] val ftpLike: FtpLike[FTPClient, S] = FtpLike.ftpLikeInstance
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpsSourceParams extends FtpsSource with FtpsDefaultSettings {
   type S = FtpsSettings
   protected[this] val ftpLike: FtpLike[FTPSClient, S] = FtpLike.ftpsLikeInstance
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait SftpSourceParams extends SftpSource with SftpDefaultSettings {
   type S = SftpSettings
   protected[this] val ftpLike: FtpLike[SSHClient, S] = FtpLike.sFtpLikeInstance

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
@@ -4,11 +4,12 @@
 
 package akka.stream.alpakka.ftp.impl
 
+import java.net.InetAddress
+
 import akka.stream.alpakka.ftp.FtpCredentials.{AnonFtpCredentials, NonAnonFtpCredentials}
-import akka.stream.alpakka.ftp.{FtpFile, FtpFileSettings, FtpSettings, FtpsSettings, RemoteFileSettings, SftpSettings}
+import akka.stream.alpakka.ftp._
 import net.schmizz.sshj.SSHClient
 import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
-import java.net.InetAddress
 
 private[ftp] trait FtpSourceFactory[FtpClient] { self =>
 
@@ -118,7 +119,7 @@ private[ftp] trait SftpSource extends FtpSourceFactory[SSHClient] {
   protected final val sFtpIOSourceName = "sFtpIOSource"
   protected final val sFtpIOSinkName = "sFtpIOSink"
   def sshClient(): SSHClient = new SSHClient()
-  protected val ftpClient: () => SSHClient = sshClient
+  protected val ftpClient: () => SSHClient = () => sshClient()
   protected val ftpBrowserSourceName: String = sFtpBrowserSourceName
   protected val ftpIOSourceName: String = sFtpIOSourceName
   protected val ftpIOSinkName: String = sFtpIOSinkName
@@ -131,8 +132,8 @@ private[ftp] trait FtpDefaultSettings {
       password: Option[String]
   ): FtpSettings =
     FtpSettings(
-      InetAddress.getByName(hostname),
-      FtpSettings.DefaultFtpPort,
+      InetAddress.getByName(hostname)
+    ).withCredentials(
       if (username.isDefined)
         NonAnonFtpCredentials(username.get, password.getOrElse(""))
       else
@@ -147,8 +148,8 @@ private[ftp] trait FtpsDefaultSettings {
       password: Option[String]
   ): FtpsSettings =
     FtpsSettings(
-      InetAddress.getByName(hostname),
-      FtpsSettings.DefaultFtpsPort,
+      InetAddress.getByName(hostname)
+    ).withCredentials(
       if (username.isDefined)
         NonAnonFtpCredentials(username.get, password.getOrElse(""))
       else
@@ -163,8 +164,8 @@ private[ftp] trait SftpDefaultSettings {
       password: Option[String]
   ): SftpSettings =
     SftpSettings(
-      InetAddress.getByName(hostname),
-      SftpSettings.DefaultSftpPort,
+      InetAddress.getByName(hostname)
+    ).withCredentials(
       if (username.isDefined)
         NonAnonFtpCredentials(username.get, password.getOrElse(""))
       else

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
@@ -4,11 +4,16 @@
 
 package akka.stream.alpakka.ftp.impl
 
+import akka.annotation.InternalApi
 import akka.stream.alpakka.ftp.FtpsSettings
 import org.apache.commons.net.ftp.{FTP, FTPSClient}
 
 import scala.util.Try
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait FtpsOperations extends CommonFtpOperations { _: FtpLike[FTPSClient, FtpsSettings] =>
 
   def connect(connectionSettings: FtpsSettings)(implicit ftpClient: FTPSClient): Try[Handler] = Try {

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
@@ -8,6 +8,7 @@ package impl
 import java.io.{File, IOException, InputStream, OutputStream}
 import java.nio.file.attribute.PosixFilePermission
 
+import akka.annotation.InternalApi
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.sftp.{OpenMode, RemoteResourceInfo, SFTPClient}
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier
@@ -19,6 +20,10 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.util.Try
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[ftp] trait SftpOperations { _: FtpLike[SSHClient, SftpSettings] =>
 
   type Handler = SFTPClient

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -132,7 +132,7 @@ object FtpSettings {
 
   /** Java API */
   def create(
-      host: java.net.InetAddress,
+      host: java.net.InetAddress
   ): FtpSettings = apply(
     host
   )
@@ -219,7 +219,7 @@ object FtpsSettings {
 
   /** Java API */
   def create(
-      host: java.net.InetAddress,
+      host: java.net.InetAddress
   ): FtpsSettings = apply(
     host
   )

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -8,6 +8,7 @@ import akka.stream.alpakka.ftp.FtpCredentials.AnonFtpCredentials
 import java.net.InetAddress
 import java.nio.file.attribute.PosixFilePermission
 
+import akka.annotation.InternalApi
 import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
 
 /**
@@ -35,7 +36,7 @@ final case class FtpFile(
 /**
  * Common remote file settings.
  */
-sealed abstract class RemoteFileSettings extends Product with Serializable {
+sealed abstract class RemoteFileSettings {
   def host: InetAddress
   def port: Int
   def credentials: FtpCredentials
@@ -60,28 +61,27 @@ sealed abstract class FtpFileSettings extends RemoteFileSettings {
  * @param configureConnection A function which will be called after connecting to the server. Use this for
  *                            any custom configuration required by the server you are connecting to.
  */
-final case class FtpSettings(
-    host: InetAddress,
-    port: Int = FtpSettings.DefaultFtpPort,
-    credentials: FtpCredentials = AnonFtpCredentials,
-    binary: Boolean = false,
-    passiveMode: Boolean = false,
-    configureConnection: FTPClient => Unit = _ => {}
+final class FtpSettings private (
+    val host: java.net.InetAddress,
+    val port: Int,
+    val credentials: FtpCredentials,
+    val binary: Boolean,
+    val passiveMode: Boolean,
+    val configureConnection: org.apache.commons.net.ftp.FTPClient => Unit
 ) extends FtpFileSettings {
-  def withPort(port: Int): FtpSettings =
-    copy(port = port)
 
-  def withCredentials(credentials: FtpCredentials): FtpSettings =
-    copy(credentials = credentials)
+  def withHost(value: java.net.InetAddress): FtpSettings = copy(host = value)
+  def withPort(value: Int): FtpSettings = copy(port = value)
+  def withCredentials(value: FtpCredentials): FtpSettings = copy(credentials = value)
+  def withBinary(value: Boolean): FtpSettings = if (binary == value) this else copy(binary = value)
+  def withPassiveMode(value: Boolean): FtpSettings = if (passiveMode == value) this else copy(passiveMode = value)
 
-  def withBinary(binary: Boolean): FtpSettings =
-    copy(binary = binary)
-
-  def withPassiveMode(passiveMode: Boolean): FtpSettings =
-    copy(passiveMode = passiveMode)
-
-  def withConfigureConnection(configureConnection: FTPClient => Unit): FtpSettings =
-    copy(configureConnection = configureConnection)
+  /**
+   * Scala API:
+   * Sets the configure connection callback.
+   */
+  def withConfigureConnection(value: FTPClient => Unit): FtpSettings =
+    copy(configureConnection = value)
 
   /**
    * Java API:
@@ -89,16 +89,53 @@ final case class FtpSettings(
    */
   def withConfigureConnectionConsumer(configureConnection: java.util.function.Consumer[FTPClient]): FtpSettings =
     copy(configureConnection = configureConnection.accept)
+
+  private def copy(
+      host: java.net.InetAddress = host,
+      port: Int = port,
+      credentials: FtpCredentials = credentials,
+      binary: Boolean = binary,
+      passiveMode: Boolean = passiveMode,
+      configureConnection: FTPClient => Unit = configureConnection
+  ): FtpSettings = new FtpSettings(
+    host = host,
+    port = port,
+    credentials = credentials,
+    binary = binary,
+    passiveMode = passiveMode,
+    configureConnection = configureConnection
+  )
+
+  override def toString =
+    s"""FtpSettings(host=$host,port=$port,credentials=$credentials,binary=$binary,passiveMode=$passiveMode,configureConnection=$configureConnection)"""
 }
 
+/**
+ * FTP settings factory
+ */
 object FtpSettings {
 
-  /** Default FTP port */
+  /** Default FTP port (21) */
   final val DefaultFtpPort = 21
 
+  /** Scala API */
+  def apply(
+      host: java.net.InetAddress
+  ): FtpSettings = new FtpSettings(
+    host,
+    port = DefaultFtpPort,
+    credentials = AnonFtpCredentials,
+    binary = false,
+    passiveMode = false,
+    configureConnection = _ => ()
+  )
+
   /** Java API */
-  def create(host: InetAddress): FtpSettings =
-    FtpSettings(host)
+  def create(
+      host: java.net.InetAddress,
+  ): FtpSettings = apply(
+    host
+  )
 }
 
 /**
@@ -112,41 +149,84 @@ object FtpSettings {
  * @param configureConnection A function which will be called after connecting to the server. Use this for
  *                            any custom configuration required by the server you are connecting to.
  */
-final case class FtpsSettings(
-    host: InetAddress,
-    port: Int = FtpsSettings.DefaultFtpsPort,
-    credentials: FtpCredentials = AnonFtpCredentials,
-    binary: Boolean = false,
-    passiveMode: Boolean = false,
-    configureConnection: FTPSClient => Unit = _ => {}
+final class FtpsSettings private (
+    val host: java.net.InetAddress,
+    val port: Int,
+    val credentials: FtpCredentials,
+    val binary: Boolean,
+    val passiveMode: Boolean,
+    val configureConnection: org.apache.commons.net.ftp.FTPSClient => Unit
 ) extends FtpFileSettings {
-  def withPort(port: Int): FtpsSettings =
-    copy(port = port)
 
-  def withCredentials(credentials: FtpCredentials): FtpsSettings =
-    copy(credentials = credentials)
+  def withHost(value: java.net.InetAddress): FtpsSettings = copy(host = value)
+  def withPort(value: Int): FtpsSettings = copy(port = value)
+  def withCredentials(value: FtpCredentials): FtpsSettings = copy(credentials = value)
+  def withBinary(value: Boolean): FtpsSettings = if (binary == value) this else copy(binary = value)
+  def withPassiveMode(value: Boolean): FtpsSettings = if (passiveMode == value) this else copy(passiveMode = value)
 
-  def withBinary(binary: Boolean): FtpsSettings =
-    copy(binary = binary)
+  /**
+   * Scala API:
+   * Sets the configure connection callback.
+   */
+  def withConfigureConnection(value: FTPSClient => Unit): FtpsSettings = copy(configureConnection = value)
 
-  def withPassiveMode(passiveMode: Boolean): FtpsSettings =
-    copy(passiveMode = passiveMode)
+  /**
+   * Java API:
+   * Sets the configure connection callback.
+   */
+  def withConfigureConnectionConsumer(configureConnection: java.util.function.Consumer[FTPSClient]): FtpsSettings =
+    copy(configureConnection = configureConnection.accept)
 
-  def withConfigureConnection(configureConnection: FTPSClient => Unit): FtpsSettings =
-    copy(configureConnection = configureConnection)
-}
+  private def copy(
+      host: java.net.InetAddress = host,
+      port: Int = port,
+      credentials: FtpCredentials = credentials,
+      binary: Boolean = binary,
+      passiveMode: Boolean = passiveMode,
+      configureConnection: FTPSClient => Unit = configureConnection
+  ): FtpsSettings = new FtpsSettings(
+    host = host,
+    port = port,
+    credentials = credentials,
+    binary = binary,
+    passiveMode = passiveMode,
+    configureConnection = configureConnection
+  )
 
-object FtpsSettings {
-
-  /** Default FTPs port */
-  final val DefaultFtpsPort = 2222
-
-  /** Java API */
-  def create(host: InetAddress): FtpsSettings =
-    FtpsSettings(host)
+  override def toString =
+    s"""FtpsSettings(host=$host,port=$port,credentials=$credentials,binary=$binary,passiveMode=$passiveMode,configureConnection=$configureConnection)"""
 }
 
 /**
+ * FTPs settings factory
+ */
+object FtpsSettings {
+
+  /** Default FTPs port (2222) */
+  final val DefaultFtpsPort = 2222
+
+  /** Scala API */
+  def apply(
+      host: java.net.InetAddress
+  ): FtpsSettings = new FtpsSettings(
+    host,
+    DefaultFtpsPort,
+    AnonFtpCredentials,
+    binary = false,
+    passiveMode = false,
+    configureConnection = _ => ()
+  )
+
+  /** Java API */
+  def create(
+      host: java.net.InetAddress,
+  ): FtpsSettings = apply(
+    host
+  )
+}
+
+/**
+ * SFTP settings
  *
  * @param host host
  * @param port port
@@ -155,59 +235,94 @@ object FtpsSettings {
  * @param knownHosts known hosts file to be used when connecting
  * @param sftpIdentity private/public key config to use when connecting
  */
-final case class SftpSettings(
-    host: InetAddress,
-    port: Int = SftpSettings.DefaultSftpPort,
-    credentials: FtpCredentials = AnonFtpCredentials,
-    strictHostKeyChecking: Boolean = true,
-    knownHosts: Option[String] = None,
-    sftpIdentity: Option[SftpIdentity] = None
+final class SftpSettings private (
+    val host: java.net.InetAddress,
+    val port: Int,
+    val credentials: FtpCredentials,
+    val strictHostKeyChecking: Boolean,
+    val knownHosts: Option[String],
+    val sftpIdentity: Option[SftpIdentity]
 ) extends RemoteFileSettings {
-  def withPort(port: Int): SftpSettings =
-    copy(port = port)
 
-  def withCredentials(credentials: FtpCredentials): SftpSettings =
-    copy(credentials = credentials)
+  def withHost(value: java.net.InetAddress): SftpSettings = copy(host = value)
+  def withPort(value: Int): SftpSettings = copy(port = value)
+  def withCredentials(value: FtpCredentials): SftpSettings = copy(credentials = value)
+  def withStrictHostKeyChecking(value: Boolean): SftpSettings =
+    if (strictHostKeyChecking == value) this else copy(strictHostKeyChecking = value)
+  def withKnownHosts(value: String): SftpSettings = copy(knownHosts = Option(value))
+  def withSftpIdentity(value: SftpIdentity): SftpSettings = copy(sftpIdentity = Option(value))
 
-  def withStrictHostKeyChecking(strictHostKeyChecking: Boolean): SftpSettings =
-    copy(strictHostKeyChecking = strictHostKeyChecking)
+  private def copy(
+      host: java.net.InetAddress = host,
+      port: Int = port,
+      credentials: FtpCredentials = credentials,
+      strictHostKeyChecking: Boolean = strictHostKeyChecking,
+      knownHosts: Option[String] = knownHosts,
+      sftpIdentity: Option[SftpIdentity] = sftpIdentity
+  ): SftpSettings = new SftpSettings(
+    host = host,
+    port = port,
+    credentials = credentials,
+    strictHostKeyChecking = strictHostKeyChecking,
+    knownHosts = knownHosts,
+    sftpIdentity = sftpIdentity
+  )
 
-  def withKnownHosts(knownHosts: String): SftpSettings =
-    copy(knownHosts = Some(knownHosts))
-
-  def withSftpIdentity(sftpIdentity: SftpIdentity): SftpSettings =
-    copy(sftpIdentity = Some(sftpIdentity))
+  override def toString =
+    s"""SftpSettings(host=$host,port=$port,credentials=$credentials,strictHostKeyChecking=$strictHostKeyChecking,knownHosts=$knownHosts,sftpIdentity=$sftpIdentity)"""
 }
 
+/**
+ * SFTP settings factory
+ */
 object SftpSettings {
 
-  /** Default SFTP port */
+  /** Default SFTP port (22) */
   final val DefaultSftpPort = 22
 
+  /** Scala API */
+  def apply(
+      host: java.net.InetAddress
+  ): SftpSettings = new SftpSettings(
+    host,
+    DefaultSftpPort,
+    AnonFtpCredentials,
+    strictHostKeyChecking = true,
+    knownHosts = None,
+    sftpIdentity = None
+  )
+
   /** Java API */
-  def create(host: InetAddress): SftpSettings =
-    SftpSettings(host)
+  def create(
+      host: java.net.InetAddress
+  ): SftpSettings = apply(
+    host
+  )
 }
 
 /**
  * FTP credentials
  */
-sealed abstract class FtpCredentials extends Product with Serializable {
+sealed abstract class FtpCredentials {
   def username: String
   def password: String
 }
+
+/**
+ * FTP credentials factory
+ */
 object FtpCredentials {
   final val Anonymous = "anonymous"
 
   /** Java API */
-  def createAnonCredentials() = AnonFtpCredentials
+  def createAnonCredentials(): FtpCredentials = AnonFtpCredentials
 
   /**
    * Anonymous credentials
    */
   case object AnonFtpCredentials extends FtpCredentials {
-    val username = Anonymous
-    val password = Anonymous
+    val username: String = Anonymous
+    val password: String = Anonymous
   }
 
   /**
@@ -219,33 +334,67 @@ object FtpCredentials {
   final case class NonAnonFtpCredentials(username: String, password: String) extends FtpCredentials
 }
 
+/**
+ * SFTP identity details
+ */
+sealed abstract class SftpIdentity {
+  type KeyType
+  val privateKey: KeyType
+  val privateKeyFilePassphrase: Option[Array[Byte]]
+}
+
+/**
+ * SFTP identity factory
+ */
 object SftpIdentity {
 
-  /** Java API */
+  /**
+   * SFTP identity for authenticating using private/public key value
+   *
+   * @param privateKey private key value to use when connecting
+   */
   def createRawSftpIdentity(privateKey: Array[Byte]): RawKeySftpIdentity =
-    RawKeySftpIdentity(privateKey)
+    new RawKeySftpIdentity(privateKey)
 
+  /**
+   * SFTP identity for authenticating using private/public key value
+   *
+   * @param privateKey private key value to use when connecting
+   * @param privateKeyFilePassphrase password to use to decrypt private key
+   */
   def createRawSftpIdentity(privateKey: Array[Byte], privateKeyFilePassphrase: Array[Byte]): RawKeySftpIdentity =
-    RawKeySftpIdentity(privateKey, Some(privateKeyFilePassphrase))
+    new RawKeySftpIdentity(privateKey, Some(privateKeyFilePassphrase))
 
+  /**
+   * SFTP identity for authenticating using private/public key value
+   *
+   * @param privateKey private key value to use when connecting
+   * @param privateKeyFilePassphrase password to use to decrypt private key
+   * @param publicKey public key value to use when connecting
+   */
   def createRawSftpIdentity(
       privateKey: Array[Byte],
       privateKeyFilePassphrase: Array[Byte],
       publicKey: Array[Byte]
   ): RawKeySftpIdentity =
-    RawKeySftpIdentity(privateKey, Some(privateKeyFilePassphrase), Some(publicKey))
+    new RawKeySftpIdentity(privateKey, Some(privateKeyFilePassphrase), Some(publicKey))
 
+  /**
+   * Create SFTP identity for authenticating using private/public key file
+   *
+   * @param privateKey private key file to use when connecting
+   */
   def createFileSftpIdentity(privateKey: String): KeyFileSftpIdentity =
-    KeyFileSftpIdentity(privateKey)
+    new KeyFileSftpIdentity(privateKey)
 
+  /**
+   * Create SFTP identity for authenticating using private/public key file
+   *
+   * @param privateKey private key file to use when connecting
+   * @param privateKeyFilePassphrase password to use to decrypt private key file
+   */
   def createFileSftpIdentity(privateKey: String, privateKeyFilePassphrase: Array[Byte]): KeyFileSftpIdentity =
-    KeyFileSftpIdentity(privateKey, Some(privateKeyFilePassphrase))
-}
-
-sealed abstract class SftpIdentity {
-  type KeyType
-  val privateKey: KeyType
-  val privateKeyFilePassphrase: Option[Array[Byte]]
+    new KeyFileSftpIdentity(privateKey, Some(privateKeyFilePassphrase))
 }
 
 /**
@@ -255,18 +404,36 @@ sealed abstract class SftpIdentity {
  * @param privateKeyFilePassphrase password to use to decrypt private key
  * @param publicKey public key value to use when connecting
  */
-final case class RawKeySftpIdentity(
-    privateKey: Array[Byte],
-    privateKeyFilePassphrase: Option[Array[Byte]] = None,
-    publicKey: Option[Array[Byte]] = None
+final class RawKeySftpIdentity @InternalApi private[ftp] (
+    val privateKey: Array[Byte],
+    val privateKeyFilePassphrase: Option[Array[Byte]] = None,
+    val publicKey: Option[Array[Byte]] = None
 ) extends SftpIdentity {
   type KeyType = Array[Byte]
+
+  def withPrivateKey(value: KeyType): RawKeySftpIdentity = copy(privateKey = value)
 
   def withPrivateKeyFilePassphrase(privateKeyFilePassphrase: Array[Byte]): RawKeySftpIdentity =
     copy(privateKeyFilePassphrase = Some(privateKeyFilePassphrase))
 
   def withPublicKey(publicKey: KeyType): RawKeySftpIdentity =
     copy(publicKey = Some(publicKey))
+
+  private def copy(
+      privateKey: Array[Byte] = privateKey,
+      privateKeyFilePassphrase: Option[Array[Byte]] = privateKeyFilePassphrase,
+      publicKey: Option[Array[Byte]] = publicKey
+  ): RawKeySftpIdentity = new RawKeySftpIdentity(
+    privateKey,
+    privateKeyFilePassphrase,
+    publicKey
+  )
+
+  override def toString: String =
+    "RawKeySftpIdentity(" +
+    s"privateKey(length)=${privateKey.length}," +
+    s"privateKeyFilePassphrase=${privateKeyFilePassphrase.isDefined}," +
+    s"publicKey=${publicKey.isDefined})"
 }
 
 /**
@@ -275,12 +442,23 @@ final case class RawKeySftpIdentity(
  * @param privateKey private key file to use when connecting
  * @param privateKeyFilePassphrase password to use to decrypt private key file
  */
-final case class KeyFileSftpIdentity(
-    privateKey: String,
-    privateKeyFilePassphrase: Option[Array[Byte]] = None
+final class KeyFileSftpIdentity @InternalApi private[ftp] (
+    val privateKey: String,
+    val privateKeyFilePassphrase: Option[Array[Byte]] = None
 ) extends SftpIdentity {
   type KeyType = String
 
+  def withPrivateKey(value: String): KeyFileSftpIdentity = copy(privateKey = value)
+
   def withPrivateKeyFilePassphrase(privateKeyFilePassphrase: Array[Byte]): KeyFileSftpIdentity =
     copy(privateKeyFilePassphrase = Some(privateKeyFilePassphrase))
+
+  private def copy(
+      privateKey: String = privateKey,
+      privateKeyFilePassphrase: Option[Array[Byte]] = privateKeyFilePassphrase
+  ): KeyFileSftpIdentity = new KeyFileSftpIdentity(
+    privateKey,
+    privateKeyFilePassphrase
+  )
+
 }

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java
@@ -67,7 +67,7 @@ public class FtpStageTest extends PlainFtpSupportImpl implements CommonFtpStageT
     final FtpSettings settings =
         FtpSettings.create(InetAddress.getByName("localhost"))
             .withPort(getPort())
-            .withCredentials(FtpCredentials.createAnonCredentials())
+            .withCredentials(FtpCredentials.anonymous())
             .withBinary(false)
             .withPassiveMode(true);
     return settings;

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
@@ -72,7 +72,7 @@ public class FtpsStageTest extends FtpsSupportImpl implements CommonFtpStageTest
     final FtpsSettings settings =
         FtpsSettings.create(InetAddress.getByName("localhost"))
             .withPort(getPort())
-            .withCredentials(FtpCredentials.createAnonCredentials())
+            .withCredentials(FtpCredentials.anonymous())
             .withBinary(false)
             .withPassiveMode(false);
     return settings;

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
@@ -69,14 +69,12 @@ public class FtpsStageTest extends FtpsSupportImpl implements CommonFtpStageTest
   }
 
   private FtpsSettings settings() throws Exception {
-    // #create-settings
     final FtpsSettings settings =
         FtpsSettings.create(InetAddress.getByName("localhost"))
             .withPort(getPort())
             .withCredentials(FtpCredentials.createAnonCredentials())
             .withBinary(false)
             .withPassiveMode(false);
-    // #create-settings
     return settings;
   }
 }

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/KeyFileSftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/KeyFileSftpSourceTest.java
@@ -53,8 +53,7 @@ public class KeyFileSftpSourceTest extends SftpSupportImpl implements CommonFtpS
         SftpSettings.create(InetAddress.getByName("localhost"))
             .withPort(getPort())
             .withCredentials(
-                new FtpCredentials.NonAnonFtpCredentials(
-                    "different user and password", "will fail password auth"))
+                FtpCredentials.create("different user and password", "will fail password auth"))
             .withStrictHostKeyChecking(false) // strictHostKeyChecking
             .withSftpIdentity(
                 SftpIdentity.createFileSftpIdentity(

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/KeyFileSftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/KeyFileSftpSourceTest.java
@@ -49,7 +49,6 @@ public class KeyFileSftpSourceTest extends SftpSupportImpl implements CommonFtpS
   }
 
   private SftpSettings settings() throws Exception {
-    // #create-settings
     final SftpSettings settings =
         SftpSettings.create(InetAddress.getByName("localhost"))
             .withPort(getPort())
@@ -60,7 +59,6 @@ public class KeyFileSftpSourceTest extends SftpSupportImpl implements CommonFtpS
             .withSftpIdentity(
                 SftpIdentity.createFileSftpIdentity(
                     getClientPrivateKeyFile().getPath(), CLIENT_PRIVATE_KEY_PASSPHRASE));
-    // #create-settings
     return settings;
   }
 }

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/RawKeySftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/RawKeySftpSourceTest.java
@@ -51,7 +51,6 @@ public class RawKeySftpSourceTest extends SftpSupportImpl implements CommonFtpSt
   }
 
   private SftpSettings settings() throws Exception {
-    // #create-settings
     final SftpSettings settings =
         SftpSettings.create(InetAddress.getByName("localhost"))
             .withPort(getPort())
@@ -63,7 +62,6 @@ public class RawKeySftpSourceTest extends SftpSupportImpl implements CommonFtpSt
                 SftpIdentity.createRawSftpIdentity(
                     Files.readAllBytes(Paths.get(getClientPrivateKeyFile().getPath())),
                     CLIENT_PRIVATE_KEY_PASSPHRASE));
-    // #create-settings
     return settings;
   }
 }

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/RawKeySftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/RawKeySftpSourceTest.java
@@ -55,8 +55,7 @@ public class RawKeySftpSourceTest extends SftpSupportImpl implements CommonFtpSt
         SftpSettings.create(InetAddress.getByName("localhost"))
             .withPort(getPort())
             .withCredentials(
-                new FtpCredentials.NonAnonFtpCredentials(
-                    "different user and password", "will fail password auth"))
+                FtpCredentials.create("different user and password", "will fail password auth"))
             .withStrictHostKeyChecking(false) // strictHostKeyChecking
             .withSftpIdentity(
                 SftpIdentity.createRawSftpIdentity(

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/SftpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/SftpStageTest.java
@@ -68,7 +68,7 @@ public class SftpStageTest extends SftpSupportImpl implements CommonFtpStageTest
     final SftpSettings settings =
         SftpSettings.create(InetAddress.getByName("localhost"))
             .withPort(getPort())
-            .withCredentials(FtpCredentials.createAnonCredentials())
+            .withCredentials(FtpCredentials.anonymous())
             .withStrictHostKeyChecking(false);
     return settings;
   }

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/SftpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/SftpStageTest.java
@@ -65,13 +65,11 @@ public class SftpStageTest extends SftpSupportImpl implements CommonFtpStageTest
   }
 
   private SftpSettings settings() throws Exception {
-    // #create-settings
     final SftpSettings settings =
         SftpSettings.create(InetAddress.getByName("localhost"))
             .withPort(getPort())
             .withCredentials(FtpCredentials.createAnonCredentials())
             .withStrictHostKeyChecking(false);
-    // #create-settings
     return settings;
   }
 }

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/SftpSupportImpl.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/SftpSupportImpl.java
@@ -37,7 +37,7 @@ abstract class SftpSupportImpl extends FtpBaseSupport {
   private File clientPrivateKeyFile;
   private File knownHostsFile;
 
-  SftpSupportImpl() {
+  protected SftpSupportImpl() {
     keyPairProviderFile = new File(getClass().getResource("/hostkey.pem").getPath());
     clientPrivateKeyFile = new File(getClass().getResource("/id_rsa").getPath());
     knownHostsFile = new File(getClass().getResource("/known_hosts").getPath());

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/StrictHostCheckingSftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/StrictHostCheckingSftpSourceTest.java
@@ -54,8 +54,7 @@ public class StrictHostCheckingSftpSourceTest extends SftpSupportImpl
         SftpSettings.create(InetAddress.getByName("localhost"))
             .withPort(getPort())
             .withCredentials(
-                new FtpCredentials.NonAnonFtpCredentials(
-                    "different user and password", "will fail password auth"))
+                FtpCredentials.create("different user and password", "will fail password auth"))
             .withStrictHostKeyChecking(true) // strictHostKeyChecking
             .withKnownHosts(getKnownHostsFile().getPath())
             .withSftpIdentity(

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/StrictHostCheckingSftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/StrictHostCheckingSftpSourceTest.java
@@ -50,7 +50,6 @@ public class StrictHostCheckingSftpSourceTest extends SftpSupportImpl
   }
 
   private SftpSettings settings() throws Exception {
-    // #create-settings
     final SftpSettings settings =
         SftpSettings.create(InetAddress.getByName("localhost"))
             .withPort(getPort())
@@ -62,7 +61,6 @@ public class StrictHostCheckingSftpSourceTest extends SftpSupportImpl
             .withSftpIdentity(
                 SftpIdentity.createFileSftpIdentity(
                     getClientPrivateKeyFile().getPath(), CLIENT_PRIVATE_KEY_PASSPHRASE));
-    // #create-settings
     return settings;
   }
 }

--- a/ftp/src/test/java/docs/javadsl/ConfigureCustomSSHClient.java
+++ b/ftp/src/test/java/docs/javadsl/ConfigureCustomSSHClient.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.stream.alpakka.ftp.examples;
+package docs.javadsl;
 
 // #configure-custom-ssh-client
 

--- a/ftp/src/test/java/docs/javadsl/FtpMovingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpMovingExample.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.stream.alpakka.ftp.examples;
+package docs.javadsl;
 
 // #moving
 import akka.stream.IOResult;

--- a/ftp/src/test/java/docs/javadsl/FtpProcessAndMoveExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpProcessAndMoveExample.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.stream.alpakka.ftp.examples;
+package docs.javadsl;
 
 // #processAndMove
 import akka.NotUsed;

--- a/ftp/src/test/java/docs/javadsl/FtpRemovingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpRemovingExample.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.stream.alpakka.ftp.examples;
+package docs.javadsl;
 
 // #removing
 import akka.stream.IOResult;

--- a/ftp/src/test/java/docs/javadsl/FtpRetrievingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpRetrievingExample.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.stream.alpakka.ftp.examples;
+package docs.javadsl;
 
 // #retrieving
 import akka.stream.IOResult;

--- a/ftp/src/test/java/docs/javadsl/FtpSettingsExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpSettingsExample.java
@@ -25,7 +25,7 @@ public class FtpSettingsExample {
 
           FtpSettings.create(InetAddress.getByName("localhost"))
               .withPort(FtpSettings.DefaultFtpPort())
-              .withCredentials(FtpCredentials.createAnonCredentials())
+              .withCredentials(FtpCredentials.anonymous())
               .withBinary(false)
               .withPassiveMode(false)
               .withConfigureConnectionConsumer(

--- a/ftp/src/test/java/docs/javadsl/FtpSettingsExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpSettingsExample.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.stream.alpakka.ftp.examples;
+package docs.javadsl;
 
 // #create-settings
 import akka.stream.alpakka.ftp.FtpCredentials;

--- a/ftp/src/test/java/docs/javadsl/FtpTraversingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpTraversingExample.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.stream.alpakka.ftp.examples;
+package docs.javadsl;
 
 // #traversing
 import akka.NotUsed;

--- a/ftp/src/test/java/docs/javadsl/FtpWritingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpWritingExample.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.stream.alpakka.ftp.examples;
+package docs.javadsl;
 
 // #storing
 import akka.stream.IOResult;

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
@@ -7,7 +7,6 @@ package akka.stream.alpakka.ftp
 import akka.NotUsed
 import akka.stream.IOResult
 import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.alpakka.ftp.FtpCredentials.AnonFtpCredentials
 import akka.stream.alpakka.ftp.scaladsl.Ftp
 import akka.util.ByteString
 import scala.concurrent.Future

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
@@ -16,12 +16,10 @@ import java.net.InetAddress
 trait BaseFtpSpec extends PlainFtpSupportImpl with BaseSpec {
 
   val settings = FtpSettings(
-    InetAddress.getByName("localhost"),
-    getPort,
-    AnonFtpCredentials,
-    binary = true,
-    passiveMode = true
-  )
+    InetAddress.getByName("localhost")
+  ).withPort(getPort)
+    .withBinary(true)
+    .withPassiveMode(true)
 
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =
     Ftp.ls(basePath, settings)

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
@@ -3,24 +3,23 @@
  */
 
 package akka.stream.alpakka.ftp
+import java.net.InetAddress
 
 import akka.NotUsed
-import akka.stream.alpakka.ftp.scaladsl.Ftps
 import akka.stream.IOResult
+import akka.stream.alpakka.ftp.scaladsl.Ftps
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
+
 import scala.concurrent.Future
-import java.net.InetAddress
 
 trait BaseFtpsSpec extends FtpsSupportImpl with BaseSpec {
 
-  //#create-settings
   val settings = FtpsSettings(
     InetAddress.getByName("localhost")
   ).withPort(getPort)
     .withBinary(true)
     .withPassiveMode(true)
-  //#create-settings
 
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =
     Ftps.ls(basePath, settings)

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
@@ -5,7 +5,6 @@
 package akka.stream.alpakka.ftp
 
 import akka.NotUsed
-import akka.stream.alpakka.ftp.FtpCredentials.AnonFtpCredentials
 import akka.stream.alpakka.ftp.scaladsl.Ftps
 import akka.stream.IOResult
 import akka.stream.scaladsl.{Sink, Source}
@@ -17,12 +16,10 @@ trait BaseFtpsSpec extends FtpsSupportImpl with BaseSpec {
 
   //#create-settings
   val settings = FtpsSettings(
-    InetAddress.getByName("localhost"),
-    getPort,
-    AnonFtpCredentials,
-    binary = true,
-    passiveMode = true
-  )
+    InetAddress.getByName("localhost")
+  ).withPort(getPort)
+    .withBinary(true)
+    .withPassiveMode(true)
   //#create-settings
 
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
@@ -17,13 +17,9 @@ trait BaseSftpSpec extends SftpSupportImpl with BaseSpec {
 
   //#create-settings
   val settings = SftpSettings(
-    InetAddress.getByName("localhost"),
-    getPort,
-    AnonFtpCredentials,
-    strictHostKeyChecking = false,
-    knownHosts = None,
-    sftpIdentity = None
-  )
+    InetAddress.getByName("localhost")
+  ).withPort(getPort)
+    .withStrictHostKeyChecking(false)
   //#create-settings
 
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
@@ -3,24 +3,22 @@
  */
 
 package akka.stream.alpakka.ftp
+import java.net.InetAddress
 
 import akka.NotUsed
-import akka.stream.alpakka.ftp.FtpCredentials.AnonFtpCredentials
-import akka.stream.alpakka.ftp.scaladsl.Sftp
 import akka.stream.IOResult
+import akka.stream.alpakka.ftp.scaladsl.Sftp
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
+
 import scala.concurrent.Future
-import java.net.InetAddress
 
 trait BaseSftpSpec extends SftpSupportImpl with BaseSpec {
 
-  //#create-settings
   val settings = SftpSettings(
     InetAddress.getByName("localhost")
   ).withPort(getPort)
     .withStrictHostKeyChecking(false)
-  //#create-settings
 
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =
     Sftp.ls(basePath, settings)

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -11,11 +11,13 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.TestSink
 import akka.util.ByteString
 import org.scalatest.time.{Millis, Seconds, Span}
+
 import scala.concurrent.duration._
 import scala.util.Random
 import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.{Files, Paths}
 import java.net.InetAddress
+
 import org.scalatest.concurrent.Eventually
 
 final class FtpStageSpec extends BaseFtpSpec with CommonFtpStageSpec

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -5,7 +5,6 @@
 package akka.stream.alpakka.ftp
 
 import akka.stream.IOResult
-import akka.stream.alpakka.ftp.FtpCredentials.NonAnonFtpCredentials
 import akka.stream.alpakka.ftp.SftpSupportImpl.{CLIENT_PRIVATE_KEY_PASSPHRASE => ClientPrivateKeyPassphrase}
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.TestSink
@@ -31,7 +30,7 @@ final class RawKeySftpSourceSpec extends BaseSftpSpec with CommonFtpStageSpec {
   override val settings = SftpSettings(
     InetAddress.getByName("localhost")
   ).withPort(getPort)
-    .withCredentials(NonAnonFtpCredentials("different user and password", "will fail password auth"))
+    .withCredentials(FtpCredentials.create("different user and password", "will fail password auth"))
     .withStrictHostKeyChecking(false)
     .withSftpIdentity(
       SftpIdentity.createRawSftpIdentity(
@@ -45,7 +44,7 @@ final class KeyFileSftpSourceSpec extends BaseSftpSpec with CommonFtpStageSpec {
   override val settings = SftpSettings(
     InetAddress.getByName("localhost")
   ).withPort(getPort)
-    .withCredentials(NonAnonFtpCredentials("different user and password", "will fail password auth"))
+    .withCredentials(FtpCredentials.create("different user and password", "will fail password auth"))
     .withStrictHostKeyChecking(false)
     .withSftpIdentity(
       SftpIdentity.createFileSftpIdentity(getClientPrivateKeyFile.getPath, ClientPrivateKeyPassphrase)
@@ -56,7 +55,7 @@ final class StrictHostCheckingSftpSourceSpec extends BaseSftpSpec with CommonFtp
   override val settings = SftpSettings(
     InetAddress.getByName("localhost")
   ).withPort(getPort)
-    .withCredentials(NonAnonFtpCredentials("different user and password", "will fail password auth"))
+    .withCredentials(FtpCredentials.create("different user and password", "will fail password auth"))
     .withStrictHostKeyChecking(true)
     .withKnownHosts(getKnownHostsFile.getPath)
     .withSftpIdentity(

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -27,44 +27,39 @@ final class FtpsStageSpec extends BaseFtpsSpec with CommonFtpStageSpec {
 
 final class RawKeySftpSourceSpec extends BaseSftpSpec with CommonFtpStageSpec {
   override val settings = SftpSettings(
-    InetAddress.getByName("localhost"),
-    getPort,
-    NonAnonFtpCredentials("different user and password", "will fail password auth"),
-    strictHostKeyChecking = false,
-    knownHosts = None,
-    Some(
-      RawKeySftpIdentity(
+    InetAddress.getByName("localhost")
+  ).withPort(getPort)
+    .withCredentials(NonAnonFtpCredentials("different user and password", "will fail password auth"))
+    .withStrictHostKeyChecking(false)
+    .withSftpIdentity(
+      SftpIdentity.createRawSftpIdentity(
         Files.readAllBytes(Paths.get(getClientPrivateKeyFile.getPath)),
-        privateKeyFilePassphrase = Some(ClientPrivateKeyPassphrase)
+        ClientPrivateKeyPassphrase
       )
     )
-  )
 }
 
 final class KeyFileSftpSourceSpec extends BaseSftpSpec with CommonFtpStageSpec {
   override val settings = SftpSettings(
-    InetAddress.getByName("localhost"),
-    getPort,
-    NonAnonFtpCredentials("different user and password", "will fail password auth"),
-    strictHostKeyChecking = false,
-    knownHosts = None,
-    Some(
-      KeyFileSftpIdentity(getClientPrivateKeyFile.getPath, Some(ClientPrivateKeyPassphrase))
+    InetAddress.getByName("localhost")
+  ).withPort(getPort)
+    .withCredentials(NonAnonFtpCredentials("different user and password", "will fail password auth"))
+    .withStrictHostKeyChecking(false)
+    .withSftpIdentity(
+      SftpIdentity.createFileSftpIdentity(getClientPrivateKeyFile.getPath, ClientPrivateKeyPassphrase)
     )
-  )
 }
 
 final class StrictHostCheckingSftpSourceSpec extends BaseSftpSpec with CommonFtpStageSpec {
   override val settings = SftpSettings(
-    InetAddress.getByName("localhost"),
-    getPort,
-    NonAnonFtpCredentials("different user and password", "will fail password auth"),
-    strictHostKeyChecking = true,
-    knownHosts = Some(getKnownHostsFile.getPath),
-    Some(
-      KeyFileSftpIdentity(getClientPrivateKeyFile.getPath, Some(ClientPrivateKeyPassphrase))
+    InetAddress.getByName("localhost")
+  ).withPort(getPort)
+    .withCredentials(NonAnonFtpCredentials("different user and password", "will fail password auth"))
+    .withStrictHostKeyChecking(true)
+    .withKnownHosts(getKnownHostsFile.getPath)
+    .withSftpIdentity(
+      SftpIdentity.createFileSftpIdentity(getClientPrivateKeyFile.getPath, ClientPrivateKeyPassphrase)
     )
-  )
 }
 
 trait CommonFtpStageSpec extends BaseSpec with Eventually {

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/scalaExamples.scala
@@ -17,14 +17,12 @@ object scalaExamples {
     import java.net.InetAddress
 
     val settings = FtpSettings(
-      InetAddress.getByName("localhost"),
-      credentials = AnonFtpCredentials,
-      binary = true,
-      passiveMode = true,
-      configureConnection = (ftpClient: FTPClient) => {
+      InetAddress.getByName("localhost")
+    ).withBinary(true)
+      .withPassiveMode(true)
+      .withConfigureConnection((ftpClient: FTPClient) => {
         ftpClient.addProtocolCommandListener(new PrintCommandListener(new PrintWriter(System.out), true))
-      }
-    )
+      })
     //#create-settings
   }
 

--- a/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala
+++ b/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala
@@ -2,19 +2,20 @@
  * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.stream.alpakka.ftp
+package docs.scaladsl
+import akka.stream.alpakka.ftp.{FtpFile, FtpSettings}
 
 object scalaExamples {
 
   // settings
   object settings {
     //#create-settings
-    import akka.stream.alpakka.ftp.FtpSettings
-    import akka.stream.alpakka.ftp.FtpCredentials.AnonFtpCredentials
-    import org.apache.commons.net.PrintCommandListener
-    import org.apache.commons.net.ftp.FTPClient
     import java.io.PrintWriter
     import java.net.InetAddress
+
+    import akka.stream.alpakka.ftp.FtpSettings
+    import org.apache.commons.net.PrintCommandListener
+    import org.apache.commons.net.ftp.FTPClient
 
     val settings = FtpSettings(
       InetAddress.getByName("localhost")
@@ -29,8 +30,7 @@ object scalaExamples {
   object sshConfigure {
     //#configure-custom-ssh-client
     import akka.stream.alpakka.ftp.scaladsl.{Sftp, SftpApi}
-    import net.schmizz.sshj.DefaultConfig
-    import net.schmizz.sshj.SSHClient
+    import net.schmizz.sshj.{DefaultConfig, SSHClient}
 
     val sshClient: SSHClient = new SSHClient(new DefaultConfig)
     val configuredClient: SftpApi = Sftp(sshClient)
@@ -55,6 +55,7 @@ object scalaExamples {
     import akka.stream.alpakka.ftp.scaladsl.Ftp
     import akka.stream.scaladsl.Source
     import akka.util.ByteString
+
     import scala.concurrent.Future
 
     def retrieveFromPath(path: String, settings: FtpSettings): Source[ByteString, Future[IOResult]] =
@@ -69,6 +70,7 @@ object scalaExamples {
     import akka.stream.alpakka.ftp.scaladsl.Ftp
     import akka.stream.scaladsl.Sink
     import akka.util.ByteString
+
     import scala.concurrent.Future
 
     def storeToPath(path: String, settings: FtpSettings, append: Boolean): Sink[ByteString, Future[IOResult]] =
@@ -81,6 +83,7 @@ object scalaExamples {
     import akka.stream.IOResult
     import akka.stream.alpakka.ftp.scaladsl.Ftp
     import akka.stream.scaladsl.Sink
+
     import scala.concurrent.Future
 
     def remove(settings: FtpSettings): Sink[FtpFile, Future[IOResult]] =
@@ -93,6 +96,7 @@ object scalaExamples {
     import akka.stream.IOResult
     import akka.stream.alpakka.ftp.scaladsl.Ftp
     import akka.stream.scaladsl.Sink
+
     import scala.concurrent.Future
 
     def move(destinationPath: FtpFile => String, settings: FtpSettings): Sink[FtpFile, Future[IOResult]] =
@@ -102,11 +106,11 @@ object scalaExamples {
 
   object processAndMove {
     //#processAndMove
+    import java.nio.file.Files
+
     import akka.NotUsed
     import akka.stream.alpakka.ftp.scaladsl.Ftp
-    import akka.stream.scaladsl.FileIO
-    import akka.stream.scaladsl.RunnableGraph
-    import java.nio.file.Files
+    import akka.stream.scaladsl.{FileIO, RunnableGraph}
 
     def processAndMove(sourcePath: String,
                        destinationPath: FtpFile => String,


### PR DESCRIPTION
API CHANGE

* Un-case classed settings, use the factories and the `withXyz` methods instead of named arguments.
* Credentials must be created via factory methods in `FtpCredentials`.

Fixes #1072 