### PR TITLE
AWS SQS: Keep message order

### DIFF
--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceStage.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceStage.scala
@@ -75,7 +75,7 @@ final class SqsSourceStage(queueUrl: String, settings: SqsSourceSettings)(implic
         currentRequests = currentRequests - 1
         maxCurrentConcurrency = if (result.getMessages.isEmpty) 1 else maxConcurrency
 
-        val receivedMessages = result.getMessages.asScala.reverse
+        val receivedMessages = result.getMessages.asScala
         receivedMessages.foreach(buffer.offer)
 
         if (receivedMessages.isEmpty && settings.closeOnEmptyReceive) {

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
@@ -7,6 +7,7 @@ package akka.stream.alpakka.sqs.scaladsl
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
 import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.amazonaws.services.sqs.model.CreateQueueRequest
 import org.elasticmq.rest.sqs.{SQSLimits, SQSRestServer, SQSRestServerBuilder}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite, Tag}
@@ -32,6 +33,12 @@ trait DefaultTestContext extends BeforeAndAfterAll with BeforeAndAfterEach with 
   def sqsClient = createAsyncClient(sqsEndpoint)
 
   def randomQueueUrl(): String = sqsClient.createQueue(s"queue-${Random.nextInt}").getQueueUrl
+
+  val fifoQueueRequest = new CreateQueueRequest(s"queue-${Random.nextInt}.fifo")
+    .addAttributesEntry("FifoQueue", "true")
+    .addAttributesEntry("ContentBasedDeduplication", "true")
+
+  def randomFifoQueueUrl(): String = sqsClient.createQueue(fifoQueueRequest).getQueueUrl
 
   override protected def beforeEach(): Unit =
     sqsServer = SQSRestServerBuilder.withActorSystem(system).withSQSLimits(SQSLimits.Relaxed).withDynamicPort().start()
@@ -62,5 +69,4 @@ trait DefaultTestContext extends BeforeAndAfterAll with BeforeAndAfterEach with 
     //#init-client
     awsSqsClient
   }
-
 }

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
@@ -192,7 +192,7 @@ class SqsSpec extends FlatSpec with Matchers with DefaultTestContext {
     val queue = randomFifoQueueUrl()
     implicit val awsSqsClient = sqsClient
 
-    for (i <- 0 until 10) yield {
+    for (i <- 0 until 10) {
       val msg = s"Message - $i"
       awsSqsClient.sendMessage(new SendMessageRequest(queue, msg).withMessageGroupId("group1"))
     }

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSpec.scala
@@ -192,13 +192,10 @@ class SqsSpec extends FlatSpec with Matchers with DefaultTestContext {
     val queue = randomFifoQueueUrl()
     implicit val awsSqsClient = sqsClient
 
-    val messages = for (i <- 0 until 10) yield s"Message - $i"
-
-    messages
-      .map(msg => {
-        awsSqsClient
-          .sendMessage(new SendMessageRequest(queue, msg).withMessageGroupId("group1"))
-      })
+    for (i <- 0 until 10) yield {
+      val msg = s"Message - $i"
+      awsSqsClient.sendMessage(new SendMessageRequest(queue, msg).withMessageGroupId("group1"))
+    }
 
     val probe = SqsSource(queue, sqsSourceSettings)
       .runWith(TestSink.probe[Message])


### PR DESCRIPTION
This fixes messages arriving order when pulling from a FIFO queue and adds test coverage for that particular scenario.

Feel free to make suggestions to this one. Otherwise, this is ready to be merged.

Cheers!
