### PR TITLE
Jms producer retries

### DIFF
--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -86,18 +86,17 @@ final case class ConnectionRetrySettings(connectTimeout: FiniteDuration = 10.sec
   def withMaxRetries(maxRetries: Int): ConnectionRetrySettings = copy(maxRetries = maxRetries)
   def withInfiniteRetries(): ConnectionRetrySettings = withMaxRetries(-1)
 
-  /** Hypothetical retry time, not accounting for maxBackoff. */
   def waitTime(retryNumber: Int): FiniteDuration =
-    (initialRetry * Math.pow(retryNumber, backoffFactor)).asInstanceOf[FiniteDuration]
+    (initialRetry * Math.pow(retryNumber, backoffFactor)).asInstanceOf[FiniteDuration].min(maxBackoff)
 }
 
 object SendRetrySettings {
   def create(): SendRetrySettings = SendRetrySettings()
 }
 
-final case class SendRetrySettings(initialRetry: FiniteDuration = 50.millis,
-                                   backoffFactor: Double = 2,
-                                   maxBackoff: FiniteDuration = 10.seconds,
+final case class SendRetrySettings(initialRetry: FiniteDuration = 20.millis,
+                                   backoffFactor: Double = 1.5,
+                                   maxBackoff: FiniteDuration = 500.millis,
                                    maxRetries: Int = 10) {
   def withInitialRetry(delay: FiniteDuration): SendRetrySettings = copy(initialRetry = delay)
   def withInitialRetry(delay: Long, unit: TimeUnit): SendRetrySettings =
@@ -109,9 +108,8 @@ final case class SendRetrySettings(initialRetry: FiniteDuration = 50.millis,
   def withMaxRetries(maxRetries: Int): SendRetrySettings = copy(maxRetries = maxRetries)
   def withInfiniteRetries(): SendRetrySettings = withMaxRetries(-1)
 
-  /** Hypothetical retry time, not accounting for maxBackoff. */
   def waitTime(retryNumber: Int): FiniteDuration =
-    (initialRetry * Math.pow(retryNumber, backoffFactor)).asInstanceOf[FiniteDuration]
+    (initialRetry * Math.pow(retryNumber, backoffFactor)).asInstanceOf[FiniteDuration].min(maxBackoff)
 }
 
 object JmsConsumerSettings {

--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -84,6 +84,30 @@ final case class ConnectionRetrySettings(connectTimeout: FiniteDuration = 10.sec
   def withMaxBackoff(maxBackoff: Long, unit: TimeUnit): ConnectionRetrySettings =
     copy(maxBackoff = Duration(maxBackoff, unit))
   def withMaxRetries(maxRetries: Int): ConnectionRetrySettings = copy(maxRetries = maxRetries)
+  def withInfiniteRetries(): ConnectionRetrySettings = withMaxRetries(-1)
+
+  /** Hypothetical retry time, not accounting for maxBackoff. */
+  def waitTime(retryNumber: Int): FiniteDuration =
+    (initialRetry * Math.pow(retryNumber, backoffFactor)).asInstanceOf[FiniteDuration]
+}
+
+object SendRetrySettings {
+  def create(): SendRetrySettings = SendRetrySettings()
+}
+
+final case class SendRetrySettings(initialRetry: FiniteDuration = 50.millis,
+                                   backoffFactor: Double = 2,
+                                   maxBackoff: FiniteDuration = 10.seconds,
+                                   maxRetries: Int = 10) {
+  def withInitialRetry(delay: FiniteDuration): SendRetrySettings = copy(initialRetry = delay)
+  def withInitialRetry(delay: Long, unit: TimeUnit): SendRetrySettings =
+    copy(initialRetry = Duration(delay, unit))
+  def withBackoffFactor(backoffFactor: Double): SendRetrySettings = copy(backoffFactor = backoffFactor)
+  def withMaxBackoff(maxBackoff: FiniteDuration): SendRetrySettings = copy(maxBackoff = maxBackoff)
+  def withMaxBackoff(maxBackoff: Long, unit: TimeUnit): SendRetrySettings =
+    copy(maxBackoff = Duration(maxBackoff, unit))
+  def withMaxRetries(maxRetries: Int): SendRetrySettings = copy(maxRetries = maxRetries)
+  def withInfiniteRetries(): SendRetrySettings = withMaxRetries(-1)
 
   /** Hypothetical retry time, not accounting for maxBackoff. */
   def waitTime(retryNumber: Int): FiniteDuration =
@@ -133,6 +157,7 @@ object JmsProducerSettings {
 
 final case class JmsProducerSettings(connectionFactory: ConnectionFactory,
                                      connectionRetrySettings: ConnectionRetrySettings = ConnectionRetrySettings(),
+                                     sendRetrySettings: SendRetrySettings = SendRetrySettings(),
                                      destination: Option[Destination] = None,
                                      credentials: Option[Credentials] = None,
                                      sessionCount: Int = 1,
@@ -142,6 +167,8 @@ final case class JmsProducerSettings(connectionFactory: ConnectionFactory,
   def withCredential(credentials: Credentials): JmsProducerSettings = copy(credentials = Some(credentials))
   def withConnectionRetrySettings(settings: ConnectionRetrySettings): JmsProducerSettings =
     copy(connectionRetrySettings = settings)
+  def withSendRetrySettings(settings: SendRetrySettings): JmsProducerSettings =
+    copy(sendRetrySettings = settings)
   def withSessionCount(count: Int): JmsProducerSettings = copy(sessionCount = count)
   def withQueue(name: String): JmsProducerSettings = copy(destination = Some(Queue(name)))
   def withTopic(name: String): JmsProducerSettings = copy(destination = Some(Topic(name)))

--- a/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/Jms.scala
@@ -154,7 +154,9 @@ final case class JmsProducerSettings(connectionFactory: ConnectionFactory,
     copy(acknowledgeMode = Option(acknowledgeMode))
 }
 
-final case class Credentials(username: String, password: String)
+final case class Credentials(username: String, password: String) {
+  override def toString = s"Credentials($username,${"*" * password.length})"
+}
 
 object JmsBrowseSettings {
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsBrowseStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsBrowseStage.scala
@@ -10,9 +10,8 @@ import akka.stream.{ActorAttributes, Attributes, Outlet, SourceShape}
 import akka.stream.stage.{GraphStage, GraphStageLogic, OutHandler}
 import java.util.{Enumeration => JEnumeration}
 
-private[jms] final class JmsBrowseStage(settings: JmsBrowseSettings) extends GraphStage[SourceShape[Message]] {
-  private val queue = settings.destination.getOrElse { throw new IllegalArgumentException("Destination is missing") }
-
+private[jms] final class JmsBrowseStage(settings: JmsBrowseSettings, queue: Destination)
+    extends GraphStage[SourceShape[Message]] {
   private val out = Outlet[Message]("JmsBrowseStage.out")
   val shape = SourceShape(out)
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -138,8 +138,7 @@ private[jms] trait JmsConnector[S <: JmsSession] {
           if (maxRetries == 0) Future.failed(t)
           else Future.failed(ConnectionRetryException(s"Could not establish connection after $n retries.", t))
         } else {
-          val delay = waitTime(nextN).min(maxBackoff)
-          after(delay, system.scheduler) {
+          after(waitTime(nextN), system.scheduler) {
             openConnectionWithRetry(startConnection, nextN)
           }
         }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -39,7 +39,7 @@ private[jms] trait JmsConnector[S <: JmsSession] {
 
   protected val fail: AsyncCallback[Throwable] = getAsyncCallback[Throwable](e => failStage(e))
 
-  private val connectionFailedCB: AsyncCallback[Throwable] = getAsyncCallback[Throwable](e => connectionFailed(e))
+  private val connectionFailedCB: AsyncCallback[Throwable] = getAsyncCallback[Throwable](connectionFailed)
 
   def connectionFailed(ex: Throwable): Unit = {
     jmsConnection = Future.failed(ex)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConnector.scala
@@ -68,7 +68,7 @@ private[jms] trait JmsConnector[S <: JmsSession] {
   protected def initSessionAsync(): Unit = {
 
     val allSessions = openSessions()
-    allSessions.failed.foreach(connectionFailedCB.invoke)
+    allSessions.failed.foreach(fail.invoke)
     // wait for all sessions to successfully initialize before invoking the onSession callback.
     // reduces flakiness (start, consume, then crash) at the cost of increased latency of startup.
     allSessions.foreach(_.foreach(onSession.invoke))

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsExceptions.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsExceptions.scala
@@ -3,6 +3,7 @@
  */
 
 package akka.stream.alpakka.jms
+import scala.util.control.NoStackTrace
 
 /**
  * Marker trait indicating that the exception thrown is persistent. The operation will always fail when retried.
@@ -36,3 +37,7 @@ case class NullMapMessageEntry(entryName: String, message: JmsMapMessage)
     with NonRetriableJmsException
 
 case class ConnectionRetryException(message: String, cause: Throwable) extends Exception(message, cause)
+
+case object RetrySkippedOnMissingConnection
+    extends Exception("JmsProducer is not connected, send attempt skipped")
+    with NoStackTrace

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -69,14 +69,10 @@ private[jms] final class JmsProducerStage[A <: JmsMessage, PassThrough](settings
         if (isAvailable(out)) pullIfNeeded()
       }
 
-      override def connectionFailed(ex: Throwable): Unit = ex match {
-        case _: jms.JMSException =>
-          jmsSessions = Seq.empty
-          jmsProducers.clear()
-          currentJmsProducerEpoch += 1
-          initSessionAsync()
-        case _ =>
-          failStage(ex)
+      override def connectionFailed(ex: Throwable): Unit = {
+        jmsProducers.clear()
+        currentJmsProducerEpoch += 1
+        super.connectionFailed(ex)
       }
 
       setHandler(out, new OutHandler {

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -69,7 +69,7 @@ private[jms] final class JmsProducerStage[A <: JmsMessage, PassThrough](settings
         if (isAvailable(out)) pullIfNeeded()
       }
 
-      override protected def connectionFailed(ex: Throwable): Unit = ex match {
+      override def connectionFailed(ex: Throwable): Unit = ex match {
         case _: jms.JMSException =>
           jmsSessions = Seq.empty
           jmsProducers.clear()
@@ -117,7 +117,7 @@ private[jms] final class JmsProducerStage[A <: JmsMessage, PassThrough](settings
 
       private def sendWithRetries(send: SendAttempt[E]): Unit = {
         import send._
-        val eventualSend = if (jmsProducers.nonEmpty) {
+        if (jmsProducers.nonEmpty) {
           val jmsProducer: JmsMessageProducer = jmsProducers.dequeue()
           Future(jmsProducer.send(message.message)).andThen {
             case tried => sendCompletedCB.invoke((send, tried, jmsProducer))

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -16,8 +16,9 @@ import scala.concurrent.Future
 import scala.util.control.{NoStackTrace, NonFatal}
 import scala.util.{Failure, Success, Try}
 
-private[jms] final class JmsProducerStage[A <: JmsMessage, PassThrough](settings: JmsProducerSettings)
-    extends GraphStage[FlowShape[Envelope[A, PassThrough], Envelope[A, PassThrough]]] {
+private[jms] final class JmsProducerStage[A <: JmsMessage, PassThrough](settings: JmsProducerSettings,
+                                                                        destination: Destination)
+    extends GraphStage[FlowShape[Envelope[A, PassThrough], Envelope[A, PassThrough]]] { stage =>
 
   private type E = Envelope[A, PassThrough]
   private val in = Inlet[E]("JmsProducer.in")
@@ -47,7 +48,8 @@ private[jms] final class JmsProducerStage[A <: JmsMessage, PassThrough](settings
       private val inFlightMessagesWithProducer: Buffer[Holder[E]] =
         Buffer(settings.sessionCount, settings.sessionCount)
 
-      protected def jmsSettings: JmsProducerSettings = settings
+      protected val destination = stage.destination
+      protected val jmsSettings: JmsProducerSettings = settings
 
       override def preStart(): Unit = {
         ec = executionContext(inheritedAttributes)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -11,7 +11,6 @@ import akka.stream.alpakka.jms.JmsProducerMessage._
 import akka.stream.impl.Buffer
 import akka.stream.stage._
 import akka.util.OptionVal
-import javax.jms
 import javax.jms.JMSException
 
 import scala.concurrent.Future

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -53,7 +53,7 @@ private[jms] final class JmsProducerStage[A <: JmsMessage, PassThrough](settings
 
       override def preStart(): Unit = {
         ec = executionContext(inheritedAttributes)
-        initSessionAsync(withReconnect = false)
+        initSessionAsync()
       }
 
       override protected def onSessionOpened(jmsSession: JmsProducerSession): Unit = {

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerStage.scala
@@ -89,7 +89,7 @@ private[jms] final class JmsProducerStage[A <: JmsMessage, PassThrough](settings
             val elem: E = grab(in)
             elem match {
               case m: Message[_, _] =>
-                // fetch a jms producer from the pool, and create a holder object to capture the in-flight message.
+                // create a holder object to capture the in-flight message, and enqueue it to preserve message order
                 val holder = new Holder[E](NotYetThere)
                 inFlightMessages.enqueue(holder)
                 sendWithRetries(SendAttempt[E](m, holder))

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsConsumer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsConsumer.scala
@@ -9,8 +9,7 @@ import javax.jms.Message
 import akka.NotUsed
 import akka.stream.KillSwitch
 import akka.stream.alpakka.jms._
-
-import scala.collection.JavaConversions
+import scala.collection.JavaConverters._
 
 object JmsConsumer {
 
@@ -18,7 +17,7 @@ object JmsConsumer {
    * Java API: Creates an [[JmsConsumer]] for [[javax.jms.Message]]
    */
   def create(settings: JmsConsumerSettings): akka.stream.javadsl.Source[Message, KillSwitch] =
-    akka.stream.javadsl.Source.fromGraph(new JmsConsumerStage(settings))
+    akka.stream.alpakka.jms.scaladsl.JmsConsumer.apply(settings).asJava
 
   /**
    * Java API: Creates an [[JmsConsumer]] for texts
@@ -38,10 +37,7 @@ object JmsConsumer {
   def mapSource(
       settings: JmsConsumerSettings
   ): akka.stream.javadsl.Source[java.util.Map[String, Any], KillSwitch] =
-    akka.stream.alpakka.jms.scaladsl.JmsConsumer
-      .mapSource(settings)
-      .map(scalaMap => JavaConversions.mapAsJavaMap(scalaMap))
-      .asJava
+    akka.stream.alpakka.jms.scaladsl.JmsConsumer.mapSource(settings).map(_.asJava).asJava
 
   /**
    * Java API: Creates an [[JmsConsumer]] for serializable objects
@@ -59,7 +55,7 @@ object JmsConsumer {
    * @return Source for JMS messages in an AckEnvelope.
    */
   def ackSource(settings: JmsConsumerSettings): akka.stream.javadsl.Source[AckEnvelope, KillSwitch] =
-    akka.stream.javadsl.Source.fromGraph(new JmsAckSourceStage(settings))
+    akka.stream.alpakka.jms.scaladsl.JmsConsumer.ackSource(settings).asJava
 
   /**
    * Java API: Creates a [[JmsConsumer]] of envelopes containing messages. It requires explicit
@@ -69,11 +65,11 @@ object JmsConsumer {
    * @return Source of the JMS messages in a TxEnvelope
    */
   def txSource(settings: JmsConsumerSettings): akka.stream.javadsl.Source[TxEnvelope, KillSwitch] =
-    akka.stream.javadsl.Source.fromGraph(new JmsTxSourceStage(settings))
+    akka.stream.alpakka.jms.scaladsl.JmsConsumer.txSource(settings).asJava
 
   /**
    * Java API: Creates a [[JmsConsumer]] for browsing messages non-destructively
    */
   def browse(settings: JmsBrowseSettings): akka.stream.javadsl.Source[Message, NotUsed] =
-    akka.stream.javadsl.Source.fromGraph(new JmsBrowseStage(settings))
+    akka.stream.alpakka.jms.scaladsl.JmsConsumer.browse(settings).asJava
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsProducer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsProducer.scala
@@ -11,7 +11,7 @@ import akka.stream.alpakka.jms.JmsProducerMessage._
 import akka.stream.scaladsl.{Flow, Keep}
 import akka.{Done, NotUsed}
 
-import scala.collection.JavaConversions
+import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters
 
 object JmsProducer {
@@ -73,7 +73,7 @@ object JmsProducer {
         .mapSink(settings)
         .mapMaterializedValue(FutureConverters.toJava)
     val javaToScalaConversion =
-      Flow.fromFunction((javaMap: java.util.Map[String, Any]) => JavaConversions.mapAsScalaMap(javaMap).toMap)
+      Flow.fromFunction((javaMap: java.util.Map[String, Any]) => javaMap.asScala.toMap)
     javaToScalaConversion.toMat(scalaSink)(Keep.right).asJava
   }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsConsumer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsConsumer.scala
@@ -17,9 +17,9 @@ object JmsConsumer {
   /**
    * Scala API: Creates an [[JmsConsumer]] for [[javax.jms.Message]] instances
    */
-  def apply(settings: JmsConsumerSettings): Source[Message, KillSwitch] = {
-    require(settings.destination.isDefined, noConsumerDestination(settings))
-    Source.fromGraph(new JmsConsumerStage(settings, settings.destination.get))
+  def apply(settings: JmsConsumerSettings): Source[Message, KillSwitch] = settings.destination match {
+    case None => throw new IllegalArgumentException(noConsumerDestination(settings))
+    case Some(destination) => Source.fromGraph(new JmsConsumerStage(settings, destination))
   }
 
   /**
@@ -66,9 +66,9 @@ object JmsConsumer {
    * @param settings The settings for the ack source.
    * @return Source for JMS messages in an AckEnvelope.
    */
-  def ackSource(settings: JmsConsumerSettings): Source[AckEnvelope, KillSwitch] = {
-    require(settings.destination.isDefined, noConsumerDestination(settings))
-    Source.fromGraph(new JmsAckSourceStage(settings, settings.destination.get))
+  def ackSource(settings: JmsConsumerSettings): Source[AckEnvelope, KillSwitch] = settings.destination match {
+    case None => throw new IllegalArgumentException(noConsumerDestination(settings))
+    case Some(destination) => Source.fromGraph(new JmsAckSourceStage(settings, destination))
   }
 
   /**
@@ -78,17 +78,17 @@ object JmsConsumer {
    * @param settings The settings for the tx source
    * @return Source of the JMS messages in a TxEnvelope
    */
-  def txSource(settings: JmsConsumerSettings): Source[TxEnvelope, KillSwitch] = {
-    require(settings.destination.isDefined, noConsumerDestination(settings))
-    Source.fromGraph(new JmsTxSourceStage(settings, settings.destination.get))
+  def txSource(settings: JmsConsumerSettings): Source[TxEnvelope, KillSwitch] = settings.destination match {
+    case None => throw new IllegalArgumentException(noConsumerDestination(settings))
+    case Some(destination) => Source.fromGraph(new JmsTxSourceStage(settings, destination))
   }
 
   /**
    * Scala API: Creates a [[JmsConsumer]] for browsing messages non-destructively
    */
-  def browse(settings: JmsBrowseSettings): Source[Message, NotUsed] = {
-    require(settings.destination.isDefined, noBrowseDestination(settings))
-    Source.fromGraph(new JmsBrowseStage(settings, settings.destination.get))
+  def browse(settings: JmsBrowseSettings): Source[Message, NotUsed] = settings.destination match {
+    case None => throw new IllegalArgumentException(noBrowseDestination(settings))
+    case Some(destination) => Source.fromGraph(new JmsBrowseStage(settings, destination))
   }
 
   private def noConsumerDestination(settings: JmsConsumerSettings) =

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
@@ -564,7 +564,9 @@ public class JmsConnectorsTest {
           ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
           Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
-              JmsProducer.create(JmsProducerSettings.create(connectionFactory).withQueue("test"));
+              JmsProducer.create(JmsProducerSettings.create(connectionFactory).withQueue("test").withConnectionRetrySettings(
+                      ConnectionRetrySettings.create().withMaxRetries(0)
+              ));
 
           List<JmsTextMessage> msgsIn = createTestMessageList();
 

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsConnectorsTest.java
@@ -564,9 +564,11 @@ public class JmsConnectorsTest {
           ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(ctx.url);
 
           Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
-              JmsProducer.create(JmsProducerSettings.create(connectionFactory).withQueue("test").withConnectionRetrySettings(
-                      ConnectionRetrySettings.create().withMaxRetries(0)
-              ));
+              JmsProducer.create(
+                  JmsProducerSettings.create(connectionFactory)
+                      .withQueue("test")
+                      .withConnectionRetrySettings(
+                          ConnectionRetrySettings.create().withMaxRetries(0)));
 
           List<JmsTextMessage> msgsIn = createTestMessageList();
 

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsSettingsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsSettingsTest.java
@@ -7,6 +7,7 @@ package akka.stream.alpakka.jms.javadsl;
 import akka.stream.alpakka.jms.ConnectionRetrySettings;
 import akka.stream.alpakka.jms.Credentials;
 import akka.stream.alpakka.jms.JmsProducerSettings;
+import akka.stream.alpakka.jms.SendRetrySettings;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.junit.Test;
 
@@ -25,8 +26,17 @@ public class JmsSettingsTest {
             .withInitialRetry(1, TimeUnit.SECONDS)
             .withBackoffFactor(1.5)
             .withMaxBackoff(30, TimeUnit.SECONDS)
-            .withMaxRetries(-1);
+            .withInfiniteRetries();
     // #retry-settings
+
+    // #send-retry-settings
+    SendRetrySettings sendRetrySettings =
+        SendRetrySettings.create()
+            .withInitialRetry(10, TimeUnit.MILLISECONDS)
+            .withBackoffFactor(2)
+            .withMaxBackoff(1, TimeUnit.SECONDS)
+            .withMaxRetries(60);
+    // #send-retry-settings
 
     // #producer-settings
     JmsProducerSettings settings =
@@ -34,6 +44,7 @@ public class JmsSettingsTest {
             .withTopic("target-topic")
             .withCredential(new Credentials("username", "password"))
             .withConnectionRetrySettings(retrySettings)
+            .withSendRetrySettings(sendRetrySettings)
             .withSessionCount(10)
             .withTimeToLive(Duration.ofHours(1));
     // #producer-settings

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsMessageProducerSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsMessageProducerSpec.scala
@@ -29,7 +29,7 @@ class JmsMessageProducerSpec extends JmsSpec with MockitoSugar {
     val settings = JmsProducerSettings(factory, destination = Some(settingsDestination))
     val jmsSession = new JmsProducerSession(connection, session, destination)
 
-    val jmsProducer = JmsMessageProducer(jmsSession, settings)
+    val jmsProducer = JmsMessageProducer(jmsSession, settings, 0)
   }
 
   "populating Jms message properties" should {

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsProducerRetrySpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsProducerRetrySpec.scala
@@ -192,7 +192,7 @@ class JmsProducerRetrySpec extends JmsSpec {
       val result = Source(List("one")).runWith(jms)
 
       result.failed.futureValue shouldBe a[JMSException]
-      sendAttempts.get() shouldBe 6
+      sendAttempts.get shouldBe 6
     }
 
     "fail send on first attempt if retry is disabled" in withMockedProducer { ctx =>
@@ -217,7 +217,7 @@ class JmsProducerRetrySpec extends JmsSpec {
       val result = Source(List("one")).runWith(jms)
 
       result.failed.futureValue shouldBe a[JMSException]
-      sendAttempts.get() shouldBe 1
+      sendAttempts.get shouldBe 1
     }
   }
 }

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsProducerRetrySpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsProducerRetrySpec.scala
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.jms
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings, OverflowStrategies, Supervision}
+import akka.stream.alpakka.jms.scaladsl.{JmsConsumer, JmsProducer}
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import javax.jms.{JMSException, Message, TextMessage}
+import org.apache.activemq.ActiveMQConnectionFactory
+import org.mockito.ArgumentMatchers.{any, anyInt, anyLong}
+import org.mockito.Mockito.when
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import scala.concurrent.duration._
+
+class JmsProducerRetrySpec extends JmsSpec {
+
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(20.seconds)
+
+  "JmsProducer retries" should {
+    "retry sending on network failures" in withServer() { ctx =>
+      val connectionFactory: javax.jms.ConnectionFactory = new ActiveMQConnectionFactory(ctx.url)
+
+      val jms = JmsProducer.flow[JmsMapMessage](
+        JmsProducerSettings(connectionFactory)
+          .withQueue("test")
+          .withSessionCount(3)
+          .withConnectionRetrySettings(
+            ConnectionRetrySettings()
+              .withConnectTimeout(100.millis)
+              .withInitialRetry(50.millis)
+              .withMaxBackoff(50.millis)
+              .withInfiniteRetries()
+          )
+          .withSendRetrySettings(
+            SendRetrySettings().withInitialRetry(10.millis).withMaxBackoff(10.millis).withInfiniteRetries()
+          )
+      )
+
+      val (queue, result) = Source
+        .queue[Int](10, OverflowStrategies.Backpressure)
+        .zipWithIndex
+        .map(e => JmsMapMessage(Map("time" -> System.currentTimeMillis(), "index" -> e._2)))
+        .via(jms)
+        .map(_.body)
+        .toMat(Sink.seq)(Keep.both)
+        .run()
+
+      val sentResult = JmsConsumer
+        .mapSource(JmsConsumerSettings(connectionFactory).withBufferSize(1).withQueue("test"))
+        .take(20)
+        .runWith(Sink.seq)
+
+      for (_ <- 1 to 10) queue.offer(1) // 10 before the crash
+      Thread.sleep(500)
+      ctx.broker.stop() // crash.
+
+      Thread.sleep(1000)
+      ctx.broker.start(true) // recover.
+      val restartTime = System.currentTimeMillis()
+      for (_ <- 1 to 10) queue.offer(1) // 10 after the crash
+      queue.complete()
+
+      val resultList = result.futureValue
+      def index(m: Map[String, Any]) = m("index").asInstanceOf[Long]
+      def time(m: Map[String, Any]) = m("time").asInstanceOf[Long]
+
+      resultList.size shouldBe 20
+      resultList.filter(b => time(b) > restartTime) shouldNot be(empty)
+      resultList.sliding(2).forall(pair => index(pair.head) + 1 == index(pair.last)) shouldBe true
+
+      val sentList = sentResult.futureValue
+      sentList.size shouldBe 20
+      // all produced elements should have been sent to the consumer.
+      resultList.forall { produced =>
+        sentList.exists(consumed => index(consumed) == index(produced))
+      } shouldBe true
+    }
+
+    "fail sending only after max retries" in withServer() { ctx =>
+      val connectionFactory: javax.jms.ConnectionFactory = new ActiveMQConnectionFactory(ctx.url)
+
+      val jms = JmsProducer.flow[JmsMapMessage](
+        JmsProducerSettings(connectionFactory)
+          .withQueue("test")
+          .withConnectionRetrySettings(ConnectionRetrySettings().withInfiniteRetries())
+          .withSendRetrySettings(
+            SendRetrySettings()
+              .withInitialRetry(100.millis)
+              .withMaxBackoff(600.millis)
+              .withBackoffFactor(2)
+              .withMaxRetries(3)
+          )
+      )
+
+      val (cancellable, result) = Source
+        .tick(50.millis, 50.millis, "")
+        .zipWithIndex
+        .map(e => JmsMapMessage(Map("time" -> System.currentTimeMillis(), "index" -> e._2)))
+        .via(jms)
+        .map(_.body)
+        .toMat(Sink.seq)(Keep.both)
+        .run()
+
+      Thread.sleep(500)
+      val crashTime = System.currentTimeMillis()
+      ctx.broker.stop()
+      val failure = result.failed.futureValue
+      val failureTime = System.currentTimeMillis()
+
+      val expectedDelay = 100L + 400L + 600L
+      failureTime - crashTime shouldBe >(expectedDelay)
+      failure shouldBe RetrySkippedOnMissingConnection
+    }
+
+    "fail immediately on non-recoverable errors" in withServer() { ctx =>
+      val connectionFactory: javax.jms.ConnectionFactory = new ActiveMQConnectionFactory(ctx.url)
+
+      val jms = JmsProducer.flow[JmsMapMessage](
+        JmsProducerSettings(connectionFactory)
+          .withQueue("test")
+          .withSendRetrySettings(SendRetrySettings().withInfiniteRetries())
+      )
+
+      val result = Source(
+        List(JmsMapMessage(Map("body" -> "1")), JmsMapMessage(Map("body" -> this)), JmsMapMessage(Map("body" -> "3")))
+      ).via(jms)
+        .map(_.body("body").toString)
+        .runWith(Sink.seq)
+
+      val failure = result.failed.futureValue
+      failure shouldBe a[UnsupportedMapMessageEntryType]
+    }
+
+    "invoke supervisor when send fails" in withServer() { ctx =>
+      val deciderCalls = new AtomicInteger()
+      val decider: Supervision.Decider = { ex =>
+        deciderCalls.incrementAndGet()
+        Supervision.Resume
+      }
+      val settings = ActorMaterializerSettings(system).withSupervisionStrategy(decider)
+      val materializer = ActorMaterializer(settings)(system)
+
+      val connectionFactory: javax.jms.ConnectionFactory = new ActiveMQConnectionFactory(ctx.url)
+
+      val jms = JmsProducer.flow[JmsMapMessage](
+        JmsProducerSettings(connectionFactory)
+          .withQueue("test")
+          .withSendRetrySettings(SendRetrySettings().withInfiniteRetries())
+      )
+
+      // second element is a wrong map message.
+      val result = Source(
+        List(JmsMapMessage(Map("body" -> "1")), JmsMapMessage(Map("body" -> this)), JmsMapMessage(Map("body" -> "3")))
+      ).via(jms)
+        .map(_.body("body").toString)
+        .runWith(Sink.seq)(materializer)
+
+      // check that second element was skipped.
+      val list = result.futureValue
+      list shouldBe List("1", "3")
+
+      deciderCalls.get shouldBe 1
+    }
+
+    "retry send as often as configured" in withMockedProducer { ctx =>
+      import ctx._
+      val sendAttempts = new AtomicInteger()
+      val message = mock[TextMessage]
+
+      when(session.createTextMessage(any[String])).thenReturn(message)
+
+      when(producer.send(any[javax.jms.Destination], any[Message], anyInt(), anyInt(), anyLong()))
+        .thenAnswer(new Answer[Unit]() {
+          override def answer(invocation: InvocationOnMock): Unit = {
+            sendAttempts.incrementAndGet()
+            throw new JMSException("send error")
+          }
+        })
+
+      val jms = JmsProducer.textSink(
+        JmsProducerSettings(factory)
+          .withQueue("test")
+          .withSendRetrySettings(
+            SendRetrySettings().withInitialRetry(10.millis).withMaxBackoff(10.millis).withMaxRetries(5)
+          )
+      )
+
+      val result = Source(List("one")).runWith(jms)
+
+      result.failed.futureValue shouldBe a[JMSException]
+      sendAttempts.get() shouldBe 6
+    }
+
+    "fail send on first attempt if retry is disabled" in withMockedProducer { ctx =>
+      import ctx._
+      val sendAttempts = new AtomicInteger()
+      val message = mock[TextMessage]
+
+      when(session.createTextMessage(any[String])).thenReturn(message)
+
+      when(producer.send(any[javax.jms.Destination], any[Message], anyInt(), anyInt(), anyLong()))
+        .thenAnswer(new Answer[Unit]() {
+          override def answer(invocation: InvocationOnMock): Unit =
+            if (sendAttempts.incrementAndGet() == 1) throw new JMSException("send error")
+        })
+
+      val jms = JmsProducer.textSink(
+        JmsProducerSettings(factory)
+          .withQueue("test")
+          .withSendRetrySettings(SendRetrySettings().withMaxRetries(0))
+      )
+
+      val result = Source(List("one")).runWith(jms)
+
+      result.failed.futureValue shouldBe a[JMSException]
+      sendAttempts.get() shouldBe 1
+    }
+  }
+}

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsProducerRetrySpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsProducerRetrySpec.scala
@@ -69,7 +69,7 @@ class JmsProducerRetrySpec extends JmsSpec {
       def time(m: Map[String, Any]) = m("time").asInstanceOf[Long]
 
       resultList.size shouldBe 20
-      resultList.filter(b => time(b) > restartTime) shouldNot be(empty)
+      resultList.filter(b => time(b) >= restartTime) shouldNot be(empty)
       resultList.sliding(2).forall(pair => index(pair.head) + 1 == index(pair.last)) shouldBe true
 
       val sentList = sentResult.futureValue

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsSpec.scala
@@ -7,9 +7,13 @@ package akka.stream.alpakka.jms
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Supervision}
 import akka.testkit.{SocketUtil, TestKit}
+import javax.jms._
 import org.apache.activemq.broker.BrokerService
+import org.mockito.ArgumentMatchers.{any, anyBoolean, anyInt}
+import org.mockito.Mockito.when
 import org.scalatest._
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.mockito.MockitoSugar
 
 abstract class JmsSpec
     extends WordSpec
@@ -17,7 +21,8 @@ abstract class JmsSpec
     with BeforeAndAfterAll
     with BeforeAndAfterEach
     with ScalaFutures
-    with Eventually {
+    with Eventually
+    with MockitoSugar {
 
   implicit val system = ActorSystem(this.getClass.getSimpleName)
 
@@ -57,4 +62,14 @@ abstract class JmsSpec
 
   case class Context(url: String, broker: BrokerService)
 
+  def withMockedProducer(test: ProducerMock => Unit): Unit = test(ProducerMock())
+
+  case class ProducerMock(factory: ConnectionFactory = mock[ConnectionFactory],
+                          connection: Connection = mock[Connection],
+                          session: Session = mock[Session],
+                          producer: MessageProducer = mock[MessageProducer]) {
+    when(factory.createConnection()).thenReturn(connection)
+    when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session)
+    when(session.createProducer(any[javax.jms.Destination])).thenReturn(producer)
+  }
 }

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsSpec.scala
@@ -20,12 +20,8 @@ abstract class JmsSpec
     with Eventually {
 
   implicit val system = ActorSystem(this.getClass.getSimpleName)
-  val decider: Supervision.Decider = {
-    case ex =>
-      println("An error occurred in the stream.  Calling Supervision.Stop inside the decider!")
-      ex.printStackTrace(System.err)
-      Supervision.Stop
-  }
+
+  val decider: Supervision.Decider = ex => Supervision.Stop
 
   val settings = ActorMaterializerSettings(system).withSupervisionStrategy(decider)
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
@@ -895,7 +895,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val result = Source(in).via(jmsFlow).toMat(Sink.seq)(Keep.right).run()
 
       result.futureValue shouldEqual in
-      delays.get() shouldBe 50
+      delays.get shouldBe 50
     }
 
     "fail fast on the first failing send" in withMockedProducer { ctx =>

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsConnectorsSpec.scala
@@ -30,7 +30,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 final case class DummyObject(payload: String)
 
-class JmsConnectorsSpec extends JmsSpec with MockitoSugar {
+class JmsConnectorsSpec extends JmsSpec {
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(2.minutes)
 
@@ -874,12 +874,9 @@ class JmsConnectorsSpec extends JmsSpec with MockitoSugar {
       result.futureValue should contain allElementsOf in
     }
 
-    "produce elements in order" in {
+    "produce elements in order" in withMockedProducer { ctx =>
+      import ctx._
       val delays = new AtomicInteger()
-      val factory = mock[ConnectionFactory]
-      val connection = mock[Connection]
-      val session = mock[Session]
-      val producer = mock[MessageProducer]
       val textMessage = mock[TextMessage]
 
       val delayedSend = new Answer[Unit] {
@@ -889,9 +886,6 @@ class JmsConnectorsSpec extends JmsSpec with MockitoSugar {
         }
       }
 
-      when(factory.createConnection()).thenReturn(connection)
-      when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session)
-      when(session.createProducer(any[javax.jms.Destination])).thenReturn(producer)
       when(session.createTextMessage(anyString())).thenReturn(textMessage)
       when(producer.send(any[javax.jms.Destination], any[Message], anyInt(), anyInt(), anyLong()))
         .thenAnswer(delayedSend)
@@ -905,16 +899,9 @@ class JmsConnectorsSpec extends JmsSpec with MockitoSugar {
       delays.get() shouldBe 50
     }
 
-    "fail fast on the first failing send" in {
-      val factory = mock[ConnectionFactory]
-      val connection = mock[Connection]
-      val session = mock[Session]
-      val producer = mock[MessageProducer]
+    "fail fast on the first failing send" in withMockedProducer { ctx =>
+      import ctx._
       val errorLatch = new CountDownLatch(3)
-
-      when(factory.createConnection()).thenReturn(connection)
-      when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session)
-      when(session.createProducer(any[javax.jms.Destination])).thenReturn(producer)
 
       val messages = (1 to 10).map(i => mock[TextMessage] -> i).toMap
       messages.foreach {
@@ -949,15 +936,8 @@ class JmsConnectorsSpec extends JmsSpec with MockitoSugar {
       result.futureValue shouldEqual in.take(3) :+ done
     }
 
-    "put back JmsProducer to the pool when send fails" in {
-      val factory = mock[ConnectionFactory]
-      val connection = mock[Connection]
-      val session = mock[Session]
-      val producer = mock[MessageProducer]
-
-      when(factory.createConnection()).thenReturn(connection)
-      when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session)
-      when(session.createProducer(any[javax.jms.Destination])).thenReturn(producer)
+    "put back JmsProducer to the pool when send fails" in withMockedProducer { ctx =>
+      import ctx._
 
       val messages = (1 to 10).map(i => mock[TextMessage] -> i).toMap
       messages.foreach {
@@ -1186,217 +1166,6 @@ class JmsConnectorsSpec extends JmsSpec with MockitoSugar {
 
       verify(session, never()).createTextMessage(any[String])
       verify(producer, never()).send(any[javax.jms.Destination], any[Message], any[Int], any[Int], any[Long])
-    }
-
-    "retry sending on network failures" in withServer() { ctx =>
-      val connectionFactory: javax.jms.ConnectionFactory = new ActiveMQConnectionFactory(ctx.url)
-
-      val jms = JmsProducer.flow[JmsMapMessage](
-        JmsProducerSettings(connectionFactory)
-          .withQueue("test")
-          .withSessionCount(3)
-          .withConnectionRetrySettings(
-            ConnectionRetrySettings()
-              .withConnectTimeout(100.millis)
-              .withInitialRetry(50.millis)
-              .withMaxBackoff(50.millis)
-              .withInfiniteRetries()
-          )
-          .withSendRetrySettings(
-            SendRetrySettings().withInitialRetry(10.millis).withMaxBackoff(10.millis).withInfiniteRetries()
-          )
-      )
-
-      val (queue, result) = Source
-        .queue[Int](10, OverflowStrategies.Backpressure)
-        .zipWithIndex
-        .map(e => JmsMapMessage(Map("time" -> System.currentTimeMillis(), "index" -> e._2)))
-        .via(jms)
-        .map(_.body)
-        .toMat(Sink.seq)(Keep.both)
-        .run()
-
-      val sentResult = JmsConsumer
-        .mapSource(JmsConsumerSettings(connectionFactory).withBufferSize(1).withQueue("test"))
-        .take(20)
-        .runWith(Sink.seq)
-
-      for (_ <- 1 to 10) queue.offer(1) // 10 before the crash
-      Thread.sleep(500)
-      ctx.broker.stop() // crash.
-
-      Thread.sleep(1000)
-      ctx.broker.start(true) // recover.
-      val restartTime = System.currentTimeMillis()
-      for (_ <- 1 to 10) queue.offer(1) // 10 after the crash
-      queue.complete()
-
-      val resultList = result.futureValue
-      def index(m: Map[String, Any]) = m("index").asInstanceOf[Long]
-      def time(m: Map[String, Any]) = m("time").asInstanceOf[Long]
-
-      resultList.size shouldBe 20
-      resultList.filter(b => time(b) > restartTime) shouldNot be(empty)
-      resultList.sliding(2).forall(pair => index(pair.head) + 1 == index(pair.last)) shouldBe true
-
-      val sentList = sentResult.futureValue
-      sentList.size shouldBe 20
-      // all produced elements should have been sent to the consumer.
-      resultList.forall { produced =>
-        sentList.exists(consumed => index(consumed) == index(produced))
-      } shouldBe true
-    }
-
-    "fail sending only after max retries" in withServer() { ctx =>
-      val connectionFactory: javax.jms.ConnectionFactory = new ActiveMQConnectionFactory(ctx.url)
-
-      val jms = JmsProducer.flow[JmsMapMessage](
-        JmsProducerSettings(connectionFactory)
-          .withQueue("test")
-          .withConnectionRetrySettings(ConnectionRetrySettings().withInfiniteRetries())
-          .withSendRetrySettings(
-            SendRetrySettings()
-              .withInitialRetry(100.millis)
-              .withMaxBackoff(600.millis)
-              .withBackoffFactor(2)
-              .withMaxRetries(3)
-          )
-      )
-
-      val (cancellable, result) = Source
-        .tick(50.millis, 50.millis, "")
-        .zipWithIndex
-        .map(e => JmsMapMessage(Map("time" -> System.currentTimeMillis(), "index" -> e._2)))
-        .via(jms)
-        .map(_.body)
-        .toMat(Sink.seq)(Keep.both)
-        .run()
-
-      Thread.sleep(500)
-      val crashTime = System.currentTimeMillis()
-      ctx.broker.stop()
-      val failure = result.failed.futureValue
-      val failureTime = System.currentTimeMillis()
-
-      val expectedDelay = 100L + 400L + 600L
-      failureTime - crashTime shouldBe >(expectedDelay)
-      failure shouldBe RetrySkippedOnMissingConnection
-    }
-
-    "fail immediately on non-recoverable errors" in withServer() { ctx =>
-      val connectionFactory: javax.jms.ConnectionFactory = new ActiveMQConnectionFactory(ctx.url)
-
-      val jms = JmsProducer.flow[JmsMapMessage](
-        JmsProducerSettings(connectionFactory)
-          .withQueue("test")
-          .withSendRetrySettings(SendRetrySettings().withInfiniteRetries())
-      )
-
-      val result = Source(
-        List(JmsMapMessage(Map("body" -> "1")), JmsMapMessage(Map("body" -> this)), JmsMapMessage(Map("body" -> "3")))
-      ).via(jms)
-        .map(_.body("body").toString)
-        .runWith(Sink.seq)
-
-      val failure = result.failed.futureValue
-      failure shouldBe a[UnsupportedMapMessageEntryType]
-    }
-
-    "invoke supervisor when send fails" in withServer() { ctx =>
-      val deciderCalls = new AtomicInteger()
-      val decider: Supervision.Decider = { ex =>
-        deciderCalls.incrementAndGet()
-        Supervision.Resume
-      }
-      val settings = ActorMaterializerSettings(system).withSupervisionStrategy(decider)
-      val materializer = ActorMaterializer(settings)(system)
-
-      val connectionFactory: javax.jms.ConnectionFactory = new ActiveMQConnectionFactory(ctx.url)
-
-      val jms = JmsProducer.flow[JmsMapMessage](
-        JmsProducerSettings(connectionFactory)
-          .withQueue("test")
-          .withSendRetrySettings(SendRetrySettings().withInfiniteRetries())
-      )
-
-      // second element is a wrong map message.
-      val result = Source(
-        List(JmsMapMessage(Map("body" -> "1")), JmsMapMessage(Map("body" -> this)), JmsMapMessage(Map("body" -> "3")))
-      ).via(jms)
-        .map(_.body("body").toString)
-        .runWith(Sink.seq)(materializer)
-
-      // check that second element was skipped.
-      val list = result.futureValue
-      list shouldBe List("1", "3")
-
-      deciderCalls.get shouldBe 1
-    }
-
-    "retry send as often as configured" in {
-      val sendAttempts = new AtomicInteger()
-      val connectionFactory = mock[ConnectionFactory]
-      val connection = mock[Connection]
-      val session = mock[Session]
-      val producer = mock[MessageProducer]
-      val message = mock[TextMessage]
-
-      when(connectionFactory.createConnection()).thenReturn(connection)
-      when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session)
-      when(session.createProducer(any[javax.jms.Destination])).thenReturn(producer)
-      when(session.createTextMessage(any[String])).thenReturn(message)
-
-      when(producer.send(any[javax.jms.Destination], any[Message], anyInt(), anyInt(), anyLong()))
-        .thenAnswer(new Answer[Unit]() {
-          override def answer(invocation: InvocationOnMock): Unit = {
-            sendAttempts.incrementAndGet()
-            throw new JMSException("send error")
-          }
-        })
-
-      val jms = JmsProducer.textSink(
-        JmsProducerSettings(connectionFactory)
-          .withQueue("test")
-          .withSendRetrySettings(
-            SendRetrySettings().withInitialRetry(10.millis).withMaxBackoff(10.millis).withMaxRetries(5)
-          )
-      )
-
-      val result = Source(List("one")).runWith(jms)
-
-      result.failed.futureValue shouldBe a[JMSException]
-      sendAttempts.get() shouldBe 6
-    }
-
-    "fail send on first attempt if retry is disabled" in {
-      val sendAttempts = new AtomicInteger()
-      val connectionFactory = mock[ConnectionFactory]
-      val connection = mock[Connection]
-      val session = mock[Session]
-      val producer = mock[MessageProducer]
-      val message = mock[TextMessage]
-
-      when(connectionFactory.createConnection()).thenReturn(connection)
-      when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session)
-      when(session.createProducer(any[javax.jms.Destination])).thenReturn(producer)
-      when(session.createTextMessage(any[String])).thenReturn(message)
-
-      when(producer.send(any[javax.jms.Destination], any[Message], anyInt(), anyInt(), anyLong()))
-        .thenAnswer(new Answer[Unit]() {
-          override def answer(invocation: InvocationOnMock): Unit =
-            if (sendAttempts.incrementAndGet() == 1) throw new JMSException("send error")
-        })
-
-      val jms = JmsProducer.textSink(
-        JmsProducerSettings(connectionFactory)
-          .withQueue("test")
-          .withSendRetrySettings(SendRetrySettings().withMaxRetries(0))
-      )
-
-      val result = Source(List("one")).runWith(jms)
-
-      result.failed.futureValue shouldBe a[JMSException]
-      sendAttempts.get() shouldBe 1
     }
   }
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsSettingsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsSettingsSpec.scala
@@ -24,11 +24,20 @@ class JmsSettingsSpec extends JmsSpec {
       )
       //#retry-settings-case-class
 
+      //#send-retry-settings
+      val sendRetrySettings = SendRetrySettings()
+        .withInitialRetry(10.millis)
+        .withBackoffFactor(2)
+        .withMaxBackoff(1.second)
+        .withMaxRetries(60)
+      //#send-retry-settings
+
       //#producer-settings
       val settings = JmsProducerSettings(new ActiveMQConnectionFactory("broker-url"))
         .withTopic("target-topic")
         .withCredential(Credentials("username", "password"))
         .withConnectionRetrySettings(retrySettings)
+        .withSendRetrySettings(sendRetrySettings)
         .withSessionCount(10)
         .withTimeToLive(1.hour)
       //#producer-settings


### PR DESCRIPTION
This is my proposal on how to achieve producer retries with reconnects.

I also simplified some code along the line (which I hope is okay for everyone).
Also, I added a missing async callback on disconnect that incidentally also changes the amount of retries performed in the reconnect test (I will point out in annotations where).

Documentation is lacking for now, I will add some examples once we are fine with the design and the way it works.

Fixes #1226