### PR TITLE
Mongo: Update driver to 2.4.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -229,7 +229,7 @@ object Dependencies {
 
   val MongoDb = Seq(
     libraryDependencies ++= Seq(
-      "org.mongodb.scala" %% "mongo-scala-driver" % "2.4.0" // ApacheV2
+      "org.mongodb.scala" %% "mongo-scala-driver" % "2.4.2" // ApacheV2
     )
   )
 


### PR DESCRIPTION
Update mongo-scala-driver to latest version (2.4.2)
