### PR TITLE
Increase java heap spave on Travis

### DIFF
--- a/.jvmopts-travis
+++ b/.jvmopts-travis
@@ -1,6 +1,6 @@
 # This is used to configure the sbt instance that Travis launches
 
--Xms1G
--Xmx1G
+-Xms2G
+-Xmx2G
 -Xss2M
 -XX:ReservedCodeCacheSize=128m


### PR DESCRIPTION
Last release from Travis failed because of `java.lang.OutOfMemoryError: Java heap space`

https://travis-ci.org/akka/alpakka/jobs/434147431