### PR TITLE
XML: fix subtree with namespace parsing

### DIFF
--- a/xml/src/main/scala/akka/stream/alpakka/xml/impl/Subtree.scala
+++ b/xml/src/main/scala/akka/stream/alpakka/xml/impl/Subtree.scala
@@ -25,7 +25,7 @@ import scala.collection.immutable
 
   private def createElement(start: StartElement): Element = {
     val element = start.namespace match {
-      case Some(ns) => doc.createElementNS(start.localName, ns)
+      case Some(ns) => doc.createElementNS(ns, start.localName)
       case None => doc.createElement(start.localName)
     }
     start.attributes.foreach {

--- a/xml/src/test/scala/docs/scaladsl/XmlSubtreeSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlSubtreeSpec.scala
@@ -141,6 +141,23 @@ class XmlSubtreeSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       )
     }
 
+    "properly extract a subtree of events even with the namespace prefix" in {
+      val doc =
+        """
+          |<doc xmlns:g="http://base.google.com/ns/1.0" version="2.0">
+          | <elem>
+          |   <item><g:id>id1</g:id></item>
+          |	</elem>
+          |</doc>
+        """.stripMargin
+
+      val result = Await.result(Source.single(doc).runWith(parse), 3.seconds)
+
+      val t = result.map(XmlHelper.asString(_).trim)
+      val f = Seq("""<item><id xmlns="http://base.google.com/ns/1.0">id1</id></item>""".stripMargin)
+      t should ===(f)
+    }
+
   }
 
   override protected def afterAll(): Unit = system.terminate()


### PR DESCRIPTION
Pull request to fix issue #1276 
Call of the function `Document.createElementNS` in `Subtree` had the arguments in inverted order (see documentation [here](https://docs.oracle.com/javase/8/docs/api/org/w3c/dom/Document.html#createElementNS))