### PR TITLE
AWS SQS: Source - Allow configuring visibility timeout

### DIFF
--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
@@ -17,7 +17,7 @@ final class SqsSourceSettings private (
     val attributeNames: immutable.Seq[AttributeName],
     val messageAttributeNames: immutable.Seq[MessageAttributeName],
     val closeOnEmptyReceive: Boolean,
-    val visibilityTimeout: Option[Int]
+    val visibilityTimeout: Option[FiniteDuration]
 ) {
   require(maxBatchSize <= maxBufferSize, "maxBatchSize must be lower or equal than maxBufferSize")
   // SQS requirements
@@ -96,7 +96,7 @@ final class SqsSourceSettings private (
    *
    * Default: None - taken from the SQS queue configuration
    */
-  def withVisibilityTimeout(timeout: Int): SqsSourceSettings =
+  def withVisibilityTimeout(timeout: FiniteDuration): SqsSourceSettings =
     copy(visibilityTimeout = Some(timeout))
 
   private def copy(
@@ -106,7 +106,7 @@ final class SqsSourceSettings private (
       attributeNames: immutable.Seq[AttributeName] = attributeNames,
       messageAttributeNames: immutable.Seq[MessageAttributeName] = messageAttributeNames,
       closeOnEmptyReceive: Boolean = closeOnEmptyReceive,
-      visibilityTimeout: Option[Int] = visibilityTimeout
+      visibilityTimeout: Option[FiniteDuration] = visibilityTimeout
   ): SqsSourceSettings = new SqsSourceSettings(
     waitTimeSeconds,
     maxBufferSize,
@@ -124,8 +124,8 @@ final class SqsSourceSettings private (
     s"maxBatchSize=$maxBatchSize, " +
     s"attributeNames=${attributeNames.mkString(",")}, " +
     s"messageAttributeNames=${messageAttributeNames.mkString(",")}, " +
-    s"closeOnEmptyReceive=$closeOnEmptyReceive" +
-    s"visibilityTomeout=$visibilityTimeout" +
+    s"closeOnEmptyReceive=$closeOnEmptyReceive," +
+    s"visibilityTomeout=${visibilityTimeout.map(_.toCoarsest)}" +
     ")"
 }
 

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
@@ -91,12 +91,13 @@ final class SqsSourceSettings private (
     else copy(closeOnEmptyReceive = value)
 
   /**
-    * the period of time (in seconds) during which Amazon SQS prevents other consumers
-    * from receiving and processing an already received message (see Amazon SQS doc)
-    *
-    * Default: None - taken from the SQS queue configuration
-    */
-  def withVisibilityTimeout(timeout: Int): SqsSourceSettings = copy(visibilityTimeout = Some(timeout))
+   * the period of time (in seconds) during which Amazon SQS prevents other consumers
+   * from receiving and processing an already received message (see Amazon SQS doc)
+   *
+   * Default: None - taken from the SQS queue configuration
+   */
+  def withVisibilityTimeout(timeout: Int): SqsSourceSettings =
+    copy(visibilityTimeout = Some(timeout))
 
   private def copy(
       waitTimeSeconds: Int = waitTimeSeconds,

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
@@ -16,7 +16,8 @@ final class SqsSourceSettings private (
     val maxBatchSize: Int,
     val attributeNames: immutable.Seq[AttributeName],
     val messageAttributeNames: immutable.Seq[MessageAttributeName],
-    val closeOnEmptyReceive: Boolean
+    val closeOnEmptyReceive: Boolean,
+    val visibilityTimeout: Option[Int]
 ) {
   require(maxBatchSize <= maxBufferSize, "maxBatchSize must be lower or equal than maxBufferSize")
   // SQS requirements
@@ -89,20 +90,30 @@ final class SqsSourceSettings private (
     if (value == closeOnEmptyReceive) this
     else copy(closeOnEmptyReceive = value)
 
+  /**
+    * the period of time (in seconds) during which Amazon SQS prevents other consumers
+    * from receiving and processing an already received message (see Amazon SQS doc)
+    *
+    * Default: None - taken from the SQS queue configuration
+    */
+  def withVisibilityTimeout(timeout: Int): SqsSourceSettings = copy(visibilityTimeout = Some(timeout))
+
   private def copy(
       waitTimeSeconds: Int = waitTimeSeconds,
       maxBufferSize: Int = maxBufferSize,
       maxBatchSize: Int = maxBatchSize,
       attributeNames: immutable.Seq[AttributeName] = attributeNames,
       messageAttributeNames: immutable.Seq[MessageAttributeName] = messageAttributeNames,
-      closeOnEmptyReceive: Boolean = closeOnEmptyReceive
+      closeOnEmptyReceive: Boolean = closeOnEmptyReceive,
+      visibilityTimeout: Option[Int] = visibilityTimeout
   ): SqsSourceSettings = new SqsSourceSettings(
     waitTimeSeconds,
     maxBufferSize,
     maxBatchSize,
     attributeNames,
     messageAttributeNames,
-    closeOnEmptyReceive
+    closeOnEmptyReceive,
+    visibilityTimeout
   )
 
   override def toString: String =
@@ -113,6 +124,7 @@ final class SqsSourceSettings private (
     s"attributeNames=${attributeNames.mkString(",")}, " +
     s"messageAttributeNames=${messageAttributeNames.mkString(",")}, " +
     s"closeOnEmptyReceive=$closeOnEmptyReceive" +
+    s"visibilityTomeout=$visibilityTimeout" +
     ")"
 }
 
@@ -122,7 +134,8 @@ object SqsSourceSettings {
                                        10,
                                        attributeNames = immutable.Seq(),
                                        messageAttributeNames = immutable.Seq(),
-                                       closeOnEmptyReceive = false)
+                                       closeOnEmptyReceive = false,
+                                       visibilityTimeout = None)
 
   /**
    * Scala API

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/impl/SqsSourceStage.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/impl/SqsSourceStage.scala
@@ -23,6 +23,8 @@ import scala.collection.JavaConverters._
     implicit sqsClient: AmazonSQSAsync
 ) extends GraphStage[SourceShape[Message]] {
 
+  import SqsSourceStage._
+
   val out: Outlet[Message] = Outlet("SqsSource.out")
   override val shape: SourceShape[Message] = SourceShape(out)
 
@@ -61,6 +63,7 @@ import scala.collection.JavaConverters._
           .withMessageAttributeNames(settings.messageAttributeNames.map(_.name).asJava)
           .withMaxNumberOfMessages(settings.maxBatchSize)
           .withWaitTimeSeconds(settings.waitTimeSeconds)
+          .withVisibilityTimeout(settings.visibilityTimeout)
 
         sqsClient.receiveMessageAsync(
           request,
@@ -115,4 +118,13 @@ import scala.collection.JavaConverters._
         }
       )
     }
+}
+
+object SqsSourceStage {
+
+  private implicit class ReceiveMessageExtension(request: ReceiveMessageRequest) {
+    def withVisibilityTimeout(visibilityTimeout: Option[Int]): ReceiveMessageRequest = {
+      visibilityTimeout.map(request.withVisibilityTimeout(_)).getOrElse(request)
+    }
+  }
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/impl/SqsSourceStage.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/impl/SqsSourceStage.scala
@@ -123,8 +123,7 @@ import scala.collection.JavaConverters._
 object SqsSourceStage {
 
   private implicit class ReceiveMessageExtension(request: ReceiveMessageRequest) {
-    def withVisibilityTimeout(visibilityTimeout: Option[Int]): ReceiveMessageRequest = {
+    def withVisibilityTimeout(visibilityTimeout: Option[Int]): ReceiveMessageRequest =
       visibilityTimeout.map(request.withVisibilityTimeout(_)).getOrElse(request)
-    }
   }
 }

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -112,6 +112,7 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
         .withAttributes(immutable.Seq(SenderId, SentTimestamp))
         .withMessageAttribute(MessageAttributeName.create("bar.*"))
         .withCloseOnEmptyReceive(true)
+        .withVisibilityTimeout(10)
       //#SqsSourceSettings
 
       settings.maxBufferSize should be(100)
@@ -200,6 +201,31 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
       //#run
 
       res.futureValue should have size 100
+    }
+
+
+    "stream single message twice from the queue when visibility timeout passed" taggedAs Integration in {
+      val queue = randomQueueUrl()
+      implicit val awsSqsClient = sqsClient
+
+      sqsClient.sendMessage(queue, "alpakka")
+
+      SqsSource(queue, SqsSourceSettings().withVisibilityTimeout(1))
+        .takeWithin(1500.milliseconds)
+        .runWith(Sink.seq)
+        .map(_.map(_.getBody) shouldBe Seq("alpakka", "alpakka"))
+    }
+
+    "stream single message once from the queue when visibility timeout did not pass" taggedAs Integration in {
+      val queue = randomQueueUrl()
+      implicit val awsSqsClient = sqsClient
+
+      sqsClient.sendMessage(queue, "alpakka")
+
+      SqsSource(queue, SqsSourceSettings().withVisibilityTimeout(3))
+        .takeWithin(500.milliseconds)
+        .runWith(Sink.seq)
+        .map(_.map(_.getBody) shouldBe Seq("alpakka"))
     }
   }
 }

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -203,7 +203,6 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
       res.futureValue should have size 100
     }
 
-
     "stream single message twice from the queue when visibility timeout passed" taggedAs Integration in {
       val queue = randomQueueUrl()
       implicit val awsSqsClient = sqsClient

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -112,7 +112,7 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
         .withAttributes(immutable.Seq(SenderId, SentTimestamp))
         .withMessageAttribute(MessageAttributeName.create("bar.*"))
         .withCloseOnEmptyReceive(true)
-        .withVisibilityTimeout(10)
+        .withVisibilityTimeout(10.seconds)
       //#SqsSourceSettings
 
       settings.maxBufferSize should be(100)
@@ -209,7 +209,7 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
 
       sqsClient.sendMessage(queue, "alpakka")
 
-      SqsSource(queue, SqsSourceSettings().withVisibilityTimeout(1))
+      SqsSource(queue, SqsSourceSettings().withVisibilityTimeout(1.second))
         .takeWithin(1500.milliseconds)
         .runWith(Sink.seq)
         .map(_.map(_.getBody) shouldBe Seq("alpakka", "alpakka"))
@@ -221,7 +221,7 @@ class SqsSourceSpec extends AsyncWordSpec with ScalaFutures with Matchers with D
 
       sqsClient.sendMessage(queue, "alpakka")
 
-      SqsSource(queue, SqsSourceSettings().withVisibilityTimeout(3))
+      SqsSource(queue, SqsSourceSettings().withVisibilityTimeout(3.seconds))
         .takeWithin(500.milliseconds)
         .runWith(Sink.seq)
         .map(_.map(_.getBody) shouldBe Seq("alpakka"))


### PR DESCRIPTION
Hi, first time contributing here, so hopefully I didn't miss anything from the instructions.
In addition, I signed the CLA

**Feature**: 
Allow setting the visibility timeout parameter in the SQS `Receive` request.
this means that in each `Receive` request it will override the default visibility timeout from SQS queue configuration. if one will not set it, the default will be taken.

The requirement:
if one knows the maximum time it takes to process a message and want to set it in the application (and not in the SQS queue console) this change will reduce the number of calls. So, instead of 2 calls - `Receive` and `ChangeVisibilityTimeout`, we will just run the `Receive`

We, At the company I'm working for, started a code migration from our old SQS client to Alpakka.
during the migration we found out this issue, which required us to run 2 consecutive calls - receive the message and change the visibility timeout. I think it's an overhead we can reduce.

I added tests dedicate for this feature
Finally, I looked at the issue tracker and PRs and didn't see any comment about this feature.