### PR TITLE
Express the carry type

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/javadsl/Mqtt.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/javadsl/Mqtt.scala
@@ -22,11 +22,11 @@ object Mqtt {
    * @param session the client session to use
    * @return the bidirectional flow
    */
-  def clientSessionFlow(
+  def clientSessionFlow[A](
       session: MqttClientSession
-  ): BidiFlow[Command[_], ByteString, ByteString, DecodeErrorOrEvent, NotUsed] =
+  ): BidiFlow[Command[A], ByteString, ByteString, DecodeErrorOrEvent[A], NotUsed] =
     inputOutputConverter
-      .atop(scaladsl.Mqtt.clientSessionFlow(session.underlying))
+      .atop(scaladsl.Mqtt.clientSessionFlow[A](session.underlying))
       .asJava
 
   /**
@@ -38,20 +38,20 @@ object Mqtt {
    * @param session the server session to use
    * @return the bidirectional flow
    */
-  def serverSessionFlow(
+  def serverSessionFlow[A](
       session: MqttServerSession,
       connectionId: ByteString
-  ): BidiFlow[Command[_], ByteString, ByteString, DecodeErrorOrEvent, NotUsed] =
+  ): BidiFlow[Command[A], ByteString, ByteString, DecodeErrorOrEvent[A], NotUsed] =
     inputOutputConverter
-      .atop(scaladsl.Mqtt.serverSessionFlow(session.underlying, connectionId))
+      .atop(scaladsl.Mqtt.serverSessionFlow[A](session.underlying, connectionId))
       .asJava
 
   /*
    * Converts Java inputs to Scala, and vice-versa.
    */
-  private val inputOutputConverter =
+  private def inputOutputConverter[A] =
     ScalaBidiFlow
-      .fromFunctions[Command[_], Command[_], Either[DecodeError, Event[_]], DecodeErrorOrEvent](
+      .fromFunctions[Command[A], Command[A], Either[DecodeError, Event[A]], DecodeErrorOrEvent[A]](
         identity,
         DecodeErrorOrEvent.apply
       )

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/model.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/model.scala
@@ -1049,8 +1049,9 @@ object Command {
   /**
    * Send a command to an MQTT session
    * @param command The command to send
+   * @tparam A The type of data being carried through in general, but not here
    */
-  def apply(command: ControlPacket): Command[Nothing] =
+  def apply[A](command: ControlPacket): Command[A] =
     new Command(command)
 
   /**
@@ -1106,8 +1107,9 @@ object Event {
   /**
    * Receive an event from a MQTT session
    * @param event The event to receive
+   * @tparam A The type of data being carried through in general, but not here
    */
-  def apply(event: ControlPacket): Event[Nothing] =
+  def apply[A](event: ControlPacket): Event[A] =
     new Event(event)
 
   /**
@@ -1161,14 +1163,14 @@ final case class Event[A](event: ControlPacket, carry: Option[A]) {
 /**
  * JAVA API
  */
-final case class DecodeErrorOrEvent(v: Either[MqttCodec.DecodeError, Event[_]]) {
+final case class DecodeErrorOrEvent[A](v: Either[MqttCodec.DecodeError, Event[A]]) {
   def getDecodeError: Optional[MqttCodec.DecodeError] =
     v match {
       case Right(_) => Optional.empty()
       case Left(de) => Optional.of(de)
     }
 
-  def getEvent: Optional[Event[_]] =
+  def getEvent: Optional[Event[A]] =
     v match {
       case Right(e) => Optional.of(e)
       case Left(_) => Optional.empty()

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/Mqtt.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/Mqtt.scala
@@ -20,9 +20,9 @@ object Mqtt {
    * @param session the MQTT client session to use
    * @return the bidirectional flow
    */
-  def clientSessionFlow(
+  def clientSessionFlow[A](
       session: MqttClientSession
-  ): BidiFlow[Command[_], ByteString, ByteString, Either[MqttCodec.DecodeError, Event[_]], NotUsed] =
+  ): BidiFlow[Command[A], ByteString, ByteString, Either[MqttCodec.DecodeError, Event[A]], NotUsed] =
     BidiFlow.fromFlows(session.commandFlow, session.eventFlow)
 
   /**
@@ -36,9 +36,9 @@ object Mqtt {
    *                     can route the incoming requests
    * @return the bidirectional flow
    */
-  def serverSessionFlow(
+  def serverSessionFlow[A](
       session: MqttServerSession,
       connectionId: ByteString
-  ): BidiFlow[Command[_], ByteString, ByteString, Either[MqttCodec.DecodeError, Event[_]], NotUsed] =
+  ): BidiFlow[Command[A], ByteString, ByteString, Either[MqttCodec.DecodeError, Event[A]], NotUsed] =
     BidiFlow.fromFlows(session.commandFlow(connectionId), session.eventFlow(connectionId))
 }

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -21,10 +21,10 @@ import scala.util.control.NoStackTrace
 
 object MqttSession {
 
-  private[streaming] type CommandFlow =
-    Flow[Command[_], ByteString, NotUsed]
-  private[streaming] type EventFlow =
-    Flow[ByteString, Either[MqttCodec.DecodeError, Event[_]], NotUsed]
+  private[streaming] type CommandFlow[A] =
+    Flow[Command[A], ByteString, NotUsed]
+  private[streaming] type EventFlow[A] =
+    Flow[ByteString, Either[MqttCodec.DecodeError, Event[A]], NotUsed]
 }
 
 /**
@@ -49,12 +49,12 @@ abstract class MqttClientSession extends MqttSession {
   /**
    * @return a flow for commands to be sent to the session
    */
-  private[streaming] def commandFlow: CommandFlow
+  private[streaming] def commandFlow[A]: CommandFlow[A]
 
   /**
    * @return a flow for events to be emitted by the session
    */
-  private[streaming] def eventFlow: EventFlow
+  private[streaming] def eventFlow[A]: EventFlow[A]
 }
 
 object ActorMqttClientSession {
@@ -120,7 +120,7 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
 
   private val pingReqBytes = PingReq.encode(ByteString.newBuilder).result()
 
-  override def commandFlow: CommandFlow =
+  override def commandFlow[A]: CommandFlow[A] =
     Flow[Command[_]]
       .watch(clientConnector.toUntyped)
       .watchTermination() {
@@ -198,7 +198,7 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
         }
       )
 
-  override def eventFlow: EventFlow =
+  override def eventFlow[A]: EventFlow[A] =
     Flow[ByteString]
       .watch(clientConnector.toUntyped)
       .watchTermination() {
@@ -213,7 +213,7 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
           (clientConnector ? (ClientConnector
             .ConnAckReceivedFromRemote(cp, _)): Future[ClientConnector.ForwardConnAck])
             .map {
-              case ClientConnector.ForwardConnAck(carry) => Right[DecodeError, Event[_]](Event(cp, carry))
+              case ClientConnector.ForwardConnAck(carry: A) => Right[DecodeError, Event[A]](Event(cp, carry))
             }
         case Right(cp: SubAck) =>
           (subscriberPacketRouter ? (
@@ -223,7 +223,7 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
                                           .SubAckReceivedFromRemote(replyTo))
           ): Future[Subscriber.ForwardSubAck])
             .map {
-              case Subscriber.ForwardSubAck(carry) => Right[DecodeError, Event[_]](Event(cp, carry))
+              case Subscriber.ForwardSubAck(carry: A) => Right[DecodeError, Event[A]](Event(cp, carry))
             }
         case Right(cp: UnsubAck) =>
           (unsubscriberPacketRouter ? (
@@ -233,12 +233,12 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
                                           .UnsubAckReceivedFromRemote(replyTo))
           ): Future[Unsubscriber.ForwardUnsubAck])
             .map {
-              case Unsubscriber.ForwardUnsubAck(carry) => Right[DecodeError, Event[_]](Event(cp, carry))
+              case Unsubscriber.ForwardUnsubAck(carry: A) => Right[DecodeError, Event[A]](Event(cp, carry))
             }
         case Right(cp: Publish) =>
           (clientConnector ? (ClientConnector
             .PublishReceivedFromRemote(cp, _)): Future[Consumer.ForwardPublish.type])
-            .map(_ => Right[DecodeError, Event[_]](Event(cp)))
+            .map(_ => Right[DecodeError, Event[A]](Event(cp)))
         case Right(cp: PubAck) =>
           (producerPacketRouter ? (
               replyTo =>
@@ -247,7 +247,7 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
                                           .PubAckReceivedFromRemote(replyTo))
           ): Future[Producer.ForwardPubAck])
             .map {
-              case Producer.ForwardPubAck(carry) => Right[DecodeError, Event[_]](Event(cp, carry))
+              case Producer.ForwardPubAck(carry: A) => Right[DecodeError, Event[A]](Event(cp, carry))
             }
         case Right(cp: PubRec) =>
           (producerPacketRouter ? (
@@ -257,7 +257,7 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
                                           .PubRecReceivedFromRemote(replyTo))
           ): Future[Producer.ForwardPubRec])
             .map {
-              case Producer.ForwardPubRec(carry) => Right[DecodeError, Event[_]](Event(cp, carry))
+              case Producer.ForwardPubRec(carry: A) => Right[DecodeError, Event[A]](Event(cp, carry))
             }
         case Right(cp: PubRel) =>
           (consumerPacketRouter ? (
@@ -265,7 +265,7 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
                 RemotePacketRouter.Route(cp.packetId,
                                          Consumer
                                            .PubRelReceivedFromRemote(replyTo))
-          ): Future[Consumer.ForwardPubRel.type]).map(_ => Right[DecodeError, Event[_]](Event(cp)))
+          ): Future[Consumer.ForwardPubRel.type]).map(_ => Right[DecodeError, Event[A]](Event(cp)))
         case Right(cp: PubComp) =>
           (producerPacketRouter ? (
               replyTo =>
@@ -274,11 +274,11 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
                                           .PubCompReceivedFromRemote(replyTo))
           ): Future[Producer.ForwardPubComp])
             .map {
-              case Producer.ForwardPubComp(carry) => Right[DecodeError, Event[_]](Event(cp, carry))
+              case Producer.ForwardPubComp(carry: A) => Right[DecodeError, Event[A]](Event(cp, carry))
             }
         case Right(PingResp) =>
           (clientConnector ? ClientConnector.PingRespReceivedFromRemote: Future[ClientConnector.ForwardPingResp.type])
-            .map(_ => Right[DecodeError, Event[_]](Event(PingResp)))
+            .map(_ => Right[DecodeError, Event[A]](Event(PingResp)))
         case Right(cp) => Future.failed(new IllegalStateException(cp + " is not a client event"))
         case Left(de) => Future.successful(Left(de))
       }
@@ -307,12 +307,12 @@ abstract class MqttServerSession extends MqttSession {
   /**
    * @return a flow for commands to be sent to the session in relation to a connection id
    */
-  private[streaming] def commandFlow(connectionId: ByteString): CommandFlow
+  private[streaming] def commandFlow[A](connectionId: ByteString): CommandFlow[A]
 
   /**
    * @return a flow for events to be emitted by the session in relation t a connection id
    */
-  private[streaming] def eventFlow(connectionId: ByteString): EventFlow
+  private[streaming] def eventFlow[A](connectionId: ByteString): EventFlow[A]
 }
 
 object ActorMqttServerSession {
@@ -393,7 +393,7 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
 
   private val pingRespBytes = PingResp.encode(ByteString.newBuilder).result()
 
-  override def commandFlow(connectionId: ByteString): CommandFlow =
+  override def commandFlow[A](connectionId: ByteString): CommandFlow[A] =
     Flow[Command[_]]
       .watch(serverConnector.toUntyped)
       .watchTermination() {
@@ -463,7 +463,7 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
         }
       )
 
-  override def eventFlow(connectionId: ByteString): EventFlow =
+  override def eventFlow[A](connectionId: ByteString): EventFlow[A] =
     Flow[ByteString]
       .watch(serverConnector.toUntyped)
       .watchTermination() {
@@ -477,19 +477,19 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
         case Right(cp: Connect) =>
           (serverConnector ? (ServerConnector
             .ConnectReceivedFromRemote(connectionId, cp, _)): Future[ClientConnection.ForwardConnect.type])
-            .map(_ => Right[DecodeError, Event[_]](Event(cp)))
+            .map(_ => Right[DecodeError, Event[A]](Event(cp)))
         case Right(cp: Subscribe) =>
           (serverConnector ? (ServerConnector
             .SubscribeReceivedFromRemote(connectionId, cp, _)): Future[Publisher.ForwardSubscribe.type])
-            .map(_ => Right[DecodeError, Event[_]](Event(cp)))
+            .map(_ => Right[DecodeError, Event[A]](Event(cp)))
         case Right(cp: Unsubscribe) =>
           (serverConnector ? (ServerConnector
             .UnsubscribeReceivedFromRemote(connectionId, cp, _)): Future[Unpublisher.ForwardUnsubscribe.type])
-            .map(_ => Right[DecodeError, Event[_]](Event(cp)))
+            .map(_ => Right[DecodeError, Event[A]](Event(cp)))
         case Right(cp: Publish) =>
           (serverConnector ? (ServerConnector
             .PublishReceivedFromRemote(connectionId, cp, _)): Future[Consumer.ForwardPublish.type])
-            .map(_ => Right[DecodeError, Event[_]](Event(cp)))
+            .map(_ => Right[DecodeError, Event[A]](Event(cp)))
         case Right(cp: PubAck) =>
           (producerPacketRouter ? (
               replyTo =>
@@ -498,7 +498,7 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
                                           .PubAckReceivedFromRemote(replyTo))
           ): Future[Producer.ForwardPubAck])
             .map {
-              case Producer.ForwardPubAck(carry) => Right[DecodeError, Event[_]](Event(cp, carry))
+              case Producer.ForwardPubAck(carry: A) => Right[DecodeError, Event[A]](Event(cp, carry))
             }
         case Right(cp: PubRec) =>
           (producerPacketRouter ? (
@@ -508,7 +508,7 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
                                           .PubRecReceivedFromRemote(replyTo))
           ): Future[Producer.ForwardPubRec])
             .map {
-              case Producer.ForwardPubRec(carry) => Right[DecodeError, Event[_]](Event(cp, carry))
+              case Producer.ForwardPubRec(carry: A) => Right[DecodeError, Event[A]](Event(cp, carry))
             }
         case Right(cp: PubRel) =>
           (consumerPacketRouter ? (
@@ -516,7 +516,7 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
                 RemotePacketRouter.Route(cp.packetId,
                                          Consumer
                                            .PubRelReceivedFromRemote(replyTo))
-          ): Future[Consumer.ForwardPubRel.type]).map(_ => Right[DecodeError, Event[_]](Event(cp)))
+          ): Future[Consumer.ForwardPubRel.type]).map(_ => Right[DecodeError, Event[A]](Event(cp)))
         case Right(cp: PubComp) =>
           (producerPacketRouter ? (
               replyTo =>
@@ -525,16 +525,16 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
                                           .PubCompReceivedFromRemote(replyTo))
           ): Future[Producer.ForwardPubComp])
             .map {
-              case Producer.ForwardPubComp(carry) => Right[DecodeError, Event[_]](Event(cp, carry))
+              case Producer.ForwardPubComp(carry: A) => Right[DecodeError, Event[A]](Event(cp, carry))
             }
         case Right(PingReq) =>
           (serverConnector ? (ServerConnector
             .PingReqReceivedFromRemote(connectionId, _)): Future[ClientConnection.ForwardPingReq.type])
-            .map(_ => Right[DecodeError, Event[_]](Event(PingReq)))
+            .map(_ => Right[DecodeError, Event[A]](Event(PingReq)))
         case Right(Disconnect) =>
           (serverConnector ? (ServerConnector
             .DisconnectReceivedFromRemote(connectionId, _)): Future[ClientConnection.ForwardDisconnect.type])
-            .map(_ => Right[DecodeError, Event[_]](Event(Disconnect)))
+            .map(_ => Right[DecodeError, Event[A]](Event(Disconnect)))
         case Right(cp) => Future.failed(new IllegalStateException(cp + " is not a server event"))
         case Left(de) => Future.successful(Left(de))
       }

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -42,7 +42,7 @@ class MqttFlowSpec
 
       val connection = Tcp().outgoingConnection("localhost", 1883)
 
-      val mqttFlow: Flow[Command[_], Either[MqttCodec.DecodeError, Event[_]], NotUsed] =
+      val mqttFlow: Flow[Command[Nothing], Either[MqttCodec.DecodeError, Event[Nothing]], NotUsed] =
         Mqtt
           .clientSessionFlow(session)
           .join(connection)
@@ -87,13 +87,13 @@ class MqttFlowSpec
           .bind(host, port)
           .flatMapMerge(
             maxConnections, { connection =>
-              val mqttFlow: Flow[Command[_], Either[MqttCodec.DecodeError, Event[_]], NotUsed] =
+              val mqttFlow: Flow[Command[Nothing], Either[MqttCodec.DecodeError, Event[Nothing]], NotUsed] =
                 Mqtt
                   .serverSessionFlow(session, ByteString(connection.remoteAddress.getAddress.getAddress))
                   .join(connection.flow)
 
               val (queue, source) = Source
-                .queue[Command[_]](3, OverflowStrategy.dropHead)
+                .queue[Command[Nothing]](3, OverflowStrategy.dropHead)
                 .via(mqttFlow)
                 .toMat(BroadcastHub.sink)(Keep.both)
                 .run()

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -413,7 +413,7 @@ class MqttSessionSpec
           .queue(1, OverflowStrategy.fail)
           .via(
             Mqtt
-              .clientSessionFlow(session)
+              .clientSessionFlow[String](session)
               .join(pipeToServer)
           )
           .drop(1)
@@ -539,7 +539,7 @@ class MqttSessionSpec
           .queue(1, OverflowStrategy.fail)
           .via(
             Mqtt
-              .clientSessionFlow(session)
+              .clientSessionFlow[String](session)
               .join(pipeToServer)
           )
           .drop(2)
@@ -746,7 +746,7 @@ class MqttSessionSpec
 
       val (server, result) =
         Source
-          .queue[Command[_]](1, OverflowStrategy.fail)
+          .queue[Command[Nothing]](1, OverflowStrategy.fail)
           .via(
             Mqtt
               .serverSessionFlow(session, ByteString.empty)
@@ -840,7 +840,7 @@ class MqttSessionSpec
 
       val (server, result) =
         Source
-          .queue[Command[_]](1, OverflowStrategy.fail)
+          .queue[Command[Nothing]](1, OverflowStrategy.fail)
           .via(
             Mqtt
               .serverSessionFlow(session, ByteString.empty)
@@ -1007,7 +1007,7 @@ class MqttSessionSpec
 
       val (server, result) =
         Source
-          .queue[Command[_]](1, OverflowStrategy.fail)
+          .queue[Command[Nothing]](1, OverflowStrategy.fail)
           .via(
             Mqtt
               .serverSessionFlow(session, ByteString(connectionId.getAndIncrement()))


### PR DESCRIPTION
This ensures that the client code usage is nicer, and tighter, when working with the carry object. The Java API is more affected that the Scala API. The Scala API is hardly affected at all, and where it is requires substituting `Command[_]` and `Event[_]` with `Command[Nothing]` and `Event[Nothing]` respectively (unless you have a carry, where then you provide its type instead of `Nothing`).

There's a problem here though, with Java and its non-ability to express parameterised classes given type erasure etc. etc. i.e.:

```java
Pair<
        SourceQueueWithComplete<Command<Object>>,
        Source<DecodeErrorOrEvent<Object>, NotUsed>>
    run =
        Source.<Command<Object>>queue(2, OverflowStrategy.dropHead())
            .via(mqttFlow)
            .toMat(BroadcastHub.of(DecodeErrorOrEvent.class), Keep.both())
            .run(materializer);
```

...is a problem given that I'm unable to create the `BroadcastHub.of` that I want. How do we work around this in Java? Ideally, you'd be able to state, `BroadcastHub.of(DecodeErrorOrEvent<Object>.class)`, but you can't - and I understand why. So, how do we cater for this?

Incidentally, [someone else had exactly this issue with Java Akka streams](https://groups.google.com/forum/#!searchin/akka-user/class$20cast%7Csort:date/akka-user/DVpN4OUCEjc/M9JLSyUlCgAJ).

I've got a feeling that I've worked around this before, and there was even an Akka utility to help me, I just don't recall where/what right now... Any help is appreciated. Thanks!