### PR TITLE
Solr: Routing value for atomic update becomes optional

### DIFF
--- a/docs/src/main/paradox/solr.md
+++ b/docs/src/main/paradox/solr.md
@@ -133,6 +133,8 @@ Java
 
 We can use typed and bean to update atomically.
 
+If a collection contains a router field, we have to use the IncomingAtomicUpdateMessage with the router field parameter.
+
 ### Delete documents by ids
 
 We can delete documents by ids.

--- a/solr/src/main/scala/akka/stream/alpakka/solr/SolrFlowStage.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/SolrFlowStage.scala
@@ -63,9 +63,14 @@ object IncomingMessage {
 
   def create[T](idField: String,
                 idValue: String,
-                routingFieldValueOpt: Option[String],
+                routingFieldValue: String,
                 updates: java.util.Map[String, Map[String, Object]]): IncomingMessage[T, NotUsed] =
-    IncomingMessage(idField, idValue, routingFieldValueOpt, updates.asScala.toMap)
+    IncomingMessage(idField, idValue, Option(routingFieldValue), updates.asScala.toMap)
+
+  def create[T](idField: String,
+                idValue: String,
+                updates: java.util.Map[String, Map[String, Object]]): IncomingMessage[T, NotUsed] =
+    IncomingMessage(idField, idValue, None, updates.asScala.toMap)
 
   // Java-api - with passThrough
   def create[T, C](source: T, passThrough: C): IncomingMessage[T, C] =
@@ -76,10 +81,16 @@ object IncomingMessage {
 
   def create[T, C](idField: String,
                    idValue: String,
-                   routingFieldValueOpt: Option[String],
+                   routingFieldValue: String,
                    updates: java.util.Map[String, Map[String, Object]],
                    passThrough: C): IncomingMessage[T, C] =
-    IncomingMessage(idField, idValue, routingFieldValueOpt, updates.asScala.toMap, passThrough)
+    IncomingMessage(idField, idValue, Option(routingFieldValue), updates.asScala.toMap, passThrough)
+
+  def create[T, C](idField: String,
+                   idValue: String,
+                   updates: java.util.Map[String, Map[String, Object]],
+                   passThrough: C): IncomingMessage[T, C] =
+    IncomingMessage(idField, idValue, None, updates.asScala.toMap, passThrough)
 
   def asScalaUpdates(jupdates: java.util.Map[String, java.util.Map[String, Object]]): Map[String, Map[String, Any]] =
     jupdates.asScala.map {

--- a/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java
+++ b/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java
@@ -427,7 +427,7 @@ public class SolrTest {
                   m2.put("set", (t.fields.get("comment") + " It's is a good book!!!"));
                   m1.put("comment", m2);
                   return IncomingAtomicUpdateMessage.<SolrInputDocument>create(
-                      "title", t.fields.get("title").toString(), "comment", m1);
+                      "title", t.fields.get("title").toString(), m1);
                 })
             .groupedWithin(5, Duration.ofMillis(10))
             .runWith(

--- a/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java
+++ b/solr/src/test/java/akka/stream/alpakka/solr/SolrTest.java
@@ -61,6 +61,8 @@ public class SolrTest {
 
     public String comment;
 
+    public String router;
+
     public Book() {}
 
     public Book(String title) {
@@ -71,6 +73,12 @@ public class SolrTest {
       this.title = title;
       this.comment = comment;
     }
+
+    public Book(String title, String comment, String router) {
+      this.title = title;
+      this.comment = comment;
+      this.router = router;
+    }
   }
 
   Function<Book, SolrInputDocument> bookToDoc =
@@ -78,6 +86,7 @@ public class SolrTest {
         SolrInputDocument doc = new SolrInputDocument();
         doc.setField("title", book.title);
         doc.setField("comment", book.comment);
+        if (book.router != null) doc.setField("router", book.router);
         return doc;
       };
 
@@ -465,6 +474,80 @@ public class SolrTest {
   }
 
   @Test
+  public void atomicUpdateDocumentsWithRouter() throws Exception {
+    // Copy collection1 to collection2 through document stream
+    createCollection("collection8-1", "router"); // create a new collection
+    TupleStream stream = getTupleStream("collection1");
+
+    SolrUpdateSettings settings = SolrUpdateSettings.create().withCommitWithin(5);
+    CompletionStage<Done> f1 =
+        SolrSource.fromTupleStream(stream)
+            .map(
+                tuple -> {
+                  Book book =
+                      new Book(
+                          tupleToBook.apply(tuple).title,
+                          "Written by good authors.",
+                          "router-value");
+                  SolrInputDocument doc = bookToDoc.apply(book);
+                  return IncomingUpsertMessage.create(doc);
+                })
+            .groupedWithin(5, Duration.ofMillis(10))
+            .runWith(
+                SolrSink.documents("collection8-1", settings, cluster.getSolrClient()),
+                materializer);
+
+    f1.toCompletableFuture().get();
+
+    TupleStream stream2 = getTupleStream("collection8-1");
+
+    CompletionStage<Done> res2 =
+        SolrSource.fromTupleStream(stream2)
+            .map(
+                t -> {
+                  Map<String, Map<String, Object>> m1 = new HashMap<>();
+                  Map<String, Object> m2 = new HashMap<>();
+                  m2.put("set", (t.fields.get("comment") + " It's is a good book!!!"));
+                  m1.put("comment", m2);
+                  return IncomingAtomicUpdateMessage.<SolrInputDocument>create(
+                      "title", t.fields.get("title").toString(), "router-value", m1);
+                })
+            .groupedWithin(5, Duration.ofMillis(10))
+            .runWith(
+                SolrSink.documents("collection8-1", settings, cluster.getSolrClient()),
+                materializer);
+
+    res2.toCompletableFuture().get();
+
+    cluster.getSolrClient().commit("collection8-1");
+
+    TupleStream stream3 = getTupleStream("collection8-1");
+
+    CompletionStage<List<String>> res3 =
+        SolrSource.fromTupleStream(stream3)
+            .map(
+                t -> {
+                  Book b = tupleToBook.apply(t);
+                  return b.title + ". " + b.comment;
+                })
+            .runWith(Sink.seq(), materializer);
+
+    List<String> result = new ArrayList<>(res3.toCompletableFuture().get());
+
+    List<String> expect =
+        Arrays.asList(
+            "Akka Concurrency. Written by good authors. It's is a good book!!!",
+            "Akka in Action. Written by good authors. It's is a good book!!!",
+            "Effective Akka. Written by good authors. It's is a good book!!!",
+            "Learning Scala. Written by good authors. It's is a good book!!!",
+            "Programming in Scala. Written by good authors. It's is a good book!!!",
+            "Scala Puzzlers. Written by good authors. It's is a good book!!!",
+            "Scala for Spark in Production. Written by good authors. It's is a good book!!!");
+
+    assertEquals(expect, result);
+  }
+
+  @Test
   public void deleteDocumentsByQuery() throws Exception {
     // Copy collection1 to collection2 through document stream
     createCollection("collection9"); // create a new collection
@@ -599,7 +682,7 @@ public class SolrTest {
     ((ZkClientClusterStateProvider) cluster.getSolrClient().getClusterStateProvider())
         .uploadConfig(confDir.toPath(), "conf");
 
-    cluster.getSolrClient().setIdField("title");
+    cluster.getSolrClient().setIdField("router");
     createCollection("collection1");
 
     assertTrue(
@@ -608,6 +691,13 @@ public class SolrTest {
 
   private static void createCollection(String name) throws IOException, SolrServerException {
     CollectionAdminRequest.createCollection(name, "conf", 1, 1).process(cluster.getSolrClient());
+  }
+
+  private static void createCollection(String name, String router)
+      throws IOException, SolrServerException {
+    CollectionAdminRequest.createCollection(name, "conf", 1, 1)
+        .setRouterField(router)
+        .process(cluster.getSolrClient());
   }
 
   private TupleStream getTupleStream(String collection) throws IOException {

--- a/solr/src/test/resources/conf/schema.xml
+++ b/solr/src/test/resources/conf/schema.xml
@@ -51,6 +51,7 @@
 
     <field name="_version_" type="long" indexed="true" stored="true"/>
     <field name="title" type="string" docValues="true" multiValued="false" indexed="true" stored="true"/>
+    <field name="router" type="string" docValues="false" multiValued="false" indexed="false" stored="false"/>
     <field name="comment" type="string" docValues="true" multiValued="false" indexed="false" stored="true"/>
 
     <uniqueKey>title</uniqueKey>

--- a/solr/src/test/scala/akka/stream/alpakka/solr/SolrSpec.scala
+++ b/solr/src/test/scala/akka/stream/alpakka/solr/SolrSpec.scala
@@ -7,7 +7,6 @@ package akka.stream.alpakka.solr
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.solr.scaladsl.{SolrFlow, SolrSink, SolrSource}
@@ -429,7 +428,7 @@ class SolrSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
           IncomingAtomicUpdateMessage[SolrInputDocument](
             "title",
             tuple.fields.get("title").toString,
-            tuple.fields.get("title").toString,
+            None,
             Map("comment" -> Map("set" -> (tuple.fields.get("comment") + " It is a good book!!!")))
           )
         }
@@ -564,7 +563,7 @@ class SolrSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
           IncomingAtomicUpdateMessage[Book](
             "title",
             tuple.fields.get("title").toString,
-            tuple.fields.get("title").toString,
+            None,
             Map("comment" -> Map("set" -> (tuple.fields.get("comment") + " It is a good book!!!")))
           )
         }

--- a/solr/src/test/scala/akka/stream/alpakka/solr/SolrSpec.scala
+++ b/solr/src/test/scala/akka/stream/alpakka/solr/SolrSpec.scala
@@ -41,12 +41,15 @@ class SolrSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
 
   //#init-client
   //#define-class
-  case class Book(title: String, comment: String = "")
+  case class Book(title: String, comment: String = "", routerOpt: Option[String] = None)
 
   val bookToDoc: Book => SolrInputDocument = { b =>
     val doc = new SolrInputDocument
     doc.setField("title", b.title)
     doc.setField("comment", b.comment)
+    b.routerOpt.foreach { router =>
+      doc.setField("router", router)
+    }
     doc
   }
 
@@ -533,13 +536,14 @@ class SolrSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
   "Solr connector" should {
     "consume and update atomically beans" in {
       // Copy collection1 to collection2 through document stream
-      createCollection("collection10") //create a new collection
+      createCollection("collection10", Some("router")) //create a new collection
       val stream = getTupleStream("collection1")
 
       val f1 = SolrSource
         .fromTupleStream(ts = stream)
         .map { tuple: Tuple =>
-          val book: Book = tupleToBook(tuple).copy(comment = "Written by good authors.")
+          val book: Book =
+            tupleToBook(tuple).copy(comment = "Written by good authors.", routerOpt = Some("router-value"))
           IncomingUpsertMessage(book)
         }
         .groupedWithin(5, new FiniteDuration(10, TimeUnit.MILLISECONDS))
@@ -563,7 +567,7 @@ class SolrSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
           IncomingAtomicUpdateMessage[Book](
             "title",
             tuple.fields.get("title").toString,
-            None,
+            Some("router-value"),
             Map("comment" -> Map("set" -> (tuple.fields.get("comment") + " It is a good book!!!")))
           )
         }
@@ -709,16 +713,17 @@ class SolrSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
     client.getClusterStateProvider
       .asInstanceOf[ZkClientClusterStateProvider]
       .uploadConfig(confDir.toPath, "conf")
-    client.setIdField("title")
+    client.setIdField("router")
 
     createCollection("collection1")
 
     assertTrue(!client.getZkStateReader.getClusterState.getLiveNodes.isEmpty)
   }
 
-  private def createCollection(name: String) =
+  private def createCollection(name: String, routerFieldOpt: Option[String] = None) =
     CollectionAdminRequest
       .createCollection(name, "conf", 1, 1)
+      .setRouterField(routerFieldOpt.orNull)
       .process(client)
 
   private def getTupleStream(collection: String): TupleStream = {


### PR DESCRIPTION
On atomic update, the routing value is required when there is a routing field configured on the server (implicit routing). With the compositeId routing, this routing value is not needed.
https://lucene.apache.org/solr/guide/7_5/shards-and-indexing-data-in-solrcloud.html#document-routing