### PR TITLE
Elasticsearch: failStage should happen when shouldRetry returns false

### DIFF
--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
@@ -62,7 +62,7 @@ private[elasticsearch] final class ElasticsearchFlowStage[T, C](
 
       private def handleFailure(args: (Seq[WriteMessage[T, C]], Throwable)): Unit = {
         val (messages, exception) = args
-        if (settings.retryLogic.shouldRetry(retryCount, List(exception.toString))) {
+        if (!settings.retryLogic.shouldRetry(retryCount, List(exception.toString))) {
           log.error("Received error from elastic. Giving up after {} tries. {}, Error: {}",
                     retryCount,
                     settings.retryLogic,


### PR DESCRIPTION
Fixes #1300 
note: I am considering adding a test for this case, however it proved to be not as straightforward as the fix itself 😄 
Opening PR in case it is acceptable to get the merge without it, will continue looking into creating a test in any case - as part of this PR or a separate one.