### PR TITLE
MQTT streaming: Retire ask in favour of promise

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/MqttSessionSettings.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/MqttSessionSettings.scala
@@ -31,7 +31,6 @@ object MqttSessionSettings {
 final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
                                          val maxClientConnectionStashSize: Int = 100,
                                          val clientTerminationWatcherBufferSize: Int = 100,
-                                         val actorMqttSessionTimeout: FiniteDuration = 3.seconds,
                                          val commandParallelism: Int = 50,
                                          val eventParallelism: Int = 10,
                                          val receiveConnectTimeout: FiniteDuration = 5.minutes,
@@ -56,20 +55,6 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
    * The maximum size of a packet that is allowed to be decoded. Defaults to 4k.
    */
   def withMaxPacketSize(maxPacketSize: Int): MqttSessionSettings = copy(maxPacketSize = maxPacketSize)
-
-  /**
-   * An internal timeout for session actor communication. Its default of 3 seconds should be more than adequate for all use-cases.
-   */
-  def withActorMqttSessionTimeout(actorMqttSessionTimeout: FiniteDuration): MqttSessionSettings =
-    copy(actorMqttSessionTimeout = actorMqttSessionTimeout)
-
-  /**
-   * Java API
-   *
-   * An internal timeout for session actor communication. Its default of 3 seconds should be more than adequate for all use-cases.
-   */
-  def withActorMqttSessionTimeout(actorMqttSessionTimeout: Duration): MqttSessionSettings =
-    copy(actorMqttSessionTimeout = actorMqttSessionTimeout.asScala)
 
   /**
    * The number of commands that can be processed at a time, with a default of 50. For client usage, note that each
@@ -222,7 +207,6 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
   private def copy(maxPacketSize: Int = maxPacketSize,
                    maxClientConnectionStashSize: Int = maxClientConnectionStashSize,
                    clientTerminationWatcherBufferSize: Int = clientTerminationWatcherBufferSize,
-                   actorMqttSessionTimeout: FiniteDuration = actorMqttSessionTimeout,
                    commandParallelism: Int = commandParallelism,
                    eventParallelism: Int = eventParallelism,
                    receiveConnectTimeout: FiniteDuration = receiveConnectTimeout,
@@ -237,7 +221,6 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
       maxPacketSize,
       maxClientConnectionStashSize,
       clientTerminationWatcherBufferSize,
-      actorMqttSessionTimeout,
       commandParallelism,
       eventParallelism,
       receiveConnectTimeout,
@@ -251,5 +234,5 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
     )
 
   override def toString: String =
-    s"MqttSessionSettings(maxPacketSize=$maxPacketSize,maxClientConnectionStashSize=$maxClientConnectionStashSize,clientTerminationWatcherBufferSize=$clientTerminationWatcherBufferSize,actorMqttSessionTimeout=$actorMqttSessionTimeout,commandParallelism=$commandParallelism,eventParallelism=$eventParallelism,receiveConnectTimeout=$receiveConnectTimeout,receiveConnAckTimeout=$receiveConnAckTimeout,receivePubAckRecTimeout=$receivePubAckRecTimeout,receivePubCompTimeout=$receivePubCompTimeout,receivePubRelTimeout=$receivePubRelTimeout,receiveSubAckTimeout=$receiveSubAckTimeout,receiveUnsubAckTimeout=$receiveUnsubAckTimeout,serverSendBufferSize=$serverSendBufferSize)"
+    s"MqttSessionSettings(maxPacketSize=$maxPacketSize,maxClientConnectionStashSize=$maxClientConnectionStashSize,clientTerminationWatcherBufferSize=$clientTerminationWatcherBufferSize,commandParallelism=$commandParallelism,eventParallelism=$eventParallelism,receiveConnectTimeout=$receiveConnectTimeout,receiveConnAckTimeout=$receiveConnAckTimeout,receivePubAckRecTimeout=$receivePubAckRecTimeout,receivePubCompTimeout=$receivePubCompTimeout,receivePubRelTimeout=$receivePubRelTimeout,receiveSubAckTimeout=$receiveSubAckTimeout,receiveUnsubAckTimeout=$receiveUnsubAckTimeout,serverSendBufferSize=$serverSendBufferSize)"
 }

--- a/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/RequestStateSpec.scala
+++ b/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/RequestStateSpec.scala
@@ -6,11 +6,13 @@ package akka.stream.alpakka.mqtt.streaming
 package impl
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 
+import scala.concurrent.Promise
 import scala.concurrent.duration._
 
-class RequestStateSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+class RequestStateSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
 
   val testKit = ActorTestKit()
   override def afterAll(): Unit = testKit.shutdownTestKit()
@@ -18,50 +20,63 @@ class RequestStateSpec extends WordSpec with Matchers with BeforeAndAfterAll {
   "local packet router" should {
     "acquire a packet id" in {
       val registrant = testKit.createTestProbe[String]()
-      val replyTo = testKit.createTestProbe[LocalPacketRouter.Registered]()
+      val reply = Promise[LocalPacketRouter.Registered]()
       val router = testKit.spawn(LocalPacketRouter[String])
-      router ! LocalPacketRouter.Register(registrant.ref, replyTo.ref)
-      replyTo.expectMessage(LocalPacketRouter.Registered(PacketId(1)))
+      router ! LocalPacketRouter.Register(registrant.ref, reply)
+      reply.future.futureValue shouldBe LocalPacketRouter.Registered(PacketId(1))
     }
 
     "acquire two packet ids" in {
       val registrant = testKit.createTestProbe[String]()
-      val replyTo = testKit.createTestProbe[LocalPacketRouter.Registered]()
+      val reply1 = Promise[LocalPacketRouter.Registered]
+      val reply2 = Promise[LocalPacketRouter.Registered]
       val router = testKit.spawn(LocalPacketRouter[String])
-      router ! LocalPacketRouter.Register(registrant.ref, replyTo.ref)
-      router ! LocalPacketRouter.Register(registrant.ref, replyTo.ref)
-      replyTo.expectMessage(LocalPacketRouter.Registered(PacketId(1)))
-      replyTo.expectMessage(LocalPacketRouter.Registered(PacketId(2)))
+      router ! LocalPacketRouter.Register(registrant.ref, reply1)
+      router ! LocalPacketRouter.Register(registrant.ref, reply2)
+      reply1.future.futureValue shouldBe LocalPacketRouter.Registered(PacketId(1))
+      reply2.future.futureValue shouldBe LocalPacketRouter.Registered(PacketId(2))
     }
 
     "acquire and release consecutive packet ids" in {
       val registrant = testKit.createTestProbe[String]()
-      val replyTo = testKit.createTestProbe[LocalPacketRouter.Registered]()
+      val reply1 = Promise[LocalPacketRouter.Registered]
+      val reply2 = Promise[LocalPacketRouter.Registered]
+      val reply3 = Promise[LocalPacketRouter.Registered]
+      val reply4 = Promise[LocalPacketRouter.Registered]
       val router = testKit.spawn(LocalPacketRouter[String])
 
-      router ! LocalPacketRouter.Register(registrant.ref, replyTo.ref)
-      router ! LocalPacketRouter.Register(registrant.ref, replyTo.ref)
-      replyTo.expectMessage(LocalPacketRouter.Registered(PacketId(1)))
-      replyTo.expectMessage(LocalPacketRouter.Registered(PacketId(2)))
+      router ! LocalPacketRouter.Register(registrant.ref, reply1)
+      router ! LocalPacketRouter.Register(registrant.ref, reply2)
+      reply1.future.futureValue shouldBe LocalPacketRouter.Registered(PacketId(1))
+      reply2.future.futureValue shouldBe LocalPacketRouter.Registered(PacketId(2))
 
       router ! LocalPacketRouter.Unregister(PacketId(1))
-      router ! LocalPacketRouter.Register(registrant.ref, replyTo.ref)
-      replyTo.expectMessage(LocalPacketRouter.Registered(PacketId(3)))
+      router ! LocalPacketRouter.Register(registrant.ref, reply3)
+      reply3.future.futureValue shouldBe LocalPacketRouter.Registered(PacketId(3))
 
       router ! LocalPacketRouter.Unregister(PacketId(2))
       router ! LocalPacketRouter.Unregister(PacketId(3))
-      router ! LocalPacketRouter.Register(registrant.ref, replyTo.ref)
-      replyTo.expectMessage(LocalPacketRouter.Registered(PacketId(1)))
+      router ! LocalPacketRouter.Register(registrant.ref, reply4)
+      reply4.future.futureValue shouldBe LocalPacketRouter.Registered(PacketId(1))
     }
 
     "route a packet" in {
       val registrant = testKit.createTestProbe[String]()
-      val replyTo = testKit.createTestProbe[LocalPacketRouter.Registered]()
+      val reply = Promise[LocalPacketRouter.Registered]()
       val router = testKit.spawn(LocalPacketRouter[String])
-      router ! LocalPacketRouter.Register(registrant.ref, replyTo.ref)
-      val registered = replyTo.expectMessageType[LocalPacketRouter.Registered]
-      router ! LocalPacketRouter.Route(registered.packetId, "some-packet")
+      router ! LocalPacketRouter.Register(registrant.ref, reply)
+      val registered = reply.future.futureValue
+      val failureReply = Promise[String]
+      router ! LocalPacketRouter.Route(registered.packetId, "some-packet", failureReply)
       registrant.expectMessage("some-packet")
+      failureReply.future.isCompleted shouldBe false
+    }
+
+    "fail to route a packet" in {
+      val reply = Promise[LocalPacketRouter.Registered]()
+      val router = testKit.spawn(LocalPacketRouter[String])
+      router ! LocalPacketRouter.Route(PacketId(1), "some-packet", reply)
+      reply.future.failed.futureValue shouldBe LocalPacketRouter.CannotRoute
     }
   }
 
@@ -71,17 +86,21 @@ class RequestStateSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       val packetId = PacketId(1)
 
       val registrant = testKit.createTestProbe[String]()
-      val replyTo = testKit.createTestProbe[RemotePacketRouter.Registered.type]()
+      val registerReply = Promise[RemotePacketRouter.Registered.type]()
+      val failureReply1 = Promise[String]
+      val failureReply2 = Promise[String]
       val router = testKit.spawn(RemotePacketRouter[String])
 
-      router ! RemotePacketRouter.Register(registrant.ref, packetId, replyTo.ref)
-      replyTo.expectMessage(RemotePacketRouter.Registered)
+      router ! RemotePacketRouter.Register(registrant.ref, packetId, registerReply)
+      registerReply.future.futureValue shouldBe RemotePacketRouter.Registered
 
-      router ! RemotePacketRouter.Route(packetId, "some-packet")
+      router ! RemotePacketRouter.Route(packetId, "some-packet", failureReply1)
       registrant.expectMessage("some-packet")
+      failureReply1.future.isCompleted shouldBe false
 
       router ! RemotePacketRouter.Unregister(packetId)
-      router ! RemotePacketRouter.Route(packetId, "some-packet")
+      router ! RemotePacketRouter.Route(packetId, "some-packet", failureReply2)
+      failureReply2.future.failed.futureValue shouldBe RemotePacketRouter.CannotRoute
       registrant.expectNoMessage(1.second)
 
     }


### PR DESCRIPTION
The ask pattern is overkill for situations where there is a strong coupling between one actor and another, as is the case between an MQTT session and its many command and event flows. For instance, if an MQTT session actor is lost for any reason, then its associated flows will also be failed. In this scenario, where a flow notifies the session of, say, an event having been received, it is effectively “calling” the session actor as per a function call, but using a message. The request is effectively synchronous in nature (although there is no blocking of course). The session actor must promise to yield a result, no matter what. Not yielding a result is a bug.

As such, we can use promises instead of the ask pattern for tightly coupled callers calling on actors. This then yields the advantage that request/reply timeouts do not have to be considered. Indeed, a strong motivation for the retirement of ask here is that it is difficult to determine a default timeout value. The performance of the MQTT session on a single core processor with memory constraints is quite different to that of a quad core with enormous amounts of memory. Timeouts perhaps make more sense when considering networks, where request/reply is required instead of a synchronous one.

Thanks to @longshorej for motivating this change and his thoughts on when to use the synchronous call pattern in place of ask.