### PR TITLE
AWS S3: make path-style access default (#1152)

### DIFF
--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -69,10 +69,10 @@ akka.stream.alpakka.s3 {
   }
 
   # Enable path style access to s3, i.e. "https://s3-eu-west-1.amazonaws.com/my.bucket/myobject"
-  # Default is virtual-hosted style.
+  # Set to false to enable virtual-hosted style.
   # When using virtual hosted–style buckets with SSL, the S3 wild card certificate only matches buckets that do not contain periods.
   # Buckets containing periods will lead to certificate errors. In those cases it's useful to enable path-style access.
-  path-style-access = false
+  path-style-access = true
 
   # Custom endpoint url, used for alternate s3 implementations
   # endpoint-url = null

--- a/s3/src/test/resources/application.conf
+++ b/s3/src/test/resources/application.conf
@@ -19,7 +19,7 @@ aws {
       credentials.provider = anon
       default-region = "us-east-1"
     }
-    path-style-access = false
+    path-style-access = true
   }
 }
 


### PR DESCRIPTION
Make path-style access default for S3.

* just a small config change, fixes #1152

Please review.