### PR TITLE
MQTT streaming: Handle connect while connected

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -559,6 +559,40 @@ import scala.util.{Failure, Success}
                 data.settings
               )
             )
+          case (context, ConnectReceivedFromRemote(connect, local))
+              if connect.connectFlags.contains(ConnectFlags.CleanSession) =>
+            context.children.foreach(context.stop)
+            clientConnect(
+              ConnectReceived(
+                connect,
+                local,
+                Set.empty,
+                Vector.empty,
+                Vector.empty,
+                Vector.empty,
+                data.consumerPacketRouter,
+                data.producerPacketRouter,
+                data.publisherPacketRouter,
+                data.unpublisherPacketRouter,
+                data.settings
+              )
+            )
+          case (_, ConnectReceivedFromRemote(connect, local)) =>
+            clientConnect(
+              ConnectReceived(
+                connect,
+                local,
+                data.publishers,
+                data.pendingLocalPublications,
+                data.pendingRemotePublications,
+                Vector.empty,
+                data.consumerPacketRouter,
+                data.producerPacketRouter,
+                data.publisherPacketRouter,
+                data.unpublisherPacketRouter,
+                data.settings
+              )
+            )
         }
         .receiveSignal {
           case (_, _: Terminated) =>


### PR DESCRIPTION
A situation can occur where a CONNECT is received by the MQTT server while in a state of already being connected. In this case, we need to process the new CONNECT i.e. CONNACK it etc.

Thanks to @longshorej for discovering the issue and providing the remedy.