### PR TITLE
Avro Parquet -  AvroParquetSinkTest.createNewParquetFile #1316

### DIFF
--- a/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java
+++ b/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java
@@ -25,6 +25,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import static junit.framework.TestCase.assertEquals;
 
 // #init-writer
@@ -61,7 +65,7 @@ public class AvroParquetSinkTest {
   }
 
   @Test
-  public void createNewParquetFile() throws InterruptedException, IOException {
+  public void createNewParquetFile() throws InterruptedException, IOException, TimeoutException, ExecutionException {
     // #init-writer
     Configuration conf = new Configuration();
     conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, true);
@@ -78,9 +82,9 @@ public class AvroParquetSinkTest {
     Sink<GenericRecord, CompletionStage<Done>> sink = AvroParquetSink.create(writer);
     // #init-sink
 
-    Source.from(records).runWith(sink, materializer);
+    CompletionStage<Done> finish = Source.from(records).runWith(sink, materializer);
 
-    Thread.sleep(1000);
+    finish.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
     assertEquals(records.size(), checkResponse());
   }


### PR DESCRIPTION
File was zero size because ParquetWriter was not closed. 

It was happened due to the one of two options:

-  Either  `Source.from(records).runWith(sink, materializer)` took more then 1 sec.
-  There was an uncaught exception in Sink.    

Anyway, I removed `Thread,sleep` method. At least we will get more clear exception next time. 