### PR TITLE
WIP - DO NOT MERGE - Avoid a race condition when creating child actors

### DIFF
--- a/docs/src/main/paradox/mqtt-streaming.md
+++ b/docs/src/main/paradox/mqtt-streaming.md
@@ -10,7 +10,7 @@ Further information on [mqtt.org](https://mqtt.org/).
 
 @@@ note { title="Paho Differences" }
 
-Alpakka contains @ref[another MQTT connector](mqtt.md) which is based on the Eclipse Paho client. Unlike the Paho version, this library has no dependencies other than those of Akka Streams i.e. it is entirely reactive. As such, there should be a significant performance advantage given its pure-Akka foundations, particularly in terms of memory usage given its diligent use of threads.
+Alpakka contains @ref[another MQTT connector](mqtt.md) which is based on the Eclipse Paho client. Unlike the Paho version, this library has no dependencies other than those of Akka Streams i.e. it is entirely reactive. As such, there should be a significant performance advantage given its pure-Akka foundations in terms of memory usage given its diligent use of threads.
 
 This library also differs in that it separates out the concern of how MQTT is connected. Unlike Paho, where TCP is assumed, this library can join in any flow. The end result is that by using this library, Unix Domain Sockets, TCP, UDP or anything else can be used to transport MQTT.
 
@@ -51,8 +51,12 @@ Scala
 Java
 : @@snip [snip](/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java) { #run-streaming-flow }
 
-We drop the first 3 events received as they will be ACKs to our connect, subscribe and publish. The next event
-received is the publication to the topic we just subscribed to.
+Note that the `Publish` command is not offered to the command flow given MQTT QoS requirements. Instead, the 
+session is told to perform `Publish` given that it can retry continuously with buffering until a command 
+flow is established.
+
+We filter the events received as there will be ACKs to our connect, subscribe and publish. The collected event
+is the publication to the topic we just subscribed to.
 
 ## Flow through a server session
 
@@ -66,7 +70,9 @@ Java
 
 The resulting source's type shows how `Event`s are received and `Command`s are queued in reply. Our example
 acknowledges a connection, subscription and publication. Upon receiving a publication, it is re-published
-from the server so that any client that is subscribed will receive it.
+from the server so that any client that is subscribed will receive it. An addition detail is that we hold
+off re-publishing until we have a subscription from the client. Note also how the session is told to perform
+`Publish` commands directly as they will be broadcast to all clients subscribed to the topic.
 
 Run the flow:
 

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -89,6 +89,8 @@ import scala.util.{Failure, Success}
       connectFlags: ConnectFlags,
       keepAlive: FiniteDuration,
       pendingPingResp: Boolean,
+      activeConsumers: Set[String],
+      activeProducers: Set[String],
       pendingLocalPublications: Seq[(String, PublishReceivedLocally)],
       pendingRemotePublications: Seq[(String, PublishReceivedFromRemote)],
       remote: SourceQueueWithComplete[ForwardConnectCommand],
@@ -210,6 +212,8 @@ import scala.util.{Failure, Success}
                 data.connect.connectFlags,
                 data.connect.keepAlive,
                 pendingPingResp = false,
+                Set.empty,
+                Set.empty,
                 Vector.empty,
                 Vector.empty,
                 data.remote,
@@ -284,27 +288,26 @@ import scala.util.{Failure, Success}
             local.success(Consumer.ForwardPublish)
             serverConnected(data)
           case (context, prfr @ PublishReceivedFromRemote(publish @ Publish(_, topicName, Some(packetId), _), local)) =>
-            val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName)
-            context.child(consumerName) match {
-              case None if !data.pendingRemotePublications.exists(_._1 == publish.topicName) =>
-                context.watchWith(
-                  context.spawn(
-                    Consumer(publish, packetId, local, data.consumerPacketRouter, data.settings),
-                    consumerName
-                  ),
-                  ConsumerFree(publish.topicName)
-                )
-                serverConnected(data)
-              case _ =>
-                serverConnected(
-                  data.copy(pendingRemotePublications = data.pendingRemotePublications :+ (publish.topicName -> prfr))
-                )
+            if (!data.activeConsumers.contains(topicName)) {
+              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + context.children.size)
+              context.watchWith(
+                context.spawn(
+                  Consumer(publish, packetId, local, data.consumerPacketRouter, data.settings),
+                  consumerName
+                ),
+                ConsumerFree(publish.topicName)
+              )
+              serverConnected(data.copy(activeConsumers = data.activeConsumers + publish.topicName))
+            } else {
+              serverConnected(
+                data.copy(pendingRemotePublications = data.pendingRemotePublications :+ (publish.topicName -> prfr))
+              )
             }
           case (context, ConsumerFree(topicName)) =>
             val i = data.pendingRemotePublications.indexWhere(_._1 == topicName)
             if (i >= 0) {
               val prfr = data.pendingRemotePublications(i)._2
-              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName)
+              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + context.children.size)
               context.watchWith(
                 context.spawn(
                   Consumer(prfr.publish,
@@ -323,35 +326,34 @@ import scala.util.{Failure, Success}
                 )
               )
             } else {
-              serverConnected(data)
+              serverConnected(data.copy(activeConsumers = data.activeConsumers - topicName))
             }
           case (_, PublishReceivedLocally(publish, _))
               if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 =>
             data.remote.offer(ForwardPublish(publish, None))
             serverConnected(data)
           case (context, prl @ PublishReceivedLocally(publish, publishData)) =>
-            val producerName = ActorName.mkName(ProducerNamePrefix + publish.topicName)
-            context.child(producerName) match {
-              case None if !data.pendingLocalPublications.exists(_._1 == publish.topicName) =>
-                val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
-                import context.executionContext
-                reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
-                context.watchWith(
-                  context.spawn(Producer(publish, publishData, reply, data.producerPacketRouter, data.settings),
-                                producerName),
-                  ProducerFree(publish.topicName)
-                )
-                serverConnected(data)
-              case _ =>
-                serverConnected(
-                  data.copy(pendingLocalPublications = data.pendingLocalPublications :+ (publish.topicName -> prl))
-                )
+            val producerName = ActorName.mkName(ProducerNamePrefix + publish.topicName + context.children.size)
+            if (!data.activeProducers.contains(publish.topicName)) {
+              val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
+              import context.executionContext
+              reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
+              context.watchWith(
+                context.spawn(Producer(publish, publishData, reply, data.producerPacketRouter, data.settings),
+                              producerName),
+                ProducerFree(publish.topicName)
+              )
+              serverConnected(data.copy(activeProducers = data.activeProducers + publish.topicName))
+            } else {
+              serverConnected(
+                data.copy(pendingLocalPublications = data.pendingLocalPublications :+ (publish.topicName -> prl))
+              )
             }
           case (context, ProducerFree(topicName)) =>
             val i = data.pendingLocalPublications.indexWhere(_._1 == topicName)
             if (i >= 0) {
               val prl = data.pendingLocalPublications(i)._2
-              val producerName = ActorName.mkName(ProducerNamePrefix + topicName)
+              val producerName = ActorName.mkName(ProducerNamePrefix + topicName + context.children.size)
               val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
               import context.executionContext
               reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
@@ -369,7 +371,7 @@ import scala.util.{Failure, Success}
                 )
               )
             } else {
-              serverConnected(data)
+              serverConnected(data.copy(activeProducers = data.activeProducers - topicName))
             }
           case (_, ReceivedProducerPublishingCommand(command)) =>
             command.runWith(Sink.foreach {

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -10,7 +10,7 @@ import akka.actor.typed.{ActorRef, Behavior, PostStop, Terminated}
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import akka.annotation.InternalApi
 import akka.stream.{Materializer, OverflowStrategy}
-import akka.stream.scaladsl.{BroadcastHub, Keep, Source, SourceQueueWithComplete}
+import akka.stream.scaladsl.{BroadcastHub, Keep, Sink, Source, SourceQueueWithComplete}
 
 import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
@@ -117,13 +117,12 @@ import scala.util.{Failure, Success}
   final case class PublishReceivedFromRemote(publish: Publish, local: Promise[Consumer.ForwardPublish.type])
       extends Event
   final case class ConsumerFree(topicName: String) extends Event
-  final case class PublishReceivedLocally(publish: Publish,
-                                          publishData: Producer.PublishData,
-                                          remote: Promise[Source[Producer.ForwardPublishingCommand, NotUsed]])
-      extends Event
+  final case class PublishReceivedLocally(publish: Publish, publishData: Producer.PublishData) extends Event
   final case class ProducerFree(topicName: String) extends Event
   case object SendPingReqTimeout extends Event
   final case class PingRespReceivedFromRemote(local: Promise[ForwardPingResp.type]) extends Event
+  final case class ReceivedProducerPublishingCommand(command: Source[Producer.ForwardPublishingCommand, NotUsed])
+      extends Event
   final case class UnsubscribeReceivedLocally(unsubscribe: Unsubscribe,
                                               unsubscribeData: Unsubscriber.UnsubscribeData,
                                               remote: Promise[Unsubscriber.ForwardUnsubscribe])
@@ -133,6 +132,8 @@ import scala.util.{Failure, Success}
   sealed abstract class ForwardConnectCommand
   case object ForwardConnect extends ForwardConnectCommand
   case object ForwardPingReq extends ForwardConnectCommand
+  final case class ForwardPublish(publish: Publish, packetId: Option[PacketId]) extends ForwardConnectCommand
+  final case class ForwardPubRel(packetId: PacketId) extends ForwardConnectCommand
   final case class ForwardConnAck(connectData: ConnectData) extends Command
   case object ForwardDisconnect extends Command
   case object ForwardPingResp extends Command
@@ -318,16 +319,19 @@ import scala.util.{Failure, Success}
             } else {
               serverConnected(data)
             }
-          case (_, PublishReceivedLocally(publish, _, remote))
+          case (_, PublishReceivedLocally(publish, _))
               if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 =>
-            remote.success(Source.single(Producer.ForwardPublish(publish, None)))
+            data.remote.offer(ForwardPublish(publish, None))
             serverConnected(data)
-          case (context, prl @ PublishReceivedLocally(publish, publishData, remote)) =>
+          case (context, prl @ PublishReceivedLocally(publish, publishData)) =>
             val producerName = ActorName.mkName(ProducerNamePrefix + publish.topicName)
             context.child(producerName) match {
               case None if !data.pendingLocalPublications.exists(_._1 == publish.topicName) =>
+                val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
+                import context.executionContext
+                reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
                 context.watchWith(
-                  context.spawn(Producer(publish, publishData, remote, data.producerPacketRouter, data.settings),
+                  context.spawn(Producer(publish, publishData, reply, data.producerPacketRouter, data.settings),
                                 producerName),
                   ProducerFree(publish.topicName)
                 )
@@ -342,9 +346,12 @@ import scala.util.{Failure, Success}
             if (i >= 0) {
               val prl = data.pendingLocalPublications(i)._2
               val producerName = ActorName.mkName(ProducerNamePrefix + topicName)
+              val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
+              import context.executionContext
+              reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
               context.watchWith(
                 context.spawn(
-                  Producer(prl.publish, prl.publishData, prl.remote, data.producerPacketRouter, data.settings),
+                  Producer(prl.publish, prl.publishData, reply, data.producerPacketRouter, data.settings),
                   producerName
                 ),
                 ProducerFree(topicName)
@@ -358,6 +365,12 @@ import scala.util.{Failure, Success}
             } else {
               serverConnected(data)
             }
+          case (_, ReceivedProducerPublishingCommand(command)) =>
+            command.runWith(Sink.foreach {
+              case Producer.ForwardPublish(publish, packetId) => data.remote.offer(ForwardPublish(publish, packetId))
+              case Producer.ForwardPubRel(_, packetId) => data.remote.offer(ForwardPubRel(packetId))
+            })
+            Behaviors.same
           case (context, SendPingReqTimeout) if data.pendingPingResp =>
             data.remote.fail(PingFailed)
             disconnect(context, data.connectFlags, data.remote, data)

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -214,6 +214,8 @@ import scala.util.{Failure, Success}
         connect,
         local,
         Set.empty,
+        Set.empty,
+        Set.empty,
         Vector.empty,
         Vector.empty,
         Vector.empty,
@@ -236,6 +238,8 @@ import scala.util.{Failure, Success}
       connect: Connect,
       local: Promise[ForwardConnect.type],
       publishers: Set[String],
+      activeConsumers: Set[String],
+      activeProducers: Set[String],
       pendingLocalPublications: Seq[(String, PublishReceivedLocally)],
       pendingRemotePublications: Seq[(String, PublishReceivedFromRemote)],
       stash: Seq[Event],
@@ -249,6 +253,8 @@ import scala.util.{Failure, Success}
       connect: Connect,
       remote: SourceQueueWithComplete[ForwardConnAckCommand],
       publishers: Set[String],
+      activeConsumers: Set[String],
+      activeProducers: Set[String],
       pendingLocalPublications: Seq[(String, PublishReceivedLocally)],
       pendingRemotePublications: Seq[(String, PublishReceivedFromRemote)],
       override val consumerPacketRouter: ActorRef[RemotePacketRouter.Request[Consumer.Event]],
@@ -262,6 +268,8 @@ import scala.util.{Failure, Success}
       connect: Connect,
       remote: SourceQueueWithComplete[ForwardConnAckCommand],
       publishers: Set[String],
+      activeConsumers: Set[String],
+      activeProducers: Set[String],
       pendingLocalPublications: Seq[(String, PublishReceivedLocally)],
       pendingRemotePublications: Seq[(String, PublishReceivedFromRemote)],
       stash: Seq[Event],
@@ -273,6 +281,8 @@ import scala.util.{Failure, Success}
   ) extends Data(consumerPacketRouter, producerPacketRouter, publisherPacketRouter, unpublisherPacketRouter, settings)
   final case class Disconnected(
       publishers: Set[String],
+      activeConsumers: Set[String],
+      activeProducers: Set[String],
       pendingLocalPublications: Seq[(String, PublishReceivedLocally)],
       pendingRemotePublications: Seq[(String, PublishReceivedFromRemote)],
       override val consumerPacketRouter: ActorRef[RemotePacketRouter.Request[Consumer.Event]],
@@ -347,6 +357,8 @@ import scala.util.{Failure, Success}
                 data.connect,
                 queue,
                 data.publishers,
+                data.activeConsumers,
+                data.activeProducers,
                 data.pendingLocalPublications,
                 data.pendingRemotePublications,
                 data.consumerPacketRouter,
@@ -392,6 +404,8 @@ import scala.util.{Failure, Success}
                     data.connect,
                     data.remote,
                     data.publishers,
+                    data.activeConsumers,
+                    data.activeProducers,
                     data.pendingLocalPublications,
                     data.pendingRemotePublications,
                     Vector.empty,
@@ -426,29 +440,28 @@ import scala.util.{Failure, Success}
           case (_, PublishReceivedFromRemote(publish, local))
               if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 =>
             local.success(Consumer.ForwardPublish)
-            Behaviors.same
+            clientConnected(data)
           case (context, prfr @ PublishReceivedFromRemote(publish @ Publish(_, topicName, Some(packetId), _), local)) =>
-            val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName)
-            context.child(consumerName) match {
-              case None if !data.pendingRemotePublications.exists(_._1 == publish.topicName) =>
-                context.watchWith(
-                  context.spawn(
-                    Consumer(publish, packetId, local, data.consumerPacketRouter, data.settings),
-                    consumerName
-                  ),
-                  ConsumerFree(publish.topicName)
-                )
-                clientConnected(data)
-              case _ =>
-                clientConnected(
-                  data.copy(pendingRemotePublications = data.pendingRemotePublications :+ (publish.topicName -> prfr))
-                )
+            if (!data.activeConsumers.contains(topicName)) {
+              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + context.children.size)
+              context.watchWith(
+                context.spawn(
+                  Consumer(publish, packetId, local, data.consumerPacketRouter, data.settings),
+                  consumerName
+                ),
+                ConsumerFree(publish.topicName)
+              )
+              clientConnected(data.copy(activeConsumers = data.activeConsumers + publish.topicName))
+            } else {
+              clientConnected(
+                data.copy(pendingRemotePublications = data.pendingRemotePublications :+ (publish.topicName -> prfr))
+              )
             }
           case (context, ConsumerFree(topicName)) =>
             val i = data.pendingRemotePublications.indexWhere(_._1 == topicName)
             if (i >= 0) {
               val prfr = data.pendingRemotePublications(i)._2
-              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName)
+              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + context.children.size)
               context.watchWith(
                 context.spawn(
                   Consumer(prfr.publish,
@@ -467,39 +480,34 @@ import scala.util.{Failure, Success}
                 )
               )
             } else {
-              clientConnected(data)
+              clientConnected(data.copy(activeConsumers = data.activeConsumers - topicName))
             }
           case (_, PublishReceivedLocally(publish, _))
-              if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 &&
-              data.publishers.exists(matchTopicFilter(_, publish.topicName)) =>
+              if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 =>
             data.remote.offer(ForwardPublish(publish, None))
             clientConnected(data)
-          case (context, prl @ PublishReceivedLocally(publish, publishData))
-              if data.publishers.exists(matchTopicFilter(_, publish.topicName)) =>
-            val producerName = ActorName.mkName(ProducerNamePrefix + publish.topicName)
-            context.child(producerName) match {
-              case None if !data.pendingLocalPublications.exists(_._1 == publish.topicName) =>
-                val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
-                import context.executionContext
-                reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
-                context.watchWith(
-                  context.spawn(
-                    Producer(publish, publishData, reply, data.producerPacketRouter, data.settings),
-                    producerName
-                  ),
-                  ProducerFree(publish.topicName)
-                )
-                clientConnected(data)
-              case _ =>
-                clientConnected(
-                  data.copy(pendingLocalPublications = data.pendingLocalPublications :+ (publish.topicName -> prl))
-                )
+          case (context, prl @ PublishReceivedLocally(publish, publishData)) =>
+            val producerName = ActorName.mkName(ProducerNamePrefix + publish.topicName + context.children.size)
+            if (!data.activeProducers.contains(publish.topicName)) {
+              val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
+              import context.executionContext
+              reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
+              context.watchWith(
+                context.spawn(Producer(publish, publishData, reply, data.producerPacketRouter, data.settings),
+                              producerName),
+                ProducerFree(publish.topicName)
+              )
+              clientConnected(data.copy(activeProducers = data.activeProducers + publish.topicName))
+            } else {
+              clientConnected(
+                data.copy(pendingLocalPublications = data.pendingLocalPublications :+ (publish.topicName -> prl))
+              )
             }
           case (context, ProducerFree(topicName)) =>
             val i = data.pendingLocalPublications.indexWhere(_._1 == topicName)
             if (i >= 0) {
               val prl = data.pendingLocalPublications(i)._2
-              val producerName = ActorName.mkName(ProducerNamePrefix + topicName)
+              val producerName = ActorName.mkName(ProducerNamePrefix + topicName + context.children.size)
               val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
               import context.executionContext
               reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
@@ -517,7 +525,7 @@ import scala.util.{Failure, Success}
                 )
               )
             } else {
-              clientConnected(data)
+              clientConnected(data.copy(activeProducers = data.activeProducers - topicName))
             }
           case (_, ReceivedProducerPublishingCommand(command)) =>
             command.runWith(Sink.foreach {
@@ -534,6 +542,8 @@ import scala.util.{Failure, Success}
             clientDisconnected(
               Disconnected(
                 data.publishers,
+                data.activeConsumers,
+                data.activeProducers,
                 data.pendingLocalPublications,
                 data.pendingRemotePublications,
                 data.consumerPacketRouter,
@@ -548,6 +558,8 @@ import scala.util.{Failure, Success}
             clientDisconnected(
               Disconnected(
                 data.publishers,
+                data.activeConsumers,
+                data.activeProducers,
                 data.pendingLocalPublications,
                 data.pendingRemotePublications,
                 data.consumerPacketRouter,
@@ -565,6 +577,8 @@ import scala.util.{Failure, Success}
                 connect,
                 local,
                 Set.empty,
+                Set.empty,
+                Set.empty,
                 Vector.empty,
                 Vector.empty,
                 Vector.empty,
@@ -581,6 +595,8 @@ import scala.util.{Failure, Success}
                 connect,
                 local,
                 data.publishers,
+                data.activeConsumers,
+                data.activeProducers,
                 data.pendingLocalPublications,
                 data.pendingRemotePublications,
                 Vector.empty,
@@ -616,6 +632,8 @@ import scala.util.{Failure, Success}
               data.remote,
               data.publishers ++ (if (t.failure.contains(Publisher.SubscribeFailed)) Vector.empty
                                   else data.subscribe.topicFilters.map(_._1)),
+              data.activeConsumers,
+              data.activeProducers,
               data.pendingLocalPublications,
               data.pendingRemotePublications,
               data.consumerPacketRouter,
@@ -644,6 +662,8 @@ import scala.util.{Failure, Success}
                 connect,
                 local,
                 Set.empty,
+                Set.empty,
+                Set.empty,
                 Vector.empty,
                 Vector.empty,
                 Vector.empty,
@@ -660,6 +680,8 @@ import scala.util.{Failure, Success}
                 connect,
                 local,
                 data.publishers,
+                data.activeConsumers,
+                data.activeProducers,
                 data.pendingLocalPublications,
                 data.pendingRemotePublications,
                 Vector.empty,

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -89,10 +89,8 @@ import scala.util.{Failure, Success}
                                              publish: Publish,
                                              local: Promise[Consumer.ForwardPublish.type])
       extends Event(connectionId)
-  final case class PublishReceivedLocally(override val connectionId: ByteString,
-                                          publish: Publish,
-                                          publishData: Producer.PublishData)
-      extends Event(connectionId)
+  final case class PublishReceivedLocally(publish: Publish, publishData: Producer.PublishData)
+      extends Event(ByteString.empty)
   final case class UnsubscribeReceivedFromRemote(override val connectionId: ByteString,
                                                  unsubscribe: Unsubscribe,
                                                  local: Promise[Unpublisher.ForwardUnsubscribe.type])
@@ -153,7 +151,7 @@ import scala.util.{Failure, Success}
           forward(connectionId, data.clientConnections, ClientConnection.SubscribeReceivedFromRemote(subscribe, local))
         case (_, PublishReceivedFromRemote(connectionId, publish, local)) =>
           forward(connectionId, data.clientConnections, ClientConnection.PublishReceivedFromRemote(publish, local))
-        case (_, PublishReceivedLocally(_, publish, publishData)) =>
+        case (_, PublishReceivedLocally(publish, publishData)) =>
           data.clientConnections.values.foreach {
             case (_, cc) => cc ! ClientConnection.PublishReceivedLocally(publish, publishData)
           }

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/javadsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/javadsl/MqttSession.scala
@@ -24,6 +24,15 @@ import akka.stream.javadsl.Source
 abstract class MqttSession {
 
   /**
+   * Tell the session to perform a command regardless of the state it is
+   * in. This is important for sending Publish messages in particular,
+   * as a connection may not have been established with a session.
+   * @param cp The command to perform
+   * @tparam A The type of any carry for the command.
+   */
+  def tell[A](cp: Command[A]): Unit
+
+  /**
    * Shutdown the session gracefully
    */
   def shutdown(): Unit
@@ -34,6 +43,9 @@ abstract class MqttSession {
  */
 abstract class MqttClientSession extends MqttSession {
   protected[javadsl] val underlying: ScalaMqttClientSession
+
+  override def tell[A](cp: Command[A]): Unit =
+    underlying ! cp
 
   override def shutdown(): Unit =
     underlying.shutdown()
@@ -75,6 +87,9 @@ abstract class MqttServerSession extends MqttSession {
    * Used to observe client connections being terminated
    */
   def watchClientSessions: Source[ClientSessionTerminated, NotUsed]
+
+  override def tell[A](cp: Command[A]): Unit =
+    underlying ! cp
 
   override def shutdown(): Unit =
     underlying.shutdown()

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -359,7 +359,6 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
   override def ![A](cp: Command[A]): Unit = cp match {
     case Command(cp: Publish, carry) =>
       serverConnector ! ServerConnector.PublishReceivedLocally(cp, carry)
-      Source.empty
     case c: Command[_] => throw new IllegalStateException(c + " is not a server command that can be sent directly")
   }
 

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -124,8 +124,6 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
 
   import system.dispatcher
 
-  def send[A](cp: Publish, carry: Option[A]): Unit =
-    tell(Command(cp, carry))
   override def ![A](cp: Command[A]): Unit = cp match {
     case Command(cp: Publish, carry) =>
       clientConnector ! ClientConnector.PublishReceivedLocally(cp, carry)

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -40,7 +40,7 @@ abstract class MqttSession {
    * @tparam A The type of any carry for the command.
    */
   final def tell[A](cp: Command[A]): Unit =
-    this.![A](cp)
+    this ! cp
 
   /**
    * Tell the session to perform a command regardless of the state it is

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -127,7 +127,6 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
   override def ![A](cp: Command[A]): Unit = cp match {
     case Command(cp: Publish, carry) =>
       clientConnector ! ClientConnector.PublishReceivedLocally(cp, carry)
-      Source.empty
     case c: Command[_] => throw new IllegalStateException(c + " is not a client command that can be sent directly")
   }
 

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -84,7 +84,7 @@ class MqttSessionSpec
       server.expectMsg(subscribeBytes)
       server.reply(subAckBytes)
 
-      client.offer(Command(publish))
+      session ! Command(publish)
 
       server.expectMsg(publishBytes)
       server.reply(pubAckBytes)
@@ -397,7 +397,7 @@ class MqttSessionSpec
       server.expectMsg(connectBytes)
       server.reply(connAckBytes)
 
-      client.offer(Command(publish))
+      session ! Command(publish)
 
       server.expectMsg(publishBytes)
     }
@@ -436,7 +436,7 @@ class MqttSessionSpec
       server.expectMsg(connectBytes)
       server.reply(connAckBytes)
 
-      client.offer(Command(publish, carry))
+      session ! Command(publish, carry)
 
       server.expectMsg(publishBytes)
       server.reply(pubAckBytes)
@@ -476,8 +476,8 @@ class MqttSessionSpec
       server.expectMsg(connectBytes)
       server.reply(connAckBytes)
 
-      client.offer(Command(publish))
-      client.offer(Command(publish))
+      session ! Command(publish)
+      session ! Command(publish)
 
       server.expectMsg(publishBytes)
       server.reply(pubAckBytes)
@@ -520,7 +520,7 @@ class MqttSessionSpec
       server.expectMsg(connectBytes)
       server.reply(connAckBytes)
 
-      client.offer(Command(publish))
+      session ! Command(publish)
 
       server.expectMsg(publishBytes)
       server.reply(connAckBytes) // It doesn't matter what the message is - our test machinery here just wants a reply
@@ -566,7 +566,7 @@ class MqttSessionSpec
       server.expectMsg(connectBytes)
       server.reply(connAckBytes)
 
-      client.offer(Command(publish, carry))
+      session ! Command(publish, carry)
 
       server.expectMsg(publishBytes)
       server.reply(pubRecBytes)
@@ -802,7 +802,7 @@ class MqttSessionSpec
       server.offer(Command(pubAck))
       client.expectMsg(pubAckBytes)
 
-      server.offer(Command(publish))
+      session ! Command(publish)
       client.expectMsg(publishBytes)
 
       fromClientQueue.offer(unsubscribeBytes)
@@ -1077,7 +1077,7 @@ class MqttSessionSpec
       server.offer(Command(pubAck))
       client.expectMsg(pubAckBytes)
 
-      server.offer(Command(publish))
+      session ! Command(publish)
       client.expectMsg(publishBytes)
     }
 


### PR DESCRIPTION
This PR requires https://github.com/akka/alpakka/pull/1315 to be merged and then re-basing. For now, review just the [last commit](https://github.com/akka/alpakka/pull/1320/commits/f6477c4c33177f8c28226d35906ac40af0bbc060).

We observed an `InvalidActorNameException` when creating child actors under load. This could have been due to the following sequence when receiving a “Publish Received Locally” message:

1. prl received, producer actor created
2. producer actor terminates and sends a termination message
3. prl received before termination message is received, the parent actor creates another producer
4. the termination message is received and then attempts to create another producer with the same name

The solution is to explicitly track active consumers and producers rather than rely on another data structure such as `context.children`, which will be updated in response to other events.
