### PR TITLE
WIP - DO NOT MERGE - Corrected misinterpretation of behaviour setup

### DIFF
--- a/docs/src/main/paradox/mqtt-streaming.md
+++ b/docs/src/main/paradox/mqtt-streaming.md
@@ -10,7 +10,7 @@ Further information on [mqtt.org](https://mqtt.org/).
 
 @@@ note { title="Paho Differences" }
 
-Alpakka contains @ref[another MQTT connector](mqtt.md) which is based on the Eclipse Paho client. Unlike the Paho version, this library has no dependencies other than those of Akka Streams i.e. it is entirely reactive. As such, there should be a significant performance advantage given its pure-Akka foundations, particularly in terms of memory usage given its diligent use of threads.
+Alpakka contains @ref[another MQTT connector](mqtt.md) which is based on the Eclipse Paho client. Unlike the Paho version, this library has no dependencies other than those of Akka Streams i.e. it is entirely reactive. As such, there should be a significant performance advantage given its pure-Akka foundations in terms of memory usage given its diligent use of threads.
 
 This library also differs in that it separates out the concern of how MQTT is connected. Unlike Paho, where TCP is assumed, this library can join in any flow. The end result is that by using this library, Unix Domain Sockets, TCP, UDP or anything else can be used to transport MQTT.
 
@@ -51,8 +51,12 @@ Scala
 Java
 : @@snip [snip](/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java) { #run-streaming-flow }
 
-We drop the first 3 events received as they will be ACKs to our connect, subscribe and publish. The next event
-received is the publication to the topic we just subscribed to.
+Note that the `Publish` command is not offered to the command flow given MQTT QoS requirements. Instead, the 
+session is told to perform `Publish` given that it can retry continuously with buffering until a command 
+flow is established.
+
+We filter the events received as there will be ACKs to our connect, subscribe and publish. The collected event
+is the publication to the topic we just subscribed to.
 
 ## Flow through a server session
 
@@ -66,7 +70,9 @@ Java
 
 The resulting source's type shows how `Event`s are received and `Command`s are queued in reply. Our example
 acknowledges a connection, subscription and publication. Upon receiving a publication, it is re-published
-from the server so that any client that is subscribed will receive it.
+from the server so that any client that is subscribed will receive it. An addition detail is that we hold
+off re-publishing until we have a subscription from the client. Note also how the session is told to perform
+`Publish` commands directly as they will be broadcast to all clients subscribed to the topic.
 
 Run the flow:
 

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -10,7 +10,7 @@ import akka.actor.typed.{ActorRef, Behavior, PostStop, Terminated}
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import akka.annotation.InternalApi
 import akka.stream.{Materializer, OverflowStrategy}
-import akka.stream.scaladsl.{BroadcastHub, Keep, Source, SourceQueueWithComplete}
+import akka.stream.scaladsl.{BroadcastHub, Keep, Sink, Source, SourceQueueWithComplete}
 
 import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
@@ -117,13 +117,12 @@ import scala.util.{Failure, Success}
   final case class PublishReceivedFromRemote(publish: Publish, local: Promise[Consumer.ForwardPublish.type])
       extends Event
   final case class ConsumerFree(topicName: String) extends Event
-  final case class PublishReceivedLocally(publish: Publish,
-                                          publishData: Producer.PublishData,
-                                          remote: Promise[Source[Producer.ForwardPublishingCommand, NotUsed]])
-      extends Event
+  final case class PublishReceivedLocally(publish: Publish, publishData: Producer.PublishData) extends Event
   final case class ProducerFree(topicName: String) extends Event
   case object SendPingReqTimeout extends Event
   final case class PingRespReceivedFromRemote(local: Promise[ForwardPingResp.type]) extends Event
+  final case class ReceivedProducerPublishingCommand(command: Source[Producer.ForwardPublishingCommand, NotUsed])
+      extends Event
   final case class UnsubscribeReceivedLocally(unsubscribe: Unsubscribe,
                                               unsubscribeData: Unsubscriber.UnsubscribeData,
                                               remote: Promise[Unsubscriber.ForwardUnsubscribe])
@@ -133,6 +132,8 @@ import scala.util.{Failure, Success}
   sealed abstract class ForwardConnectCommand
   case object ForwardConnect extends ForwardConnectCommand
   case object ForwardPingReq extends ForwardConnectCommand
+  final case class ForwardPublish(publish: Publish, packetId: Option[PacketId]) extends ForwardConnectCommand
+  final case class ForwardPubRel(packetId: PacketId) extends ForwardConnectCommand
   final case class ForwardConnAck(connectData: ConnectData) extends Command
   case object ForwardDisconnect extends Command
   case object ForwardPingResp extends Command
@@ -318,16 +319,19 @@ import scala.util.{Failure, Success}
             } else {
               serverConnected(data)
             }
-          case (_, PublishReceivedLocally(publish, _, remote))
+          case (_, PublishReceivedLocally(publish, _))
               if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 =>
-            remote.success(Source.single(Producer.ForwardPublish(publish, None)))
+            data.remote.offer(ForwardPublish(publish, None))
             serverConnected(data)
-          case (context, prl @ PublishReceivedLocally(publish, publishData, remote)) =>
+          case (context, prl @ PublishReceivedLocally(publish, publishData)) =>
             val producerName = ActorName.mkName(ProducerNamePrefix + publish.topicName)
             context.child(producerName) match {
               case None if !data.pendingLocalPublications.exists(_._1 == publish.topicName) =>
+                val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
+                import context.executionContext
+                reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
                 context.watchWith(
-                  context.spawn(Producer(publish, publishData, remote, data.producerPacketRouter, data.settings),
+                  context.spawn(Producer(publish, publishData, reply, data.producerPacketRouter, data.settings),
                                 producerName),
                   ProducerFree(publish.topicName)
                 )
@@ -342,9 +346,12 @@ import scala.util.{Failure, Success}
             if (i >= 0) {
               val prl = data.pendingLocalPublications(i)._2
               val producerName = ActorName.mkName(ProducerNamePrefix + topicName)
+              val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
+              import context.executionContext
+              reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
               context.watchWith(
                 context.spawn(
-                  Producer(prl.publish, prl.publishData, prl.remote, data.producerPacketRouter, data.settings),
+                  Producer(prl.publish, prl.publishData, reply, data.producerPacketRouter, data.settings),
                   producerName
                 ),
                 ProducerFree(topicName)
@@ -358,6 +365,12 @@ import scala.util.{Failure, Success}
             } else {
               serverConnected(data)
             }
+          case (_, ReceivedProducerPublishingCommand(command)) =>
+            command.runWith(Sink.foreach {
+              case Producer.ForwardPublish(publish, packetId) => data.remote.offer(ForwardPublish(publish, packetId))
+              case Producer.ForwardPubRel(_, packetId) => data.remote.offer(ForwardPubRel(packetId))
+            })
+            Behaviors.same
           case (context, SendPingReqTimeout) if data.pendingPingResp =>
             data.remote.fail(PingFailed)
             disconnect(context, data.connectFlags, data.remote, data)

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -325,7 +325,7 @@ import scala.util.{Failure, Success}
   private val UnpublisherNamePrefix = "unpublisher-"
 
   def clientConnect(data: ConnectReceived)(implicit mat: Materializer): Behavior[Event] = Behaviors.setup { _ =>
-    data.local.success(ForwardConnect)
+    data.local.trySuccess(ForwardConnect)
 
     Behaviors.withTimers { timer =>
       timer.startSingleTimer("receive-connack", ReceiveConnAckTimeout, data.settings.receiveConnAckTimeout)

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -89,10 +89,8 @@ import scala.util.{Failure, Success}
                                              publish: Publish,
                                              local: Promise[Consumer.ForwardPublish.type])
       extends Event(connectionId)
-  final case class PublishReceivedLocally(override val connectionId: ByteString,
-                                          publish: Publish,
-                                          publishData: Producer.PublishData)
-      extends Event(connectionId)
+  final case class PublishReceivedLocally(publish: Publish, publishData: Producer.PublishData)
+      extends Event(ByteString.empty)
   final case class UnsubscribeReceivedFromRemote(override val connectionId: ByteString,
                                                  unsubscribe: Unsubscribe,
                                                  local: Promise[Unpublisher.ForwardUnsubscribe.type])
@@ -153,7 +151,7 @@ import scala.util.{Failure, Success}
           forward(connectionId, data.clientConnections, ClientConnection.SubscribeReceivedFromRemote(subscribe, local))
         case (_, PublishReceivedFromRemote(connectionId, publish, local)) =>
           forward(connectionId, data.clientConnections, ClientConnection.PublishReceivedFromRemote(publish, local))
-        case (_, PublishReceivedLocally(_, publish, publishData)) =>
+        case (_, PublishReceivedLocally(publish, publishData)) =>
           data.clientConnections.values.foreach {
             case (_, cc) => cc ! ClientConnection.PublishReceivedLocally(publish, publishData)
           }

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/javadsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/javadsl/MqttSession.scala
@@ -24,6 +24,15 @@ import akka.stream.javadsl.Source
 abstract class MqttSession {
 
   /**
+   * Tell the session to perform a command regardless of the state it is
+   * in. This is important for sending Publish messages in particular,
+   * as a connection may not have been established with a session.
+   * @param cp The command to perform
+   * @tparam A The type of any carry for the command.
+   */
+  def tell[A](cp: Command[A]): Unit
+
+  /**
    * Shutdown the session gracefully
    */
   def shutdown(): Unit
@@ -34,6 +43,9 @@ abstract class MqttSession {
  */
 abstract class MqttClientSession extends MqttSession {
   protected[javadsl] val underlying: ScalaMqttClientSession
+
+  override def tell[A](cp: Command[A]): Unit =
+    underlying ! cp
 
   override def shutdown(): Unit =
     underlying.shutdown()
@@ -75,6 +87,9 @@ abstract class MqttServerSession extends MqttSession {
    * Used to observe client connections being terminated
    */
   def watchClientSessions: Source[ClientSessionTerminated, NotUsed]
+
+  override def tell[A](cp: Command[A]): Unit =
+    underlying ! cp
 
   override def shutdown(): Unit =
     underlying.shutdown()

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -359,7 +359,6 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
   override def ![A](cp: Command[A]): Unit = cp match {
     case Command(cp: Publish, carry) =>
       serverConnector ! ServerConnector.PublishReceivedLocally(cp, carry)
-      Source.empty
     case c: Command[_] => throw new IllegalStateException(c + " is not a server command that can be sent directly")
   }
 

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -124,8 +124,6 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
 
   import system.dispatcher
 
-  def send[A](cp: Publish, carry: Option[A]): Unit =
-    tell(Command(cp, carry))
   override def ![A](cp: Command[A]): Unit = cp match {
     case Command(cp: Publish, carry) =>
       clientConnector ! ClientConnector.PublishReceivedLocally(cp, carry)

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -40,7 +40,7 @@ abstract class MqttSession {
    * @tparam A The type of any carry for the command.
    */
   final def tell[A](cp: Command[A]): Unit =
-    this.![A](cp)
+    this ! cp
 
   /**
    * Tell the session to perform a command regardless of the state it is

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -127,7 +127,6 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
   override def ![A](cp: Command[A]): Unit = cp match {
     case Command(cp: Publish, carry) =>
       clientConnector ! ClientConnector.PublishReceivedLocally(cp, carry)
-      Source.empty
     case c: Command[_] => throw new IllegalStateException(c + " is not a client command that can be sent directly")
   }
 

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -84,7 +84,7 @@ class MqttSessionSpec
       server.expectMsg(subscribeBytes)
       server.reply(subAckBytes)
 
-      client.offer(Command(publish))
+      session ! Command(publish)
 
       server.expectMsg(publishBytes)
       server.reply(pubAckBytes)
@@ -397,7 +397,7 @@ class MqttSessionSpec
       server.expectMsg(connectBytes)
       server.reply(connAckBytes)
 
-      client.offer(Command(publish))
+      session ! Command(publish)
 
       server.expectMsg(publishBytes)
     }
@@ -436,7 +436,7 @@ class MqttSessionSpec
       server.expectMsg(connectBytes)
       server.reply(connAckBytes)
 
-      client.offer(Command(publish, carry))
+      session ! Command(publish, carry)
 
       server.expectMsg(publishBytes)
       server.reply(pubAckBytes)
@@ -476,8 +476,8 @@ class MqttSessionSpec
       server.expectMsg(connectBytes)
       server.reply(connAckBytes)
 
-      client.offer(Command(publish))
-      client.offer(Command(publish))
+      session ! Command(publish)
+      session ! Command(publish)
 
       server.expectMsg(publishBytes)
       server.reply(pubAckBytes)
@@ -520,7 +520,7 @@ class MqttSessionSpec
       server.expectMsg(connectBytes)
       server.reply(connAckBytes)
 
-      client.offer(Command(publish))
+      session ! Command(publish)
 
       server.expectMsg(publishBytes)
       server.reply(connAckBytes) // It doesn't matter what the message is - our test machinery here just wants a reply
@@ -566,7 +566,7 @@ class MqttSessionSpec
       server.expectMsg(connectBytes)
       server.reply(connAckBytes)
 
-      client.offer(Command(publish, carry))
+      session ! Command(publish, carry)
 
       server.expectMsg(publishBytes)
       server.reply(pubRecBytes)
@@ -802,7 +802,7 @@ class MqttSessionSpec
       server.offer(Command(pubAck))
       client.expectMsg(pubAckBytes)
 
-      server.offer(Command(publish))
+      session ! Command(publish)
       client.expectMsg(publishBytes)
 
       fromClientQueue.offer(unsubscribeBytes)
@@ -1077,7 +1077,7 @@ class MqttSessionSpec
       server.offer(Command(pubAck))
       client.expectMsg(pubAckBytes)
 
-      server.offer(Command(publish))
+      session ! Command(publish)
       client.expectMsg(publishBytes)
     }
 


### PR DESCRIPTION
This PR requires https://github.com/akka/alpakka/pull/1315 to be merged and then re-basing. For now, review just the [last commit](https://github.com/akka/alpakka/pull/1321/commits/a4445d4a4b0bacdc40615a0ce8016d2a495ef3c2).

I had thought that `Behaviors.setup` would only get called once for an actor. This is not the case - it is called each time a behaviour is transitioned to.

There was only one place where my misunderstanding mattered, which was where a promise could be tried to be completed multiple times.
