### PR TITLE
Further MQTT streaming hardening

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -292,7 +292,7 @@ import scala.util.{Failure, Success}
               val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + "-" + context.children.size)
               context.watchWith(
                 context.spawn(
-                  Consumer(publish, packetId, local, data.consumerPacketRouter, data.settings),
+                  Consumer(publish, None, packetId, local, data.consumerPacketRouter, data.settings),
                   consumerName
                 ),
                 ConsumerFree(publish.topicName)
@@ -311,6 +311,7 @@ import scala.util.{Failure, Success}
               context.watchWith(
                 context.spawn(
                   Consumer(prfr.publish,
+                           None,
                            prfr.publish.packetId.get,
                            prfr.local,
                            data.consumerPacketRouter,

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -289,7 +289,7 @@ import scala.util.{Failure, Success}
             serverConnected(data)
           case (context, prfr @ PublishReceivedFromRemote(publish @ Publish(_, topicName, Some(packetId), _), local)) =>
             if (!data.activeConsumers.contains(topicName)) {
-              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + context.children.size)
+              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + "-" + context.children.size)
               context.watchWith(
                 context.spawn(
                   Consumer(publish, packetId, local, data.consumerPacketRouter, data.settings),
@@ -307,7 +307,7 @@ import scala.util.{Failure, Success}
             val i = data.pendingRemotePublications.indexWhere(_._1 == topicName)
             if (i >= 0) {
               val prfr = data.pendingRemotePublications(i)._2
-              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + context.children.size)
+              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + "-" + context.children.size)
               context.watchWith(
                 context.spawn(
                   Consumer(prfr.publish,
@@ -333,7 +333,7 @@ import scala.util.{Failure, Success}
             data.remote.offer(ForwardPublish(publish, None))
             serverConnected(data)
           case (context, prl @ PublishReceivedLocally(publish, publishData)) =>
-            val producerName = ActorName.mkName(ProducerNamePrefix + publish.topicName + context.children.size)
+            val producerName = ActorName.mkName(ProducerNamePrefix + publish.topicName + "-" + context.children.size)
             if (!data.activeProducers.contains(publish.topicName)) {
               val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
               import context.executionContext
@@ -353,7 +353,7 @@ import scala.util.{Failure, Success}
             val i = data.pendingLocalPublications.indexWhere(_._1 == topicName)
             if (i >= 0) {
               val prl = data.pendingLocalPublications(i)._2
-              val producerName = ActorName.mkName(ProducerNamePrefix + topicName + context.children.size)
+              val producerName = ActorName.mkName(ProducerNamePrefix + topicName + "-" + context.children.size)
               val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
               import context.executionContext
               reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -89,6 +89,8 @@ import scala.util.{Failure, Success}
       connectFlags: ConnectFlags,
       keepAlive: FiniteDuration,
       pendingPingResp: Boolean,
+      activeConsumers: Set[String],
+      activeProducers: Set[String],
       pendingLocalPublications: Seq[(String, PublishReceivedLocally)],
       pendingRemotePublications: Seq[(String, PublishReceivedFromRemote)],
       remote: SourceQueueWithComplete[ForwardConnectCommand],
@@ -210,6 +212,8 @@ import scala.util.{Failure, Success}
                 data.connect.connectFlags,
                 data.connect.keepAlive,
                 pendingPingResp = false,
+                Set.empty,
+                Set.empty,
                 Vector.empty,
                 Vector.empty,
                 data.remote,
@@ -284,27 +288,26 @@ import scala.util.{Failure, Success}
             local.success(Consumer.ForwardPublish)
             serverConnected(data)
           case (context, prfr @ PublishReceivedFromRemote(publish @ Publish(_, topicName, Some(packetId), _), local)) =>
-            val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName)
-            context.child(consumerName) match {
-              case None if !data.pendingRemotePublications.exists(_._1 == publish.topicName) =>
-                context.watchWith(
-                  context.spawn(
-                    Consumer(publish, packetId, local, data.consumerPacketRouter, data.settings),
-                    consumerName
-                  ),
-                  ConsumerFree(publish.topicName)
-                )
-                serverConnected(data)
-              case _ =>
-                serverConnected(
-                  data.copy(pendingRemotePublications = data.pendingRemotePublications :+ (publish.topicName -> prfr))
-                )
+            if (!data.activeConsumers.contains(topicName)) {
+              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + context.children.size)
+              context.watchWith(
+                context.spawn(
+                  Consumer(publish, packetId, local, data.consumerPacketRouter, data.settings),
+                  consumerName
+                ),
+                ConsumerFree(publish.topicName)
+              )
+              serverConnected(data.copy(activeConsumers = data.activeConsumers + publish.topicName))
+            } else {
+              serverConnected(
+                data.copy(pendingRemotePublications = data.pendingRemotePublications :+ (publish.topicName -> prfr))
+              )
             }
           case (context, ConsumerFree(topicName)) =>
             val i = data.pendingRemotePublications.indexWhere(_._1 == topicName)
             if (i >= 0) {
               val prfr = data.pendingRemotePublications(i)._2
-              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName)
+              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + context.children.size)
               context.watchWith(
                 context.spawn(
                   Consumer(prfr.publish,
@@ -323,35 +326,34 @@ import scala.util.{Failure, Success}
                 )
               )
             } else {
-              serverConnected(data)
+              serverConnected(data.copy(activeConsumers = data.activeConsumers - topicName))
             }
           case (_, PublishReceivedLocally(publish, _))
               if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 =>
             data.remote.offer(ForwardPublish(publish, None))
             serverConnected(data)
           case (context, prl @ PublishReceivedLocally(publish, publishData)) =>
-            val producerName = ActorName.mkName(ProducerNamePrefix + publish.topicName)
-            context.child(producerName) match {
-              case None if !data.pendingLocalPublications.exists(_._1 == publish.topicName) =>
-                val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
-                import context.executionContext
-                reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
-                context.watchWith(
-                  context.spawn(Producer(publish, publishData, reply, data.producerPacketRouter, data.settings),
-                                producerName),
-                  ProducerFree(publish.topicName)
-                )
-                serverConnected(data)
-              case _ =>
-                serverConnected(
-                  data.copy(pendingLocalPublications = data.pendingLocalPublications :+ (publish.topicName -> prl))
-                )
+            val producerName = ActorName.mkName(ProducerNamePrefix + publish.topicName + context.children.size)
+            if (!data.activeProducers.contains(publish.topicName)) {
+              val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
+              import context.executionContext
+              reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
+              context.watchWith(
+                context.spawn(Producer(publish, publishData, reply, data.producerPacketRouter, data.settings),
+                              producerName),
+                ProducerFree(publish.topicName)
+              )
+              serverConnected(data.copy(activeProducers = data.activeProducers + publish.topicName))
+            } else {
+              serverConnected(
+                data.copy(pendingLocalPublications = data.pendingLocalPublications :+ (publish.topicName -> prl))
+              )
             }
           case (context, ProducerFree(topicName)) =>
             val i = data.pendingLocalPublications.indexWhere(_._1 == topicName)
             if (i >= 0) {
               val prl = data.pendingLocalPublications(i)._2
-              val producerName = ActorName.mkName(ProducerNamePrefix + topicName)
+              val producerName = ActorName.mkName(ProducerNamePrefix + topicName + context.children.size)
               val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
               import context.executionContext
               reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
@@ -369,7 +371,7 @@ import scala.util.{Failure, Success}
                 )
               )
             } else {
-              serverConnected(data)
+              serverConnected(data.copy(activeProducers = data.activeProducers - topicName))
             }
           case (_, ReceivedProducerPublishingCommand(command)) =>
             command.runWith(Sink.foreach {

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -325,7 +325,7 @@ import scala.util.{Failure, Success}
   private val UnpublisherNamePrefix = "unpublisher-"
 
   def clientConnect(data: ConnectReceived)(implicit mat: Materializer): Behavior[Event] = Behaviors.setup { _ =>
-    data.local.success(ForwardConnect)
+    data.local.trySuccess(ForwardConnect)
 
     Behaviors.withTimers { timer =>
       timer.startSingleTimer("receive-connack", ReceiveConnAckTimeout, data.settings.receiveConnAckTimeout)

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -214,6 +214,8 @@ import scala.util.{Failure, Success}
         connect,
         local,
         Set.empty,
+        Set.empty,
+        Set.empty,
         Vector.empty,
         Vector.empty,
         Vector.empty,
@@ -236,6 +238,8 @@ import scala.util.{Failure, Success}
       connect: Connect,
       local: Promise[ForwardConnect.type],
       publishers: Set[String],
+      activeConsumers: Set[String],
+      activeProducers: Set[String],
       pendingLocalPublications: Seq[(String, PublishReceivedLocally)],
       pendingRemotePublications: Seq[(String, PublishReceivedFromRemote)],
       stash: Seq[Event],
@@ -249,6 +253,8 @@ import scala.util.{Failure, Success}
       connect: Connect,
       remote: SourceQueueWithComplete[ForwardConnAckCommand],
       publishers: Set[String],
+      activeConsumers: Set[String],
+      activeProducers: Set[String],
       pendingLocalPublications: Seq[(String, PublishReceivedLocally)],
       pendingRemotePublications: Seq[(String, PublishReceivedFromRemote)],
       override val consumerPacketRouter: ActorRef[RemotePacketRouter.Request[Consumer.Event]],
@@ -262,6 +268,8 @@ import scala.util.{Failure, Success}
       connect: Connect,
       remote: SourceQueueWithComplete[ForwardConnAckCommand],
       publishers: Set[String],
+      activeConsumers: Set[String],
+      activeProducers: Set[String],
       pendingLocalPublications: Seq[(String, PublishReceivedLocally)],
       pendingRemotePublications: Seq[(String, PublishReceivedFromRemote)],
       stash: Seq[Event],
@@ -273,6 +281,8 @@ import scala.util.{Failure, Success}
   ) extends Data(consumerPacketRouter, producerPacketRouter, publisherPacketRouter, unpublisherPacketRouter, settings)
   final case class Disconnected(
       publishers: Set[String],
+      activeConsumers: Set[String],
+      activeProducers: Set[String],
       pendingLocalPublications: Seq[(String, PublishReceivedLocally)],
       pendingRemotePublications: Seq[(String, PublishReceivedFromRemote)],
       override val consumerPacketRouter: ActorRef[RemotePacketRouter.Request[Consumer.Event]],
@@ -347,6 +357,8 @@ import scala.util.{Failure, Success}
                 data.connect,
                 queue,
                 data.publishers,
+                data.activeConsumers,
+                data.activeProducers,
                 data.pendingLocalPublications,
                 data.pendingRemotePublications,
                 data.consumerPacketRouter,
@@ -392,6 +404,8 @@ import scala.util.{Failure, Success}
                     data.connect,
                     data.remote,
                     data.publishers,
+                    data.activeConsumers,
+                    data.activeProducers,
                     data.pendingLocalPublications,
                     data.pendingRemotePublications,
                     Vector.empty,
@@ -426,29 +440,28 @@ import scala.util.{Failure, Success}
           case (_, PublishReceivedFromRemote(publish, local))
               if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 =>
             local.success(Consumer.ForwardPublish)
-            Behaviors.same
+            clientConnected(data)
           case (context, prfr @ PublishReceivedFromRemote(publish @ Publish(_, topicName, Some(packetId), _), local)) =>
-            val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName)
-            context.child(consumerName) match {
-              case None if !data.pendingRemotePublications.exists(_._1 == publish.topicName) =>
-                context.watchWith(
-                  context.spawn(
-                    Consumer(publish, packetId, local, data.consumerPacketRouter, data.settings),
-                    consumerName
-                  ),
-                  ConsumerFree(publish.topicName)
-                )
-                clientConnected(data)
-              case _ =>
-                clientConnected(
-                  data.copy(pendingRemotePublications = data.pendingRemotePublications :+ (publish.topicName -> prfr))
-                )
+            if (!data.activeConsumers.contains(topicName)) {
+              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + context.children.size)
+              context.watchWith(
+                context.spawn(
+                  Consumer(publish, packetId, local, data.consumerPacketRouter, data.settings),
+                  consumerName
+                ),
+                ConsumerFree(publish.topicName)
+              )
+              clientConnected(data.copy(activeConsumers = data.activeConsumers + publish.topicName))
+            } else {
+              clientConnected(
+                data.copy(pendingRemotePublications = data.pendingRemotePublications :+ (publish.topicName -> prfr))
+              )
             }
           case (context, ConsumerFree(topicName)) =>
             val i = data.pendingRemotePublications.indexWhere(_._1 == topicName)
             if (i >= 0) {
               val prfr = data.pendingRemotePublications(i)._2
-              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName)
+              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + context.children.size)
               context.watchWith(
                 context.spawn(
                   Consumer(prfr.publish,
@@ -467,39 +480,34 @@ import scala.util.{Failure, Success}
                 )
               )
             } else {
-              clientConnected(data)
+              clientConnected(data.copy(activeConsumers = data.activeConsumers - topicName))
             }
           case (_, PublishReceivedLocally(publish, _))
-              if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 &&
-              data.publishers.exists(matchTopicFilter(_, publish.topicName)) =>
+              if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 =>
             data.remote.offer(ForwardPublish(publish, None))
             clientConnected(data)
-          case (context, prl @ PublishReceivedLocally(publish, publishData))
-              if data.publishers.exists(matchTopicFilter(_, publish.topicName)) =>
-            val producerName = ActorName.mkName(ProducerNamePrefix + publish.topicName)
-            context.child(producerName) match {
-              case None if !data.pendingLocalPublications.exists(_._1 == publish.topicName) =>
-                val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
-                import context.executionContext
-                reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
-                context.watchWith(
-                  context.spawn(
-                    Producer(publish, publishData, reply, data.producerPacketRouter, data.settings),
-                    producerName
-                  ),
-                  ProducerFree(publish.topicName)
-                )
-                clientConnected(data)
-              case _ =>
-                clientConnected(
-                  data.copy(pendingLocalPublications = data.pendingLocalPublications :+ (publish.topicName -> prl))
-                )
+          case (context, prl @ PublishReceivedLocally(publish, publishData)) =>
+            val producerName = ActorName.mkName(ProducerNamePrefix + publish.topicName + context.children.size)
+            if (!data.activeProducers.contains(publish.topicName)) {
+              val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
+              import context.executionContext
+              reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
+              context.watchWith(
+                context.spawn(Producer(publish, publishData, reply, data.producerPacketRouter, data.settings),
+                              producerName),
+                ProducerFree(publish.topicName)
+              )
+              clientConnected(data.copy(activeProducers = data.activeProducers + publish.topicName))
+            } else {
+              clientConnected(
+                data.copy(pendingLocalPublications = data.pendingLocalPublications :+ (publish.topicName -> prl))
+              )
             }
           case (context, ProducerFree(topicName)) =>
             val i = data.pendingLocalPublications.indexWhere(_._1 == topicName)
             if (i >= 0) {
               val prl = data.pendingLocalPublications(i)._2
-              val producerName = ActorName.mkName(ProducerNamePrefix + topicName)
+              val producerName = ActorName.mkName(ProducerNamePrefix + topicName + context.children.size)
               val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
               import context.executionContext
               reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))
@@ -517,7 +525,7 @@ import scala.util.{Failure, Success}
                 )
               )
             } else {
-              clientConnected(data)
+              clientConnected(data.copy(activeProducers = data.activeProducers - topicName))
             }
           case (_, ReceivedProducerPublishingCommand(command)) =>
             command.runWith(Sink.foreach {
@@ -534,6 +542,8 @@ import scala.util.{Failure, Success}
             clientDisconnected(
               Disconnected(
                 data.publishers,
+                data.activeConsumers,
+                data.activeProducers,
                 data.pendingLocalPublications,
                 data.pendingRemotePublications,
                 data.consumerPacketRouter,
@@ -548,6 +558,8 @@ import scala.util.{Failure, Success}
             clientDisconnected(
               Disconnected(
                 data.publishers,
+                data.activeConsumers,
+                data.activeProducers,
                 data.pendingLocalPublications,
                 data.pendingRemotePublications,
                 data.consumerPacketRouter,
@@ -565,6 +577,8 @@ import scala.util.{Failure, Success}
                 connect,
                 local,
                 Set.empty,
+                Set.empty,
+                Set.empty,
                 Vector.empty,
                 Vector.empty,
                 Vector.empty,
@@ -581,6 +595,8 @@ import scala.util.{Failure, Success}
                 connect,
                 local,
                 data.publishers,
+                data.activeConsumers,
+                data.activeProducers,
                 data.pendingLocalPublications,
                 data.pendingRemotePublications,
                 Vector.empty,
@@ -616,6 +632,8 @@ import scala.util.{Failure, Success}
               data.remote,
               data.publishers ++ (if (t.failure.contains(Publisher.SubscribeFailed)) Vector.empty
                                   else data.subscribe.topicFilters.map(_._1)),
+              data.activeConsumers,
+              data.activeProducers,
               data.pendingLocalPublications,
               data.pendingRemotePublications,
               data.consumerPacketRouter,
@@ -644,6 +662,8 @@ import scala.util.{Failure, Success}
                 connect,
                 local,
                 Set.empty,
+                Set.empty,
+                Set.empty,
                 Vector.empty,
                 Vector.empty,
                 Vector.empty,
@@ -660,6 +680,8 @@ import scala.util.{Failure, Success}
                 connect,
                 local,
                 data.publishers,
+                data.activeConsumers,
+                data.activeProducers,
                 data.pendingLocalPublications,
                 data.pendingRemotePublications,
                 Vector.empty,

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -443,7 +443,7 @@ import scala.util.{Failure, Success}
             clientConnected(data)
           case (context, prfr @ PublishReceivedFromRemote(publish @ Publish(_, topicName, Some(packetId), _), local)) =>
             if (!data.activeConsumers.contains(topicName)) {
-              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + context.children.size)
+              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + "-" + context.children.size)
               context.watchWith(
                 context.spawn(
                   Consumer(publish, packetId, local, data.consumerPacketRouter, data.settings),
@@ -461,7 +461,7 @@ import scala.util.{Failure, Success}
             val i = data.pendingRemotePublications.indexWhere(_._1 == topicName)
             if (i >= 0) {
               val prfr = data.pendingRemotePublications(i)._2
-              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + context.children.size)
+              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + "-" + context.children.size)
               context.watchWith(
                 context.spawn(
                   Consumer(prfr.publish,
@@ -487,7 +487,7 @@ import scala.util.{Failure, Success}
             data.remote.offer(ForwardPublish(publish, None))
             clientConnected(data)
           case (context, prl @ PublishReceivedLocally(publish, publishData)) =>
-            val producerName = ActorName.mkName(ProducerNamePrefix + publish.topicName + context.children.size)
+            val producerName = ActorName.mkName(ProducerNamePrefix + publish.topicName + "-" + context.children.size)
             if (!data.activeProducers.contains(publish.topicName)) {
               val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
               import context.executionContext
@@ -507,7 +507,7 @@ import scala.util.{Failure, Success}
             val i = data.pendingLocalPublications.indexWhere(_._1 == topicName)
             if (i >= 0) {
               val prl = data.pendingLocalPublications(i)._2
-              val producerName = ActorName.mkName(ProducerNamePrefix + topicName + context.children.size)
+              val producerName = ActorName.mkName(ProducerNamePrefix + topicName + "-" + context.children.size)
               val reply = Promise[Source[Producer.ForwardPublishingCommand, NotUsed]]
               import context.executionContext
               reply.future.foreach(command => context.self ! ReceivedProducerPublishingCommand(command))

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -57,7 +57,7 @@ class MqttSessionSpec
               .join(pipeToServer)
           )
           .toMat(Sink.collection)(Keep.both)
-          .run
+          .run()
 
       val connect = Connect("some-client-id", ConnectFlags.None)
       val connectBytes = connect.encode(ByteString.newBuilder).result()
@@ -176,7 +176,7 @@ class MqttSessionSpec
             .join(pipeToServer)
         )
         .toMat(Sink.ignore)(Keep.left)
-        .run
+        .run()
 
       val connectBytes = connect.encode(ByteString.newBuilder).result()
       val connAck = ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)
@@ -211,7 +211,7 @@ class MqttSessionSpec
         )
         .drop(2)
         .toMat(Sink.head)(Keep.both)
-        .run
+        .run()
 
       val connectBytes = connect.encode(ByteString.newBuilder).result()
       val connAck = ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)
@@ -260,7 +260,7 @@ class MqttSessionSpec
         }
         .wireTap(_ => publishReceived.success(Done))
         .toMat(Sink.ignore)(Keep.left)
-        .run
+        .run()
 
       val connectBytes = connect.encode(ByteString.newBuilder).result()
       val connAck = ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)
@@ -323,7 +323,7 @@ class MqttSessionSpec
           }
         }
         .toMat(Sink.ignore)(Keep.left)
-        .run
+        .run()
 
       val connectBytes = connect.encode(ByteString.newBuilder).result()
       val connAck = ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)
@@ -382,7 +382,7 @@ class MqttSessionSpec
               .join(pipeToServer)
           )
           .toMat(Sink.ignore)(Keep.left)
-          .run
+          .run()
 
       val connect = Connect("some-client-id", ConnectFlags.None)
       val connectBytes = connect.encode(ByteString.newBuilder).result()
@@ -418,7 +418,7 @@ class MqttSessionSpec
           )
           .drop(1)
           .toMat(Sink.head)(Keep.both)
-          .run
+          .run()
 
       val connect = Connect("some-client-id", ConnectFlags.None)
       val connectBytes = connect.encode(ByteString.newBuilder).result()
@@ -459,7 +459,7 @@ class MqttSessionSpec
               .join(pipeToServer)
           )
           .toMat(Sink.ignore)(Keep.left)
-          .run
+          .run()
 
       val connect = Connect("some-client-id", ConnectFlags.None)
       val connectBytes = connect.encode(ByteString.newBuilder).result()
@@ -501,7 +501,7 @@ class MqttSessionSpec
               .join(pipeToServer)
           )
           .toMat(Sink.ignore)(Keep.left)
-          .run
+          .run()
 
       val connect = Connect("some-client-id", ConnectFlags.None)
       val connectBytes = connect.encode(ByteString.newBuilder).result()
@@ -544,7 +544,7 @@ class MqttSessionSpec
           )
           .drop(2)
           .toMat(Sink.head)(Keep.both)
-          .run
+          .run()
 
       val connect = Connect("some-client-id", ConnectFlags.None)
       val connectBytes = connect.encode(ByteString.newBuilder).result()
@@ -592,7 +592,7 @@ class MqttSessionSpec
               .join(pipeToServer)
           )
           .toMat(Sink.ignore)(Keep.left)
-          .run
+          .run()
 
       val connect = Connect("some-client-id", ConnectFlags.None).copy(keepAlive = 200.millis.dilated)
       val connectBytes = connect.encode(ByteString.newBuilder).result()
@@ -631,7 +631,7 @@ class MqttSessionSpec
               .join(pipeToServer)
           )
           .toMat(Sink.ignore)(Keep.both)
-          .run
+          .run()
 
       val connect = Connect("some-client-id", ConnectFlags.None).copy(keepAlive = 100.millis.dilated)
       val connectBytes = connect.encode(ByteString.newBuilder).result()
@@ -666,7 +666,7 @@ class MqttSessionSpec
           )
           .drop(1)
           .toMat(Sink.head)(Keep.both)
-          .run
+          .run()
 
       val connect = Connect("some-client-id", ConnectFlags.None)
       val connectBytes = connect.encode(ByteString.newBuilder).result()
@@ -707,7 +707,7 @@ class MqttSessionSpec
               .join(pipeToServer)
           )
           .toMat(Sink.ignore)(Keep.both)
-          .run
+          .run()
 
       val connect = Connect("some-client-id", ConnectFlags.None)
 
@@ -763,7 +763,7 @@ class MqttSessionSpec
               unsubscribeReceived.success(Done)
           })
           .toMat(Sink.collection)(Keep.both)
-          .run
+          .run()
 
       val connectBytes = connect.encode(ByteString.newBuilder).result()
       val connAck = ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)
@@ -851,7 +851,7 @@ class MqttSessionSpec
             case _ =>
           })
           .toMat(Sink.collection)(Keep.both)
-          .run
+          .run()
 
       val connectBytes = connect.encode(ByteString.newBuilder).result()
       val connAck = ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)
@@ -905,7 +905,7 @@ class MqttSessionSpec
             case _ =>
           })
           .toMat(Sink.ignore)(Keep.both)
-          .run
+          .run()
 
       val connectBytes = connect.encode(ByteString.newBuilder).result()
       val connAck = ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)
@@ -955,7 +955,7 @@ class MqttSessionSpec
             case _ =>
           })
           .toMat(Sink.ignore)(Keep.left)
-          .run
+          .run()
 
       val connectBytes = connect.encode(ByteString.newBuilder).result()
       val connAck = ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)
@@ -1027,7 +1027,7 @@ class MqttSessionSpec
           })
           .drop(4)
           .toMat(Sink.head)(Keep.left)
-          .run
+          .run()
 
       val connectBytes = connect.encode(ByteString.newBuilder).result()
       val connAck = ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)
@@ -1123,7 +1123,7 @@ class MqttSessionSpec
               publishReceived.success(Done)
           })
           .toMat(Sink.collection)(Keep.left)
-          .run
+          .run()
 
       val connectBytes = connect.encode(ByteString.newBuilder).result()
       val connAck = ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)


### PR DESCRIPTION
Numerous hardening activities around MQTT streaming. Please visit each commit for a full description. However, in summary:

* Corrected misinterpretation of behaviour setup
* Avoid a race condition when creating child actors
* Handle a duplicate publish while consuming
* Connection packet id distinction which now allows more than one client to send the same packet id as another