### PR TITLE
AWS S3 - allow to get object metadata without size limit

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -143,7 +143,7 @@ private[alpakka] final class S3Stream(settings: S3Settings)(implicit system: Act
     val s3Headers = S3Headers(sse.fold[Seq[HttpHeader]](Seq.empty) { _.headersFor(HeadObject) })
     request(S3Location(bucket, key), HttpMethods.HEAD, versionId = versionId, s3Headers = s3Headers).flatMap {
       case HttpResponse(OK, headers, entity, _) =>
-        entity.discardBytes().future().map { _ =>
+        entity.withoutSizeLimit().discardBytes().future().map { _ =>
           Some(computeMetaData(headers, entity))
         }
       case HttpResponse(NotFound, _, entity, _) =>

--- a/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
+++ b/s3/src/test/java/akka/stream/alpakka/s3/javadsl/S3ClientTest.java
@@ -134,7 +134,8 @@ public class S3ClientTest extends S3WireMockBase {
   @Test
   public void head() throws Exception {
 
-    mockHead();
+    long contentLength = 8L;
+    mockHead(contentLength);
 
     // #objectMetadata
     final CompletionStage<Optional<ObjectMetadata>> source =
@@ -145,9 +146,11 @@ public class S3ClientTest extends S3WireMockBase {
 
     final ObjectMetadata objectMetadata = result.get();
     Optional<String> s3eTag = objectMetadata.getETag();
+    long actualContentLength = objectMetadata.getContentLength();
     Optional<String> versionId = objectMetadata.getVersionId();
 
     assertEquals(s3eTag, Optional.of(etag()));
+    assertEquals(actualContentLength, contentLength);
     assertEquals(versionId, Optional.empty());
   }
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SourceSpec.scala
@@ -47,7 +47,8 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
 
   "S3Source" should "download a metadata from S3" in {
 
-    mockHead()
+    val contentLength = 8
+    mockHead(contentLength)
 
     //#objectMetadata
     val metadata = s3Client.getObjectMetadata(bucket, bucketKey)
@@ -56,7 +57,23 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     val Some(result) = metadata.futureValue
 
     result.eTag shouldBe Some(etag)
-    result.contentLength shouldBe 8
+    result.contentLength shouldBe contentLength
+    result.versionId shouldBe empty
+  }
+
+  "S3Source" should "download a metadata from S3 for a big file" in {
+
+    val contentLength = Long.MaxValue
+    mockHead(contentLength)
+
+    //#objectMetadata
+    val metadata = s3Client.getObjectMetadata(bucket, bucketKey)
+    //#objectMetadata
+
+    val Some(result) = metadata.futureValue
+
+    result.eTag shouldBe Some(etag)
+    result.contentLength shouldBe contentLength
     result.versionId shouldBe empty
   }
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -111,11 +111,14 @@ abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockSer
           )
       )
 
-  def mockHead(): Unit =
+  def mockHead(contentLength: Long): Unit =
     mock
       .register(
         head(urlEqualTo(s"/$bucketKey")).willReturn(
-          aResponse().withStatus(200).withHeader("ETag", s""""$etag"""").withHeader("Content-Length", "8")
+          aResponse()
+            .withStatus(200)
+            .withHeader("ETag", s""""$etag"""")
+            .withHeader("Content-Length", contentLength.toString)
         )
       )
 


### PR DESCRIPTION
AWS S3 - allow to get object metadata without size limit

fixes #1348

1. [getObjectMetadata](https://github.com/akka/alpakka/blob/daba7df05114420c7470962310e0ed8d0557150c/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala#L138) calls HEAD on a file in S3.
2. s3-server returns the response with `Content-Length` set but [without the real data](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html).
3. if the value in `Content-Length` is greater than `http.client.parsing.max-content-length` (8 mb by default), HEAD operation (and hence getObjectMetadata) fails, e.g.:

```
Failure(EntityStreamSizeException: actual entity size (Some(10380000)) exceeded content length limit (8388608 bytes)!
You can configure this by setting `akka.http.[server|client].parsing.max-content-length`
or calling `HttpEntity.withSizeLimit` before materializing the dataBytes stream.)
```

The fix allows to query metadata for large files without adjusting the `http.client.parsing.max-content-length` setting to infinite.
This is a safe operation since we're not getting any data in `getObjectMetadata` except for the headers.

Please review.