### PR TITLE
MQTT streaming: Modal subscriptions

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -427,7 +427,8 @@ import scala.util.{Failure, Success}
                   )
                 )
               case _: Some[_] => // It is an error to get here
-                local.failure(new IllegalStateException("Shouldn't be able to receive subscriptions here"))
+                local
+                  .failure(new IllegalStateException("Shouldn't be able to receive subscriptions here: " + subscribe))
                 Behaviors.same
             }
           case (context, UnsubscribeReceivedFromRemote(unsubscribe, local)) =>


### PR DESCRIPTION
Prior to this change, an MQTT client could only send one SUBSCRIBE for a given topic at a time without receiving an `IllegalStateException`. It is quite plausible that multiple SUBSCRIBE requests for the same topic are made in succession given connection failures. This change now stashes requests while a SUBSCRIBE is occurring on the client, in the same way that the server does.

Also, I was sending out a SUBSCRIBE request for each topic filter, whereas it should go out as just one request. This would have caused errors had the feature been leveraged by someone (we aren’t leveraging this feature presently). (same for UNSUBSCRIBE - doh!)