### PR TITLE
Akka 2.5.19 upgrade

### DIFF
--- a/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java
+++ b/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java
@@ -65,7 +65,8 @@ public class AvroParquetSinkTest {
   }
 
   @Test
-  public void createNewParquetFile() throws InterruptedException, IOException, TimeoutException, ExecutionException {
+  public void createNewParquetFile()
+      throws InterruptedException, IOException, TimeoutException, ExecutionException {
     // #init-writer
     Configuration conf = new Configuration();
     conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, true);

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsProducerRetrySpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsProducerRetrySpec.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.jms
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings, OverflowStrategies, Supervision}
+import akka.stream._
 import akka.stream.alpakka.jms.scaladsl.{JmsConsumer, JmsProducer}
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import javax.jms.{JMSException, Message, TextMessage}
@@ -15,6 +15,7 @@ import org.mockito.ArgumentMatchers.{any, anyInt, anyLong}
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
+
 import scala.concurrent.duration._
 
 class JmsProducerRetrySpec extends JmsSpec {
@@ -42,7 +43,7 @@ class JmsProducerRetrySpec extends JmsSpec {
       )
 
       val (queue, result) = Source
-        .queue[Int](10, OverflowStrategies.Backpressure)
+        .queue[Int](10, OverflowStrategy.backpressure)
         .zipWithIndex
         .map(e => JmsMapMessage(Map("time" -> System.currentTimeMillis(), "index" -> e._2)))
         .via(jms)

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/RequestState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/RequestState.scala
@@ -78,7 +78,7 @@ import scala.util.{Failure, Success}
   def preparePublish(data: Start)(implicit mat: Materializer): Behavior[Event] = Behaviors.setup { context =>
     def requestPacketId(): Unit = {
       val reply = Promise[LocalPacketRouter.Registered]
-      data.packetRouter ! LocalPacketRouter.Register(context.self.upcast, reply)
+      data.packetRouter ! LocalPacketRouter.Register(context.self.unsafeUpcast, reply)
       import context.executionContext
       reply.future.onComplete {
         case Success(acquired: LocalPacketRouter.Registered) => context.self ! AcquiredPacketId(acquired.packetId)
@@ -236,7 +236,7 @@ import scala.util.{Failure, Success}
 
   def prepareClientConsumption(data: Start): Behavior[Event] = Behaviors.setup { context =>
     val reply = Promise[RemotePacketRouter.Registered.type]
-    data.packetRouter ! RemotePacketRouter.Register(context.self.upcast, data.clientId, data.packetId, reply)
+    data.packetRouter ! RemotePacketRouter.Register(context.self.unsafeUpcast, data.clientId, data.packetId, reply)
     import context.executionContext
     reply.future.onComplete {
       case Success(RemotePacketRouter.Registered) => context.self ! RegisteredPacketId

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val AkkaVersion = sys.env.get("AKKA_SERIES") match {
     case Some("2.4") => sys.error("Akka 2.4 is not supported anymore")
-    case _ => "2.5.17"
+    case _ => "2.5.19"
   }
 
   val AwsSdkVersion = "1.11.414"


### PR DESCRIPTION
Affects Akka Typed usage in mqtt-streaming given some API changes.

Also found a bug in matt-streaming along the way in that it was incorrect in handling client connection failures. We should handle a client connection actor terminating only when it terminates gracefully or with an exception that we expect. If we get an unexpected exception then we should not try to handle it. We should also notify observers of the client connection being terminated no matter whether it stops gracefully or not.