### PR TITLE
ES: Making the scroll value configurable

### DIFF
--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -98,7 +98,7 @@ Java
 | ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
 | bufferSize             | 10      | `ElasticsearchSource` retrieves messages from Elasticsearch by scroll scan. This buffer size is used as the scroll size. | 
 | includeDocumentVersion | false   | Tell Elasticsearch to return the documents `_version` property with the search results. See [Version](http://nocf-www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html) and [Optimistic Concurrenct Control](https://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html) to know about this property. |
-| scrollDuration         | FiniteDuration(5, TimeUnit.MINUTES)      | `ElasticsearchSource`  retrieves messages from Elasticsearch by scroll scan. This parameter is used as a scroll value and will be converted to a string value in the following format: s"$Length$Unit". ie: 5m, 10ms. See [Time units](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units) for supported units.                |
+| scrollDuration         | 5 min   | `ElasticsearchSource`  retrieves messages from Elasticsearch by scroll scan. This parameter is used as a scroll value. See [Time units](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units) for supported units.                |
 
 
 ### Sink and flow configuration

--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -98,6 +98,7 @@ Java
 | ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
 | bufferSize             | 10      | `ElasticsearchSource` retrieves messages from Elasticsearch by scroll scan. This buffer size is used as the scroll size. | 
 | includeDocumentVersion | false   | Tell Elasticsearch to return the documents `_version` property with the search results. See [Version](http://nocf-www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html) and [Optimistic Concurrenct Control](https://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html) to know about this property. |
+| scrollDuration         | FiniteDuration(5, TimeUnit.MINUTES)      | `ElasticsearchSource`  retrieves messages from Elasticsearch by scroll scan. This parameter is used as a scroll value and will be converted to a string value in the following format: s"$Length$Unit". ie: 5m, 10ms. See [Time units](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units) for supported units.                |
 
 
 ### Sink and flow configuration

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSourceSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSourceSettings.scala
@@ -5,8 +5,8 @@
 package akka.stream.alpakka.elasticsearch
 
 import java.util.concurrent.TimeUnit
-
 import scala.concurrent.duration.FiniteDuration
+import akka.util.JavaDurationConverters._
 
 /**
  * Configure Elastiscsearch sources.
@@ -19,6 +19,8 @@ final class ElasticsearchSourceSettings private (val bufferSize: Int,
   def withBufferSize(value: Int): ElasticsearchSourceSettings = copy(bufferSize = value)
 
   def withScrollDuration(value: FiniteDuration): ElasticsearchSourceSettings = copy(scrollDuration = value)
+
+  def withScrollDuration(value: java.time.Duration): ElasticsearchSourceSettings = copy(scrollDuration = value.asScala)
 
   /**
    * If includeDocumentVersion is true, '_version' is returned with the search-results

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSourceSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSourceSettings.scala
@@ -4,17 +4,21 @@
 
 package akka.stream.alpakka.elasticsearch
 
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.FiniteDuration
+
 /**
  * Configure Elastiscsearch sources.
  *
  */
 final class ElasticsearchSourceSettings private (val bufferSize: Int,
                                                  val includeDocumentVersion: Boolean,
-                                                 val scroll: String) {
+                                                 val scrollDuration: FiniteDuration) {
 
   def withBufferSize(value: Int): ElasticsearchSourceSettings = copy(bufferSize = value)
 
-  def withScroll(value: String): ElasticsearchSourceSettings = copy(scroll = value)
+  def withScrollDuration(value: FiniteDuration): ElasticsearchSourceSettings = copy(scrollDuration = value)
 
   /**
    * If includeDocumentVersion is true, '_version' is returned with the search-results
@@ -26,19 +30,37 @@ final class ElasticsearchSourceSettings private (val bufferSize: Int,
 
   private def copy(bufferSize: Int = bufferSize,
                    includeDocumentVersion: Boolean = includeDocumentVersion,
-                   scroll: String = scroll): ElasticsearchSourceSettings =
+                   scrollDuration: FiniteDuration = scrollDuration): ElasticsearchSourceSettings =
     new ElasticsearchSourceSettings(bufferSize = bufferSize,
                                     includeDocumentVersion = includeDocumentVersion,
-                                    scroll = scroll)
+                                    scrollDuration = scrollDuration)
+
+  def scroll: String = {
+    val scrollString = scrollDuration.unit match {
+      case TimeUnit.DAYS => "d"
+      case TimeUnit.HOURS => "h"
+      case TimeUnit.MINUTES => "m"
+      case TimeUnit.SECONDS => "s"
+      case TimeUnit.MILLISECONDS => "ms"
+      case TimeUnit.MICROSECONDS => "micros"
+      case TimeUnit.NANOSECONDS => "nanos"
+    }
+
+    s"${scrollDuration.length}$scrollString"
+  }
 
   override def toString =
-    s"""ElasticsearchSourceSettings(bufferSize=$bufferSize,includeDocumentVersion=$includeDocumentVersion)"""
+    s"""ElasticsearchSourceSettings(bufferSize=$bufferSize,includeDocumentVersion=$includeDocumentVersion,scrollDuration=$scrollDuration)"""
 
 }
 
 object ElasticsearchSourceSettings {
 
-  val Default = new ElasticsearchSourceSettings(bufferSize = 10, includeDocumentVersion = false, scroll = "5m")
+  val Default = new ElasticsearchSourceSettings(
+    bufferSize = 10,
+    includeDocumentVersion = false,
+    scrollDuration = FiniteDuration(5, TimeUnit.MINUTES)
+  )
 
   /** Scala API */
   def apply(): ElasticsearchSourceSettings = Default

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSourceSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSourceSettings.scala
@@ -8,9 +8,13 @@ package akka.stream.alpakka.elasticsearch
  * Configure Elastiscsearch sources.
  *
  */
-final class ElasticsearchSourceSettings private (val bufferSize: Int, val includeDocumentVersion: Boolean) {
+final class ElasticsearchSourceSettings private (val bufferSize: Int,
+                                                 val includeDocumentVersion: Boolean,
+                                                 val scroll: String) {
 
   def withBufferSize(value: Int): ElasticsearchSourceSettings = copy(bufferSize = value)
+
+  def withScroll(value: String): ElasticsearchSourceSettings = copy(scroll = value)
 
   /**
    * If includeDocumentVersion is true, '_version' is returned with the search-results
@@ -21,8 +25,11 @@ final class ElasticsearchSourceSettings private (val bufferSize: Int, val includ
     if (includeDocumentVersion == value) this else copy(includeDocumentVersion = value)
 
   private def copy(bufferSize: Int = bufferSize,
-                   includeDocumentVersion: Boolean = includeDocumentVersion): ElasticsearchSourceSettings =
-    new ElasticsearchSourceSettings(bufferSize = bufferSize, includeDocumentVersion = includeDocumentVersion)
+                   includeDocumentVersion: Boolean = includeDocumentVersion,
+                   scroll: String = scroll): ElasticsearchSourceSettings =
+    new ElasticsearchSourceSettings(bufferSize = bufferSize,
+                                    includeDocumentVersion = includeDocumentVersion,
+                                    scroll = scroll)
 
   override def toString =
     s"""ElasticsearchSourceSettings(bufferSize=$bufferSize,includeDocumentVersion=$includeDocumentVersion)"""
@@ -31,7 +38,7 @@ final class ElasticsearchSourceSettings private (val bufferSize: Int, val includ
 
 object ElasticsearchSourceSettings {
 
-  val Default = new ElasticsearchSourceSettings(bufferSize = 10, includeDocumentVersion = false)
+  val Default = new ElasticsearchSourceSettings(bufferSize = 10, includeDocumentVersion = false, scroll = "5m")
 
   /** Scala API */
   def apply(): ElasticsearchSourceSettings = Default

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSourceStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSourceStage.scala
@@ -123,7 +123,7 @@ private[elasticsearch] final class ElasticsearchSourceLogic[T](indexName: String
         client.performRequestAsync(
           "POST",
           endpoint,
-          Map("scroll" -> "5m", "sort" -> "_doc").asJava,
+          Map("scroll" -> settings.scroll, "sort" -> "_doc").asJava,
           new StringEntity(searchBody),
           this,
           new BasicHeader("Content-Type", "application/json")
@@ -135,7 +135,7 @@ private[elasticsearch] final class ElasticsearchSourceLogic[T](indexName: String
           "POST",
           s"/_search/scroll",
           Map[String, String]().asJava,
-          new StringEntity(Map("scroll" -> "5m", "scroll_id" -> scrollId).toJson.toString),
+          new StringEntity(Map("scroll" -> settings.scroll, "scroll_id" -> scrollId).toJson.toString),
           this,
           new BasicHeader("Content-Type", "application/json")
         )

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
@@ -4,6 +4,8 @@
 
 package docs.scaladsl
 
+import java.util.concurrent.TimeUnit
+
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
@@ -104,7 +106,9 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
 
   private def documentation: Unit = {
     //#source-settings
-    val sourceSettings = ElasticsearchSourceSettings().withBufferSize(10)
+    val sourceSettings = ElasticsearchSourceSettings()
+      .withBufferSize(10)
+      .withScrollDuration(FiniteDuration(5, TimeUnit.MINUTES))
     //#source-settings
     //#sink-settings
     val sinkSettings =
@@ -113,6 +117,51 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
         .withVersionType("internal")
         .withRetryLogic(RetryAtFixedRate(maxRetries = 5, retryInterval = 1.second))
     //#sink-settings
+  }
+
+  "ElasticsearchSourceSettings" should {
+    "convert scrollDuration value to correct scroll string value (Days)" in {
+      val sourceSettings = ElasticsearchSourceSettings()
+        .withScrollDuration(FiniteDuration(5, TimeUnit.DAYS))
+
+      sourceSettings.scroll shouldEqual "5d"
+    }
+    "convert scrollDuration value to correct scroll string value (Hours)" in {
+      val sourceSettings = ElasticsearchSourceSettings()
+        .withScrollDuration(FiniteDuration(5, TimeUnit.HOURS))
+
+      sourceSettings.scroll shouldEqual "5h"
+    }
+    "convert scrollDuration value to correct scroll string value (Minutes)" in {
+      val sourceSettings = ElasticsearchSourceSettings()
+        .withScrollDuration(FiniteDuration(5, TimeUnit.MINUTES))
+
+      sourceSettings.scroll shouldEqual "5m"
+    }
+    "convert scrollDuration value to correct scroll string value (Seconds)" in {
+      val sourceSettings = ElasticsearchSourceSettings()
+        .withScrollDuration(FiniteDuration(5, TimeUnit.SECONDS))
+
+      sourceSettings.scroll shouldEqual "5s"
+    }
+    "convert scrollDuration value to correct scroll string value (Milliseconds)" in {
+      val sourceSettings = ElasticsearchSourceSettings()
+        .withScrollDuration(FiniteDuration(5, TimeUnit.MILLISECONDS))
+
+      sourceSettings.scroll shouldEqual "5ms"
+    }
+    "convert scrollDuration value to correct scroll string value (Microseconds)" in {
+      val sourceSettings = ElasticsearchSourceSettings()
+        .withScrollDuration(FiniteDuration(5, TimeUnit.MICROSECONDS))
+
+      sourceSettings.scroll shouldEqual "5micros"
+    }
+    "convert scrollDuration value to correct scroll string value (Nanoseconds)" in {
+      val sourceSettings = ElasticsearchSourceSettings()
+        .withScrollDuration(FiniteDuration(5, TimeUnit.NANOSECONDS))
+
+      sourceSettings.scroll shouldEqual "5nanos"
+    }
   }
 
   "Un-typed Elasticsearch connector" should {


### PR DESCRIPTION
Sometimes, depending on the Elasticsearch cluster configuration, we need to change the scroll value (1m, 5m, 15m, 60m, etc.).

=> ES: Moving the scroll value to ElasticsearchSourceSettings in order to be able to change it if necessary.