### PR TITLE
Use to Jackson 2.9.8, Spray Json 1.3.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -227,6 +227,7 @@ lazy val docs = project
   .settings(
     name := "Alpakka",
     publish / skip := true,
+    whitesourceIgnore := true,
     paradoxProperties ++= Map(
       "project.url" -> "https://developer.lightbend.com/docs/alpakka/current/",
       "akka.version" -> Dependencies.AkkaVersion,
@@ -266,6 +267,7 @@ lazy val `doc-examples` = project
   .settings(
     name := s"akka-stream-alpakka-doc-examples",
     publish / skip := true,
+    whitesourceIgnore := true,
     Dependencies.`Doc-examples`
   )
 

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
@@ -404,7 +404,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
           MessageFactory.createWriteResult[JsValue, NotUsed](
             WriteMessage.createIndexMessage("1", Map("subject" -> "Akka Concurrency").toJson),
             Some(
-              """{"type":"strict_dynamic_mapping_exception","reason":"mapping set to strict, dynamic introduction of [subject] within [_doc] is not allowed"}"""
+              """{"reason":"mapping set to strict, dynamic introduction of [subject] within [_doc] is not allowed","type":"strict_dynamic_mapping_exception"}"""
             )
           )
         )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -87,8 +87,8 @@ object Dependencies {
       "org.elasticsearch.client" % "elasticsearch-rest-client" % "6.3.1", // ApacheV2
       "org.codelibs" % "elasticsearch-cluster-runner" % "6.3.1.0", // ApacheV2
       "io.netty" % "netty-all" % "4.1.29.Final", // ApacheV2
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.9.6",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.6",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.9.8",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8",
       "org.slf4j" % "log4j-over-slf4j" % "1.7.25",
       "org.slf4j" % "jcl-over-slf4j" % "1.7.25",
       "ch.qos.logback" % "logback-classic" % "1.2.3" // Eclipse Public License 1.0
@@ -105,8 +105,8 @@ object Dependencies {
   val Elasticsearch = Seq(
     libraryDependencies ++= Seq(
       "org.elasticsearch.client" % "elasticsearch-rest-client" % "6.3.1", // ApacheV2
-      "io.spray" %% "spray-json" % "1.3.4", // ApacheV2
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.6", // ApacheV2
+      "io.spray" %% "spray-json" % "1.3.5", // ApacheV2
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.8", // ApacheV2
       "org.codelibs" % "elasticsearch-cluster-runner" % "6.3.1.0" % Test // ApacheV2
     )
   )


### PR DESCRIPTION
* exclude docs from Whitesource reporting
* Spray upgrade has reordered fields in expected JSON