### PR TITLE
[DynamoDB][#1380] Base URL should be overridable in `DynamoClientImpl`

### DIFF
--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
@@ -55,6 +55,8 @@ private[dynamodb] trait AwsClient[S <: AwsClientSettings] {
   protected val defaultContentType: ContentType
   protected val errorResponseHandler: HttpResponseHandler[AmazonServiceException]
 
+  protected def url: String = s"https://${settings.host}/"
+
   private val requestId = new AtomicInteger()
   private val credentials = settings.credentialsProvider
 
@@ -74,8 +76,6 @@ private[dynamodb] trait AwsClient[S <: AwsClientSettings] {
     case HttpMethodName.OPTIONS => HttpMethods.OPTIONS
     case HttpMethodName.PATCH => HttpMethods.PATCH
   }
-
-  private val url = s"https://${settings.host}/"
 
   private val signableUrl = Uri(url)
 

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
@@ -81,7 +81,7 @@ private[dynamodb] trait AwsClient[S <: AwsClientSettings] {
 
   private val uri = new java.net.URI(url)
 
-  private val decider: Supervision.Decider = { case _ => Supervision.Stop }
+  private val decider: Supervision.Decider = _ => Supervision.Stop
 
   def flow[Op <: AwsOp]: Flow[Op, Op#B, NotUsed] =
     Flow[Op]

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
@@ -89,7 +89,7 @@ private[dynamodb] trait AwsClient[S <: AwsClientSettings] {
       .via(connection)
       .mapAsync(settings.parallelism) {
         case (Success(response), i) => toAwsResult(response, i)
-        case (Failure(ex), i) => Future.failed(ex)
+        case (Failure(ex), _) => Future.failed(ex)
       }
       .withAttributes(ActorAttributes.supervisionStrategy(decider))
       .map(_.asInstanceOf[Op#B])

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
@@ -105,10 +105,10 @@ private[dynamodb] trait AwsClient[S <: AwsClientSettings] {
     val body = read(original.getContent)
 
     val tokenHeader: List[headers.RawHeader] = {
-      credentials.getCredentials() match {
-        case sessionCredentials: auth.AWSSessionCredentials =>
+      credentials.getCredentials match {
+        case _: auth.AWSSessionCredentials =>
           Some(headers.RawHeader("x-amz-security-token", amzHeaders.get("X-Amz-Security-Token")))
-        case other =>
+        case _ =>
           None
       }
     }.toList

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoClientImpl.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoClientImpl.scala
@@ -43,4 +43,5 @@ private[dynamodb] class DynamoClientImpl(
       Http().cachedHostConnectionPool[AwsRequestMetadata](settings.host, settings.port, settings = poolSettings)
   }
 
+  override protected def url: String = if (settings.tls) s"https://${settings.host}/" else s"http://${settings.host}/"
 }


### PR DESCRIPTION
It is currently impossible to configure the plain HTTP protocol, since the `AwsClient` trait [hard-codes the HTTP protocol scheme](https://github.com/akka/alpakka/blob/master/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala#L78).

We need to expose this to the implementations of the `AwsClient` trait, and in this specific case, the `DynamoClientImpl`.

* Did a bit of boy-scouting in `AwsClient`
* Converted the `private var url` to `protected def url: String`
* Overrode the `url` definition in `DynamoClientImpl`

This PR closes #1380 