### PR TITLE
MQTT streaming: Connection hardening

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/MqttSessionSettings.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/MqttSessionSettings.scala
@@ -29,7 +29,6 @@ object MqttSessionSettings {
  * Configuration settings for client and server usage.
  */
 final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
-                                         val maxClientConnectionStashSize: Int = 100,
                                          val clientTerminationWatcherBufferSize: Int = 100,
                                          val commandParallelism: Int = 50,
                                          val eventParallelism: Int = 10,
@@ -183,14 +182,6 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
     copy(receiveUnsubAckTimeout = receiveUnsubAckTimeout.asScala)
 
   /**
-   * For clients, the number of commands to buffer in memory while waiting for a connection ack. For servers,
-   * the number of commands to buffer in memory while waiting for a local connection ack command. Defaults
-   * to 100.
-   */
-  def withMaxClientConnectionStashSize(maxClientConnectionStashSize: Int): MqttSessionSettings =
-    copy(maxClientConnectionStashSize = maxClientConnectionStashSize)
-
-  /**
    * The maximum number of client termination event observers permitted. Defaults to 100 which should be
    * more than adequate for most situations.
    */
@@ -205,7 +196,6 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
     copy(serverSendBufferSize = serverSendBufferSize)
 
   private def copy(maxPacketSize: Int = maxPacketSize,
-                   maxClientConnectionStashSize: Int = maxClientConnectionStashSize,
                    clientTerminationWatcherBufferSize: Int = clientTerminationWatcherBufferSize,
                    commandParallelism: Int = commandParallelism,
                    eventParallelism: Int = eventParallelism,
@@ -219,7 +209,6 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
                    serverSendBufferSize: Int = serverSendBufferSize) =
     new MqttSessionSettings(
       maxPacketSize,
-      maxClientConnectionStashSize,
       clientTerminationWatcherBufferSize,
       commandParallelism,
       eventParallelism,
@@ -234,5 +223,5 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
     )
 
   override def toString: String =
-    s"MqttSessionSettings(maxPacketSize=$maxPacketSize,maxClientConnectionStashSize=$maxClientConnectionStashSize,clientTerminationWatcherBufferSize=$clientTerminationWatcherBufferSize,commandParallelism=$commandParallelism,eventParallelism=$eventParallelism,receiveConnectTimeout=$receiveConnectTimeout,receiveConnAckTimeout=$receiveConnAckTimeout,receivePubAckRecTimeout=$receivePubAckRecTimeout,receivePubCompTimeout=$receivePubCompTimeout,receivePubRelTimeout=$receivePubRelTimeout,receiveSubAckTimeout=$receiveSubAckTimeout,receiveUnsubAckTimeout=$receiveUnsubAckTimeout,serverSendBufferSize=$serverSendBufferSize)"
+    s"MqttSessionSettings(maxPacketSize=$maxPacketSize,clientTerminationWatcherBufferSize=$clientTerminationWatcherBufferSize,commandParallelism=$commandParallelism,eventParallelism=$eventParallelism,receiveConnectTimeout=$receiveConnectTimeout,receiveConnAckTimeout=$receiveConnAckTimeout,receivePubAckRecTimeout=$receivePubAckRecTimeout,receivePubCompTimeout=$receivePubCompTimeout,receivePubRelTimeout=$receivePubRelTimeout,receiveSubAckTimeout=$receiveSubAckTimeout,receiveUnsubAckTimeout=$receiveUnsubAckTimeout,serverSendBufferSize=$serverSendBufferSize)"
 }

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/Mqtt.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/Mqtt.scala
@@ -6,7 +6,9 @@ package akka.stream.alpakka.mqtt.streaming
 package scaladsl
 
 import akka.NotUsed
+import akka.stream.{Attributes, BidiShape, Inlet, Outlet}
 import akka.stream.scaladsl.BidiFlow
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import akka.util.ByteString
 
 object Mqtt {
@@ -23,7 +25,13 @@ object Mqtt {
   def clientSessionFlow[A](
       session: MqttClientSession
   ): BidiFlow[Command[A], ByteString, ByteString, Either[MqttCodec.DecodeError, Event[A]], NotUsed] =
-    BidiFlow.fromFlows(session.commandFlow, session.eventFlow)
+    BidiFlow
+      .fromFlows(session.commandFlow[A], session.eventFlow[A])
+      .atop(
+        BidiFlow.fromGraph(
+          new CoupledTerminationBidi
+        )
+      )
 
   /**
    * Create a bidirectional flow that maintains server session state with an MQTT endpoint.
@@ -40,5 +48,36 @@ object Mqtt {
       session: MqttServerSession,
       connectionId: ByteString
   ): BidiFlow[Command[A], ByteString, ByteString, Either[MqttCodec.DecodeError, Event[A]], NotUsed] =
-    BidiFlow.fromFlows(session.commandFlow(connectionId), session.eventFlow(connectionId))
+    BidiFlow
+      .fromFlows(session.commandFlow[A](connectionId), session.eventFlow[A](connectionId))
+      .atop(
+        BidiFlow.fromGraph(
+          new CoupledTerminationBidi
+        )
+      )
+}
+
+/** INTERNAL API - taken from Akka streams - perhaps it should be made public */
+private[scaladsl] class CoupledTerminationBidi[I, O] extends GraphStage[BidiShape[I, I, O, O]] {
+  val in1: Inlet[I] = Inlet("CoupledCompletion.in1")
+  val out1: Outlet[I] = Outlet("CoupledCompletion.out1")
+  val in2: Inlet[O] = Inlet("CoupledCompletion.in2")
+  val out2: Outlet[O] = Outlet("CoupledCompletion.out2")
+  override val shape: BidiShape[I, I, O, O] = BidiShape(in1, out1, in2, out2)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+
+    val handler1: InHandler with OutHandler = new InHandler with OutHandler {
+      override def onPush(): Unit = push(out1, grab(in1))
+      override def onPull(): Unit = pull(in1)
+    }
+
+    val handler2: InHandler with OutHandler = new InHandler with OutHandler {
+      override def onPush(): Unit = push(out2, grab(in2))
+      override def onPull(): Unit = pull(in2)
+    }
+
+    setHandlers(in1, out1, handler1)
+    setHandlers(in2, out2, handler2)
+  }
 }


### PR DESCRIPTION
When connections are lost the client and server flows now shutdown appropriately. This was not always the case previously.

In addition, the stashing was artificially limited which could cause problems. Overflowing memory is now entirely a caller concern.