### PR TITLE
MQTT streaming: More connection failure hardening

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -276,8 +276,6 @@ import scala.util.{Failure, Success}
     timer =>
       if (data.keepAlive.toMillis > 0)
         timer.startSingleTimer("send-pingreq", SendPingReqTimeout, data.keepAlive)
-      else
-        data.remote.complete() // We'll never be sending pings so free up the command channel for other things
 
       Behaviors
         .receivePartial[Event] {

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -198,6 +198,8 @@ import scala.util.{Failure, Success}
           data.settings
         )
       )
+    case (_, ConnectionLost) =>
+      Behavior.same
     case (_, e) =>
       disconnected(data.copy(stash = data.stash :+ e))
   }

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -221,9 +221,12 @@ import scala.util.{Failure, Success}
     )
   }
 
+  private val ReceiveConnAck = "receive-connack"
+
   def serverConnect(data: ConnectReceived)(implicit mat: Materializer): Behavior[Event] = Behaviors.withTimers {
     timer =>
-      timer.startSingleTimer("receive-connack", ReceiveConnAckTimeout, data.settings.receiveConnAckTimeout)
+      if (!timer.isTimerActive(ReceiveConnAck))
+        timer.startSingleTimer(ReceiveConnAck, ReceiveConnAckTimeout, data.settings.receiveConnAckTimeout)
 
       Behaviors
         .receivePartial[Event] {

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -344,11 +344,14 @@ import scala.util.{Failure, Success}
   private val PublisherNamePrefix = "publisher-"
   private val UnpublisherNamePrefix = "unpublisher-"
 
+  private val ReceiveConnAck = "receive-connack"
+
   def clientConnect(data: ConnectReceived)(implicit mat: Materializer): Behavior[Event] = Behaviors.setup { _ =>
     data.local.trySuccess(ForwardConnect)
 
     Behaviors.withTimers { timer =>
-      timer.startSingleTimer("receive-connack", ReceiveConnAckTimeout, data.settings.receiveConnAckTimeout)
+      if (!timer.isTimerActive(ReceiveConnAck))
+        timer.startSingleTimer(ReceiveConnAck, ReceiveConnAckTimeout, data.settings.receiveConnAckTimeout)
 
       Behaviors
         .receivePartial[Event] {

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -176,14 +176,14 @@ class MqttSessionSpec
       val connect = Connect("some-client-id", ConnectFlags.None)
       val disconnect = Disconnect
 
-      val client = Source
+      val (client, result) = Source
         .queue(1, OverflowStrategy.fail)
         .via(
           Mqtt
             .clientSessionFlow(session)
             .join(pipeToServer)
         )
-        .toMat(Sink.ignore)(Keep.left)
+        .toMat(Sink.ignore)(Keep.both)
         .run()
 
       val connectBytes = connect.encode(ByteString.newBuilder).result()
@@ -200,6 +200,8 @@ class MqttSessionSpec
       client.offer(Command(disconnect))
 
       server.expectMsg(disconnectBytes)
+
+      result.futureValue shouldBe Done
     }
 
     "disconnect when connection lost" in {


### PR DESCRIPTION
We've been testing the MQTT connector in a production environment, hence discovering a few bugs. The production environment consists of a very low powered CPU and so the scenarios being fixed are largely as a result of a completely different timing behaviour to that of much faster machines.

The collection of commits here largely address an oversight on my part where I had misunderstood `flatMapMerge` to complete on a `Source` completing. It doesn't, and it shouldn't, and I don't know what I was thinking. :-)

I've now introduced a kill switch so that when a disconnection occurs within a client or server session then their associated command flows are terminated. I've enhanced a test to prove this out.

I've made some inline comments of other little things that I've fixed.

Finally, I've done some observational testing with our code that uses this library. We will be continuing to perform these hardening tests in the near term.