### PR TITLE
Licensing: Explicitly depend on jaxb-impl 2.2.3-1 in Hbase

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -186,6 +186,9 @@ object Dependencies {
     val hadoopVersion = "2.5.2"
     Seq(
       libraryDependencies ++= Seq(
+        // for some reason version 2.2.3U1 started to get picked which was not accepted by Whitesource)
+        "com.sun.xml.bind" % "jaxb-impl" % "2.2.3-1", // CDDL + GPLv2
+        // TODO: remove direct dependency ^^ when updating from these very old versions
         "org.apache.hbase" % "hbase-client" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
         "org.apache.hbase" % "hbase-common" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
         "org.apache.hadoop" % "hadoop-common" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,


### PR DESCRIPTION
Whitesource started reporting `jaxb-impl-2.2.3U1.jar (rejected by policy '*GPL* - Reject')` when that version got picked.