### PR TITLE
Connection hardening III - Unique kill switch to solve a regression

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -449,6 +449,8 @@ import scala.util.{Failure, Success}
   def pendingSubAck(data: PendingSubscribe)(implicit mat: Materializer): Behavior[Event] =
     Behaviors
       .receivePartial[Event] {
+        case (context, ConnectionLost) =>
+          disconnect(context, data.connectFlags, data.remote, data)
         case (_, e) =>
           pendingSubAck(data.copy(stash = data.stash :+ e))
       }

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -214,7 +214,7 @@ import scala.util.{Failure, Success}
     remote.complete()
 
     disconnected(
-      Uninitialized(data.stash,
+      Uninitialized(Vector.empty,
                     data.consumerPacketRouter,
                     data.producerPacketRouter,
                     data.subscriberPacketRouter,

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -686,6 +686,21 @@ import scala.util.{Failure, Success}
     }
     Behaviors
       .receivePartial[Event] {
+        case (_, ClientConnection.ConnectionLost) =>
+          clientDisconnected(
+            Disconnected(
+              data.publishers,
+              data.activeConsumers,
+              data.activeProducers,
+              data.pendingLocalPublications,
+              data.pendingRemotePublications,
+              data.consumerPacketRouter,
+              data.producerPacketRouter,
+              data.publisherPacketRouter,
+              data.unpublisherPacketRouter,
+              data.settings
+            )
+          )
         case (_, e) =>
           pendingSubAck(data.copy(stash = data.stash :+ e))
       }


### PR DESCRIPTION
The kill switch introduced in the last PR remained in effect across multiple flows - I hadn’t noticed this. The flows now each have their own kill switch which solves the regression that was introduced with the last PR.

Thanks to @longshorej for educating me on `lazyInitAsync` - very useful!

I've also strengthened the handling of connections being lost while waiting for SUBACKs.