### PR TITLE
google-cloud-pub-sub: remove redundant api key

### DIFF
--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/impl/GooglePubSubSource.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/impl/GooglePubSubSource.scala
@@ -18,7 +18,6 @@ import scala.util.{Failure, Success, Try}
 
 @InternalApi
 private[pubsub] final class GooglePubSubSource(projectId: String,
-                                               apiKey: String,
                                                session: GoogleSession,
                                                subscription: String,
                                                httpApi: PubSubApi)(implicit as: ActorSystem)
@@ -36,15 +35,12 @@ private[pubsub] final class GooglePubSubSource(projectId: String,
 
         val req = if (httpApi.isEmulated) {
           httpApi
-            .pull(project = projectId, subscription = subscription, maybeAccessToken = None, apiKey = apiKey)
+            .pull(project = projectId, subscription = subscription, maybeAccessToken = None)
         } else {
           session
             .getToken()
             .flatMap { token =>
-              httpApi.pull(project = projectId,
-                           subscription = subscription,
-                           maybeAccessToken = Some(token),
-                           apiKey = apiKey)
+              httpApi.pull(project = projectId, subscription = subscription, maybeAccessToken = Some(token))
             }
         }
         req.onComplete { tr =>

--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/impl/PubSubApi.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/impl/PubSubApi.scala
@@ -66,7 +66,7 @@ private[pubsub] trait PubSubApi {
     DefaultJsonProtocol.jsonFormat1(AcknowledgeRequest.apply)
   private implicit val pullRequestFormat = DefaultJsonProtocol.jsonFormat2(PubSubApi.PullRequest)
 
-  def pull(project: String, subscription: String, maybeAccessToken: Option[String], apiKey: String)(
+  def pull(project: String, subscription: String, maybeAccessToken: Option[String])(
       implicit as: ActorSystem,
       materializer: Materializer
   ): Future[PullResponse] = {
@@ -83,11 +83,10 @@ private[pubsub] trait PubSubApi {
     } yield pullResponse
   }
 
-  def acknowledge(project: String,
-                  subscription: String,
-                  maybeAccessToken: Option[String],
-                  apiKey: String,
-                  request: AcknowledgeRequest)(implicit as: ActorSystem, materializer: Materializer): Future[Unit] = {
+  def acknowledge(project: String, subscription: String, maybeAccessToken: Option[String], request: AcknowledgeRequest)(
+      implicit as: ActorSystem,
+      materializer: Materializer
+  ): Future[Unit] = {
     import materializer.executionContext
 
     val url: Uri =
@@ -111,11 +110,7 @@ private[pubsub] trait PubSubApi {
       maybeAccessToken.map(accessToken => request.addCredentials(OAuth2BearerToken(accessToken))).getOrElse(request)
     )
 
-  def publish(project: String,
-              topic: String,
-              maybeAccessToken: Option[String],
-              apiKey: String,
-              request: PublishRequest)(
+  def publish(project: String, topic: String, maybeAccessToken: Option[String], request: PublishRequest)(
       implicit as: ActorSystem,
       materializer: Materializer
   ): Future[immutable.Seq[String]] = {

--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/model.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/model.scala
@@ -15,7 +15,6 @@ import scala.collection.immutable
 import scala.collection.JavaConverters._
 
 class PubSubConfig private (val projectId: String,
-                            val apiKey: String,
                             /**
                              * Internal API
                              */
@@ -28,23 +27,19 @@ class PubSubConfig private (val projectId: String,
     copy(session = session)
 
   private def copy(session: GoogleSession) =
-    new PubSubConfig(projectId, apiKey, session)
+    new PubSubConfig(projectId, session)
 
   override def toString: String =
-    s"PubSubConfig(projectId=$projectId, apiKey=$apiKey)"
+    s"PubSubConfig(projectId=$projectId)"
 }
 
 object PubSubConfig {
-  def apply(projectId: String, apiKey: String, clientEmail: String, privateKey: String)(
+  def apply(projectId: String, clientEmail: String, privateKey: String)(
       implicit actorSystem: ActorSystem
-  ) = new PubSubConfig(projectId, apiKey, new GoogleSession(clientEmail, privateKey, new GoogleTokenApi(Http())))
+  ) = new PubSubConfig(projectId, new GoogleSession(clientEmail, privateKey, new GoogleTokenApi(Http())))
 
-  def create(projectId: String,
-             apiKey: String,
-             clientEmail: String,
-             privateKey: String,
-             actorSystem: ActorSystem): PubSubConfig =
-    apply(projectId, apiKey, clientEmail, privateKey)(actorSystem)
+  def create(projectId: String, clientEmail: String, privateKey: String, actorSystem: ActorSystem): PubSubConfig =
+    apply(projectId, clientEmail, privateKey)(actorSystem)
 }
 
 final case class PubSubMessage(data: String,

--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/scaladsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/scaladsl/GooglePubSub.scala
@@ -32,12 +32,12 @@ protected[pubsub] trait GooglePubSub {
 
     if (httpApi.isEmulated) {
       Flow[PublishRequest].mapAsyncUnordered(parallelism) { request =>
-        httpApi.publish(config.projectId, topic, maybeAccessToken = None, config.apiKey, request)
+        httpApi.publish(config.projectId, topic, maybeAccessToken = None, request)
       }
     } else {
       Flow[PublishRequest].mapAsyncUnordered(parallelism) { request =>
         config.session.getToken().flatMap { accessToken =>
-          httpApi.publish(config.projectId, topic, Some(accessToken), config.apiKey, request)
+          httpApi.publish(config.projectId, topic, Some(accessToken), request)
         }
       }
     }
@@ -48,7 +48,6 @@ protected[pubsub] trait GooglePubSub {
   ): Source[ReceivedMessage, NotUsed] =
     Source.fromGraph(
       new GooglePubSubSource(projectId = config.projectId,
-                             apiKey = config.apiKey,
                              session = config.session,
                              subscription = subscription,
                              httpApi = httpApi)
@@ -66,7 +65,6 @@ protected[pubsub] trait GooglePubSub {
          httpApi.acknowledge(project = config.projectId,
                              subscription = subscription,
                              maybeAccessToken = None,
-                             apiKey = config.apiKey,
                              request = ackReq)
        }
      } else {
@@ -76,7 +74,6 @@ protected[pubsub] trait GooglePubSub {
              httpApi.acknowledge(project = config.projectId,
                                  subscription = subscription,
                                  maybeAccessToken = Some(accessToken),
-                                 apiKey = config.apiKey,
                                  request = ackReq)
            }
          }

--- a/google-cloud-pub-sub/src/test/java/docs/javadsl/ExampleUsageJava.java
+++ b/google-cloud-pub-sub/src/test/java/docs/javadsl/ExampleUsageJava.java
@@ -47,7 +47,7 @@ public class ExampleUsageJava {
     String projectId = "test-XXXXX";
     String apiKey = "AIzaSyCVvqrlz057gCssc70n5JERyTW4TpB4ebE";
 
-    PubSubConfig config = PubSubConfig.create(projectId, apiKey, clientEmail, privateKey, system);
+    PubSubConfig config = PubSubConfig.create(projectId, clientEmail, privateKey, system);
 
     String topic = "topic1";
     String subscription = "subscription1";

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
@@ -37,10 +37,8 @@ class GooglePubSubSpec extends FlatSpec with MockitoSugar with ScalaFutures with
       val httpApi = mockHttpApi
     }
     val http: HttpExt = mock[HttpExt]
-    val config = PubSubConfig(TestCredentials.projectId,
-                              TestCredentials.apiKey,
-                              TestCredentials.clientEmail,
-                              TestCredentials.privateKey).withSession(mock[GoogleSession])
+    val config = PubSubConfig(TestCredentials.projectId, TestCredentials.clientEmail, TestCredentials.privateKey)
+      .withSession(mock[GoogleSession])
   }
 
   it should "auth and publish the message" in new Fixtures {
@@ -59,7 +57,6 @@ class GooglePubSubSpec extends FlatSpec with MockitoSugar with ScalaFutures with
       mockHttpApi.publish(project = TestCredentials.projectId,
                           topic = "topic1",
                           maybeAccessToken = Some("ok"),
-                          apiKey = TestCredentials.apiKey,
                           request = request)
     ).thenReturn(Future.successful(Seq("id1")))
 
@@ -80,7 +77,6 @@ class GooglePubSubSpec extends FlatSpec with MockitoSugar with ScalaFutures with
           project: String,
           topic: String,
           maybeAccessToken: Option[String],
-          apiKey: String,
           request: PublishRequest
       )(implicit as: ActorSystem, materializer: Materializer): Future[Seq[String]] =
         Future.successful(Seq("id2"))
@@ -104,10 +100,7 @@ class GooglePubSubSpec extends FlatSpec with MockitoSugar with ScalaFutures with
 
     when(config.session.getToken()).thenReturn(Future.successful("ok"))
     when(
-      mockHttpApi.pull(project = TestCredentials.projectId,
-                       subscription = "sub1",
-                       apiKey = TestCredentials.apiKey,
-                       maybeAccessToken = Some("ok"))
+      mockHttpApi.pull(project = TestCredentials.projectId, subscription = "sub1", maybeAccessToken = Some("ok"))
     ).thenReturn(Future.successful(PullResponse(receivedMessages = Some(Seq()))))
       .thenReturn(Future.successful(PullResponse(receivedMessages = Some(Seq(message)))))
 
@@ -127,7 +120,6 @@ class GooglePubSubSpec extends FlatSpec with MockitoSugar with ScalaFutures with
       mockHttpApi.acknowledge(
         project = TestCredentials.projectId,
         subscription = "sub1",
-        apiKey = TestCredentials.apiKey,
         maybeAccessToken = Some("ok"),
         request = AcknowledgeRequest(ackIds = Seq("a1"))
       )
@@ -155,7 +147,6 @@ class GooglePubSubSpec extends FlatSpec with MockitoSugar with ScalaFutures with
           project: String,
           subscription: String,
           maybeAccessToken: Option[String],
-          apiKey: String,
           request: AcknowledgeRequest
       )(implicit as: ActorSystem, materializer: Materializer): Future[Unit] =
         Future.successful(())

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/PubSubApiSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/PubSubApiSpec.scala
@@ -43,10 +43,7 @@ class PubSubApiSpec extends FlatSpec with BeforeAndAfterAll with ScalaFutures wi
     val GoogleApisHost = s"http://localhost:${wiremockServer.port()}"
   }
 
-  val config = PubSubConfig(TestCredentials.projectId,
-                            TestCredentials.apiKey,
-                            TestCredentials.clientEmail,
-                            TestCredentials.privateKey)
+  val config = PubSubConfig(TestCredentials.projectId, TestCredentials.clientEmail, TestCredentials.privateKey)
 
   val accessToken =
     "ya29.Elz4A2XkfGKJ4CoS5x_umUBHsvjGdeWQzu6gRRCnNXI0fuIyoDP_6aYktBQEOI4YAhLNgUl2OpxWQaN8Z3hd5YfFw1y4EGAtr2o28vSID-c8ul_xxHuudE7RmhH9sg"
@@ -82,7 +79,7 @@ class PubSubApiSpec extends FlatSpec with BeforeAndAfterAll with ScalaFutures wi
     )
 
     val result =
-      TestHttpApi.publish(config.projectId, "topic1", Some(accessToken), config.apiKey, publishRequest)
+      TestHttpApi.publish(config.projectId, "topic1", Some(accessToken), publishRequest)
 
     result.futureValue shouldBe Seq("1")
   }
@@ -119,7 +116,7 @@ class PubSubApiSpec extends FlatSpec with BeforeAndAfterAll with ScalaFutures wi
     )
 
     val result =
-      TestEmulatorHttpApi.publish(config.projectId, "topic1", None, config.apiKey, publishRequest)
+      TestEmulatorHttpApi.publish(config.projectId, "topic1", None, publishRequest)
 
     result.futureValue shouldBe Seq("1")
   }
@@ -146,7 +143,7 @@ class PubSubApiSpec extends FlatSpec with BeforeAndAfterAll with ScalaFutures wi
         .willReturn(aResponse().withStatus(200).withBody(pullResponse).withHeader("Content-Type", "application/json"))
     )
 
-    val result = TestHttpApi.pull(config.projectId, "sub1", Some(accessToken), config.apiKey)
+    val result = TestHttpApi.pull(config.projectId, "sub1", Some(accessToken))
     result.futureValue shouldBe PullResponse(Some(Seq(ReceivedMessage("ack1", publishMessage))))
 
   }
@@ -178,7 +175,7 @@ class PubSubApiSpec extends FlatSpec with BeforeAndAfterAll with ScalaFutures wi
         .willReturn(aResponse().withStatus(200).withBody(pullResponse).withHeader("Content-Type", "application/json"))
     )
 
-    val result = TestEmulatorHttpApi.pull(config.projectId, "sub1", None, config.apiKey)
+    val result = TestEmulatorHttpApi.pull(config.projectId, "sub1", None)
     result.futureValue shouldBe PullResponse(Some(Seq(ReceivedMessage("ack1", publishMessage))))
 
   }
@@ -201,7 +198,7 @@ class PubSubApiSpec extends FlatSpec with BeforeAndAfterAll with ScalaFutures wi
         .willReturn(aResponse().withStatus(200).withBody(pullResponse).withHeader("Content-Type", "application/json"))
     )
 
-    val result = TestHttpApi.pull(config.projectId, "sub1", Some(accessToken), config.apiKey)
+    val result = TestHttpApi.pull(config.projectId, "sub1", Some(accessToken))
     result.futureValue shouldBe PullResponse(None)
 
   }
@@ -222,7 +219,7 @@ class PubSubApiSpec extends FlatSpec with BeforeAndAfterAll with ScalaFutures wi
 
     val acknowledgeRequest = AcknowledgeRequest(Seq("ack1"))
 
-    val result = TestHttpApi.acknowledge(config.projectId, "sub1", Some(accessToken), config.apiKey, acknowledgeRequest)
+    val result = TestHttpApi.acknowledge(config.projectId, "sub1", Some(accessToken), acknowledgeRequest)
 
     result.futureValue shouldBe (())
   }
@@ -257,7 +254,7 @@ class PubSubApiSpec extends FlatSpec with BeforeAndAfterAll with ScalaFutures wi
     )
 
     val result =
-      TestHttpApi.publish(config.projectId, "topic1", Some(accessToken), config.apiKey, publishRequest)
+      TestHttpApi.publish(config.projectId, "topic1", Some(accessToken), publishRequest)
 
     assertThrows[RuntimeException] { result.futureValue }
   }
@@ -293,5 +290,4 @@ object TestCredentials {
                      |-----END RSA PRIVATE KEY-----""".stripMargin
   val clientEmail = "test-XXX@test-XXXXX.iam.gserviceaccount.com"
   val projectId = "testX-XXXXX"
-  val apiKey = "AIzaSyCVvqrlz057gCssc70n5JERyTW4TpB4ebE"
 }

--- a/google-cloud-pub-sub/src/test/scala/docs/scaladsl/ExampleUsage.scala
+++ b/google-cloud-pub-sub/src/test/scala/docs/scaladsl/ExampleUsage.scala
@@ -39,7 +39,7 @@ class ExampleUsage {
   val projectId = "test-XXXXX"
   val apiKey = "AIzaSyCVvqrlz057gCssc70n5JERyTW4TpB4ebE"
 
-  val config = PubSubConfig(projectId, apiKey, clientEmail, privateKey)
+  val config = PubSubConfig(projectId, clientEmail, privateKey)
 
   val topic = "topic1"
   val subscription = "subscription1"


### PR DESCRIPTION
Fixes issue https://github.com/akka/alpakka/issues/832

The usage of the api key was removed in https://github.com/akka/alpakka/pull/683

Hopefully we can get this in before 1.0 as it will be a breaking change for the scala/java api.