### PR TITLE
MQTT streaming: Fixup the continuation of a session

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/model.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/model.scala
@@ -196,6 +196,10 @@ final case class Connect(protocolName: Connect.ProtocolName,
       Some(username),
       Some(password)
     )
+
+  override def toString: String =
+    s"""Connect(protocolName:$protocolName,protocolLevel:$protocolLevel,clientId:$clientId,connectFlags:$connectFlags,keepAlive:$keepAlive,willTopic:$willTopic,willMessage:$willMessage,username:$username,password:${password
+      .map(_ => "********")})"""
 }
 
 object ConnAckFlags {
@@ -288,6 +292,9 @@ final case class Publish @InternalApi private[streaming] (override val flags: Co
    */
   def this(topicName: String, payload: ByteString) =
     this(ControlPacketFlags.QoSAtLeastOnceDelivery, topicName, Some(PacketId(0)), payload)
+
+  override def toString: String =
+    s"""Publish(flags:$flags,topicName:$topicName,packetId:$packetId,payload:${payload.size}b)"""
 }
 
 /**
@@ -503,7 +510,14 @@ object MqttCodec {
                                      willMessage: Option[Either[MqttCodec.DecodeError, String]],
                                      username: Option[Either[MqttCodec.DecodeError, String]],
                                      password: Option[Either[MqttCodec.DecodeError, String]])
-      extends DecodeError
+      extends DecodeError {
+    override def toString: String =
+      s"""BadConnectMessage(clientId:$clientId,willTopic:$willTopic,willMessage:$willMessage,username:$username,password:${password
+        .map {
+          case Left(x) => s"Left($x)"
+          case Right(x) => s"Right(" + x.map(_ => "********") + ")"
+        }})"""
+  }
 
   /**
    * A reserved QoS was specified
@@ -521,7 +535,10 @@ object MqttCodec {
   final case class BadPublishMessage(topicName: Either[DecodeError, String],
                                      packetId: Option[PacketId],
                                      payload: ByteString)
-      extends DecodeError
+      extends DecodeError {
+    override def toString: String =
+      s"""BadPublishMessage(topicName:$topicName,packetId:$packetId,payload:${payload.size}b)"""
+  }
 
   /**
    * Something is wrong with the subscribe message

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import akka.{NotUsed, actor => untyped}
 import akka.actor.typed.scaladsl.adapter._
+import akka.event.Logging
 import akka.stream._
 import akka.stream.alpakka.mqtt.streaming.impl._
 import akka.stream.scaladsl.{BroadcastHub, Flow, Keep, Source}
@@ -148,6 +149,8 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
 
         Future.successful(
           Flow[Command[A]]
+            .log("client-commandFlow")
+            .withAttributes(ActorAttributes.logLevels(onFailure = Logging.DebugLevel))
             .watch(clientConnector.toUntyped)
             .watchTermination() {
               case (_, terminated) =>
@@ -320,6 +323,8 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
         case _ =>
           Supervision.Stop
       })
+      .log("client-events")
+      .withAttributes(ActorAttributes.logLevels(onFailure = Logging.DebugLevel))
 }
 
 object MqttServerSession {
@@ -441,6 +446,8 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
 
         Future.successful(
           Flow[Command[A]]
+            .log("server-commandFlow")
+            .withAttributes(ActorAttributes.logLevels(onFailure = Logging.DebugLevel))
             .watch(serverConnector.toUntyped)
             .watchTermination() {
               case (_, terminated) =>
@@ -605,4 +612,6 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
         case _ =>
           Supervision.Stop
       })
+      .log("server-events")
+      .withAttributes(ActorAttributes.logLevels(onFailure = Logging.DebugLevel))
 }

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -151,7 +151,11 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
             .watch(clientConnector.toUntyped)
             .watchTermination() {
               case (_, terminated) =>
-                terminated.onComplete(_ => clientConnector ! ClientConnector.ConnectionLost)
+                terminated.onComplete {
+                  case Failure(_: WatchedActorTerminatedException) =>
+                  case _ =>
+                    clientConnector ! ClientConnector.ConnectionLost
+                }
                 NotUsed
             }
             .via(killSwitch.flow)
@@ -234,7 +238,11 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
       .watch(clientConnector.toUntyped)
       .watchTermination() {
         case (_, terminated) =>
-          terminated.onComplete(_ => clientConnector ! ClientConnector.ConnectionLost)
+          terminated.onComplete {
+            case Failure(_: WatchedActorTerminatedException) =>
+            case _ =>
+              clientConnector ! ClientConnector.ConnectionLost
+          }
           NotUsed
       }
       .via(new MqttFrameStage(settings.maxPacketSize))
@@ -436,7 +444,11 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
             .watch(serverConnector.toUntyped)
             .watchTermination() {
               case (_, terminated) =>
-                terminated.onComplete(_ => serverConnector ! ServerConnector.ConnectionLost(connectionId))
+                terminated.onComplete {
+                  case Failure(_: WatchedActorTerminatedException) =>
+                  case _ =>
+                    serverConnector ! ServerConnector.ConnectionLost(connectionId)
+                }
                 NotUsed
             }
             .via(killSwitch.flow)
@@ -517,7 +529,11 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
       .watch(serverConnector.toUntyped)
       .watchTermination() {
         case (_, terminated) =>
-          terminated.onComplete(_ => serverConnector ! ServerConnector.ConnectionLost(connectionId))
+          terminated.onComplete {
+            case Failure(_: WatchedActorTerminatedException) =>
+            case _ =>
+              serverConnector ! ServerConnector.ConnectionLost(connectionId)
+          }
           NotUsed
       }
       .via(new MqttFrameStage(settings.maxPacketSize))


### PR DESCRIPTION
Prior to this commit, if a server-side session was publishing to a client and the client disconnected, and then subsequently reconnected, its publications would be lost. This is because I was closing over some actor state within a future. Whoops.

I’ve now written a comprehensive test for this scenario, along with some additional, unrelated, subscription tests along the way.

I also cancel timers explicitly to be tidy (and to avoid potential misfiring issues, although I've not seen any), and the logging has been improved so that debug log levels outputs MQTT events sans sensitive info (passwords, payloads); the latter being useful toward logging.