### PR TITLE
Fail the client when no CONNACK or SUBACK

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.mqtt.streaming
 package impl
 
 import akka.NotUsed
-import akka.actor.typed.{ActorRef, Behavior, PostStop, Terminated}
+import akka.actor.typed.{ActorRef, Behavior, ChildFailed, PostStop, Terminated}
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import akka.annotation.InternalApi
 import akka.stream.{Materializer, OverflowStrategy}
@@ -25,6 +25,11 @@ import scala.util.{Failure, Success}
 @InternalApi private[streaming] object ClientConnector {
 
   type ConnectData = Option[_]
+
+  /*
+   * No ACK received - the CONNECT failed
+   */
+  case object ConnectFailed extends Exception with NoStackTrace
 
   /*
    * A PINGREQ failed to receive a PINGRESP - the connection must close
@@ -262,6 +267,7 @@ import scala.util.{Failure, Success}
             timer.cancel(ReceiveConnAck)
             disconnect(context, data.connect.connectFlags, data.remote, data)
           case (context, ReceiveConnAckTimeout) =>
+            data.remote.fail(ConnectFailed)
             timer.cancel(ReceiveConnAck)
             disconnect(context, data.connect.connectFlags, data.remote, data)
           case (context, ConnectionLost) =>
@@ -464,6 +470,9 @@ import scala.util.{Failure, Success}
           pendingSubAck(data.copy(stash = data.stash :+ e))
       }
       .receiveSignal {
+        case (context, ChildFailed(_, failure)) if failure == Subscriber.SubscribeFailed =>
+          data.remote.fail(Subscriber.SubscribeFailed)
+          disconnect(context, data.connectFlags, data.remote, data)
         case (context, _: Terminated) =>
           data.stash.foreach(context.self.tell)
           serverConnected(

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -313,7 +313,7 @@ import scala.util.{Failure, Success}
                   PendingSubscribe(
                     data.connectFlags,
                     data.keepAlive,
-                    data.pendingPingResp,
+                    pendingPingResp = false,
                     data.activeConsumers,
                     data.activeProducers,
                     data.pendingLocalPublications,

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -159,8 +159,6 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
 
         Future.successful(
           Flow[Command[A]]
-            .log("client-commandFlow")
-            .withAttributes(ActorAttributes.logLevels(onFailure = Logging.DebugLevel))
             .watch(clientConnector.toUntyped)
             .watchTermination() {
               case (_, terminated) =>
@@ -244,6 +242,8 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
               case _ =>
                 Supervision.Stop
             })
+            .log("client-commandFlow", _.iterator.decodeControlPacket(settings.maxPacketSize)) // we decode here so we can see the generated packet id
+            .withAttributes(ActorAttributes.logLevels(onFailure = Logging.DebugLevel))
         )
       }
       .mapMaterializedValue(_ => NotUsed)
@@ -458,8 +458,6 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
 
         Future.successful(
           Flow[Command[A]]
-            .log("server-commandFlow")
-            .withAttributes(ActorAttributes.logLevels(onFailure = Logging.DebugLevel))
             .watch(serverConnector.toUntyped)
             .watchTermination() {
               case (_, terminated) =>
@@ -539,6 +537,8 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
               case _ =>
                 Supervision.Stop
             })
+            .log("server-commandFlow", _.iterator.decodeControlPacket(settings.maxPacketSize)) // we decode here so we can see the generated packet id
+            .withAttributes(ActorAttributes.logLevels(onFailure = Logging.DebugLevel))
         )
       }
       .mapMaterializedValue(_ => NotUsed)

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -186,11 +186,7 @@ class MqttSessionSpec
           .toMat(Sink.ignore)(Keep.both)
           .run()
 
-      val connectBytes = connect.encode(ByteString.newBuilder).result()
-
       client.offer(Command(connect))
-
-      server.expectMsg(connectBytes)
 
       result.failed.futureValue shouldBe an[ActorMqttClientSession.ConnectFailed.type]
     }
@@ -219,16 +215,12 @@ class MqttSessionSpec
       val connAck = ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)
       val connAckBytes = connAck.encode(ByteString.newBuilder).result()
 
-      val subscribeBytes = subscribe.encode(ByteString.newBuilder, PacketId(1)).result()
-
       client.offer(Command(connect))
 
       server.expectMsg(connectBytes)
       server.reply(connAckBytes)
 
       client.offer(Command(subscribe))
-
-      server.expectMsg(subscribeBytes)
 
       result.failed.futureValue shouldBe an[ActorMqttClientSession.SubscribeFailed.type]
     }


### PR DESCRIPTION
Prior to this PR, a lack of a CONNACK would result in the client stream completing, but with no explanation. We now fail the client stream with an appropriate exception.

Also, the lack of a SUBACK would be silently ignored. This PR makes the lack of a SUBACK consistent with a lack of a CONNACK in that the client stream will be failed with an appropriate exception.

Also, a small improvement to the command logging so that we can capture any generated packet ids.