### PR TITLE
Fix snapshot documentation deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ jobs:
     - stage: publish
       script: sbt -jvm-opts .jvmopts-travis +publish
       name: "Publish artifacts for all Scala versions"
-    - script: openssl aes-256-cbc -K $encrypted_bbf1dc4f2a07_key -iv $encrypted_bbf1dc4f2a07_iv -in .travis/travis_alpakka_rsa.enc -out .travis/id_rsa -d && eval "$(ssh-agent -s)" && chmod 600 .travis/id_rsa && ssh-add .travis/id_rsa && sbt -jvm-opts .jvmopts-travis docs/publishRsync
+    - script: openssl aes-256-cbc -K $encrypted_bbf1dc4f2a07_key -iv $encrypted_bbf1dc4f2a07_iv -in .travis/travis_alpakka_rsa.enc -out .travis/id_rsa -d && chmod 600 .travis/id_rsa && sbt -jvm-opts .jvmopts-travis docs/publishRsync
       name: "Publish API and reference documentation"
 
 stages:

--- a/project/PublishRsync.scala
+++ b/project/PublishRsync.scala
@@ -23,7 +23,7 @@ object PublishRsyncPlugin extends AutoPlugin {
       val (from, to) = publishRsyncArtifact.value
       Process(Seq("rsync", "-azP", s"$from/", s"${publishRsyncHost.value}:$to"),
               None,
-              "RSYNC_RSH" -> "ssh -o StrictHostKeyChecking=no").! match {
+              "RSYNC_RSH" -> "ssh -o StrictHostKeyChecking=no -i .travis/id_rsa").! match {
         case 0 => () // success
         case error => throw new IllegalStateException(s"rsync command exited with an error code $error")
       }


### PR DESCRIPTION
Currently snapshot documentation deployment jobs [succeed with rsync failing silently](https://travis-ci.org/akka/alpakka/jobs/479553487). This PR makes it so the sbt task fails if rsync fails. Also it makes rsync use the explicitly specified identity file instead of using agent.