### PR TITLE
Drop the unneccessary level in documentation

### DIFF
--- a/docs/src/main/paradox/amqp.md
+++ b/docs/src/main/paradox/amqp.md
@@ -18,9 +18,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 @@dependencies { projectId="amqp" }
 
-## Usage
-
-### Connecting to AMQP server
+## Connecting to server
 
 All the AMQP connectors are configured using a @scaladoc[AmqpConnectionProvider](akka.stream.alpakka.amqp.AmqpConnectionProvider) and a list of @scaladoc[Declaration](akka.stream.alpakka.amqp.Declaration)
 
@@ -32,7 +30,7 @@ There are several types of @scaladoc[AmqpConnectionProvider](akka.stream.alpakka
 * @scaladoc[AmqpConnectionFactoryConnectionProvider](akka.stream.alpakka.amqp.AmqpConnectionFactoryConnectionProvider) which takes a raw [ConnectionFactory](https://www.rabbitmq.com/releases/rabbitmq-java-client/current-javadoc/com/rabbitmq/client/ConnectionFactory.html). It creates a new connection for each stage.
 * @scaladoc[AmqpCachedConnectionProvider](akka.stream.alpakka.amqp.AmqpCachedConnectionProvider) which receive any other provider as parameter and caches the connection it provides to be used in all stages. By default it closes the connection whenever the last stage using the provider stops. Optionally, it takes `automaticRelease` boolean parameter so the connection is not automatically release and the user have to release it explicitly.
 
-### Sending messages to AMQP server
+## Sending messages
 
 First define a queue name and the declaration of the queue that the messages will be sent to.
 
@@ -62,7 +60,7 @@ Scala
 Java
 : @@snip [snip](/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java) { #run-sink }
 
-### Receiving messages from AMQP server
+## Receiving messages
 
 Create a source using the same queue declaration as before.
 
@@ -84,7 +82,7 @@ Java
 
 This is how you send and receive message from AMQP server using this connector.
 
-### Using Pub/Sub with an AMQP server
+## Using Pub/Sub
 
 Instead of sending messages directly to queues, it is possible to send messages to an exchange and then provide instructions to AMQP server what to do with incoming messages to the exchange. We are going to use the *fanout* type of the exchange, which enables message broadcasting to multiple consumers. We are going to do that by using an exchange declaration for the sink and all of the sources.
 
@@ -114,7 +112,7 @@ We merge all sources into one and add the index of the source to all incoming me
 
 Such sink and source can be started the same way as in the previous example.
 
-### Using rabbitmq as an RPC mechanism
+## Using rabbitmq as an RPC mechanism
 
 If you have remote workers that you want to incorporate into a stream, you can do it using rabbit RPC workflow [RabbitMQ RPC](https://www.rabbitmq.com/tutorials/tutorial-six-java.html)
 
@@ -132,7 +130,7 @@ Java
 : @@snip [snip](/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java) { #run-rpc-flow }
 
 
-### Acknowledging messages downstream
+## Acknowledging messages downstream
 
 Create a committable sink which returns 
 
@@ -160,7 +158,7 @@ Scala
 Java
 : @@snip [snip](/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java) { #run-source-withoutautoack-and-nack }
 
-### Running the example code
+## Running the example code
 
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
 

--- a/docs/src/main/paradox/avroparquet.md
+++ b/docs/src/main/paradox/avroparquet.md
@@ -1,4 +1,4 @@
-#Avro Parquet
+# Avro Parquet
 
 The Avro Parquet connector provides an Akka Stream Source, Sink and Flow for push and pull data to and from parquet files.
 
@@ -18,7 +18,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 @@dependencies { projectId="avroparquet" }
 
-#Usage
+## Source Initiation
 
 We will need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and an @scaladoc[ActorMaterializer](akka.stream.ActorMaterializer).
 
@@ -28,7 +28,6 @@ Scala
 Java
 : @@snip (/avroparquet/src/test/java/docs/javadsl/Examples.java) { #init-system }
 
-#Source Initiation
 Sometimes it might be useful to use parquet file as stream Source. For this we will need to create `AvroParquetReader` 
 instance which produces Parquet `GenericRecord` instances.
  
@@ -46,7 +45,8 @@ Scala
 Java
 : @@snip (/avroparquet/src/test/java/docs/javadsl/Examples.java) { #init-source }
 
-#Sink Initiation
+## Sink Initiation
+
 Sometimes it might be useful to use Parquet file as akka stream Sink. For an instance, if you need to store data on 
 Parquet files on HDFS (or any other distributed file system) and perform map-reduce jobs on it further. 
 For this we first of all need to create `AvroParquetWriter` instance which accepts `GenericRecord`.
@@ -65,7 +65,7 @@ Scala
 Java
 : @@snip (/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java) { #init-sink }
 
-#Flow Initiation
+## Flow Initiation
 
 It might be useful to use ParquetWriter as the streams flow stage, which accepts Parquet `GenericRecord`, writes it to
 Parquet file, and returns the same `GenericRecords`. Such Flow stage can be easily created by creating `AvroParquetFlow`
@@ -78,7 +78,7 @@ This is all preparation that we are going to need.
 Java
 : @@snip (/avroparquet/src/test/java/docs/javadsl/Examples.java) { #init-flow }
 
-### Running the example code
+## Running the example code
 
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
 

--- a/docs/src/main/paradox/awslambda.md
+++ b/docs/src/main/paradox/awslambda.md
@@ -18,9 +18,9 @@ The table below shows direct dependencies of this module and the second tab show
 
 @@dependencies { projectId="awslambda" }
 
-## Usage
+## Sending messages
 
-Flow provided by this connector need a prepared `AWSLambdaAsyncClient` to be able to invoke lambda functions.
+Flow provided by this connector needs a prepared `AWSLambdaAsyncClient` to be able to invoke lambda functions.
 
 Scala
 : @@snip (/awslambda/src/test/scala/docs/scaladsl/Examples.scala) { #init-client }
@@ -38,8 +38,6 @@ Java
 
 This is all preparation that we are going to need.
 
-### Flow messages to AWS Lambda
-
 Now we can stream AWS Java SDK Lambda `InvokeRequest` to AWS Lambda functions
 @scaladoc[AwsLambdaFlow](akka.stream.alpakka.awslambda.scaladsl.AwsLambdaFlow$) factory.
 
@@ -49,7 +47,7 @@ Scala
 Java
 : @@snip (/awslambda/src/test/java/docs/javadsl/Examples.java) { #run }
 
-#### AwsLambdaFlow configuration
+## AwsLambdaFlow configuration
 
 Options:
 

--- a/docs/src/main/paradox/azure-storage-queue.md
+++ b/docs/src/main/paradox/azure-storage-queue.md
@@ -6,7 +6,7 @@ Azure Storage Queue is a queuing service similar to Amazon's SQS. It is designed
 
 @@project-info{ projectId="azure-storage-queue" }
 
-### Artifacts
+## Artifacts
 
 @@dependency [sbt,Maven,Gradle] {
   group=com.lightbend.akka
@@ -19,9 +19,7 @@ The table below shows direct dependencies of this module and the second tab show
 @@dependencies { projectId="azure-storage-queue" }
 
 
-## Example usage
-
-#### Init Azure Storage API
+## Init Azure Storage API
 
 ```scala
 import com.microsoft.azure.storage._
@@ -33,9 +31,11 @@ val queueFactory = () => { // Since azure storage JDK is not guaranteed to be th
   queueClient.getQueueReference("myQueue")
 }
 ```
+
 For more details, see [Microsoft Azure Storage Docs](https://docs.microsoft.com/en-us/azure/storage/storage-java-how-to-use-queue-storage).
 
-#### Queuing a message
+## Queuing a message
+
 ```scala
 import one.aleph.akkzure.queue._
 import one.aleph.akkzure.queue.scaladsl._
@@ -46,7 +46,8 @@ val message = new CloudQueueMessage("Hello Azure")
 Source.single(message).runWith(AzureQueueSink(queueFactory))
 ```
 
-#### Processing and deleting messages
+## Processing and deleting messages
+
 ```scala
 AzureQueueSource(queueFactory).take(10)
 .map({ msg: CloudQueueMessage =>

--- a/docs/src/main/paradox/cassandra.md
+++ b/docs/src/main/paradox/cassandra.md
@@ -19,7 +19,7 @@ The table below shows direct dependencies of this module and the second tab show
 @@dependencies { projectId="cassandra" }
 
 
-## Usage
+## Source
 
 Sources provided by this connector need a prepared session to communicate with Cassandra cluster. First, let's initialize a Cassandra session.
 
@@ -36,10 +36,6 @@ Scala
 
 Java
 : @@snip [snip](/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java) { #init-mat }
-
-This is all preparation that we are going to need.
-
-### Source Usage
 
 Let's create a Cassandra statement with a query that we want to execute.
 
@@ -59,7 +55,7 @@ Java
 
 Here we used a basic sink to complete the stream by collecting all of the stream elements to a collection. The power of streams comes from building larger data pipelines which leverage backpressure to ensure efficient flow control. Feel free to edit the example code and build @extref[more advanced stream topologies](akka-docs:scala/stream/stream-introduction).
 
-### Flow with passthrough Usage
+## Flow with passthrough
 
 Let's create a Cassandra Prepared statement with a query that we want to execute.
 
@@ -85,7 +81,7 @@ Scala
 Java
 : @@snip [snip](/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java) { #run-flow }
 
-### Flow with passthrough and unlogged batching Usage
+## Flow with passthrough and unlogged batching
 
 Use this when most of the elements in the stream share the same partition key. 
 
@@ -137,7 +133,7 @@ Java
 : @@snip [snip](/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java) { #run-batching-flow }
 
 
-### Sink Usage
+## Sink
 
 Let's create a Cassandra Prepared statement with a query that we want to execute.
 
@@ -164,7 +160,7 @@ Java
 : @@snip [snip](/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java) { #run-sink }
 
 
-### Running the example code
+## Running the example code
 
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
 

--- a/docs/src/main/paradox/dynamodb.md
+++ b/docs/src/main/paradox/dynamodb.md
@@ -66,7 +66,7 @@ Scala
 Java
 : @@snip [snip](/dynamodb/src/test/java/docs/javadsl/ExampleTest.java) { #paginated }
 
-### Running the example code
+## Running the example code
 
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
 

--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -20,9 +20,7 @@ The table below shows direct dependencies of this module and the second tab show
 @@dependencies { projectId="ftp" }
 
 
-## Usage
-
-### Configuring the connection settings
+## Configuring the connection settings
 
 In order to establish a connection with the remote server, you need to provide a specialized version of a @scaladoc[RemoteFileSettings](akka.stream.alpakka.ftp.RemoteFileSettings) instance. It's specialized as it depends on the kind of server you're connecting to: FTP, FTPs or SFTP.
 
@@ -49,7 +47,7 @@ Scala
 Java
 : @@snip [snip](/ftp/src/test/java/docs/javadsl/ConfigureCustomSSHClient.java) { #configure-custom-ssh-client }
 
-### Traversing a remote FTP folder recursively
+## Traversing a remote FTP folder recursively
 
 In order to traverse a remote folder recursively, you need to use the `ls` method in the FTP API:
 
@@ -63,7 +61,7 @@ This source will emit @scaladoc[FtpFile](akka.stream.alpakka.ftp.FtpFile) elemen
 
 For both FTPs and SFTP servers, you will need to use the `FTPs` and `SFTP` API respectively.
 
-### Retrieving files
+## Retrieving files
 
 In order to retrieve a remote file as a stream of bytes, you need to use the `fromPath` method in the FTP API:
 
@@ -77,7 +75,7 @@ This source will emit @scaladoc[ByteString](akka.util.ByteString) elements and m
 
 For both FTPs and SFTP servers, you will need to use the `FTPs` and `SFTP` API respectively.
 
-### Writing files
+## Writing files
 
 In order to store a remote file from a stream of bytes, you need to use the `toPath` method in the FTP API:
 
@@ -91,7 +89,7 @@ This sink will consume @scaladoc[ByteString](akka.util.ByteString) elements and 
 
 For both FTPs and SFTP servers, you will need to use the `FTPs` and `SFTP` API respectively.
 
-### Removing files
+## Removing files
 
 In order to remove a remote file, you need to use the `remove` method in the FTP API:
 
@@ -103,7 +101,7 @@ Java
 
 This sink will consume @scaladoc[FtpFile](akka.stream.alpakka.ftp.FtpFile) elements and materializes to @scaladoc[Future](scala.concurrent.Future) in Scala API and @javadoc[CompletionStage](java/util/concurrent/CompletionStage) in Java API of @scaladoc[IOResult](akka.stream.IOResult) when the stream finishes.
 
-### Moving files
+## Moving files
 
 In order to move a remote file, you need to use the `move` method in the FTP API. The `move` method takes a function to calculate the path to which the file should be moved based on the consumed @scaladoc[FtpFile](akka.stream.alpakka.ftp.FtpFile).   
 

--- a/docs/src/main/paradox/geode.md
+++ b/docs/src/main/paradox/geode.md
@@ -21,9 +21,7 @@ The table below shows direct dependencies of this module and the second tab show
 @@dependencies { projectId="geode" }
 
 
-#Usage
-
-##Connection
+## Connection
 
 First of all you need to connect to the geode cache. In a client application, connection is handle by a
  @extref[ClientCache](geode:basic_config/the_cache/managing_a_client_cache.html). A single
@@ -44,7 +42,7 @@ scala
 java
 : @@snip [snip](/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java) { #connection-with-pool }
 
-##Region
+## Region
 
 Define a @extref[region](geode:/basic_config/data_regions/chapter_overview.html) setting to
 describe how to access region and the key extraction function.
@@ -56,7 +54,7 @@ java
 : @@snip [snip](/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java) { #region }
 
 
-###Serialization
+## Serialization
 
 Object must be serialized to flow in a geode region.
 
@@ -84,7 +82,7 @@ Java user will need to write by hand their custom serializer.
 
 Runtime reflection is also an option see @extref[auto_serialization.html](geode:/developing/data_serialization/auto_serialization.html).
 
-###Flow usage
+## Flow usage
 
 This sample stores (case) classes in Geode.
 
@@ -95,7 +93,7 @@ java
 : @@snip [snip](/geode/src/test/java/docs/javadsl/GeodeFlowTestCase.java) { #flow }
 
 
-###Sink usage
+## Sink usage
 
 scala
 : @@snip [snip](/geode/src/test/scala/docs/scaladsl/GeodeSinkSpec.scala) { #sink }
@@ -104,9 +102,9 @@ java
 : @@snip [snip](/geode/src/test/java/docs/javadsl/GeodeSinkTestCase.java) { #sink }
 
 
-###Source usage
+### ource usage
 
-####Simple query
+### Simple query
 
 Apache Geode support simple queries.
 
@@ -117,7 +115,7 @@ java
 : @@snip [snip](/geode/src/test/java/docs/javadsl/GeodeFiniteSourceTestCase.java) { #query }
 
 
-####Continuous query
+### Continuous query
 
 
 scala
@@ -127,7 +125,7 @@ java
 : @@snip [snip](/geode/src/test/java/docs/javadsl/GeodeContinuousSourceTestCase.java) { #continuousQuery }
 
 
-##Geode basic command:
+## Geode basic commands
 
 Assuming Apache geode is installed:
 
@@ -147,7 +145,7 @@ create region --name=persons --type=PARTITION_REDUNDANT --redundant-copies=2
 
 ```
 
-###Run the test
+## Run the example code
 
 Integration test are run against localhost geode, but IT_GEODE_HOSTNAME environment variable can change this:
 

--- a/docs/src/main/paradox/hbase.md
+++ b/docs/src/main/paradox/hbase.md
@@ -19,7 +19,7 @@ The table below shows direct dependencies of this module and the second tab show
 @@dependencies { projectId="hbase" }
 
 
-# Usage
+## Converters
 
 Build a converter and a tableSetting.
 
@@ -80,7 +80,7 @@ scala
 java
 :   @@snip [snip](/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java) { #create-settings }
 
-### Flow usage 
+## Flow
 
 scala
 : @@snip [snip](/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala) { #flow }
@@ -89,7 +89,7 @@ java
 : @@snip [snip](/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java) { #flow }
 
 
-### Sink usage
+## Sink
 
 scala
 : @@snip [snip](/hbase/src/test/scala/akka/stream/alpakka/hbase/scaladsl/HBaseStageSpec.scala) { #sink }
@@ -97,7 +97,7 @@ scala
 java
 : @@snip [snip](/hbase/src/test/java/akka/stream/alpakka/hbase/javadsl/HBaseStageTest.java) { #sink }
 
-## HBase basic command:
+## HBase basic commands
 
 ```
 $HBASE_HOME/bin/start-hbase.sh

--- a/docs/src/main/paradox/ironmq.md
+++ b/docs/src/main/paradox/ironmq.md
@@ -20,15 +20,12 @@ The table below shows direct dependencies of this module and the second tab show
 
 @@dependencies { projectId="ironmq" }
 
-
-## Usage
+## Consumer
 
 IronMQ can be used either in cloud or on-premise. Either way you need a authentication token and a project ID. These can
 be set in the Typesafe config:
 
 @@snip [snip](/ironmq/src/main/resources/reference.conf)
-
-### Consumer
 
 The consumer is poll based one. It will poll every `n` milliseconds, waiting for `m` milliseconds to consume new messages and
 will push them to the downstream. All These parameters are configurable by the Typesafe config.
@@ -41,7 +38,8 @@ The consumer could be instantiated using the @scaladoc[IronMqConsumer](akka.stre
 It provides methods to obtain either a `Source[Message, NotUsed]` or `Source[CommittableMessage, NotUsed]`. The first is
 for at-most-one semantic, the latter for at-least-once semantic.
 
-### Producer
+## Producer
+
 The producer is very trivial at this time, it does not provide any batching mechanism, but sends messages to IronMq as
 soon as they arrive to the stage.
 
@@ -60,6 +58,8 @@ if the producer will implement a batch mechanism in the future.
 
 The producer also provides a Committable aware Flow/Sink as `Flow[(PushMessage, ToCommit), (Message.Id, CommitResult), CommitMat]`.
 It can be used to consume a Flow from an IronMQ consumer or any other source that provides a commit mechanism.
+
+## Running the test code
 
 > Test code requires IronMQ running in the background. You can start it quickly using docker:
 >

--- a/docs/src/main/paradox/mongodb.md
+++ b/docs/src/main/paradox/mongodb.md
@@ -29,7 +29,7 @@ The table below shows direct dependencies of this module and the second tab show
 @@dependencies { projectId="mongodb" }
 
 
-## Usage
+## Initialization
 
 Sources provided by this connector need a prepared session to communicate with MongoDB server.
 
@@ -55,7 +55,7 @@ Scala
 
 This is all preparation that we are going to need.
 
-### Source Usage
+## Source
 
 Let's create a source from a MongoDB collection observable, which can optionally take a filter.
 
@@ -79,7 +79,7 @@ Scala
 
 Here we used a basic sink to complete the stream by collecting all of the stream elements to a collection. The power of streams comes from building larger data pipelines which leverage backpressure to ensure efficient flow control. Feel free to edit the example code and build @extref[more advanced stream topologies](akka-docs:scala/stream/stream-introduction).
 
-### Flow and Sink Usage
+## Flow and Sink
 
 Each of these sink factory methods have a corresponding factory in @scaladoc[insertOne](akka.stream.alpakka.mongodb.scaladsl.MongoFlow) which will emit the written document or result of the operation downstream.
 
@@ -88,7 +88,7 @@ For codec support, the type must be specified in the database or collection decl
 Scala
 : @@snip [snip](/mongodb/src/test/scala/akka/stream/alpakka/mongodb/MongoSinkSpec.scala) { #init-connection-codec }
 
-#### Insert
+### Insert
 
 We can use a Source of documents to save them to a mongo collection using @scaladoc[insertOne](akka.stream.alpakka.mongodb.scaladsl.MongoSink$#insertOne) or @scaladoc[insertMany](akka.stream.alpakka.mongodb.scaladsl.MongoSink$#insertMany).
 
@@ -101,7 +101,7 @@ With codec support
 Scala
 : @@snip [snip](/mongodb/src/test/scala/akka/stream/alpakka/mongodb/MongoSinkSpec.scala) { #insertOneCodec }
 
-#### Insert Many
+### Insert Many
 
 Insert many can be used if you have a collection of documents to insert at once.
 
@@ -113,7 +113,7 @@ With codec support
 Scala
 : @@snip [snip](/mongodb/src/test/scala/akka/stream/alpakka/mongodb/MongoSinkSpec.scala) { #insertManyCodec }
 
-#### Update
+### Update
 
 We can update documents with a Source of @scaladoc[DocumentUpdate](akka.stream.alpakka.mongodb.scaladsl.DocumentUpdate) which is a filter and a update definition.
 Use either @scaladoc[updateOne](akka.stream.alpakka.mongodb.scaladsl.MongoSink$#updateOne) or @scaladoc[updateMany](akka.stream.alpakka.mongodb.scaladsl.MongoSink$#updateMany) if the filter should target one or many documents.
@@ -121,13 +121,14 @@ Use either @scaladoc[updateOne](akka.stream.alpakka.mongodb.scaladsl.MongoSink$#
 Scala
 : @@snip [snip](../../../../mongodb/src/test/scala/akka/stream/alpakka/mongodb/MongoSinkSpec.scala) { #updateOne }
 
-#### Delete
+### Delete
+
 We can delete documents with a Source of filters. Use either @scaladoc[deleteOne](akka.stream.alpakka.mongodb.scaladsl.MongoSink$#deleteOne) or @scaladoc[deleteMany](akka.stream.alpakka.mongodb.scaladsl.MongoSink$#deleteMany) if the filter should target one or many documents.
 
 Scala
 : @@snip [snip](../../../../mongodb/src/test/scala/akka/stream/alpakka/mongodb/MongoSinkSpec.scala) { #deleteOne }
 
-### Running the example code
+## Running the example code
 
 The code in this guide is part of runnable tests of this project. You are welcome to edit the code and run it in sbt.
 

--- a/docs/src/main/paradox/slick.md
+++ b/docs/src/main/paradox/slick.md
@@ -19,7 +19,7 @@ The table below shows direct dependencies of this module and the second tab show
 @@dependencies { projectId="slick" }
 
 
-## Usage
+## Initialization
 
 As always, before we get started we will need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and a @scaladoc[Materializer](akka.stream.Materializer).
 
@@ -39,7 +39,7 @@ Java
 
 The full examples for using the `Source`, `Sink`, and `Flow` (listed further down) also include all required imports.
 
-### Starting a Database Session
+## Starting a Database Session
 
 All functionality provided by this connector requires the user to first create an instance of `SlickSession`, which is a thin wrapper around Slick's database connection management and database profile API.
 
@@ -84,7 +84,8 @@ SQL Server
 
 Of course these are just examples. Please visit the @extref[Slick documentation for `DatabaseConfig.fromConfig`](slick:api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader%29:Database) for the full list of things to configure.
 
-### Closing a Database Session
+## Closing a Database Session
+
 Slick requires you to eventually close your database session to free up connection pool resources. You would usually do this when terminating the `ActorSystem`, by registering a termination handler like this:
 
 Scala
@@ -93,10 +94,12 @@ Scala
 Java
 : @@snip [snip](/slick/src/test/java/docs/javadsl/SlickTest.java) { #close-session }
 
-### Using a Slick Source
+## Using a Slick Source
+
 The Slick connector allows you to perform a SQL query and expose the resulting stream of results as an Akka Streams `Source[T]`. Where `T` is any type that can be constructed using a database row.
 
-#### Plain SQL queries
+### Plain SQL queries
+
 Both the Scala and Java DSLs support the use of @extref[plain SQL queries](slick:concepts.html#plain-sql-statements).
 
 The Scala DSL expects you to use the special `sql"..."`, `sqlu"..."`, and `sqlt"..."` @extref[String interpolators provided by Slick](slick:sql.html#string-interpolation) to construct queries.
@@ -112,14 +115,16 @@ Java
 : @@snip [snip](/slick/src/test/java/docs/javadsl/DocSnippetSource.java) { #source-example }
 
 
-#### Typed Queries
+### Typed Queries
+
 The Scala DSL also supports the use of @extref[Slick Scala queries](slick:concepts.html#scala-queries), which are more type-safe then their plain SQL equivalent. The code will look very similar to the plain SQL example.
 
 Scala
 : @@snip [snip](/slick/src/test/scala/docs/scaladsl/DocSnippets.scala) { #source-with-typed-query }
 
 
-### Using a Slick Flow or Sink
+## Using a Slick Flow or Sink
+
 If you want to take stream of elements and turn them into side-effecting actions in a relational database, the Slick connector allows you to perform any DML or DDL statement using either a `Sink` or a `Flow`. This includes the typical `insert`/`update`/`delete` statements but also `create table`, `drop table`, etc. The unit tests have a couple of good examples of the latter usage.
 
 The following example show the use of a Slick `Sink` to take a stream of elements and insert them into the database. There is an optional `parallelism` argument to specify how many concurrent streams will be sent to the database. The unit tests for the slick connector have example of performing parallel inserts.
@@ -131,7 +136,7 @@ Java
 : @@snip [snip](/slick/src/test/java/docs/javadsl/DocSnippetSink.java) { #sink-example }
 
 
-### Flow
+## Flow
 
 The Slick connector also exposes a `Flow` that has the exact same functionality as the `Sink` but it allows you to continue the stream for further processing. The return value of every executed statement, e.g. the element values is the fixed type `Int` denoting the number of updated/inserted/deleted rows.
 
@@ -142,7 +147,7 @@ Java
 : @@snip [snip](/slick/src/test/java/docs/javadsl/DocSnippetFlow.java) { #flow-example }
 
 
-### Flow with pass-through
+## Flow with pass-through
 
 To have a different return type, use the `flowWithPassThrough` function.
 E.g. when consuming Kafka messages, this allows you to maintain the kafka committable offset so the message can be committed in a next stage in the flow.

--- a/docs/src/main/paradox/udp.md
+++ b/docs/src/main/paradox/udp.md
@@ -17,9 +17,7 @@ The table below shows direct dependencies of this module and the second tab show
 @@dependencies { projectId="udp" }
 
 
-## Usage
-
-### Sending
+## Sending
 
 Datagrams can be sent to remote destinations by using a `Udp.sendFlow` or `Udp.sendSink` which can be found in the
 @scaladoc[Udp](akka.stream.alpakka.udp.scaladsl.Udp$) factory object.
@@ -30,7 +28,7 @@ Scala
 Java
 : @@snip [snip](/udp/src/test/java/docs/javadsl/UdpTest.java) { #send-datagrams }
 
-### Receiving
+## Receiving
 
 First create an address which will be used to bind and listen for incoming datagrams.
 
@@ -53,7 +51,7 @@ Scala
 Java
 : @@snip [snip](/udp/src/test/java/docs/javadsl/UdpTest.java) { #bind-flow }
 
-### Running the example code
+## Running the example code
 
 The code in this guide is part of runnable tests of this project. You are welcome to browse the code, edit and run it in sbt.
 

--- a/docs/src/main/paradox/unix-domain-socket.md
+++ b/docs/src/main/paradox/unix-domain-socket.md
@@ -4,6 +4,12 @@
 
 This connector provides an implementation of a Unix Domain Socket with interfaces modelled on the conventional `Tcp` Akka Streams class. The connector uses JNI and so there are no native dependencies.
 
+The binding and connecting APIs are extremely similar to the `Tcp` Akka Streams class. `UnixDomainSocket` is generally substitutable for `Tcp` except that the `SocketAddress` is different (Unix Domain Sockets requires a `java.io.File` as opposed to a host and port). Please read the following for details:
+
+* [Scala user reference for `Tcp`](https://doc.akka.io/docs/akka/current/stream/stream-io.html?language=scala)
+* [Java user reference for `Tcp`](https://doc.akka.io/docs/akka/current/stream/stream-io.html?language=java)
+
+
 > Note that Unix Domain Sockets, as the name implies, do not apply to Windows.
 
 @@project-info{ projectId="unix-domain-socket" }
@@ -21,15 +27,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 @@dependencies { projectId="unix-domain-socket" }
 
-
-## Usage
-
-The binding and connecting APIs are extremely similar to the `Tcp` Akka Streams class. `UnixDomainSocket` is generally substitutable for `Tcp` except that the `SocketAddress` is different (Unix Domain Sockets requires a `java.io.File` as opposed to a host and port). Please read the following for details:
-
-* [Scala user reference for `Tcp`](https://doc.akka.io/docs/akka/current/stream/stream-io.html?language=scala)
-* [Java user reference for `Tcp`](https://doc.akka.io/docs/akka/current/stream/stream-io.html?language=java)
-
-### Binding to a file
+## Binding to a file
 
 Scala
 : @@snip [snip](/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala) { #binding }
@@ -37,7 +35,7 @@ Scala
 Java
 : @@snip [snip](/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java) { #binding }
 
-### Connecting to a file
+## Connecting to a file
 
 Scala
 : @@snip [snip](/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala) { #outgoingConnection }


### PR DESCRIPTION
Removes the `Usage` documentation topic sub-header from most of the connectors where it was present (except S3 and couchbase as those have PRs pending).

With this change the connector TOC boxes in the main page contain more relevant information and are `Ctrl+f` friendly.