### PR TITLE
Couchbase: introduce upsertDocWithResult to handle write errors in-stream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
       - PRE_CMD="docker-compose up -d cassandra"
       - CMD=+cassandra/testChanged
     - env:
-      - PRE_CMD="docker-compose up -d couchbase"
+      - PRE_CMD="docker-compose up -d couchbase_prep"
       - CMD=+couchbase/testChanged
     - env: CMD=+csv/testChanged
     - env:

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/javadsl/CouchbaseFlow.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/javadsl/CouchbaseFlow.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.couchbase.javadsl
 
 import akka.NotUsed
-import akka.stream.alpakka.couchbase.{scaladsl, CouchbaseSessionSettings, CouchbaseWriteSettings}
+import akka.stream.alpakka.couchbase.{scaladsl, CouchbaseSessionSettings, CouchbaseWriteResult, CouchbaseWriteSettings}
 import akka.stream.javadsl.Flow
 import com.couchbase.client.java.document.{Document, JsonDocument}
 
@@ -43,6 +43,15 @@ object CouchbaseFlow {
                                   writeSettings: CouchbaseWriteSettings,
                                   bucketName: String): Flow[T, T, NotUsed] =
     scaladsl.CouchbaseFlow.upsertDoc(sessionSettings, writeSettings, bucketName).asJava
+
+  /**
+   * Create a flow to update or insert a Couchbase document of the given class and emit a result so that write failures
+   * can be handled in-stream.
+   */
+  def upsertDocWithResult[T <: Document[_]](sessionSettings: CouchbaseSessionSettings,
+                                            writeSettings: CouchbaseWriteSettings,
+                                            bucketName: String): Flow[T, CouchbaseWriteResult[T], NotUsed] =
+    scaladsl.CouchbaseFlow.upsertDocWithResult(sessionSettings, writeSettings, bucketName).asJava
 
   /**
    * Create a flow to delete documents from Couchbase by `id`. Emits the same `id`.

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/javadsl/CouchbaseFlow.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/javadsl/CouchbaseFlow.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.couchbase.javadsl
 
 import akka.NotUsed
-import akka.stream.alpakka.couchbase.{scaladsl, CouchbaseSessionSettings, CouchbaseWriteResult, CouchbaseWriteSettings}
+import akka.stream.alpakka.couchbase._
 import akka.stream.javadsl.Flow
 import com.couchbase.client.java.document.{Document, JsonDocument}
 
@@ -60,4 +60,13 @@ object CouchbaseFlow {
              writeSettings: CouchbaseWriteSettings,
              bucketName: String): Flow[String, String, NotUsed] =
     scaladsl.CouchbaseFlow.delete(sessionSettings, writeSettings, bucketName).asJava
+
+  /**
+   * Create a flow to delete documents from Couchbase by `id` and emit operation outcome containing the same `id`.
+   */
+  def deleteWithResult(sessionSettings: CouchbaseSessionSettings,
+                       writeSettings: CouchbaseWriteSettings,
+                       bucketName: String): Flow[String, CouchbaseDeleteResult, NotUsed] =
+    scaladsl.CouchbaseFlow.deleteWithResult(sessionSettings, writeSettings, bucketName).asJava
+
 }

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/model.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/model.scala
@@ -227,3 +227,29 @@ final case class CouchbaseWriteFailure[T <: Document[_]] private (override val d
   val isSuccess: Boolean = false
   val isFailure: Boolean = true
 }
+
+/**
+ * Wrapper to for handling Couchbase write failures in-stream instead of failing the stream.
+ */
+sealed trait CouchbaseDeleteResult {
+  def isSuccess: Boolean
+  def isFailure: Boolean
+  def id: String
+}
+
+/**
+ * Emitted for a successful Couchbase write operation.
+ */
+final case class CouchbaseDeleteSuccess private (override val id: String) extends CouchbaseDeleteResult {
+  val isSuccess: Boolean = true
+  val isFailure: Boolean = false
+}
+
+/**
+ * Emitted for a failed Couchbase write operation.
+ */
+final case class CouchbaseDeleteFailure private (override val id: String, failure: Throwable)
+    extends CouchbaseDeleteResult {
+  val isSuccess: Boolean = false
+  val isFailure: Boolean = true
+}

--- a/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
+++ b/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
@@ -79,7 +79,7 @@ public class CouchbaseExamplesTest {
     actorSystem = support.actorSystem();
     materializer = support.mat();
     sampleData = support.sampleData();
-    sampleSequence = JavaConverters$.MODULE$.seqAsJavaList(support.sampleSequence());
+    sampleSequence = support.sampleJavaList();
   }
 
   @AfterClass

--- a/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
+++ b/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
@@ -7,6 +7,9 @@ package docs.javadsl;
 import akka.Done;
 import akka.actor.ActorSystem;
 import akka.stream.Materializer;
+// #deleteWithResult
+import akka.stream.alpakka.couchbase.CouchbaseDeleteResult;
+// #deleteWithResult
 // #upsertDocWithResult
 import akka.stream.alpakka.couchbase.CouchbaseWriteFailure;
 import akka.stream.alpakka.couchbase.CouchbaseWriteResult;
@@ -57,7 +60,6 @@ import static com.couchbase.client.java.query.dsl.Expression.*;
 // #statement
 
 import scala.concurrent.duration.FiniteDuration;
-import scala.collection.JavaConverters$;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
@@ -263,6 +265,18 @@ public class CouchbaseExamplesTest {
             .via(CouchbaseFlow.delete(sessionSettings, writeSettings, bucketName))
             .runWith(Sink.ignore(), materializer);
     // #delete
+  }
 
+  @Test
+  public void deleteWithResult() throws Exception {
+    CouchbaseWriteSettings writeSettings = CouchbaseWriteSettings.create();
+    // #deleteWithResult
+    CompletionStage<CouchbaseDeleteResult> result =
+        Source.single("non-existent")
+            .via(CouchbaseFlow.deleteWithResult(sessionSettings, writeSettings, bucketName))
+            .runWith(Sink.head(), materializer);
+    // #deleteWithResult
+    CouchbaseDeleteResult deleteResult = result.toCompletableFuture().get(3, TimeUnit.SECONDS);
+    assertTrue(deleteResult.isFailure());
   }
 }

--- a/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
+++ b/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
@@ -7,6 +7,10 @@ package docs.javadsl;
 import akka.Done;
 import akka.actor.ActorSystem;
 import akka.stream.Materializer;
+// #upsertDocWithResult
+import akka.stream.alpakka.couchbase.CouchbaseWriteFailure;
+import akka.stream.alpakka.couchbase.CouchbaseWriteResult;
+// #upsertDocWithResult
 import akka.stream.alpakka.couchbase.CouchbaseWriteSettings;
 import akka.stream.alpakka.couchbase.javadsl.CouchbaseFlow;
 import akka.stream.alpakka.couchbase.javadsl.CouchbaseSource;
@@ -17,9 +21,12 @@ import akka.stream.javadsl.Source;
 import com.couchbase.client.java.PersistTo;
 import com.couchbase.client.java.ReplicateTo;
 import com.couchbase.client.java.document.JsonDocument;
+import com.couchbase.client.java.document.StringDocument;
 import com.couchbase.client.java.document.json.JsonObject;
+// #n1ql
 import com.couchbase.client.java.query.N1qlParams;
 import com.couchbase.client.java.query.N1qlQuery;
+// #n1ql
 import com.couchbase.client.java.query.SimpleN1qlQuery;
 
 import org.junit.AfterClass;
@@ -36,8 +43,9 @@ import akka.stream.alpakka.couchbase.CouchbaseSessionSettings;
 import akka.stream.alpakka.couchbase.javadsl.CouchbaseSession;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 // #session
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 // #sessionFromBucket
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.CouchbaseCluster;
@@ -47,10 +55,11 @@ import com.couchbase.client.java.auth.PasswordAuthenticator;
 import static com.couchbase.client.java.query.Select.select;
 import static com.couchbase.client.java.query.dsl.Expression.*;
 // #statement
-// #n1ql
-import scala.concurrent.duration.FiniteDuration;
-// #n1ql
 
+import scala.concurrent.duration.FiniteDuration;
+import scala.collection.JavaConverters$;
+
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 public class CouchbaseExamplesTest {
@@ -62,6 +71,7 @@ public class CouchbaseExamplesTest {
   private static ActorSystem actorSystem;
   private static Materializer materializer;
   private static TestObject sampleData;
+  private static List<TestObject> sampleSequence;
 
   @BeforeClass
   public static void beforeAll() {
@@ -69,6 +79,7 @@ public class CouchbaseExamplesTest {
     actorSystem = support.actorSystem();
     materializer = support.mat();
     sampleData = support.sampleData();
+    sampleSequence = JavaConverters$.MODULE$.seqAsJavaList(support.sampleSequence());
   }
 
   @AfterClass
@@ -217,6 +228,30 @@ public class CouchbaseExamplesTest {
             .via(CouchbaseFlow.upsertDoc(sessionSettings, writeSettings, bucketName))
             .runWith(Sink.ignore(), materializer);
     // #upsert
+  }
+
+  @Test
+  public void upsertDocWitResult() throws Exception {
+    CouchbaseWriteSettings writeSettings = CouchbaseWriteSettings.create();
+    // #upsertDocWithResult
+
+    CompletionStage<List<CouchbaseWriteResult<StringDocument>>> upsertResults =
+        Source.from(sampleSequence)
+            .map(support::toStringDocument)
+            .via(CouchbaseFlow.upsertDocWithResult(sessionSettings, writeSettings, bucketName))
+            .runWith(Sink.seq(), materializer);
+
+    List<CouchbaseWriteResult<StringDocument>> writeResults =
+        upsertResults.toCompletableFuture().get(3, TimeUnit.SECONDS);
+    List<CouchbaseWriteFailure<StringDocument>> failedDocs =
+        writeResults
+            .stream()
+            .filter(CouchbaseWriteResult::isFailure)
+            .map(res -> (CouchbaseWriteFailure<StringDocument>) res)
+            .collect(Collectors.toList());
+    // #upsertDocWithResult
+    assertThat(writeResults.size(), is(sampleSequence.size()));
+    assertTrue("unexpected failed writes", failedDocs.isEmpty());
   }
 
   @Test

--- a/couchbase/src/test/resources/logback-test.xml
+++ b/couchbase/src/test/resources/logback-test.xml
@@ -7,6 +7,11 @@
         </encoder>
     </appender>
 
+    <logger name="akka" level="INFO"/>
+    <logger name="akka.http.impl" level="WARN"/>
+    <logger name="akka.stream.alpakka" level="DEBUG"/>
+    <logger name="com.couchbase" level="INFO"/>
+
     <root level="debug">
         <appender-ref ref="FILE" />
     </root>

--- a/couchbase/src/test/scala/akka/stream/alpakka/couchbase/testing/CouchbaseSupport.scala
+++ b/couchbase/src/test/scala/akka/stream/alpakka/couchbase/testing/CouchbaseSupport.scala
@@ -6,18 +6,15 @@ package akka.stream.alpakka.couchbase.testing
 
 import akka.Done
 import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.couchbase.scaladsl._
 import akka.stream.alpakka.couchbase.{CouchbaseSessionSettings, CouchbaseWriteSettings}
 import akka.stream.scaladsl.{Sink, Source}
 import com.couchbase.client.deps.io.netty.buffer.Unpooled
 import com.couchbase.client.deps.io.netty.util.CharsetUtil
-import com.couchbase.client.java.auth.PasswordAuthenticator
 import com.couchbase.client.java.document.json.JsonObject
 import com.couchbase.client.java.document.{BinaryDocument, JsonDocument, RawJsonDocument, StringDocument}
-import com.couchbase.client.java.{CouchbaseCluster, ReplicateTo}
+import com.couchbase.client.java.ReplicateTo
 import org.slf4j.LoggerFactory
 import play.api.libs.json.Json
 
@@ -46,10 +43,6 @@ trait CouchbaseSupport {
 
   val sampleJavaList: java.util.List[TestObject] = sampleSequence.asJava
 
-  val cluster: CouchbaseCluster = CouchbaseCluster.create("localhost")
-
-  cluster.authenticate(new PasswordAuthenticator("Administrator", "password"))
-
   val sessionSettings = CouchbaseSessionSettings(actorSystem)
   val writeSettings: CouchbaseWriteSettings = CouchbaseWriteSettings().withReplicateTo(ReplicateTo.NONE)
   val bucketName = "akka"
@@ -58,117 +51,6 @@ trait CouchbaseSupport {
   var session: CouchbaseSession = _
 
   def beforeAll(): Unit = {
-    def setupIndexAndQuota =
-      Http().singleRequest(
-        HttpRequest(
-          method = HttpMethods.POST,
-          uri = "http://127.0.0.1:8091/pools/default",
-          entity = akka.http.scaladsl.model
-            .FormData(Map("memoryQuota" -> "300", "indexMemoryQuota" -> "256"))
-            .toEntity(HttpCharsets.`UTF-8`),
-          protocol = HttpProtocols.`HTTP/1.1`
-        )
-      )
-
-    def setupServices =
-      Http().singleRequest(
-        HttpRequest(
-          method = HttpMethods.POST,
-          uri = "http://127.0.0.1:8091/node/controller/setupServices",
-          entity = akka.http.scaladsl.model.FormData(Map("services" -> "kv,n1ql,index")).toEntity(HttpCharsets.`UTF-8`),
-          protocol = HttpProtocols.`HTTP/1.1`
-        )
-      )
-
-    def setupCredentials = Http().singleRequest(
-      HttpRequest(
-        method = HttpMethods.POST,
-        uri = "http://127.0.0.1:8091/settings/web",
-        entity = akka.http.scaladsl.model
-          .FormData(Map("port" -> "8091", "username" -> "Administrator", "password" -> "password"))
-          .toEntity(HttpCharsets.`UTF-8`),
-        protocol = HttpProtocols.`HTTP/1.1`
-      )
-    )
-
-    def setupIndexService = Http().singleRequest(
-      HttpRequest(
-        method = HttpMethods.POST,
-        uri = "http://127.0.0.1:8091/settings/indexes",
-        entity = akka.http.scaladsl.model.FormData(Map("storageMode" -> "forestdb")).toEntity(HttpCharsets.`UTF-8`),
-        protocol = HttpProtocols.`HTTP/1.1`
-      ).withHeaders(headers.RawHeader("Authorization", "Basic QWRtaW5pc3RyYXRvcjpwYXNzd29yZA=="))
-    )
-
-    def setupQueryBucket = Http().singleRequest(
-      HttpRequest(
-        method = HttpMethods.POST,
-        uri = "http://127.0.0.1:8091/pools/default/buckets",
-        entity = akka.http.scaladsl.model
-          .FormData(
-            Map("name" -> queryBucketName, "ramQuotaMB" -> "100", "authType" -> "none", "replicaNumber" -> "1")
-          )
-          .toEntity(HttpCharsets.`UTF-8`),
-        protocol = HttpProtocols.`HTTP/1.1`
-      ).withHeaders(headers.RawHeader("Authorization", "Basic QWRtaW5pc3RyYXRvcjpwYXNzd29yZA=="))
-    )
-
-    def setupBucket = Http().singleRequest(
-      HttpRequest(
-        method = HttpMethods.POST,
-        uri = "http://127.0.0.1:8091/pools/default/buckets",
-        entity = akka.http.scaladsl.model
-          .FormData(Map("name" -> bucketName, "ramQuotaMB" -> "100", "authType" -> "none", "replicaNumber" -> "1"))
-          .toEntity(HttpCharsets.`UTF-8`),
-        protocol = HttpProtocols.`HTTP/1.1`
-      ).withHeaders(headers.RawHeader("Authorization", "Basic QWRtaW5pc3RyYXRvcjpwYXNzd29yZA=="))
-    )
-
-    def createIndex = Http().singleRequest(
-      HttpRequest(
-        method = HttpMethods.POST,
-        uri = "http://localhost:8093/query/service",
-        entity = akka.http.scaladsl.model
-          .FormData(Map("statement" -> s"CREATE PRIMARY INDEX ON $queryBucketName USING GSI"))
-          .toEntity(HttpCharsets.`UTF-8`),
-        protocol = HttpProtocols.`HTTP/1.1`
-      ).withHeaders(headers.RawHeader("Authorization", "Basic QWRtaW5pc3RyYXRvcjpwYXNzd29yZA=="))
-    )
-
-    def logError(name: String, fut: Future[HttpResponse]): Future[Unit] =
-      fut
-        .map { res =>
-          log.debug(s"$name: ${res.status}")
-        }
-        .recover {
-          case e: Throwable =>
-            log.error(s"$name: $e")
-        }
-
-    log.info("Creating CB Server")
-    try {
-      Await.result(
-        {
-          for {
-            _ <- logError("setupIndexAndQuota", setupIndexAndQuota)
-            _ <- logError("setupServices", setupServices)
-            _ <- logError("setupCredentials", setupCredentials)
-            _ <- logError("setupIndexService", setupIndexService)
-            _ <- logError("setupQueryBucket", setupQueryBucket)
-            _ <- logError("setupBucket", setupBucket)
-            _ <- logError("createIndex", createIndex)
-          } yield ()
-        },
-        10.seconds
-      )
-    } catch {
-      case ex: Throwable => log.error(ex.toString, ex)
-    }
-
-//    Thread.sleep(4000)
-//    Await.result(createIndex, 10.seconds)
-    Thread.sleep(4000)
-
     session = Await.result(CouchbaseSession(sessionSettings, bucketName), 2.seconds)
     log.info("Done Creating CB Server")
   }

--- a/couchbase/src/test/scala/akka/stream/alpakka/couchbase/testing/CouchbaseSupport.scala
+++ b/couchbase/src/test/scala/akka/stream/alpakka/couchbase/testing/CouchbaseSupport.scala
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory
 import play.api.libs.json.Json
 
 import scala.collection.immutable.Seq
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -42,6 +43,8 @@ trait CouchbaseSupport {
   val sampleSequence: Seq[TestObject] = sampleData +: Seq[TestObject](TestObject("Second", "Second"),
                                                                       TestObject("Third", "Third"),
                                                                       TestObject("Fourth", "Fourth"))
+
+  val sampleJavaList: java.util.List[TestObject] = sampleSequence.asJava
 
   val cluster: CouchbaseCluster = CouchbaseCluster.create("localhost")
 

--- a/couchbase/src/test/scala/akka/stream/alpakka/couchbase/testing/CouchbaseSupport.scala
+++ b/couchbase/src/test/scala/akka/stream/alpakka/couchbase/testing/CouchbaseSupport.scala
@@ -192,7 +192,8 @@ trait CouchbaseSupport {
   def cleanAllInBucket(ids: Seq[String], bucketName: String): Unit = {
     val result: Future[Done] =
       Source(ids)
-        .runWith(CouchbaseSink.delete(sessionSettings, CouchbaseWriteSettings.inMemory, bucketName))
+        .via(CouchbaseFlow.deleteWithResult(sessionSettings, CouchbaseWriteSettings.inMemory, bucketName))
+        .runWith(Sink.ignore)
     Await.result(result, 5.seconds)
     ()
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,43 @@ services:
   couchbase:
     image: couchbase:community-5.1.1
     ports:
-    - "8091-8094:8091-8094"
-    - "11210:11210"
+      - "8091-8094:8091-8094"
+      - "11210:11210"
+  couchbase_prep:
+    image: couchbase:community-5.1.1
+    links:
+      - "couchbase"
+    entrypoint: ""
+    command: >
+      bash -c "
+        echo 'waiting until couchbase is up'
+        until `curl --output /dev/null --silent --head --fail http://couchbase:8091`; do
+            printf '.'
+            sleep 2
+        done
+        couchbase-cli cluster-init -c couchbase \
+          --cluster-username Administrator --cluster-password password \
+          --cluster-ramsize 300 \
+          --cluster-index-ramsize 256 \
+          --services data,index,query,fts
+        couchbase-cli bucket-create -c couchbase \
+          -u Administrator -p password \
+          --bucket akka \
+          --bucket-type couchbase \
+          --bucket-ramsize 100 \
+          --bucket-replica 1 \
+          --wait
+        couchbase-cli bucket-create -c couchbase \
+          -u Administrator -p password \
+          --bucket akkaquery \
+          --bucket-type couchbase \
+          --bucket-ramsize 100 \
+          --bucket-replica 1 \
+          --wait
+        sleep 2 # just wait a tiny bit more after creating the bucket
+        echo 'CREATE PRIMARY INDEX ON akkaquery USING GSI;' | \
+          cbq -c Administrator:password -e http://couchbase:8093
+      "
   elasticmq:
     image: softwaremill/elasticmq:0.14.6
     ports:

--- a/docs/src/main/paradox/couchbase.md
+++ b/docs/src/main/paradox/couchbase.md
@@ -133,6 +133,14 @@ Scala
 Java
 : @@snip [snip](/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #delete }
 
+To handle any delete failures such as non-existent documents in-stream, use the the `deleteWithResult` operator. It captures failures from Couchbase and emits `CouchbaseDeleteResult`s.
+
+Scala
+: @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala) { #deleteWithResult }
+
+Java
+: @@snip [snip](/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #deleteWithResult }
+
 
 # Using `CouchbaseSession` directly
 

--- a/docs/src/main/paradox/couchbase.md
+++ b/docs/src/main/paradox/couchbase.md
@@ -87,7 +87,7 @@ For each mutation operation we need to create `CouchbaseWriteSettings` instance 
 These default values are not recommended for production use, as they do not persist to disk for any node. 
 
 Scala
-: @@snip (/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala) { #write-settings }
+: @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala) { #write-settings }
 
 Java
 : @@snip [snip](/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #write-settings }
@@ -99,8 +99,10 @@ Read more about durability settings in the @extref[Couchbase documentation](couc
 
 The `CouchbaseFlow` and `CouchbaseSink` offer factories for upserting documents (insert or update) in Couchbase. `upsert` is used for the most commonly used `JsonDocument`, and `upsertDoc` has as type parameter to support any variants of @scala[`Document[T]`]@java[`Document<T>`] which may be `RawJsonDocument`, `StringDocument` or `BinaryDocument`.
 
+The `upsert` and `upsertDoc` operators fail the stream on any error when writing to Couchbase. To handle failures in-stream use `upsertDocWithResult` shown below. 
+
 Scala
-: @@snip (/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala) { #upsert }
+: @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala) { #upsert }
 
 Java
 : @@snip [snip](/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #upsert }
@@ -112,12 +114,21 @@ For single document modifications you may consider using the `CouchbaseSession` 
 
 @@@
 
+Couchbase writes may fail temporarily for a particular node. If you want to handle such failures without restarting the whole stream, the `upsertDocWithResult` operator captures failures from Couchbase and emits `CouchbaseWriteResult` sub-classes `CouchbaseWriteSuccess` and `CouchbaseWriteFailure` downstream.
+
+Scala
+: @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala) { #upsertDocWithResult }
+
+Java
+: @@snip [snip](/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #upsertDocWithResult }
+
+
 ## Delete
 
 The `CouchbaseFlow` and `CouchbaseSink` offer factories to delete documents in Couchbase by ID.
 
 Scala
-: @@snip (/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala) { #delete }
+: @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala) { #delete }
 
 Java
 : @@snip [snip](/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #delete }
@@ -131,7 +142,7 @@ Scala
 : @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/CouchbaseSessionExamplesSpec.scala) { #create }
 
 Java
-: @@snip (/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #session }
+: @@snip [snip](/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #session }
 
 
 Alternatively a `CouchbaseSession` may be created from a Couchbase `Bucket`:
@@ -140,6 +151,6 @@ Scala
 : @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/CouchbaseSessionExamplesSpec.scala) { #fromBucket }
 
 Java
-: @@snip (/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #sessionFromBucket }
+: @@snip [snip](/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #sessionFromBucket }
 
 To learn about the full range of operations on `CouchbaseSession`, read the @scala[@scaladoc[API docs](akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession)]@java[@scaladoc[API docs](akka.stream.alpakka.couchbase.javadsl.CouchbaseSession)].


### PR DESCRIPTION
Add a `upsertDocWithResult` operator emitting `CouchbaseWriteResult` subclasses for users that need to handle write failures in-stream.

cc @dannylesnik 