### PR TITLE
Separate producer/consumer timeouts

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/MqttSessionSettings.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/MqttSessionSettings.scala
@@ -34,9 +34,11 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
                                          val eventParallelism: Int = 10,
                                          val receiveConnectTimeout: FiniteDuration = 5.minutes,
                                          val receiveConnAckTimeout: FiniteDuration = 30.seconds,
-                                         val receivePubAckRecTimeout: FiniteDuration = 30.seconds,
-                                         val receivePubCompTimeout: FiniteDuration = 30.seconds,
-                                         val receivePubRelTimeout: FiniteDuration = 30.seconds,
+                                         val producerPubAckRecTimeout: FiniteDuration = 15.seconds,
+                                         val producerPubCompTimeout: FiniteDuration = 15.seconds,
+                                         val consumerPubAckRecTimeout: FiniteDuration = 30.seconds,
+                                         val consumerPubCompTimeout: FiniteDuration = 30.seconds,
+                                         val consumerPubRelTimeout: FiniteDuration = 30.seconds,
                                          val receiveSubAckTimeout: FiniteDuration = 30.seconds,
                                          val receiveUnsubAckTimeout: FiniteDuration = 30.seconds,
                                          val serverSendBufferSize: Int = 100) {
@@ -102,52 +104,84 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
     copy(receiveConnAckTimeout = receiveConnAckTimeout.asScala)
 
   /**
-   * For clients, the amount of time to wait for a server to ack/receive a QoS 1/2 publish. For servers, the amount of time
-   * to wait before receiving an ack/receive command locally in reply to a QoS 1/2 publish event. Defaults to 30 seconds.
+   * For producers of PUBLISH, the amount of time to wait to ack/receive a QoS 1/2 publish before retrying with
+   * the DUP flag set. Defaults to 15 seconds.
    */
-  def withReceivePubAckRecTimeout(receivePubAckRecTimeout: FiniteDuration): MqttSessionSettings =
-    copy(receivePubAckRecTimeout = receivePubAckRecTimeout)
+  def withProducerPubAckRecTimeout(producerPubAckRecTimeout: FiniteDuration): MqttSessionSettings =
+    copy(producerPubAckRecTimeout = producerPubAckRecTimeout)
 
   /**
    * JAVA API
    *
-   * For clients, the amount of time to wait for a server to ack/receive a QoS 1/2 publish. For servers, the amount of time
-   * to wait before receiving an ack/receive command locally in reply to a QoS 1/2 publish event. Defaults to 30 seconds.
+   * For producers of PUBLISH, the amount of time to wait to ack/receive a QoS 1/2 publish before retrying with
+   * the DUP flag set. Defaults to 15 seconds.
    */
-  def withReceivePubAckRecTimeout(receivePubAckRecTimeout: Duration): MqttSessionSettings =
-    copy(receivePubAckRecTimeout = receivePubAckRecTimeout.asScala)
+  def withProducerPubAckRecTimeout(producerPubAckRecTimeout: Duration): MqttSessionSettings =
+    copy(producerPubAckRecTimeout = producerPubAckRecTimeout.asScala)
 
   /**
-   * For clients, the amount of time to wait for a server to complete a QoS 2 publish. For servers, the amount of time
-   * to wait before receiving a complete command locally in reply to a QoS 2 publish event. Defaults to 30 seconds.
+   * For producers of PUBLISH, the amount of time to wait for a server to complete a QoS 2 publish before retrying
+   * with another PUBREL. Defaults to 15 seconds.
    */
-  def withReceivePubCompTimeout(receivePubCompTimeout: FiniteDuration): MqttSessionSettings =
-    copy(receivePubCompTimeout = receivePubCompTimeout)
-
-  /**
-   * JAVA API
-   *
-   * For clients, the amount of time to wait for a server to complete a QoS 2 publish. For servers, the amount of time
-   * to wait before receiving a complete command locally in reply to a QoS 2 publish event. Defaults to 30 seconds.
-   */
-  def withReceivePubCompTimeout(receivePubCompTimeout: Duration): MqttSessionSettings =
-    copy(receivePubCompTimeout = receivePubCompTimeout.asScala)
-
-  /**
-   * For clients, the amount of time to wait for a server to release a QoS 2 publish. For servers, the amount of time
-   * to wait before receiving a release command locally in reply to a QoS 2 publish event. Defaults to 30 seconds.
-   */
-  def withReceivePubRelTimeout(receivePubRelTimeout: FiniteDuration): MqttSessionSettings =
-    copy(receivePubRelTimeout = receivePubRelTimeout)
+  def withProducerPubCompTimeout(producerPubCompTimeout: FiniteDuration): MqttSessionSettings =
+    copy(producerPubCompTimeout = producerPubCompTimeout)
 
   /**
    * JAVA API
    *
-   * For clients, the amount of time to wait for a server to release a QoS 2 publish. For servers, the amount of time
-   * to wait before receiving a release command locally in reply to a QoS 2 publish event. Defaults to 30 seconds.
+   * For producers of PUBLISH, the amount of time to wait for a server to complete a QoS 2 publish before retrying
+   * with another PUBREL. Defaults to 15 seconds.
    */
-  def withReceivePubRelTimeout(receivePubRelTimeout: Duration): MqttSessionSettings =
-    copy(receivePubRelTimeout = receivePubRelTimeout.asScala)
+  def withProducerPubCompTimeout(producerPubCompTimeout: Duration): MqttSessionSettings =
+    copy(producerPubCompTimeout = producerPubCompTimeout.asScala)
+
+  /**
+   * For consumers of PUBLISH, the amount of time to wait before receiving an ack/receive command locally in reply
+   * to a QoS 1/2 publish event before failing. Defaults to 30 seconds.
+   */
+  def withConsumerPubAckRecTimeout(consumerPubAckRecTimeout: FiniteDuration): MqttSessionSettings =
+    copy(consumerPubAckRecTimeout = consumerPubAckRecTimeout)
+
+  /**
+   * JAVA API
+   *
+   * For consumers of PUBLISH, the amount of time to wait before receiving an ack/receive command locally in reply
+   * to a QoS 1/2 publish event before failing. Defaults to 30 seconds.
+   */
+  def withConsumerPubAckRecTimeout(consumerPubAckRecTimeout: Duration): MqttSessionSettings =
+    copy(consumerPubAckRecTimeout = consumerPubAckRecTimeout.asScala)
+
+  /**
+   * For consumers of PUBLISH, the amount of time to wait before receiving a complete command locally in reply to a
+   * QoS 2 publish event before failing. Defaults to 30 seconds.
+   */
+  def withConsumerPubCompTimeout(consumerPubCompTimeout: FiniteDuration): MqttSessionSettings =
+    copy(consumerPubCompTimeout = consumerPubCompTimeout)
+
+  /**
+   * JAVA API
+   *
+   * For consumers of PUBLISH, the amount of time to wait before receiving a complete command locally in reply to a
+   * QoS 2 publish event before failing. Defaults to 30 seconds.
+   */
+  def withConsumerPubCompTimeout(consumerPubCompTimeout: Duration): MqttSessionSettings =
+    copy(consumerPubCompTimeout = consumerPubCompTimeout.asScala)
+
+  /**
+   * For consumers of PUBLISH, the amount of time to wait for a server to release a QoS 2 publish before failing.
+   * Defaults to 30 seconds.
+   */
+  def withConsumerPubRelTimeout(consumerPubRelTimeout: FiniteDuration): MqttSessionSettings =
+    copy(consumerPubRelTimeout = consumerPubRelTimeout)
+
+  /**
+   * JAVA API
+   *
+   * For consumers of PUBLISH, the amount of time to wait for a server to release a QoS 2 publish before failing.
+   * Defaults to 30 seconds.
+   */
+  def withConsumerPubRelTimeout(consumerPubRelTimeout: Duration): MqttSessionSettings =
+    copy(consumerPubRelTimeout = consumerPubRelTimeout.asScala)
 
   /**
    * For clients, the amount of time to wait for a server to ack a subscribe. For servers, the amount of time
@@ -201,9 +235,11 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
                    eventParallelism: Int = eventParallelism,
                    receiveConnectTimeout: FiniteDuration = receiveConnectTimeout,
                    receiveConnAckTimeout: FiniteDuration = receiveConnAckTimeout,
-                   receivePubAckRecTimeout: FiniteDuration = receivePubAckRecTimeout,
-                   receivePubCompTimeout: FiniteDuration = receivePubCompTimeout,
-                   receivePubRelTimeout: FiniteDuration = receivePubRelTimeout,
+                   producerPubAckRecTimeout: FiniteDuration = producerPubAckRecTimeout,
+                   producerPubCompTimeout: FiniteDuration = producerPubCompTimeout,
+                   consumerPubAckRecTimeout: FiniteDuration = consumerPubAckRecTimeout,
+                   consumerPubCompTimeout: FiniteDuration = consumerPubCompTimeout,
+                   consumerPubRelTimeout: FiniteDuration = consumerPubRelTimeout,
                    receiveSubAckTimeout: FiniteDuration = receiveSubAckTimeout,
                    receiveUnsubAckTimeout: FiniteDuration = receiveUnsubAckTimeout,
                    serverSendBufferSize: Int = serverSendBufferSize) =
@@ -214,14 +250,16 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
       eventParallelism,
       receiveConnectTimeout,
       receiveConnAckTimeout,
-      receivePubAckRecTimeout,
-      receivePubCompTimeout,
-      receivePubRelTimeout,
+      producerPubAckRecTimeout,
+      producerPubCompTimeout,
+      consumerPubAckRecTimeout,
+      consumerPubCompTimeout,
+      consumerPubRelTimeout,
       receiveSubAckTimeout,
       receiveUnsubAckTimeout,
       serverSendBufferSize
     )
 
   override def toString: String =
-    s"MqttSessionSettings(maxPacketSize=$maxPacketSize,clientTerminationWatcherBufferSize=$clientTerminationWatcherBufferSize,commandParallelism=$commandParallelism,eventParallelism=$eventParallelism,receiveConnectTimeout=$receiveConnectTimeout,receiveConnAckTimeout=$receiveConnAckTimeout,receivePubAckRecTimeout=$receivePubAckRecTimeout,receivePubCompTimeout=$receivePubCompTimeout,receivePubRelTimeout=$receivePubRelTimeout,receiveSubAckTimeout=$receiveSubAckTimeout,receiveUnsubAckTimeout=$receiveUnsubAckTimeout,serverSendBufferSize=$serverSendBufferSize)"
+    s"MqttSessionSettings(maxPacketSize=$maxPacketSize,clientTerminationWatcherBufferSize=$clientTerminationWatcherBufferSize,commandParallelism=$commandParallelism,eventParallelism=$eventParallelism,receiveConnectTimeout=$receiveConnectTimeout,receiveConnAckTimeout=$receiveConnAckTimeout,receivePubAckRecTimeout=$producerPubAckRecTimeout,receivePubCompTimeout=$producerPubCompTimeout,receivePubAckRecTimeout=$consumerPubAckRecTimeout,receivePubCompTimeout=$consumerPubCompTimeout,receivePubRelTimeout=$consumerPubRelTimeout,receiveSubAckTimeout=$receiveSubAckTimeout,receiveUnsubAckTimeout=$receiveUnsubAckTimeout,serverSendBufferSize=$serverSendBufferSize)"
 }

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/RequestState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/RequestState.scala
@@ -115,7 +115,7 @@ import scala.util.{Failure, Success}
   def publishUnacknowledged(data: Publishing)(implicit mat: Materializer): Behavior[Event] = Behaviors.withTimers {
     val ReceivePubackrec = "producer-receive-pubackrec"
     timer =>
-      timer.startSingleTimer(ReceivePubackrec, ReceivePubAckRecTimeout, data.settings.receivePubAckRecTimeout)
+      timer.startSingleTimer(ReceivePubackrec, ReceivePubAckRecTimeout, data.settings.producerPubAckRecTimeout)
 
       Behaviors
         .receiveMessagePartial[Event] {
@@ -146,7 +146,7 @@ import scala.util.{Failure, Success}
   def publishAcknowledged(data: Publishing)(implicit mat: Materializer): Behavior[Event] = Behaviors.withTimers {
     val ReceivePubrel = "producer-receive-pubrel"
     timer =>
-      timer.startSingleTimer(ReceivePubrel, ReceivePubCompTimeout, data.settings.receivePubCompTimeout)
+      timer.startSingleTimer(ReceivePubrel, ReceivePubCompTimeout, data.settings.producerPubCompTimeout)
 
       data.remote.offer(ForwardPubRel(data.publish, data.packetId))
 
@@ -157,7 +157,6 @@ import scala.util.{Failure, Success}
             Behaviors.stopped
           case ReceivePubCompTimeout =>
             data.remote.offer(ForwardPubRel(data.publish, data.packetId))
-            timer.cancel(ReceivePubrel)
             publishAcknowledged(data)
         }
         .receiveSignal {
@@ -265,7 +264,7 @@ import scala.util.{Failure, Success}
 
   def consumeUnacknowledged(data: ClientConsuming): Behavior[Event] = Behaviors.withTimers { timer =>
     val ReceivePubackrel = "consumer-receive-pubackrel"
-    timer.startSingleTimer(ReceivePubackrel, ReceivePubAckRecTimeout, data.settings.receivePubAckRecTimeout)
+    timer.startSingleTimer(ReceivePubackrel, ReceivePubAckRecTimeout, data.settings.consumerPubAckRecTimeout)
     Behaviors
       .receiveMessagePartial[Event] {
         case PubAckReceivedLocally(remote) if data.publish.flags.contains(ControlPacketFlags.QoSAtLeastOnceDelivery) =>
@@ -290,7 +289,7 @@ import scala.util.{Failure, Success}
 
   def consumeReceived(data: ClientConsuming): Behavior[Event] = Behaviors.withTimers { timer =>
     val ReceivePubrel = "consumer-receive-pubrel"
-    timer.startSingleTimer(ReceivePubrel, ReceivePubRelTimeout, data.settings.receivePubRelTimeout)
+    timer.startSingleTimer(ReceivePubrel, ReceivePubRelTimeout, data.settings.consumerPubRelTimeout)
     Behaviors
       .receiveMessagePartial[Event] {
         case PubRelReceivedFromRemote(local) =>
@@ -312,7 +311,7 @@ import scala.util.{Failure, Success}
 
   def consumeAcknowledged(data: ClientConsuming): Behavior[Event] = Behaviors.withTimers { timer =>
     val ReceivePubcomp = "consumer-receive-pubcomp"
-    timer.startSingleTimer(ReceivePubcomp, ReceivePubCompTimeout, data.settings.receivePubCompTimeout)
+    timer.startSingleTimer(ReceivePubcomp, ReceivePubCompTimeout, data.settings.consumerPubCompTimeout)
     Behaviors
       .receiveMessagePartial[Event] {
         case PubCompReceivedLocally(remote) =>

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -668,7 +668,7 @@ class MqttSessionSpec
     }
 
     "publish with a QoS of 1 and cause a retry given a timeout" in {
-      val session = ActorMqttClientSession(settings.withReceivePubAckRecTimeout(10.millis))
+      val session = ActorMqttClientSession(settings.withProducerPubAckRecTimeout(10.millis))
 
       val server = TestProbe()
       val pipeToServer = Flow[ByteString].mapAsync(1)(msg => server.ref.ask(msg).mapTo[ByteString])
@@ -1409,7 +1409,7 @@ class MqttSessionSpec
     }
 
     "produce a duplicate publish on the server given two client connections" in {
-      val serverSession = ActorMqttServerSession(settings.withReceivePubAckRecTimeout(10.millis))
+      val serverSession = ActorMqttServerSession(settings.withProducerPubAckRecTimeout(10.millis))
 
       val client1 = TestProbe()
       val toClient1 = Sink.foreach[ByteString](bytes => client1.ref ! bytes)


### PR DESCRIPTION
Producers of PUBLISH should tend to need to re-send messages faster than the consumer may be able to process them, otherwise the consumer may fail the connection entirely and cascade the problem. Sending multiple publications is benign with MQTT and has the positive effect of resetting the consumer’s timers. This works particularly well on machines where the JVM startup is very slow e.g. a single core Atom processor.

As a side note, Paho’s client has the same separation of concerns in terms of retry interval and receive timeout. We also have the same values of 15 seconds and 30 seconds respectively.