### PR TITLE
Pass the argument from the method

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectionProvider.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectionProvider.scala
@@ -296,7 +296,7 @@ final class AmqpConnectionFactoryConnectionProvider private (val factory: Connec
     factory.newConnection(hostAndPortList.map(hp => new Address(hp._1, hp._2)).asJava)
   }
 
-  private def copy(hostAndPorts: immutable.Seq[(String, Int)] = hostAndPorts) =
+  private def copy(hostAndPorts: immutable.Seq[(String, Int)]) =
     new AmqpConnectionFactoryConnectionProvider(factory, hostAndPorts)
 
   override def toString: String =
@@ -372,7 +372,7 @@ final class AmqpCachedConnectionProvider private (val provider: AmqpConnectionPr
     case Closing => release(connection)
   }
 
-  private def copy(automaticRelease: Boolean = automaticRelease): AmqpCachedConnectionProvider =
+  private def copy(automaticRelease: Boolean): AmqpCachedConnectionProvider =
     new AmqpCachedConnectionProvider(provider, automaticRelease)
 
   override def toString: String =

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectionProvider.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectionProvider.scala
@@ -224,7 +224,7 @@ final class AmqpSSLConfiguration private (val protocol: Option[String] = None,
     copy(protocol = Some(protocol), trustManager = Some(trustManager))
 
   def withSSLContext(context: Option[javax.net.ssl.SSLContext]): AmqpSSLConfiguration =
-    copy(protocol = protocol)
+    copy(context = context)
 
   private def copy(protocol: Option[String] = protocol,
                    trustManager: Option[TrustManager] = trustManager,

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectorSettings.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectorSettings.scala
@@ -144,8 +144,7 @@ final class AmqpReplyToSinkSettings private (
   def withFailIfReplyToMissing(failIfReplyToMissing: Boolean): AmqpReplyToSinkSettings =
     copy(failIfReplyToMissing = failIfReplyToMissing)
 
-  private def copy(connectionProvider: AmqpConnectionProvider = connectionProvider,
-                   failIfReplyToMissing: Boolean = failIfReplyToMissing) =
+  private def copy(connectionProvider: AmqpConnectionProvider = connectionProvider, failIfReplyToMissing: Boolean) =
     new AmqpReplyToSinkSettings(connectionProvider, failIfReplyToMissing)
 
   override def toString: String =


### PR DESCRIPTION
Fixes `withSSLContext` being effectively a NOOP.