### PR TITLE
Fixes for doc publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ jobs:
     - stage: publish
       script: sbt -jvm-opts .jvmopts-travis +publish
       name: "Publish artifacts for all Scala versions"
-    - script: openssl aes-256-cbc -K $encrypted_bbf1dc4f2a07_key -iv $encrypted_bbf1dc4f2a07_iv -in .travis/travis_alpakka_rsa.enc -out .travis/id_rsa -d && chmod 600 .travis/id_rsa && sbt -jvm-opts .jvmopts-travis docs/publishRsync
+    - script: openssl aes-256-cbc -K $encrypted_bbf1dc4f2a07_key -iv $encrypted_bbf1dc4f2a07_iv -in .travis/travis_alpakka_rsa.enc -out .travis/id_rsa -d && eval "$(ssh-agent -s)" && chmod 600 .travis/id_rsa && ssh-add .travis/id_rsa && sbt -jvm-opts .jvmopts-travis docs/publishRsync
       name: "Publish API and reference documentation"
 
 stages:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,6 +7,18 @@ Create a new issue from the [Alpakka Release Train Issue Template](docs/release-
 It is possible to release a revised documentation to the already existing release.
 
 1. Create a new branch from a release tag. If a revised documentation is for the `v0.3` release, then the name of the new branch should be `docs/v0.3`.
-2. Make all of the required changes to the documentation.
-3. Add and commit `version.sbt` file that sets the version to the one, that is being revised. For example `version in ThisBuild := "0.3"`.
-4. Push the branch. Tech Hub will see the new branch and will build and publish revised documentation.
+1. Add and commit `version.sbt` file that pins the version to the one, that is being revised. Also set `isSnapshot` to `false` for the stable documentation links. For example:
+    ```scala
+    version in ThisBuild := "0.3"
+    isSnapshot in ThisBuild := false
+    ```
+1. Make all of the required changes to the documentation.
+1. Build documentation locally with `CI` settings:
+    ```sh
+    env CI=true sbt docs/previewSite
+    ```
+1. If the generated documentation looks good, send it to Gustav:
+    ```sh
+    env CI=true sbt docs/publishRsync
+    ```
+1. Do not forget to push the new branch back to GitHub.

--- a/build.sbt
+++ b/build.sbt
@@ -288,7 +288,7 @@ lazy val docs = project
     ),
     Paradox / paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
     resolvers += Resolver.jcenterRepo,
-    publishRsyncArtifact := makeSite.value -> "",
+    publishRsyncArtifact := makeSite.value -> "www/",
     publishRsyncHost := "akkarepo@gustav.akka.io"
   )
 

--- a/project/PublishRsync.scala
+++ b/project/PublishRsync.scala
@@ -23,7 +23,7 @@ object PublishRsyncPlugin extends AutoPlugin {
       val (from, to) = publishRsyncArtifact.value
       Process(Seq("rsync", "-azP", s"$from/", s"${publishRsyncHost.value}:$to"),
               None,
-              "RSYNC_RSH" -> "ssh -o StrictHostKeyChecking=no -i .travis/id_rsa").! match {
+              "RSYNC_RSH" -> "ssh -o StrictHostKeyChecking=no").! match {
         case 0 => () // success
         case error => throw new IllegalStateException(s"rsync command exited with an error code $error")
       }


### PR DESCRIPTION
This reverts back to using ssh-agent in Travis. This allows us to not hardcode paths to the identity files, so the deployment setup works in Travis and locally.