### PR TITLE
MQTT streaming: Tolerate DUP PUBLISH messages on first connecting

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -224,7 +224,7 @@ import scala.util.{Failure, Success}
         connect,
         local,
         Set.empty,
-        Set.empty,
+        Map.empty,
         Set.empty,
         Vector.empty,
         Vector.empty,
@@ -248,7 +248,7 @@ import scala.util.{Failure, Success}
       connect: Connect,
       local: Promise[ForwardConnect.type],
       publishers: Set[String],
-      activeConsumers: Set[String],
+      activeConsumers: Map[String, ActorRef[Consumer.Event]],
       activeProducers: Set[String],
       pendingLocalPublications: Seq[(String, PublishReceivedLocally)],
       pendingRemotePublications: Seq[(String, PublishReceivedFromRemote)],
@@ -263,7 +263,7 @@ import scala.util.{Failure, Success}
       connect: Connect,
       remote: SourceQueueWithComplete[ForwardConnAckCommand],
       publishers: Set[String],
-      activeConsumers: Set[String],
+      activeConsumers: Map[String, ActorRef[Consumer.Event]],
       activeProducers: Set[String],
       pendingLocalPublications: Seq[(String, PublishReceivedLocally)],
       pendingRemotePublications: Seq[(String, PublishReceivedFromRemote)],
@@ -278,7 +278,7 @@ import scala.util.{Failure, Success}
       connect: Connect,
       remote: SourceQueueWithComplete[ForwardConnAckCommand],
       publishers: Set[String],
-      activeConsumers: Set[String],
+      activeConsumers: Map[String, ActorRef[Consumer.Event]],
       activeProducers: Set[String],
       pendingLocalPublications: Seq[(String, PublishReceivedLocally)],
       pendingRemotePublications: Seq[(String, PublishReceivedFromRemote)],
@@ -291,7 +291,7 @@ import scala.util.{Failure, Success}
   ) extends Data(consumerPacketRouter, producerPacketRouter, publisherPacketRouter, unpublisherPacketRouter, settings)
   final case class Disconnected(
       publishers: Set[String],
-      activeConsumers: Set[String],
+      activeConsumers: Map[String, ActorRef[Consumer.Event]],
       activeProducers: Set[String],
       pendingLocalPublications: Seq[(String, PublishReceivedLocally)],
       pendingRemotePublications: Seq[(String, PublishReceivedFromRemote)],
@@ -467,45 +467,48 @@ import scala.util.{Failure, Success}
             local.success(Consumer.ForwardPublish)
             clientConnected(data)
           case (context, prfr @ PublishReceivedFromRemote(publish @ Publish(_, topicName, Some(packetId), _), local)) =>
-            if (!data.activeConsumers.contains(topicName)) {
-              val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + "-" + context.children.size)
-              context.watchWith(
-                context.spawn(
-                  Consumer(publish,
-                           Some(data.connect.clientId),
-                           packetId,
-                           local,
-                           data.consumerPacketRouter,
-                           data.settings),
-                  consumerName
-                ),
-                ConsumerFree(publish.topicName)
-              )
-              clientConnected(data.copy(activeConsumers = data.activeConsumers + publish.topicName))
-            } else {
-              clientConnected(
-                data.copy(pendingRemotePublications = data.pendingRemotePublications :+ (publish.topicName -> prfr))
-              )
+            data.activeConsumers.get(topicName) match {
+              case None =>
+                val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + "-" + context.children.size)
+                val consumer =
+                  context.spawn(Consumer(publish,
+                                         Some(data.connect.clientId),
+                                         packetId,
+                                         local,
+                                         data.consumerPacketRouter,
+                                         data.settings),
+                                consumerName)
+                context.watchWith(consumer, ConsumerFree(publish.topicName))
+                clientConnected(data.copy(activeConsumers = data.activeConsumers + (publish.topicName -> consumer)))
+              case Some(consumer) if publish.flags.contains(ControlPacketFlags.DUP) =>
+                consumer ! Consumer.DupPublishReceivedFromRemote(local)
+                clientConnected(data)
+              case Some(_) =>
+                clientConnected(
+                  data.copy(pendingRemotePublications = data.pendingRemotePublications :+ (publish.topicName -> prfr))
+                )
             }
           case (context, ConsumerFree(topicName)) =>
             val i = data.pendingRemotePublications.indexWhere(_._1 == topicName)
             if (i >= 0) {
               val prfr = data.pendingRemotePublications(i)._2
               val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + "-" + context.children.size)
+              val consumer = context.spawn(
+                Consumer(prfr.publish,
+                         Some(data.connect.clientId),
+                         prfr.publish.packetId.get,
+                         prfr.local,
+                         data.consumerPacketRouter,
+                         data.settings),
+                consumerName
+              )
               context.watchWith(
-                context.spawn(
-                  Consumer(prfr.publish,
-                           Some(data.connect.clientId),
-                           prfr.publish.packetId.get,
-                           prfr.local,
-                           data.consumerPacketRouter,
-                           data.settings),
-                  consumerName
-                ),
+                consumer,
                 ConsumerFree(topicName)
               )
               clientConnected(
                 data.copy(
+                  activeConsumers = data.activeConsumers + (topicName -> consumer),
                   pendingRemotePublications =
                   data.pendingRemotePublications.take(i) ++ data.pendingRemotePublications.drop(i + 1)
                 )
@@ -633,7 +636,7 @@ import scala.util.{Failure, Success}
                 connect,
                 local,
                 Set.empty,
-                Set.empty,
+                Map.empty,
                 Set.empty,
                 Vector.empty,
                 Vector.empty,
@@ -741,7 +744,7 @@ import scala.util.{Failure, Success}
                 connect,
                 local,
                 Set.empty,
-                Set.empty,
+                Map.empty,
                 Set.empty,
                 Vector.empty,
                 Vector.empty,


### PR DESCRIPTION
It is quite possible that a client can receive a `PUBLISH` message immediately on connection and before a subscription occurs given the prior establishment of a server-side session. In this case, the `PUBLISH` message will often have the `DUP` flag set. Prior to this PR, the `DUP` flag would cause a packet router failure given that the routing decision was being performed out of step with where the routing state is managed. This PR moves that routing logic to the correct place.

A new test has also been added for the use-case described above along with existing coverage validating the `DUP` processing.