### PR TITLE
S3: Propagate attributes when nesting Akka Stream operators with Setup

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/SetupStage.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/SetupStage.scala
@@ -32,7 +32,7 @@ private final class SetupSinkStage[T, M](factory: ActorMaterializer => Attribute
     override def preStart(): Unit = {
       val sink = factory(actorMaterializer(materializer))(attributes)
 
-      val mat = Source.fromGraph(subOutlet.source).runWith(sink)(subFusingMaterializer)
+      val mat = Source.fromGraph(subOutlet.source).runWith(sink.withAttributes(attributes))(subFusingMaterializer)
       matPromise.success(mat)
     }
   }
@@ -68,7 +68,7 @@ private final class SetupFlowStage[T, U, M](factory: ActorMaterializer => Attrib
 
       val mat = Source
         .fromGraph(subOutlet.source)
-        .viaMat(flow)(Keep.right)
+        .viaMat(flow.withAttributes(attributes))(Keep.right)
         .to(Sink.fromGraph(subInlet.sink))
         .run()(subFusingMaterializer)
       matPromise.success(mat)
@@ -98,6 +98,7 @@ private final class SetupSourceStage[T, M](factory: ActorMaterializer => Attribu
       val source = factory(actorMaterializer(materializer))(attributes)
 
       val mat = source
+        .withAttributes(attributes)
         .to(Sink.fromGraph(subInlet.sink))
         .run()(subFusingMaterializer)
       matPromise.success(mat)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -14,7 +14,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
-import com.github.tomakehurst.wiremock.matching.EqualToPattern
+import com.github.tomakehurst.wiremock.matching.{ContainsPattern, EqualToPattern}
 import com.github.tomakehurst.wiremock.stubbing.Scenario
 import com.typesafe.config.ConfigFactory
 
@@ -86,6 +86,20 @@ abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockSer
             .withHeader("Content-Length", body.length.toString)
             .withBody(body)
         )
+      )
+
+  def mockDownload(region: String): Unit =
+    mock
+      .register(
+        get(urlEqualTo(s"/$bucketKey"))
+          .withHeader("Authorization", new ContainsPattern(region))
+          .willReturn(
+            aResponse()
+              .withStatus(200)
+              .withHeader("ETag", """"fba9dede5f27731c9771645a39863328"""")
+              .withHeader("Content-Length", body.length.toString)
+              .withBody(body)
+          )
       )
 
   def mockDownloadSSEC(): Unit =


### PR DESCRIPTION
Fixes #1443