### PR TITLE
LogRotator with sink factory

### DIFF
--- a/docs/src/main/paradox/file.md
+++ b/docs/src/main/paradox/file.md
@@ -1,4 +1,4 @@
-# Files
+# File
 
 The File connectors provide additional connectors for filesystems complementing
 the sources and sinks for files already included in core Akka Streams
@@ -83,13 +83,13 @@ Java
 The @scala[@scaladoc[LogRotatatorSink](akka.stream.alpakka.file.scaladsl.LogRotatorSink$)]
  @java[@scaladoc[LogRotatatorSink](akka.stream.alpakka.file.javadsl.LogRotatorSink$)] will create and 
  write to multiple files.  
-This sink will takes a function as parameter which returns a
+This sink takes a function as parameter which returns a
  @scala[`Bytestring => Option[Path]` function]@java[`Function<ByteString, Optional<Path>>`]. If the generated function returns a path
  the sink will rotate the file output to this new path and the actual `ByteString` will be
   written to this new file too.
  With this approach the user can define a custom stateful file generation implementation.
 
-A small snippet for the usage
+This example usage shows the built-in target file creation and a custom sink factory which is required to use @scala[@scaladoc[Compression](akka.stream.scaladsl.Compression$)]@java[@scaladoc[Compression](akka.stream.javadsl.Compression$)] for the target files.
 
 Scala
 : @@snip [snip](/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala) { #sample }
@@ -112,40 +112,3 @@ Scala
 
 Java
 : @@snip [snip](/file/src/test/java/docs/javadsl/LogRotatorSinkTest.java) { #time }
-
-### Running the example code
-
-Both the samples are contained in standalone runnable mains, they can be run
- from `sbt` like this:
-
-Scala
-:   &#9;
-
-    ```
-    sbt
-
-    // tail source
-    > file/Test/runMain akka.stream.alpakka.file.scaladsl.FileTailSourceSpec /some/path/toa/file
-
-    // or directory changes
-    > file/Test/runMain akka.stream.alpakka.file.scaladsl.DirectoryChangesSourceSpec /some/directory/path
-
-    // File rotator
-    > file/Test/runMain akka.stream.alpakka.file.scaladsl.LogRotatorSinkTest
-    ```
-
-Java
-:   &#9;
-
-    ```
-    sbt
-
-    // tail source
-    > file/Test/runMain docs.javadsl.FileTailSourceTest /some/path/toa/file
-
-    // or directory changes
-    > file/Test/runMain docs.javadsl.DirectoryChangesSourceTest /some/directory/path
-
-    // File rotator
-    > file/Test/runMain docs.javadsl.LogRotatorSinkTest
-    ```

--- a/file/src/main/scala/akka/stream/alpakka/file/javadsl/LogRotatorSink.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/javadsl/LogRotatorSink.scala
@@ -11,11 +11,15 @@ import java.util.concurrent.CompletionStage
 
 import akka.Done
 import akka.stream.javadsl
+import akka.stream.scaladsl
 import akka.stream.javadsl.Sink
 import akka.util.ByteString
-import akka.japi.{function}
+import akka.japi.function
 
 import scala.collection.JavaConverters._
+import scala.concurrent.Future
+
+import scala.compat.java8.FutureConverters._
 
 object LogRotatorSink {
   def createFromFunction(
@@ -23,25 +27,39 @@ object LogRotatorSink {
   ): javadsl.Sink[ByteString, CompletionStage[Done]] =
     new Sink(
       akka.stream.alpakka.file.scaladsl
-        .LogRotatorSink({ () =>
-          val fun = f.create()
-          elem =>
-            Option(fun(elem).orElse(null))
-        })
+        .LogRotatorSink(asScala(f))
         .toCompletionStage()
     )
 
-  def createFromFunctionAndOptions[T](
+  def createFromFunctionAndOptions(
       f: function.Creator[function.Function[ByteString, Optional[Path]]],
       options: util.Set[StandardOpenOption]
   ): javadsl.Sink[ByteString, CompletionStage[Done]] =
     new Sink(
       akka.stream.alpakka.file.scaladsl
-        .LogRotatorSink({ () =>
-          val fun = f.create()
-          elem =>
-            Option(fun(elem).orElse(null))
-        }, options.asScala.toSet)
+        .LogRotatorSink(asScala(f), options.asScala.toSet)
         .toCompletionStage()
     )
+
+  def withSinkFactory[R](
+      f: function.Creator[function.Function[ByteString, Optional[Path]]],
+      target: function.Function[Path, Sink[ByteString, CompletionStage[R]]]
+  ): javadsl.Sink[ByteString, CompletionStage[Done]] = {
+    val t: Path => scaladsl.Sink[ByteString, Future[R]] = path =>
+      target.apply(path).asScala.mapMaterializedValue(_.toScala)
+    new Sink(
+      akka.stream.alpakka.file.scaladsl.LogRotatorSink
+        .withSinkFactory(asScala(f), t)
+        .toCompletionStage()
+    )
+  }
+
+  private def asScala(
+      f: function.Creator[function.Function[ByteString, Optional[Path]]]
+  ): () => ByteString => Option[Path] = () => {
+    val fun = f.create()
+    elem =>
+      Option(fun(elem).orElse(null))
+  }
+
 }

--- a/file/src/main/scala/akka/stream/alpakka/file/scaladsl/LogRotatorSink.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/scaladsl/LogRotatorSink.scala
@@ -8,33 +8,58 @@ import java.nio.file.{OpenOption, Path, StandardOpenOption}
 
 import akka.Done
 import akka.stream.ActorAttributes.SupervisionStrategy
+import akka.stream.Supervision.Decider
 import akka.stream._
 import akka.stream.impl.fusing.MapAsync.{Holder, NotYetThere}
 import akka.stream.scaladsl.{FileIO, Sink, Source}
 import akka.stream.stage._
 import akka.util.ByteString
 
+import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
 object LogRotatorSink {
+
+  /**
+   * Sink directing the incoming `ByteString`s to new files whenever `generatorFunction` returns a new value.
+   *
+   * @param functionGeneratorFunction creates a function that triggers rotation by returning a value
+   * @param fileOpenOptions file options for file creation
+   */
   def apply(
       functionGeneratorFunction: () => ByteString => Option[Path],
       fileOpenOptions: Set[OpenOption] = Set(StandardOpenOption.APPEND, StandardOpenOption.CREATE)
   ): Sink[ByteString, Future[Done]] =
     Sink.fromGraph(
-      new LogRotatorSink(functionGeneratorFunction, sinkFactory = FileIO.toPath(_, fileOpenOptions))
+      new LogRotatorSink[Path, IOResult](functionGeneratorFunction, sinkFactory = FileIO.toPath(_, fileOpenOptions))
     )
 
-  def withSinkFactory[R](
-      functionGeneratorFunction: () => ByteString => Option[Path],
-      target: Path => Sink[ByteString, Future[R]]
+  /**
+   * Sink directing the incoming `ByteString`s to a new `Sink` created bye `sinkFactory` whenever `generatorFunction returns a new value.
+   *
+   * @param functionGeneratorFunction creates a function that triggers rotation by returning a value
+   * @param sinkFactory creates sinks for `ByteString`s from the value returned by `functionGeneratorFunction`
+   * @tparam C criterion type (for files a `Path`)
+   * @tparam R result type in materialized futures of `sinkFactory`
+   **/
+  def withSinkFactory[C, R](
+      functionGeneratorFunction: () => ByteString => Option[C],
+      sinkFactory: C => Sink[ByteString, Future[R]]
   ): Sink[ByteString, Future[Done]] =
-    Sink.fromGraph(new LogRotatorSink[R](functionGeneratorFunction, target))
+    Sink.fromGraph(new LogRotatorSink[C, R](functionGeneratorFunction, sinkFactory))
 }
 
-final private class LogRotatorSink[R](functionGeneratorFunction: () => ByteString => Option[Path],
-                                      sinkFactory: Path => Sink[ByteString, Future[R]])
+/**
+ * "Log Rotator Sink" graph stage
+ *
+ * @param functionGeneratorFunction creates a function that triggers rotation by returning a value
+ * @param sinkFactory creates sinks for `ByteString`s from the value returned by `functionGeneratorFunction`
+ * @tparam C criterion type (for files a `Path`)
+ * @tparam R result type in materialized futures of `sinkFactory`
+ */
+final private class LogRotatorSink[C, R](functionGeneratorFunction: () => ByteString => Option[C],
+                                         sinkFactory: C => Sink[ByteString, Future[R]])
     extends GraphStageWithMaterializedValue[SinkShape[ByteString], Future[Done]] {
 
   val in = Inlet[ByteString]("FRotator.in")
@@ -42,48 +67,109 @@ final private class LogRotatorSink[R](functionGeneratorFunction: () => ByteStrin
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Done]) = {
     val promise = Promise[Done]()
-    val logic = new GraphStageLogic(shape) {
-      val pathGeneratorFunction: ByteString => Option[Path] = functionGeneratorFunction()
-      var sourceOut: SubSourceOutlet[ByteString] = _
-      var fileSinkCompleted: Seq[Future[R]] = Seq.empty
-      val decider =
-        inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+    val decider =
+      inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+    val logic = new Logic(promise, decider)
+    (logic, promise.future)
+  }
 
-      def failThisStage(ex: Throwable): Unit =
-        if (!promise.isCompleted) {
-          if (sourceOut != null) {
-            sourceOut.fail(ex)
-          }
-          cancel(in)
-          promise.failure(ex)
+  private final class Logic(promise: Promise[Done], decider: Decider) extends GraphStageLogic(shape) {
+    val pathGeneratorFunction: ByteString => Option[C] = functionGeneratorFunction()
+    var sourceOut: SubSourceOutlet[ByteString] = _
+    var fileSinkCompleted: immutable.Seq[Future[R]] = immutable.Seq.empty
+    def failThisStage(ex: Throwable): Unit =
+      if (!promise.isCompleted) {
+        if (sourceOut != null) {
+          sourceOut.fail(ex)
         }
-
-      def generatePathOrFailPeacefully(data: ByteString): Option[Path] = {
-        var ret = Option.empty[Path]
-        try {
-          ret = pathGeneratorFunction(data)
-        } catch {
-          case ex: Throwable =>
-            failThisStage(ex)
-        }
-        ret
+        cancel(in)
+        promise.failure(ex)
       }
 
-      def fileSinkFutureCallbackHandler(future: Future[R])(h: Holder[R]): Unit =
-        h.elem match {
-          case Success(IOResult(_, Failure(ex))) if decider(ex) == Supervision.Stop =>
-            promise.failure(ex)
-          case Success(x) if fileSinkCompleted.size == 1 && fileSinkCompleted.head == future =>
-            promise.trySuccess(Done)
-            completeStage()
-          case x: Success[R] =>
-            fileSinkCompleted = fileSinkCompleted.filter(_ != future)
-          case Failure(ex) =>
-            failThisStage(ex)
-          case _ =>
+    def generatePathOrFailPeacefully(data: ByteString): Option[C] = {
+      var ret = Option.empty[C]
+      try {
+        ret = pathGeneratorFunction(data)
+      } catch {
+        case ex: Throwable =>
+          failThisStage(ex)
+      }
+      ret
+    }
+
+    def fileSinkFutureCallbackHandler(future: Future[R])(h: Holder[R]): Unit =
+      h.elem match {
+        case Success(IOResult(_, Failure(ex))) if decider(ex) == Supervision.Stop =>
+          promise.failure(ex)
+        case Success(x) if fileSinkCompleted.size == 1 && fileSinkCompleted.head == future =>
+          promise.trySuccess(Done)
+          completeStage()
+        case x: Success[R] =>
+          fileSinkCompleted = fileSinkCompleted.filter(_ != future)
+        case Failure(ex) =>
+          failThisStage(ex)
+        case _ =>
+      }
+
+    //init stage where we are waiting for the first path
+    setHandler(
+      in,
+      new InHandler {
+        override def onPush(): Unit = {
+          val data = grab(in)
+          val pathO = generatePathOrFailPeacefully(data)
+          pathO.fold(
+            if (!isClosed(in)) pull(in)
+          )(
+            switchPath(_, data)
+          )
         }
 
-      //init stage where we are waiting for the first path
+        override def onUpstreamFinish(): Unit =
+          completeStage()
+
+        override def onUpstreamFailure(ex: Throwable): Unit =
+          failThisStage(ex)
+      }
+    )
+
+    //we must pull the first element cos we are a sink
+    override def preStart(): Unit = {
+      super.preStart()
+      pull(in)
+    }
+
+    def futureCB(newFuture: Future[R]) =
+      getAsyncCallback[Holder[R]](fileSinkFutureCallbackHandler(newFuture))
+
+    //we recreate the tail of the stream, and emit the data for the next req
+    def switchPath(path: C, data: ByteString): Unit = {
+      val prevOut = Option(sourceOut)
+
+      sourceOut = new SubSourceOutlet[ByteString]("FRotatorSource")
+      sourceOut.setHandler(new OutHandler {
+        override def onPull(): Unit = {
+          sourceOut.push(data)
+          switchToNormalMode()
+        }
+      })
+      val newFuture = Source
+        .fromGraph(sourceOut.source)
+        .runWith(sinkFactory(path))(interpreter.subFusingMaterializer)
+
+      fileSinkCompleted = fileSinkCompleted :+ newFuture
+
+      val holder = new Holder[R](NotYetThere, futureCB(newFuture))
+
+      newFuture.onComplete(holder)(
+        akka.dispatch.ExecutionContexts.sameThreadExecutionContext
+      )
+
+      prevOut.foreach(_.complete())
+    }
+
+    //we change path if needed or push the grabbed data
+    def switchToNormalMode(): Unit = {
       setHandler(
         in,
         new InHandler {
@@ -91,88 +177,28 @@ final private class LogRotatorSink[R](functionGeneratorFunction: () => ByteStrin
             val data = grab(in)
             val pathO = generatePathOrFailPeacefully(data)
             pathO.fold(
-              if (!isClosed(in)) pull(in)
+              sourceOut.push(data)
             )(
               switchPath(_, data)
             )
           }
 
-          override def onUpstreamFinish(): Unit =
-            completeStage()
+          override def onUpstreamFinish(): Unit = {
+            implicit val executionContext: ExecutionContext =
+              akka.dispatch.ExecutionContexts.sameThreadExecutionContext
+            promise.completeWith(Future.sequence(fileSinkCompleted).map(_ => Done))
+            sourceOut.complete()
+          }
 
           override def onUpstreamFailure(ex: Throwable): Unit =
             failThisStage(ex)
         }
       )
-
-      //we must pull the first element cos we are a sink
-      override def preStart(): Unit = {
-        super.preStart()
-        pull(in)
-      }
-
-      def futureCB(newFuture: Future[R]) =
-        getAsyncCallback[Holder[R]](fileSinkFutureCallbackHandler(newFuture))
-
-      //we recreate the tail of the stream, and emit the data for the next req
-      def switchPath(path: Path, data: ByteString): Unit = {
-        val prevOut = Option(sourceOut)
-
-        sourceOut = new SubSourceOutlet[ByteString]("FRotatorSource")
-        sourceOut.setHandler(new OutHandler {
-          override def onPull(): Unit = {
-            sourceOut.push(data)
-            switchToNormalMode()
-          }
-        })
-        val newFuture = Source
-          .fromGraph(sourceOut.source)
-          .runWith(sinkFactory(path))(interpreter.subFusingMaterializer)
-
-        fileSinkCompleted = fileSinkCompleted :+ newFuture
-
-        val holder = new Holder[R](NotYetThere, futureCB(newFuture))
-
-        newFuture.onComplete(holder)(
-          akka.dispatch.ExecutionContexts.sameThreadExecutionContext
-        )
-
-        prevOut.foreach(_.complete())
-      }
-
-      //we change path if needed or push the grabbed data
-      def switchToNormalMode(): Unit = {
-        setHandler(
-          in,
-          new InHandler {
-            override def onPush(): Unit = {
-              val data = grab(in)
-              val pathO = generatePathOrFailPeacefully(data)
-              pathO.fold(
-                sourceOut.push(data)
-              )(
-                switchPath(_, data)
-              )
-            }
-
-            override def onUpstreamFinish(): Unit = {
-              implicit val executionContext: ExecutionContext =
-                akka.dispatch.ExecutionContexts.sameThreadExecutionContext
-              promise.completeWith(Future.sequence(fileSinkCompleted).map(_ => Done))
-              sourceOut.complete()
-            }
-
-            override def onUpstreamFailure(ex: Throwable): Unit =
-              failThisStage(ex)
-          }
-        )
-        sourceOut.setHandler(new OutHandler {
-          override def onPull(): Unit =
-            pull(in)
-        })
-      }
+      sourceOut.setHandler(new OutHandler {
+        override def onPull(): Unit =
+          pull(in)
+      })
     }
-    (logic, promise.future)
   }
 
 }

--- a/file/src/test/java/docs/javadsl/LogRotatorSinkTest.java
+++ b/file/src/test/java/docs/javadsl/LogRotatorSinkTest.java
@@ -5,15 +5,18 @@
 package docs.javadsl;
 
 import akka.Done;
+import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.japi.function.Creator;
 import akka.japi.function.Function;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.file.javadsl.LogRotatorSink;
-import akka.stream.javadsl.Sink;
-import akka.stream.javadsl.Source;
+import akka.stream.javadsl.*;
+import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
+import org.junit.AfterClass;
+import org.junit.Test;
 
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -23,13 +26,22 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
 
 public class LogRotatorSinkTest {
 
-  public static void main(String... args) {
-    final ActorSystem system = ActorSystem.create();
-    final Materializer materializer = ActorMaterializer.create(system);
+  private static final ActorSystem system = ActorSystem.create();
+  private static final Materializer materializer = ActorMaterializer.create(system);
 
+  @AfterClass
+  public static void afterAll() {
+    TestKit.shutdownActorSystem(system);
+  }
+
+  @Test
+  public void sizeBased() throws Exception {
     // #size
     Creator<Function<ByteString, Optional<Path>>> sizeBasedPathGenerator =
         () -> {
@@ -50,7 +62,17 @@ public class LogRotatorSinkTest {
     Sink<ByteString, CompletionStage<Done>> sizeRotatorSink =
         LogRotatorSink.createFromFunction(sizeBasedPathGenerator);
     // #size
+    CompletionStage<Done> fileSizeCompletion =
+        Source.from(Arrays.asList("test1", "test2", "test3", "test4", "test5", "test6"))
+            .map(ByteString::fromString)
+            .runWith(sizeRotatorSink, materializer);
 
+    assertEquals(
+        Done.getInstance(), fileSizeCompletion.toCompletableFuture().get(2, TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void timeBased() throws Exception {
     // #time
     final Path destinationDir = FileSystems.getDefault().getPath("/tmp");
     final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("'stream-'yyyy-MM-dd_HH'.log'");
@@ -69,9 +91,17 @@ public class LogRotatorSinkTest {
           };
         };
 
-    Sink<ByteString, CompletionStage<Done>> timeBaseSink =
+    Sink<ByteString, CompletionStage<Done>> timeBasedSink =
         LogRotatorSink.createFromFunction(timeBasedPathCreator);
     // #time
+
+    CompletionStage<Done> fileSizeCompletion =
+        Source.from(Arrays.asList("test1", "test2", "test3", "test4", "test5", "test6"))
+            .map(ByteString::fromString)
+            .runWith(timeBasedSink, materializer);
+
+    assertEquals(
+        Done.getInstance(), fileSizeCompletion.toCompletableFuture().get(2, TimeUnit.SECONDS));
 
     /*
     // #sample
@@ -82,13 +112,30 @@ public class LogRotatorSinkTest {
     // #sample
     */
     Creator<Function<ByteString, Optional<Path>>> pathGeneratorCreator = timeBasedPathCreator;
+
+    Source<ByteString, NotUsed> source =
+        Source.from(Arrays.asList("test1", "test2", "test3", "test4", "test5", "test6"))
+            .map(ByteString::fromString);
     // #sample
     CompletionStage<Done> completion =
         Source.from(Arrays.asList("test1", "test2", "test3", "test4", "test5", "test6"))
             .map(ByteString::fromString)
             .runWith(LogRotatorSink.createFromFunction(pathGeneratorCreator), materializer);
+
+    // GZip compressing the data written
+    CompletionStage<Done> compressedCompletion =
+        source.runWith(
+            LogRotatorSink.withSinkFactory(
+                pathGeneratorCreator,
+                path ->
+                    Flow.of(ByteString.class)
+                        .via(Compression.gzip())
+                        .toMat(FileIO.toPath(path), Keep.right())),
+            materializer);
     // #sample
 
-    completion.thenRun(() -> system.terminate());
+    assertEquals(Done.getInstance(), completion.toCompletableFuture().get(2, TimeUnit.SECONDS));
+    assertEquals(
+        Done.getInstance(), compressedCompletion.toCompletableFuture().get(2, TimeUnit.SECONDS));
   }
 }

--- a/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
@@ -273,14 +273,8 @@ class LogRotatorSinkSpec
   }
 
   def readUpFilesAndSizesThenClean(files: Seq[Path]): (Seq[String], Seq[Long]) = {
-    var sizes = Seq.empty[Long]
-    var data = Seq.empty[String]
-    files.foreach { path =>
-      sizes = sizes :+ Files.size(path)
-      data = data :+ new String(Files.readAllBytes(path))
-      Files.delete(path)
-    }
-    (data, sizes)
+    val (bytes, sizes) = readUpFileBytesAndSizesThenClean(files)
+    (bytes.map(_.utf8String), sizes)
   }
 
   def readUpFileBytesAndSizesThenClean(files: Seq[Path]): (Seq[ByteString], Seq[Long]) = {

--- a/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
@@ -13,96 +13,17 @@ import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Compression, FileIO, Flow, Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.TestSource
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Materializer}
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.TestKit
 import akka.util.ByteString
 import com.google.common.jimfs.{Configuration, Jimfs}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
+import scala.collection.immutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
-
-object LogRotatorSinkSpec {
-
-  def main(args: Array[String]): Unit = {
-    implicit val system: ActorSystem = ActorSystem()
-    implicit val materializer: Materializer = ActorMaterializer()
-    import system.dispatcher
-
-    // #size
-    import akka.stream.alpakka.file.scaladsl.LogRotatorSink
-
-    val fileSizeRotationFunction = () => {
-      val max = 10 * 1024 * 1024
-      var size: Long = max
-      (element: ByteString) =>
-        {
-          if (size + element.size > max) {
-            val path = Files.createTempFile("out-", ".log")
-            size = element.size
-            Some(path)
-          } else {
-            size += element.size
-            None
-          }
-        }
-    }
-
-    val sizeRotatorSink: Sink[ByteString, Future[Done]] =
-      LogRotatorSink(fileSizeRotationFunction)
-    // #size
-
-    val fileSizeCompletion = Source(Seq("test1", "test2", "test3", "test4", "test5", "test6").toList)
-      .map(ByteString(_))
-      .runWith(sizeRotatorSink)
-
-    // #time
-    val destinationDir = FileSystems.getDefault.getPath("/tmp")
-    val formatter = DateTimeFormatter.ofPattern("'stream-'yyyy-MM-dd_HH'.log'")
-
-    val timeBasedRotationFunction = () => {
-      var currentFilename: Option[String] = None
-      (_: ByteString) =>
-        {
-          val newName = LocalDateTime.now().format(formatter)
-          if (currentFilename.contains(newName)) {
-            None
-          } else {
-            currentFilename = Some(newName)
-            Some(destinationDir.resolve(newName))
-          }
-        }
-    }
-
-    val timeBasedSink: Sink[ByteString, Future[Done]] =
-      LogRotatorSink(timeBasedRotationFunction)
-    // #time
-
-    val timeBaseCompletion = Source(Seq("test1", "test2", "test3", "test4", "test5", "test6").toList)
-      .map(ByteString(_))
-      .runWith(timeBasedSink)
-
-    /*
-    // #sample
-    val pathGeneratorFunction: () => ByteString => Option[Path] = ???
-
-    // #sample
-     */
-    val pathGeneratorFunction: () => ByteString => Option[Path] = timeBasedRotationFunction
-    // #sample
-    val completion = Source(Seq("test1", "test2", "test3", "test4", "test5", "test6").toList)
-      .map(ByteString(_))
-      .runWith(LogRotatorSink(pathGeneratorFunction))
-    // #sample
-
-    Future
-      .sequence(Seq(timeBaseCompletion, fileSizeCompletion, completion))
-      .onComplete(_ => system.terminate())
-  }
-
-}
 
 class LogRotatorSinkSpec
     extends TestKit(ActorSystem("LogRotatorSinkSpec"))
@@ -159,6 +80,80 @@ class LogRotatorSinkSpec
   val testByteStrings = TestLines.map(ByteString(_))
 
   "LogRotatorSink" must {
+    "work for size-based rotation " in {
+      // #size
+      import akka.stream.alpakka.file.scaladsl.LogRotatorSink
+
+      val fileSizeRotationFunction: () => ByteString => Option[Path] = () => {
+        val max = 10 * 1024 * 1024
+        var size: Long = max
+        element: ByteString =>
+          if (size + element.size > max) {
+            val path = Files.createTempFile("out-", ".log")
+            size = element.size
+            Some(path)
+          } else {
+            size += element.size
+            None
+          }
+      }
+
+      val sizeRotatorSink: Sink[ByteString, Future[Done]] =
+        LogRotatorSink(fileSizeRotationFunction)
+      // #size
+
+      val fileSizeCompletion = Source(immutable.Seq("test1", "test2", "test3", "test4", "test5", "test6"))
+        .map(ByteString(_))
+        .runWith(sizeRotatorSink)
+
+      fileSizeCompletion.futureValue shouldBe Done
+    }
+
+    "work for time-based rotation " in {
+      // #time
+      val destinationDir = FileSystems.getDefault.getPath("/tmp")
+      val formatter = DateTimeFormatter.ofPattern("'stream-'yyyy-MM-dd_HH'.log'")
+
+      val timeBasedRotationFunction = () => {
+        var currentFilename: Option[String] = None
+        (_: ByteString) =>
+          {
+            val newName = LocalDateTime.now().format(formatter)
+            if (currentFilename.contains(newName)) {
+              None
+            } else {
+              currentFilename = Some(newName)
+              Some(destinationDir.resolve(newName))
+            }
+          }
+      }
+
+      val timeBasedSink: Sink[ByteString, Future[Done]] =
+        LogRotatorSink(timeBasedRotationFunction)
+      // #time
+
+      val timeBaseCompletion = Source(immutable.Seq("test1", "test2", "test3", "test4", "test5", "test6"))
+        .map(ByteString(_))
+        .runWith(timeBasedSink)
+
+      /*
+      // #sample
+      val pathGeneratorFunction: () => ByteString => Option[Path] = ???
+
+      // #sample
+       */
+      val pathGeneratorFunction: () => ByteString => Option[Path] = timeBasedRotationFunction
+      // #sample
+      val completion = Source(immutable.Seq("test1", "test2", "test3", "test4", "test5", "test6"))
+        .map(ByteString(_))
+        .runWith(LogRotatorSink(pathGeneratorFunction))
+      // #sample
+      completion.futureValue shouldBe Done
+
+      timeBaseCompletion.futureValue shouldBe Done
+
+    }
+
     "write lines to a single file" in {
       var files = Seq.empty[Path]
       val testFunction = () => {
@@ -196,17 +191,23 @@ class LogRotatorSinkSpec
     }
 
     "write compressed lines to multiple targets" in {
-      val (testFunction, files) = fileLengthFunctionFactory()
+      val (pathGeneratorFunction, files) = fileLengthFunctionFactory()
+      val source = Source(testByteStrings)
+      // #sample
+
+      // GZip compressing the data written
       val completion =
-        Source(testByteStrings).runWith(
-          LogRotatorSink.withSinkFactory(
-            testFunction,
-            path =>
-              Flow[ByteString]
-                .via(Compression.gzip)
-                .toMat(FileIO.toPath(path, Set(StandardOpenOption.APPEND, StandardOpenOption.CREATE)))(Keep.right)
+        source
+          .runWith(
+            LogRotatorSink.withSinkFactory(
+              pathGeneratorFunction,
+              (path: Path) =>
+                Flow[ByteString]
+                  .via(Compression.gzip)
+                  .toMat(FileIO.toPath(path))(Keep.right)
+            )
           )
-        )
+      // #sample
 
       completion.futureValue shouldBe Done
 


### PR DESCRIPTION
* Add the `LogRotatorSink.withSinkFactory`
* Allow for non-`IOResult`-returning sinks
* Allow for other rotation value than `Path`
* Run Java snippets

Fixes #1452