### PR TITLE
Manage kudu client in an extension

### DIFF
--- a/docs/src/main/paradox/kudu.md
+++ b/docs/src/main/paradox/kudu.md
@@ -21,14 +21,12 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Configuration
 
-To connect to Kudu
+To connect to Kudu you need:
 
-1. Create a Kudu client and manage its life-cycle
-1. Describe the Kudu `Schema` (@javadoc[API](org.apache.kudu.Schema))
-1. Define a converter function to map your data type to a `PartialRow` (@javadoc[API](org.apache.kudu.client.PartialRow))
-1. Specify Kudu `CreateTableOptions` (@javadoc[API](org.apache.kudu.client.CreateTableOptions))
-1. Set up Alpakka's `KuduTableSettings` (@scaladoc[API](akka.stream.alpakka.kudu.KuduTableSettings)).
-
+1. Describe the Kudu @javadoc[`Schema`](org.apache.kudu.Schema)
+1. Define a converter function to map your data type to a @javadoc[`PartialRow`](org.apache.kudu.client.PartialRow)
+1. Specify Kudu @javadoc[`CreateTableOptions`](org.apache.kudu.client.CreateTableOptions)
+1. Set up Alpakka's @scaladoc[`KuduTableSettings`](akka.stream.alpakka.kudu.KuduTableSettings)
 
 Scala
 :   @@snip [snip](/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala) { #configure }
@@ -36,6 +34,15 @@ Scala
 Java
 :   @@snip [snip](/kudu/src/test/java/docs/javadsl/KuduTableTest.java) { #configure }
 
+The @javadoc[`KuduClient`](org.apache.kudu.client.KuduClient) by default is automatically managed by the connector.
+Settings for the client are read from the @github[reference.conf](/kudu/src/main/resources/reference.conf) file.
+A manually initialized client can be injected to the stream using @scaladoc[`KuduAttributes`](akka.stream.alpakka.kudu.KuduAttributes$)
+
+Scala
+:   @@snip [snip](/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala) { #attributes }
+
+Java
+:   @@snip [snip](/kudu/src/test/java/docs/javadsl/KuduTableTest.java) { #attributes }
 
 ## Writing to Kudu in a Flow
 

--- a/kudu/src/main/resources/reference.conf
+++ b/kudu/src/main/resources/reference.conf
@@ -1,0 +1,6 @@
+alpakka.kudu {
+
+  # the hostname and port to locate the master
+  master-address = ""
+
+}

--- a/kudu/src/main/scala/akka/stream/alpakka/kudu/KuduAttributes.scala
+++ b/kudu/src/main/scala/akka/stream/alpakka/kudu/KuduAttributes.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kudu
+
+import akka.annotation.InternalApi
+import akka.stream.Attributes
+import akka.stream.Attributes.Attribute
+import org.apache.kudu.client.KuduClient
+
+/**
+ * Akka Stream attributes that are used when materializing Kudu stream blueprints.
+ */
+object KuduAttributes {
+
+  /**
+   * Kudu client to use for the stream
+   */
+  def client(client: KuduClient): Attributes = Attributes(new Client(client))
+
+  final class Client @InternalApi private[KuduAttributes] (val client: KuduClient) extends Attribute
+}

--- a/kudu/src/main/scala/akka/stream/alpakka/kudu/KuduClientExt.scala
+++ b/kudu/src/main/scala/akka/stream/alpakka/kudu/KuduClientExt.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kudu
+
+import akka.actor.{ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import org.apache.kudu.client.KuduClient
+
+/**
+ * Manages one [[org.apache.kudu.client.KuduClient]] per `ActorSystem`.
+ */
+final class KuduClientExt private (sys: ExtendedActorSystem) extends Extension {
+  val client = {
+    val masterAddress = sys.settings.config.getString("alpakka.kudu.master-address")
+    new KuduClient.KuduClientBuilder(masterAddress).build
+  }
+
+  sys.registerOnTermination(client.shutdown())
+}
+
+object KuduClientExt extends ExtensionId[KuduClientExt] with ExtensionIdProvider {
+  override def lookup = KuduClientExt
+  override def createExtension(system: ExtendedActorSystem) = new KuduClientExt(system)
+}

--- a/kudu/src/main/scala/akka/stream/alpakka/kudu/impl/SetupStage.scala
+++ b/kudu/src/main/scala/akka/stream/alpakka/kudu/impl/SetupStage.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kudu.impl
+
+import akka.annotation.InternalApi
+import akka.stream._
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.stage._
+
+import scala.concurrent.{Future, Promise}
+
+private final class SetupSinkStage[T, M](factory: ActorMaterializer => Attributes => Sink[T, M])
+    extends GraphStageWithMaterializedValue[SinkShape[T], Future[M]] {
+
+  private val in = Inlet[T]("SetupSinkStage.in")
+  override val shape = SinkShape(in)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[M]) = {
+    val matPromise = Promise[M]
+    (createStageLogic(matPromise), matPromise.future)
+  }
+
+  private def createStageLogic(matPromise: Promise[M]) = new GraphStageLogic(shape) {
+    import SetupStage._
+
+    val subOutlet = new SubSourceOutlet[T]("SetupSinkStage")
+    subOutlet.setHandler(delegateToInlet(() => pull(in), () => cancel(in)))
+    setHandler(in, delegateToSubOutlet(() => grab(in), subOutlet))
+
+    override def preStart(): Unit = {
+      val sink = factory(actorMaterializer(materializer))(attributes)
+
+      val mat = Source.fromGraph(subOutlet.source).runWith(sink.withAttributes(attributes))(subFusingMaterializer)
+      matPromise.success(mat)
+    }
+  }
+
+}
+
+private final class SetupFlowStage[T, U, M](factory: ActorMaterializer => Attributes => Flow[T, U, M])
+    extends GraphStageWithMaterializedValue[FlowShape[T, U], Future[M]] {
+
+  private val in = Inlet[T]("SetupFlowStage.in")
+  private val out = Outlet[U]("SetupFlowStage.out")
+  override val shape = FlowShape(in, out)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[M]) = {
+    val matPromise = Promise[M]
+    (createStageLogic(matPromise), matPromise.future)
+  }
+
+  private def createStageLogic(matPromise: Promise[M]) = new GraphStageLogic(shape) {
+    import SetupStage._
+
+    val subInlet = new SubSinkInlet[U]("SetupFlowStage")
+    val subOutlet = new SubSourceOutlet[T]("SetupFlowStage")
+
+    subInlet.setHandler(delegateToOutlet(push(out, _: U), () => complete(out), fail(out, _), subInlet))
+    subOutlet.setHandler(delegateToInlet(() => pull(in), () => cancel(in)))
+
+    setHandler(in, delegateToSubOutlet(() => grab(in), subOutlet))
+    setHandler(out, delegateToSubInlet(subInlet))
+
+    override def preStart(): Unit = {
+      val flow = factory(actorMaterializer(materializer))(attributes)
+
+      val mat = Source
+        .fromGraph(subOutlet.source)
+        .viaMat(flow.withAttributes(attributes))(Keep.right)
+        .to(Sink.fromGraph(subInlet.sink))
+        .run()(subFusingMaterializer)
+      matPromise.success(mat)
+    }
+  }
+}
+
+private final class SetupSourceStage[T, M](factory: ActorMaterializer => Attributes => Source[T, M])
+    extends GraphStageWithMaterializedValue[SourceShape[T], Future[M]] {
+
+  private val out = Outlet[T]("SetupSourceStage.out")
+  override val shape = SourceShape(out)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[M]) = {
+    val matPromise = Promise[M]
+    (createStageLogic(matPromise), matPromise.future)
+  }
+
+  private def createStageLogic(matPromise: Promise[M]) = new GraphStageLogic(shape) {
+    import SetupStage._
+
+    val subInlet = new SubSinkInlet[T]("SetupSourceStage")
+    subInlet.setHandler(delegateToOutlet(push(out, _: T), () => complete(out), fail(out, _), subInlet))
+    setHandler(out, delegateToSubInlet(subInlet))
+
+    override def preStart(): Unit = {
+      val source = factory(actorMaterializer(materializer))(attributes)
+
+      val mat = source
+        .withAttributes(attributes)
+        .to(Sink.fromGraph(subInlet.sink))
+        .run()(subFusingMaterializer)
+      matPromise.success(mat)
+    }
+  }
+}
+
+private object SetupStage {
+  def delegateToSubOutlet[T](grab: () => T, subOutlet: GraphStageLogic#SubSourceOutlet[T]) = new InHandler {
+    override def onPush(): Unit =
+      subOutlet.push(grab())
+    override def onUpstreamFinish(): Unit =
+      subOutlet.complete()
+    override def onUpstreamFailure(ex: Throwable): Unit =
+      subOutlet.fail(ex)
+  }
+
+  def delegateToOutlet[T](push: T => Unit,
+                          complete: () => Unit,
+                          fail: Throwable => Unit,
+                          subInlet: GraphStageLogic#SubSinkInlet[T]) = new InHandler {
+    override def onPush(): Unit =
+      push(subInlet.grab())
+    override def onUpstreamFinish(): Unit =
+      complete()
+    override def onUpstreamFailure(ex: Throwable): Unit =
+      fail(ex)
+  }
+
+  def delegateToSubInlet[T](subInlet: GraphStageLogic#SubSinkInlet[T]) = new OutHandler {
+    override def onPull(): Unit =
+      subInlet.pull()
+    override def onDownstreamFinish(): Unit =
+      subInlet.cancel()
+  }
+
+  def delegateToInlet(pull: () => Unit, cancel: () => Unit) = new OutHandler {
+    override def onPull(): Unit =
+      pull()
+    override def onDownstreamFinish(): Unit =
+      cancel()
+  }
+
+  def actorMaterializer(mat: Materializer): ActorMaterializer = mat match {
+    case am: ActorMaterializer => am
+    case _ => throw new Error("ActorMaterializer required")
+  }
+}
+
+@InternalApi private[kudu] object Setup {
+  def sink[T, M](factory: ActorMaterializer => Attributes => Sink[T, M]): Sink[T, Future[M]] =
+    Sink.fromGraph(new SetupSinkStage(factory))
+
+  def flow[T, U, M](factory: ActorMaterializer => Attributes => Flow[T, U, M]): Flow[T, U, Future[M]] =
+    Flow.fromGraph(new SetupFlowStage(factory))
+
+  def source[T, M](factory: ActorMaterializer => Attributes => Source[T, M]): Source[T, Future[M]] =
+    Source.fromGraph(new SetupSourceStage(factory))
+}

--- a/kudu/src/main/scala/akka/stream/alpakka/kudu/javadsl/KuduTable.scala
+++ b/kudu/src/main/scala/akka/stream/alpakka/kudu/javadsl/KuduTable.scala
@@ -7,10 +7,9 @@ package akka.stream.alpakka.kudu.javadsl
 import java.util.concurrent.CompletionStage
 
 import akka.stream.alpakka.kudu.KuduTableSettings
-import akka.stream.alpakka.kudu.impl.KuduFlowStage
 import akka.stream.javadsl.{Flow, Keep, Sink}
+import akka.stream.alpakka.kudu.scaladsl
 import akka.{Done, NotUsed}
-import org.apache.kudu.client.KuduClient
 
 /**
  * Java API
@@ -20,13 +19,13 @@ object KuduTable {
   /**
    * Create a Sink writing elements to a Kudu table.
    */
-  def sink[A](settings: KuduTableSettings[A], kuduClient: KuduClient): Sink[A, CompletionStage[Done]] =
-    flow(settings, kuduClient).toMat(Sink.ignore(), Keep.right[NotUsed, CompletionStage[Done]])
+  def sink[A](settings: KuduTableSettings[A]): Sink[A, CompletionStage[Done]] =
+    flow(settings).toMat(Sink.ignore(), Keep.right[NotUsed, CompletionStage[Done]])
 
   /**
    * Create a Flow writing elements to a Kudu table.
    */
-  def flow[A](settings: KuduTableSettings[A], kuduClient: KuduClient): Flow[A, A, NotUsed] =
-    Flow.fromGraph(new KuduFlowStage[A](settings, kuduClient))
+  def flow[A](settings: KuduTableSettings[A]): Flow[A, A, NotUsed] =
+    scaladsl.KuduTable.flow(settings).asJava
 
 }

--- a/kudu/src/main/scala/akka/stream/alpakka/kudu/scaladsl/KuduTable.scala
+++ b/kudu/src/main/scala/akka/stream/alpakka/kudu/scaladsl/KuduTable.scala
@@ -4,11 +4,11 @@
 
 package akka.stream.alpakka.kudu.scaladsl
 
-import akka.stream.alpakka.kudu.KuduTableSettings
-import akka.stream.alpakka.kudu.impl.KuduFlowStage
+import akka.stream.{ActorMaterializer, Attributes}
+import akka.stream.alpakka.kudu.{KuduAttributes, KuduClientExt, KuduTableSettings}
+import akka.stream.alpakka.kudu.impl.{KuduFlowStage, Setup}
 import akka.stream.scaladsl.{Flow, Keep, Sink}
 import akka.{Done, NotUsed}
-import org.apache.kudu.client.KuduClient
 
 import scala.concurrent.Future
 
@@ -20,13 +20,22 @@ object KuduTable {
   /**
    * Create a Sink writing elements to a Kudu table.
    */
-  def sink[A](settings: KuduTableSettings[A])(implicit kuduClient: KuduClient): Sink[A, Future[Done]] =
-    flow(settings)(kuduClient).toMat(Sink.ignore)(Keep.right)
+  def sink[A](settings: KuduTableSettings[A]): Sink[A, Future[Done]] =
+    flow(settings).toMat(Sink.ignore)(Keep.right)
 
   /**
    * Create a Flow writing elements to a Kudu table.
    */
-  def flow[A](settings: KuduTableSettings[A])(implicit kuduClient: KuduClient): Flow[A, A, NotUsed] =
-    Flow.fromGraph(new KuduFlowStage[A](settings, kuduClient))
+  def flow[A](settings: KuduTableSettings[A]): Flow[A, A, NotUsed] =
+    Setup
+      .flow { implicit mat => implicit attr =>
+        Flow.fromGraph(new KuduFlowStage[A](settings, client()))
+      }
+      .mapMaterializedValue(_ => NotUsed)
 
+  private def client()(implicit mat: ActorMaterializer, attr: Attributes) =
+    attr
+      .get[KuduAttributes.Client]
+      .map(_.client)
+      .getOrElse(KuduClientExt(mat.system).client)
 }

--- a/kudu/src/test/java/docs/javadsl/KuduTableTest.java
+++ b/kudu/src/test/java/docs/javadsl/KuduTableTest.java
@@ -7,9 +7,9 @@ package docs.javadsl;
 import akka.Done;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.japi.Pair;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
+import akka.stream.alpakka.kudu.KuduAttributes;
 import akka.stream.alpakka.kudu.KuduTableSettings;
 import akka.stream.alpakka.kudu.javadsl.KuduTable;
 import akka.stream.javadsl.Flow;
@@ -38,13 +38,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 public class KuduTableTest {
-  private static final String kuduMasterAddresses = "127.0.0.1:7051";
-
   private static ActorSystem system;
   private static Materializer materializer;
   private static Schema schema;
 
-  private static KuduClient kuduClient;
   private static KuduTableSettings<Person> tableSettings;
 
   @BeforeClass
@@ -53,17 +50,6 @@ public class KuduTableTest {
     materializer = ActorMaterializer.create(system);
 
     // #configure
-    // Kudu Client
-    kuduClient = new KuduClient.KuduClientBuilder(kuduMasterAddresses).build();
-    system.registerOnTermination(
-        () -> {
-          try {
-            kuduClient.shutdown();
-          } catch (KuduException e) {
-            e.printStackTrace();
-          }
-        });
-
     // Kudu Schema
     List<ColumnSchema> columns = new ArrayList<>(2);
     columns.add(new ColumnSchema.ColumnSchemaBuilder("key", Type.INT32).key(true).build());
@@ -100,7 +86,7 @@ public class KuduTableTest {
   public void sink() throws Exception {
     // #sink
     final Sink<Person, CompletionStage<Done>> sink =
-        KuduTable.sink(tableSettings.withTableName("Sink"), kuduClient);
+        KuduTable.sink(tableSettings.withTableName("Sink"));
 
     CompletionStage<Done> o =
         Source.from(Arrays.asList(100, 101, 102, 103, 104))
@@ -113,8 +99,7 @@ public class KuduTableTest {
   @Test
   public void flow() throws Exception {
     // #flow
-    Flow<Person, Person, NotUsed> flow =
-        KuduTable.flow(tableSettings.withTableName("Flow"), kuduClient);
+    Flow<Person, Person, NotUsed> flow = KuduTable.flow(tableSettings.withTableName("Flow"));
 
     CompletionStage<List<Person>> run =
         Source.from(Arrays.asList(200, 201, 202, 203, 204))
@@ -123,6 +108,35 @@ public class KuduTableTest {
             .toMat(Sink.seq(), Keep.right())
             .run(materializer);
     // #flow
+    assertEquals(5, run.toCompletableFuture().get(5, TimeUnit.SECONDS).size());
+  }
+
+  @Test
+  public void customClient() throws Exception {
+    // #attributes
+    final String masterAddress = "localhost:7051";
+    final KuduClient client = new KuduClient.KuduClientBuilder(masterAddress).build();
+    system.registerOnTermination(
+        () -> {
+          try {
+            client.shutdown();
+          } catch (KuduException e) {
+            e.printStackTrace();
+          }
+        });
+
+    final Flow<Person, Person, NotUsed> flow =
+        KuduTable.flow(tableSettings.withTableName("Flow"))
+            .withAttributes(KuduAttributes.client(client));
+    // #attributes
+
+    CompletionStage<List<Person>> run =
+        Source.from(Arrays.asList(200, 201, 202, 203, 204))
+            .map((i) -> new Person(i, String.format("name_%d", i)))
+            .via(flow)
+            .toMat(Sink.seq(), Keep.right())
+            .run(materializer);
+
     assertEquals(5, run.toCompletableFuture().get(5, TimeUnit.SECONDS).size());
   }
 }

--- a/kudu/src/test/resources/application.conf
+++ b/kudu/src/test/resources/application.conf
@@ -3,3 +3,7 @@ akka {
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   loglevel = "DEBUG"
 }
+
+alpakka.kudu {
+  master-address = "localhost:7051"
+}

--- a/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala
+++ b/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala
@@ -6,7 +6,7 @@ package docs.scaladsl
 
 import akka.{Done, NotUsed}
 import akka.actor.ActorSystem
-import akka.stream.alpakka.kudu.KuduTableSettings
+import akka.stream.alpakka.kudu.{KuduAttributes, KuduTableSettings}
 import akka.stream.alpakka.kudu.scaladsl.KuduTable
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.stream.{ActorMaterializer, Materializer}
@@ -33,13 +33,7 @@ class KuduTableSpec
 
   override def afterAll(): Unit = TestKit.shutdownActorSystem(system)
 
-  val kuduMasterAddress = "localhost:7051"
-
   //#configure
-  // Kudu Client
-  implicit val kuduClient = new KuduClient.KuduClientBuilder(kuduMasterAddress).build
-  system.registerOnTermination(kuduClient.shutdown())
-
   // Kudu Schema
   val cols = List(new ColumnSchema.ColumnSchemaBuilder("key", Type.INT32).key(true).build,
                   new ColumnSchema.ColumnSchemaBuilder("value", Type.STRING).build)
@@ -87,6 +81,26 @@ class KuduTableSpec
         .via(flow)
         .runWith(Sink.fold(0)((a, d) => a + d.id))
       //#flow
+
+      f.futureValue should be(155)
+    }
+
+    "custom client" in {
+      // #attributes
+      val masterAddress = "localhost:7051"
+      val client = new KuduClient.KuduClientBuilder(masterAddress).build
+      system.registerOnTermination(client.shutdown())
+
+      val flow: Flow[Person, Person, NotUsed] =
+        KuduTable
+          .flow(kuduTableSettings.withTableName("Flow"))
+          .withAttributes(KuduAttributes.client(client))
+      // #attributes
+
+      val f = Source(11 to 20)
+        .map(i => Person(i, s"zozo_$i"))
+        .via(flow)
+        .runWith(Sink.fold(0)((a, d) => a + d.id))
 
       f.futureValue should be(155)
     }


### PR DESCRIPTION
Fixes #1217

## Purpose

Clean up Kudu Akka Stream operator factories from resources. 

## Background Context

Akka Stream operators are blueprints which are meant to be reused. Therefore external resources needed for the operators should either be resolved during materialization or injected via stream attributes.