### PR TITLE
FTP: replace windows path separator by unix separator after path norm…

### DIFF
--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
@@ -30,7 +30,10 @@ private[ftp] trait CommonFtpOperations {
         case file: FTPFile if file.getName != "." && file.getName != ".." =>
           FtpFile(
             file.getName,
-            Paths.get(s"$path/${file.getName}").normalize.toString,
+            if (java.io.File.separatorChar == '\\')
+              Paths.get(s"$path/${file.getName}").normalize.toString.replace('\\', '/')
+            else
+              Paths.get(s"$path/${file.getName}").normalize.toString,
             file.isDirectory,
             file.getSize,
             file.getTimestamp.getTimeInMillis,


### PR DESCRIPTION
## Fixes

Fixes [#1470](https://github.com/akka/alpakka/issues/1470)

## Purpose

This PR replaces the Windows \ file separator characters after file name normalization in case that the FTP client runs on a Windows system.

## Background Context

File names used on FTP servers should in amost all cases be in Unix style since also the Windows FTP servers support Unix style pathes. The opposite (Unix FTP servers supporting Windows style) is normally not the case.

## References

[Discussion in the Alpakka forum](https://discuss.lightbend.com/t/alpakka-ftp-recursive-listing-of-directory-tree/3304)
