### PR TITLE
ElasticSearch null check for index and type name on source and flow

### DIFF
--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
@@ -32,6 +32,8 @@ private[elasticsearch] final class ElasticsearchFlowStage[T, C](
     settings: ElasticsearchWriteSettings,
     writer: MessageWriter[T]
 ) extends GraphStage[FlowShape[WriteMessage[T, C], Future[Seq[WriteResult[T, C]]]]] {
+  require(indexName != null, "You must define an index name")
+  require(typeName != null, "You must define a type name")
 
   private val in = Inlet[WriteMessage[T, C]]("messages")
   private val out = Outlet[Future[Seq[WriteResult[T, C]]]]("result")

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSourceStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSourceStage.scala
@@ -49,6 +49,7 @@ private[elasticsearch] final class ElasticsearchSourceStage[T](indexName: String
                                                                settings: ElasticsearchSourceSettings,
                                                                reader: MessageReader[T])
     extends GraphStage[SourceShape[ReadResult[T]]] {
+  require(indexName != null, "You must define an index name")
 
   val out: Outlet[ReadResult[T]] = Outlet("ElasticsearchSource.out")
   override val shape: SourceShape[ReadResult[T]] = SourceShape(out)

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
@@ -859,6 +859,37 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll {
         "Scala for Spark in Production"
       )
     }
+
+    "should throw an IllegalArgumentException if indexName is null when passed to ElasticsearchSource" in {
+      assertThrows[IllegalArgumentException] {
+        ElasticsearchSource
+          .create(
+            indexName = null,
+            typeName = "_doc",
+            query = """{"match_all": {}}"""
+        )
+      }
+    }
+
+    "should throw an IllegalArgumentException if indexName is null when passed to ElasticsearchFlow" in {
+      assertThrows[IllegalArgumentException] {
+        ElasticsearchFlow
+          .create[Book](
+            indexName = null,
+            typeName = "_doc"
+          )
+      }
+    }
+
+    "should throw an IllegalArgumentException if typeName is null when passed to ElasticsearchFlow" in {
+      assertThrows[IllegalArgumentException] {
+        ElasticsearchFlow
+          .create[Book](
+            indexName = "foo",
+            typeName = null
+          )
+      }
+    }
   }
 
   "ElasticsearchSource" should {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/akka/alpakka/tree/master/CONTRIBUTING.md) and [contributor advice](https://github.com/akka/alpakka/blob/master/contributor-advice.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Purpose

Add null checks for `indexName` on `ElasticsearchSource`.  Add null checks for `indexName` and `typeName` on `ElasticsearchFlow`

## Background Context

The `indexName` and `typeName` `String` params are used in `ElasticsearchFlowStage` when creating the indexing JSON request for Elasticsearch.  If the parameters are `null` and added as `JsStrings` to the request JSON (https://github.com/akka/alpakka/blob/v1.0-M2/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala#L157..L158) then an NPE will be thrown from deep inside spray-json when the request JSON is serialized.  This is a known issue in spray-json (https://github.com/spray/spray-json/issues/70).  The reason I passed `null` to these parameters was due to a different issue related to a known Scala bug (https://github.com/scala/bug/issues/1352) and initialization quirks in Scala ([Why is my abstract or overridden val null?](https://docs.scala-lang.org/tutorials/FAQ/initialization-order.html)), but nonetheless I think it would be prudent to add a `null` check to avoid the possible spray-json NPE in the first place because it can be challenging to troubleshoot.

I added a similar null check for `indexName` to `ElasticsearchSourceStage` because it's encoded into query path to Elasticsearch.  In this case `typeName` is an `Option` so any potential NPE would be easier to reason about in a stack trace.
