### PR TITLE
Parallel subscriptions/unsubscriptions and SubAck notifications

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -341,12 +341,12 @@ import scala.util.{Failure, Success}
             remote.success(ForwardDisconnect)
             timer.cancel(SendPingreq)
             disconnect(context, data.remote, data)
-          case (context, SubscribeReceivedLocally(subscribe, subscribeData, remote)) =>
+          case (context, SubscribeReceivedLocally(_, subscribeData, remote)) =>
             context.watch(
               context.spawnAnonymous(Subscriber(subscribeData, remote, data.subscriberPacketRouter, data.settings))
             )
             serverConnected(data)
-          case (context, UnsubscribeReceivedLocally(unsubscribe, unsubscribeData, remote)) =>
+          case (context, UnsubscribeReceivedLocally(_, unsubscribeData, remote)) =>
             context.watch(
               context
                 .spawnAnonymous(Unsubscriber(unsubscribeData, remote, data.unsubscriberPacketRouter, data.settings))

--- a/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -60,6 +60,8 @@ import static org.junit.Assert.assertEquals;
 
 public class MqttFlowTest {
 
+  private static int TIMEOUT_SECONDS = 5;
+
   private static ActorSystem system;
   private static Materializer materializer;
 
@@ -126,7 +128,7 @@ public class MqttFlowTest {
     // #run-streaming-flow
 
     CompletionStage<Publish> event = run.second();
-    Publish publishEvent = event.toCompletableFuture().get(3, TimeUnit.SECONDS);
+    Publish publishEvent = event.toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
     assertEquals(publishEvent.topicName(), topic);
     assertEquals(publishEvent.payload(), ByteString.fromString("ohi"));
   }
@@ -215,7 +217,7 @@ public class MqttFlowTest {
         bindSource.toMat(Sink.ignore(), Keep.left()).run(materializer);
     // #run-streaming-bind-flow
 
-    bound.toCompletableFuture().get(3, TimeUnit.SECONDS);
+    bound.toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
     Flow<ByteString, ByteString, CompletionStage<Tcp.OutgoingConnection>> connection =
         Tcp.get(system).outgoingConnection(host, port);
@@ -251,7 +253,7 @@ public class MqttFlowTest {
                 ByteString.fromString("ohi"))));
 
     CompletionStage<Publish> event = run.second();
-    Publish publish = event.toCompletableFuture().get(3, TimeUnit.SECONDS);
+    Publish publish = event.toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
     assertEquals(publish.topicName(), topic);
     assertEquals(publish.payload(), ByteString.fromString("ohi"));
   }

--- a/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -49,6 +49,7 @@ import scala.collection.JavaConverters;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
@@ -194,8 +195,11 @@ public class MqttFlowTest {
                                     .stream()
                                     .map(x -> x._2().underlying())
                                     .collect(Collectors.toList());
-                            queue.offer(new Command<>(new SubAck(subscribe.packetId(), flags)));
-                            subscribed.complete(Done.getInstance());
+                            queue.offer(
+                                new Command<>(
+                                    new SubAck(subscribe.packetId(), flags),
+                                    Optional.of(subscribed),
+                                    Optional.empty()));
                           } else if (cp instanceof Publish) {
                             Publish publish = (Publish) cp;
                             if ((publish.flags() & ControlPacketFlags.RETAIN()) != 0) {

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -109,8 +109,7 @@ class MqttFlowSpec
                   case Right(Event(_: Connect, _)) =>
                     queue.offer(Command(ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)))
                   case Right(Event(cp: Subscribe, _)) =>
-                    queue.offer(Command(SubAck(cp.packetId, cp.topicFilters.map(_._2))))
-                    subscribed.success(Done)
+                    queue.offer(Command(SubAck(cp.packetId, cp.topicFilters.map(_._2)), Some(subscribed), None))
                   case Right(Event(publish @ Publish(flags, _, Some(packetId), _), _))
                       if flags.contains(ControlPacketFlags.RETAIN) =>
                     queue.offer(Command(PubAck(packetId)))


### PR DESCRIPTION
Prior to this PR, more than 10 control packets (configurable) could come in very quickly and prevent the client or server handling more. This created a problem if, say, 10 `PUBLISH` packets were received then followed by a `SUBACK`. The `SUBACK` would never be processed.

The changes here no longer restrict subscriptions and unsubscriptions for both the client and server from occurring only one at a time. This then frees the session to process packets without effectively being blocked.

An added bonus is that the code is somewhat simplified. :-)

Also new, is the introduction of the ability to be notified of server-side SubAck completion. It is important for the server to know when it is the right time to start publishing for a newly subscribed topic; too early and the publications will be dropped given that internal state hasn’t yet updated (sometimes!). This PR introduces the ability for certain commands, presently only server-side SubAck, to complete a process when the `SubAck` has been dispatched and internal state updated. A couple of flaky tests have been fixed as a consequence of this new feature.

Lastly, Producers are messages are kept around post an unsubscribe. Producers still need the opportunity of receiving PUBACKs and so forth, even if they’ve now been unsubscribed.

BONUS: a flaky test has been fixed.