### PR TITLE
AWS Kinesis: Better error for GetShardIteratorFailure

### DIFF
--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisSourceStage.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisSourceStage.scala
@@ -66,8 +66,7 @@ class KinesisSourceStage(shardSettings: ShardSettings, amazonKinesisAsync: => Am
           requestRecords(self.ref)
         }
         case (_, GetShardIteratorFailure(ex)) => {
-          log.error("Failed to get a shard iterator for shard {}", shardId)
-          log.error(ex.getMessage)
+          log.error(ex,"Failed to get a shard iterator for shard {}", shardId)
           failStage(Errors.GetShardIteratorError)
         }
         case (_, Pump) => ()

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisSourceStage.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisSourceStage.scala
@@ -89,8 +89,8 @@ class KinesisSourceStage(shardSettings: ShardSettings, amazonKinesisAsync: => Am
             scheduleOnce('GET_RECORDS, refreshInterval)
           }
         }
-        case (_, GetRecordsFailure(_)) => {
-          log.error("Failed to fetch records from Kinesis for shard {}", shardId)
+        case (_, GetRecordsFailure(ex)) => {
+          log.error(ex,"Failed to fetch records from Kinesis for shard {}", shardId)
           failStage(Errors.GetRecordsError)
         }
         case (_, Pump) => ()

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisSourceStage.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisSourceStage.scala
@@ -66,7 +66,7 @@ class KinesisSourceStage(shardSettings: ShardSettings, amazonKinesisAsync: => Am
           requestRecords(self.ref)
         }
         case (_, GetShardIteratorFailure(ex)) => {
-          log.error(ex,"Failed to get a shard iterator for shard {}", shardId)
+          log.error(ex, "Failed to get a shard iterator for shard {}", shardId)
           failStage(Errors.GetShardIteratorError)
         }
         case (_, Pump) => ()
@@ -90,7 +90,7 @@ class KinesisSourceStage(shardSettings: ShardSettings, amazonKinesisAsync: => Am
           }
         }
         case (_, GetRecordsFailure(ex)) => {
-          log.error(ex,"Failed to fetch records from Kinesis for shard {}", shardId)
+          log.error(ex, "Failed to fetch records from Kinesis for shard {}", shardId)
           failStage(Errors.GetRecordsError)
         }
         case (_, Pump) => ()

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisSourceStage.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisSourceStage.scala
@@ -47,7 +47,7 @@ class KinesisSourceStage(shardSettings: ShardSettings, amazonKinesisAsync: => Am
       import shardSettings._
 
       private[this] var iterator: String = _
-      private[this] var buffer = mutable.Queue.empty[Record]
+      private[this] val buffer = mutable.Queue.empty[Record]
       private[this] var self: StageActor = _
 
       override def preStart(): Unit = {

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisSourceStage.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisSourceStage.scala
@@ -65,8 +65,9 @@ class KinesisSourceStage(shardSettings: ShardSettings, amazonKinesisAsync: => Am
           self.become(awaitingRecords)
           requestRecords(self.ref)
         }
-        case ((_, GetShardIteratorFailure(_))) => {
+        case ((_, GetShardIteratorFailure(ex))) => {
           log.error("Failed to get a shard iterator for shard {}", shardId)
+          log.error(ex.getMessage)
           failStage(Errors.GetShardIteratorError)
         }
         case ((_, Pump)) => ()


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/akka/alpakka/tree/master/CONTRIBUTING.md) and [contributor advice](https://github.com/akka/alpakka/blob/master/contributor-advice.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Purpose
When using `akka-stream-alpakka-elasticsearch` and `akka-stream-alpakka-kinesis` in the same project, the following error will get swallowed:
```
Exception in thread "main" java.util.concurrent.ExecutionException: com.amazonaws.SdkClientException: Unable to marshall request to JSON: Jackson jackson-core/jackson-dataformat-cbor incompatible library version detected.
You have two possible resolutions:
		1) Ensure the com.fasterxml.jackson.core:jackson-core & com.fasterxml.jackson.dataformat:jackson-dataformat-cbor libraries on your classpath have the same version number
		2) Disable CBOR wire-protocol by passing the -Dcom.amazonaws.sdk.disableCbor property or setting the AWS_CBOR_DISABLE environment variable (warning this may affect performance)
```