### PR TITLE
mqtt-streaming: Prefer wrapping instead of reissuing packet ids

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -202,7 +202,8 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
                                                                   Consumer.PubAckReceivedLocally(reply),
                                                                   reply)
                   Source.fromFuture(reply.future.map(_ => cp.encode(ByteString.newBuilder).result())).recover {
-                    case _: RemotePacketRouter.CannotRoute => ByteString.empty
+                    case e: RemotePacketRouter.CannotRoute =>
+                      ByteString.empty
                   }
                 case Command(cp: PubRec, _, _) =>
                   val reply = Promise[Consumer.ForwardPubRec.type]
@@ -513,7 +514,8 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
                                                                                Consumer.PubAckReceivedLocally(reply),
                                                                                reply)
                   Source.fromFuture(reply.future.map(_ => cp.encode(ByteString.newBuilder).result())).recover {
-                    case _: RemotePacketRouter.CannotRoute => ByteString.empty
+                    case _: RemotePacketRouter.CannotRoute =>
+                      ByteString.empty
                   }
                 case Command(cp: PubRec, _, _) =>
                   val reply = Promise[Consumer.ForwardPubRec.type]

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -704,9 +704,12 @@ class MqttSessionSpec
       val connAckBytes = connAck.encode(ByteString.newBuilder).result()
 
       val publish = Publish("some-topic", ByteString("some-payload"))
-      val publishBytes = publish.encode(ByteString.newBuilder, Some(PacketId(1))).result()
-      val pubAck = PubAck(PacketId(1))
-      val pubAckBytes = pubAck.encode(ByteString.newBuilder).result()
+      val firstPublishBytes = publish.encode(ByteString.newBuilder, Some(PacketId(1))).result()
+      val secondPublishBytes = publish.encode(ByteString.newBuilder, Some(PacketId(2))).result()
+      val firstPubAck = PubAck(PacketId(1))
+      val firstPubAckBytes = firstPubAck.encode(ByteString.newBuilder).result()
+      val secondPubAck = PubAck(PacketId(2))
+      val secondPubAckBytes = secondPubAck.encode(ByteString.newBuilder).result()
 
       client.offer(Command(connect))
 
@@ -716,11 +719,11 @@ class MqttSessionSpec
       session ! Command(publish)
       session ! Command(publish)
 
-      server.expectMsg(publishBytes)
-      server.reply(pubAckBytes)
+      server.expectMsg(firstPublishBytes)
+      server.reply(firstPubAckBytes)
 
-      server.expectMsg(publishBytes)
-      server.reply(pubAckBytes)
+      server.expectMsg(secondPublishBytes)
+      server.reply(secondPubAckBytes)
     }
 
     "publish with a QoS of 1 and cause a retry given a timeout" in {


### PR DESCRIPTION
Packet ids now monotonically increase until they reach the maximum value, upon which they wrap around to the minimum. Care is taken to ensure that packet ids that are in use are not issued, as it is
technically possible, albeit rare.

This fixes a number of potential race conditions. For example, consider a PUBLISH -> PUBACK exchange with QoS1 with the old behavior:

1) Server retransmits an unacknowledged publish
2) Before client receives retransmission, it finally ACKs original publish.
3) Server receives ACK, and performs new publish, reusing the last id.
4) Client receives retransmission from # 1, and ACKs it.
5) Server receives ACK, and misinterprets it as an ack from # 3
6) Oh no!

By wrapping around, we've effectively eliminated the changes of this happening. This is similar to how Linux issues PIDs for processes to avoid a similar sort of problem.

/cc @huntc 