### PR TITLE
Use IODispatcher attribute

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpReplyToSinkStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpReplyToSinkStage.scala
@@ -26,9 +26,7 @@ private[amqp] final class AmqpReplyToSinkStage(settings: AmqpReplyToSinkSettings
   override def shape: SinkShape[OutgoingMessage] = SinkShape.of(in)
 
   override protected def initialAttributes: Attributes =
-    Attributes
-      .name("AmqpReplyToSink")
-      .and(ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher"))
+    super.initialAttributes and Attributes.name("AmqpReplyToSink") and ActorAttributes.IODispatcher
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Done]) = {
     val promise = Promise[Done]()

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpRpcFlowStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpRpcFlowStage.scala
@@ -37,9 +37,7 @@ private[amqp] final class AmqpRpcFlowStage(settings: AmqpSinkSettings, bufferSiz
   override def shape: FlowShape[OutgoingMessage, CommittableIncomingMessage] = FlowShape.of(in, out)
 
   override protected def initialAttributes: Attributes =
-    Attributes
-      .name("AmqpRpcFlow")
-      .and(ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher"))
+    super.initialAttributes and Attributes.name("AmqpRpcFlow") and ActorAttributes.IODispatcher
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[String]) = {
     val promise = Promise[String]()

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpSinkStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpSinkStage.scala
@@ -25,9 +25,7 @@ private[amqp] final class AmqpSinkStage(settings: AmqpSinkSettings)
   override def shape: SinkShape[OutgoingMessage] = SinkShape.of(in)
 
   override protected def initialAttributes: Attributes =
-    Attributes
-      .name("AmqpSink")
-      .and(ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher"))
+    super.initialAttributes and Attributes.name("AmqpSink") and ActorAttributes.IODispatcher
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Done]) = {
     val promise = Promise[Done]()

--- a/geode/src/main/scala/akka/stream/alpakka/geode/impl/stage/GeodeContinuousSourceStage.scala
+++ b/geode/src/main/scala/akka/stream/alpakka/geode/impl/stage/GeodeContinuousSourceStage.scala
@@ -17,9 +17,7 @@ private[geode] class GeodeContinuousSourceStage[V](cache: ClientCache, name: Str
     extends GraphStageWithMaterializedValue[SourceShape[V], Future[Done]] {
 
   override protected def initialAttributes: Attributes =
-    Attributes
-      .name("GeodeContinuousSource")
-      .and(ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher"))
+    super.initialAttributes and Attributes.name("GeodeContinuousSource") and ActorAttributes.IODispatcher
 
   val out = Outlet[V](s"geode.continuousSource")
 

--- a/geode/src/main/scala/akka/stream/alpakka/geode/impl/stage/GeodeFiniteSourceStage.scala
+++ b/geode/src/main/scala/akka/stream/alpakka/geode/impl/stage/GeodeFiniteSourceStage.scala
@@ -17,7 +17,7 @@ private[geode] class GeodeFiniteSourceStage[V](cache: ClientCache, sql: String)
     extends GraphStageWithMaterializedValue[SourceShape[V], Future[Done]] {
 
   override protected def initialAttributes: Attributes =
-    Attributes.name("GeodeFiniteSource").and(ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher"))
+    super.initialAttributes and Attributes.name("GeodeFiniteSource") and ActorAttributes.IODispatcher
 
   val out = Outlet[V]("geode.finiteSource")
 

--- a/geode/src/main/scala/akka/stream/alpakka/geode/impl/stage/GeodeFlowStage.scala
+++ b/geode/src/main/scala/akka/stream/alpakka/geode/impl/stage/GeodeFlowStage.scala
@@ -16,7 +16,7 @@ private[geode] class GeodeFlowStage[K, T <: AnyRef](cache: ClientCache, settings
     extends GraphStage[FlowShape[T, T]] {
 
   override protected def initialAttributes: Attributes =
-    Attributes.name("GeodeFLow").and(ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher"))
+    super.initialAttributes and Attributes.name("GeodeFlow") and ActorAttributes.IODispatcher
 
   private val in = Inlet[T]("geode.in")
   private val out = Outlet[T]("geode.out")

--- a/hbase/src/main/scala/akka/stream/alpakka/hbase/impl/HBaseFlowStage.scala
+++ b/hbase/src/main/scala/akka/stream/alpakka/hbase/impl/HBaseFlowStage.scala
@@ -14,7 +14,7 @@ import scala.util.control.NonFatal
 private[hbase] class HBaseFlowStage[A](settings: HTableSettings[A]) extends GraphStage[FlowShape[A, A]] {
 
   override protected def initialAttributes: Attributes =
-    Attributes.name("HBaseFLow").and(ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher"))
+    super.initialAttributes and Attributes.name("HBaseFlow") and ActorAttributes.IODispatcher
 
   private val in = Inlet[A]("messages")
   private val out = Outlet[A]("result")

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsBrowseStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsBrowseStage.scala
@@ -20,7 +20,7 @@ private[jms] final class JmsBrowseStage(settings: JmsBrowseSettings, queue: Dest
   val shape = SourceShape(out)
 
   override protected def initialAttributes: Attributes =
-    ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher")
+    super.initialAttributes and Attributes.name("JmsBrowse") and ActorAttributes.IODispatcher
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with OutHandler {

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsConnector.scala
@@ -206,10 +206,10 @@ trait JmsConnector[S <: JmsSession] {
 
   protected def executionContext(attributes: Attributes): ExecutionContext = {
     val dispatcher = attributes.get[ActorAttributes.Dispatcher](
-      ActorAttributes.Dispatcher("akka.stream.default-blocking-io-dispatcher")
+      ActorAttributes.IODispatcher
     ) match {
       case ActorAttributes.Dispatcher("") =>
-        ActorAttributes.Dispatcher("akka.stream.default-blocking-io-dispatcher")
+        ActorAttributes.IODispatcher
       case d => d
     }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsProducerStage.scala
@@ -55,7 +55,7 @@ private[jms] final class JmsProducerStage[E <: JmsEnvelope[PassThrough], PassThr
   override def shape: FlowShape[E, E] = FlowShape.of(in, out)
 
   override protected def initialAttributes: Attributes =
-    ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher").and(Attributes.name("JmsProducer"))
+    super.initialAttributes and Attributes.name("JmsProducer") and ActorAttributes.IODispatcher
 
   override def createLogicAndMaterializedValue(
       inheritedAttributes: Attributes

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/DiskBuffer.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/DiskBuffer.scala
@@ -46,7 +46,8 @@ import akka.annotation.InternalApi
   val out = Outlet[Chunk]("DiskBuffer.out")
   override val shape = FlowShape.of(in, out)
 
-  override def initialAttributes = ActorAttributes.dispatcher("akka.stream.default-blocking-io-dispatcher")
+  override def initialAttributes =
+    super.initialAttributes and Attributes.name("DiskBuffer") and ActorAttributes.IODispatcher
 
   override def createLogic(attr: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with OutHandler with InHandler {


### PR DESCRIPTION
## Fixes

Fixes #1173

## Purpose

Uses the IODispatcher attribute value provided by akka-stream jar, instead of the config path.