### PR TITLE
Amqp: assert all stages stopped and fix source shutdown

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectionProvider.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectionProvider.scala
@@ -44,7 +44,9 @@ final class AmqpUriConnectionProvider private (val uri: String) extends AmqpConn
   }
 
   override def toString: String =
-    s"AmqpUriConnectionProvider(uri=$uri)"
+    "AmqpUriConnectionProvider(" +
+    s"uri=$uri" +
+    ")"
 }
 
 object AmqpUriConnectionProvider {
@@ -179,7 +181,21 @@ final class AmqpDetailsConnectionProvider private (
     )
 
   override def toString: String =
-    s"AmqpDetailsConnectionProvider(hostAndPortList=$hostAndPortList, credentials=$credentials, virtualHost=$virtualHost, sslConfiguration=$sslConfiguration, requestedHeartbeat=$requestedHeartbeat, connectionTimeout=$connectionTimeout, handshakeTimeout=$handshakeTimeout, shutdownTimeout=$shutdownTimeout, networkRecoveryInterval=$networkRecoveryInterval, automaticRecoveryEnabled=$automaticRecoveryEnabled, topologyRecoveryEnabled=$topologyRecoveryEnabled, exceptionHandler=$exceptionHandler, connectionName=$connectionName)"
+    "AmqpDetailsConnectionProvider(" +
+    s"hostAndPortList=$hostAndPortList, " +
+    s"credentials=$credentials, " +
+    s"virtualHost=$virtualHost, " +
+    s"sslConfiguration=$sslConfiguration, " +
+    s"requestedHeartbeat=$requestedHeartbeat, " +
+    s"connectionTimeout=$connectionTimeout, " +
+    s"handshakeTimeout=$handshakeTimeout, " +
+    s"shutdownTimeout=$shutdownTimeout, " +
+    s"networkRecoveryInterval=$networkRecoveryInterval, " +
+    s"automaticRecoveryEnabled=$automaticRecoveryEnabled, " +
+    s"topologyRecoveryEnabled=$topologyRecoveryEnabled, " +
+    s"exceptionHandler=$exceptionHandler, " +
+    s"connectionName=$connectionName" +
+    ")"
 }
 
 object AmqpDetailsConnectionProvider {
@@ -242,16 +258,27 @@ final class AmqpSSLConfiguration private (val protocol: Option[String] = None,
     }
 }
 
-/**
- * Java API
- */
 object AmqpSSLConfiguration {
 
+  def apply(protocol: String): AmqpSSLConfiguration = new AmqpSSLConfiguration(Some(protocol))
+  def apply(protocol: String, trustManager: TrustManager): AmqpSSLConfiguration =
+    new AmqpSSLConfiguration(Some(protocol), Some(trustManager))
+  def apply(context: SSLContext): AmqpSSLConfiguration = new AmqpSSLConfiguration(context = Some(context))
+
+  /**
+   * Java API
+   */
   def create(protocol: String): AmqpSSLConfiguration = new AmqpSSLConfiguration(Some(protocol))
 
+  /**
+   * Java API
+   */
   def create(protocol: String, trustManager: TrustManager): AmqpSSLConfiguration =
     new AmqpSSLConfiguration(Some(protocol), Some(trustManager))
 
+  /**
+   * Java API
+   */
   def create(context: SSLContext): AmqpSSLConfiguration = new AmqpSSLConfiguration(context = Some(context))
 }
 
@@ -300,7 +327,10 @@ final class AmqpConnectionFactoryConnectionProvider private (val factory: Connec
     new AmqpConnectionFactoryConnectionProvider(factory, hostAndPorts)
 
   override def toString: String =
-    s"AmqpConnectionFactoryConnectionProvider(factory=$factory, hostAndPorts=$hostAndPorts)"
+    "AmqpConnectionFactoryConnectionProvider(" +
+    s"factory=$factory, " +
+    s"hostAndPorts=$hostAndPorts" +
+    ")"
 }
 
 object AmqpConnectionFactoryConnectionProvider {
@@ -376,7 +406,10 @@ final class AmqpCachedConnectionProvider private (val provider: AmqpConnectionPr
     new AmqpCachedConnectionProvider(provider, automaticRelease)
 
   override def toString: String =
-    s"AmqpCachedConnectionProvider(provider=$provider, automaticRelease=$automaticRelease)"
+    "AmqpCachedConnectionProvider(" +
+    s"provider=$provider, " +
+    s"automaticRelease=$automaticRelease" +
+    ")"
 }
 
 object AmqpCachedConnectionProvider {

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectorSettings.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectorSettings.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.amqp
 
-import akka.annotation.InternalApi
+import akka.annotation.{ApiMayChange, InternalApi}
 
 import scala.collection.immutable
 import scala.collection.JavaConverters._
@@ -53,6 +53,7 @@ final class NamedQueueSourceSettings private (
    * Ack/Nack is required as default. Setting this to false will configure AMQP's `autoAck` so that the
    * server considers messages acknowledged once delivered.
    */
+  @ApiMayChange //
   def withAckRequired(ackRequired: Boolean): NamedQueueSourceSettings =
     copy(ackRequired = ackRequired)
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectorSettings.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectorSettings.scala
@@ -49,6 +49,10 @@ final class NamedQueueSourceSettings private (
   def withExclusive(exclusive: Boolean): NamedQueueSourceSettings =
     copy(exclusive = exclusive)
 
+  /**
+   * Ack/Nack is required as default. Setting this to false will configure AMQP's `autoAck` so that the
+   * server considers messages acknowledged once delivered.
+   */
   def withAckRequired(ackRequired: Boolean): NamedQueueSourceSettings =
     copy(ackRequired = ackRequired)
 
@@ -82,7 +86,16 @@ final class NamedQueueSourceSettings private (
     )
 
   override def toString: String =
-    s"NamedQueueSourceSettings(connectionProvider=$connectionProvider, queue=$queue, declarations=$declarations, noLocal=$noLocal, exclusive=$exclusive, ackRequired=$ackRequired, consumerTag=$consumerTag, arguments=$arguments)"
+    "NamedQueueSourceSettings(" +
+    s"connectionProvider=$connectionProvider, " +
+    s"queue=$queue, " +
+    s"declarations=$declarations, " +
+    s"noLocal=$noLocal, " +
+    s"exclusive=$exclusive, " +
+    s"ackRequired=$ackRequired, " +
+    s"consumerTag=$consumerTag, " +
+    s"arguments=$arguments" +
+    ")"
 }
 
 object NamedQueueSourceSettings {
@@ -121,7 +134,12 @@ final class TemporaryQueueSourceSettings private (
     new TemporaryQueueSourceSettings(connectionProvider, exchange, declarations = declarations, routingKey = routingKey)
 
   override def toString: String =
-    s"TemporaryQueueSourceSettings(connectionProvider=$connectionProvider, exchange=$exchange, declarations=$declarations, routingKey=$routingKey)"
+    "TemporaryQueueSourceSettings(" +
+    s"connectionProvider=$connectionProvider, " +
+    s"exchange=$exchange, " +
+    s"declarations=$declarations, " +
+    s"routingKey=$routingKey" +
+    ")"
 }
 
 object TemporaryQueueSourceSettings {
@@ -148,7 +166,10 @@ final class AmqpReplyToSinkSettings private (
     new AmqpReplyToSinkSettings(connectionProvider, failIfReplyToMissing)
 
   override def toString: String =
-    s"AmqpReplyToSinkSettings(connectionProvider=$connectionProvider, failIfReplyToMissing=$failIfReplyToMissing)"
+    "AmqpReplyToSinkSettings(" +
+    s"connectionProvider=$connectionProvider, " +
+    s"failIfReplyToMissing=$failIfReplyToMissing" +
+    ")"
 }
 
 object AmqpReplyToSinkSettings {
@@ -194,7 +215,12 @@ final class AmqpSinkSettings private (
     new AmqpSinkSettings(connectionProvider, exchange, routingKey, declarations)
 
   override def toString: String =
-    s"AmqpSinkSettings(connectionProvider=$connectionProvider, exchange=$exchange, routingKey=$routingKey, declarations=$declarations)"
+    "AmqpSinkSettings(" +
+    s"connectionProvider=$connectionProvider, " +
+    s"exchange=$exchange, " +
+    s"routingKey=$routingKey, " +
+    s"declarations=$declarations" +
+    ")"
 }
 
 object AmqpSinkSettings {
@@ -244,7 +270,13 @@ final class QueueDeclaration private (
     new QueueDeclaration(name, durable, exclusive, autoDelete, arguments)
 
   override def toString: String =
-    s"QueueDeclaration(name=$name, durable=$durable, exclusive=$exclusive, autoDelete=$autoDelete, arguments=$arguments)"
+    s"QueueDeclaration(" +
+    s"name=$name, " +
+    s"durable=$durable, " +
+    s"exclusive=$exclusive, " +
+    s"autoDelete=$autoDelete, " +
+    s"arguments=$arguments" +
+    ")"
 }
 
 object QueueDeclaration {
@@ -278,7 +310,12 @@ final class BindingDeclaration private (
     new BindingDeclaration(queue, exchange, routingKey, arguments)
 
   override def toString: String =
-    s"BindingDeclaration(queue=$queue, exchange=$exchange, routingKey=$routingKey, arguments=$arguments)"
+    "BindingDeclaration(" +
+    s"queue=$queue, " +
+    s"exchange=$exchange, " +
+    s"routingKey=$routingKey, " +
+    s"arguments=$arguments" +
+    ")"
 }
 
 object BindingDeclaration {
@@ -323,7 +360,14 @@ final class ExchangeDeclaration private (
     new ExchangeDeclaration(name, exchangeType, durable, autoDelete, internal, arguments)
 
   override def toString: String =
-    s"ExchangeDeclaration(name=$name, exchangeType=$exchangeType, durable=$durable, autoDelete=$autoDelete, internal=$internal, arguments=$arguments)"
+    "ExchangeDeclaration(" +
+    s"name=$name, " +
+    s"exchangeType=$exchangeType, " +
+    s"durable=$durable, " +
+    s"autoDelete=$autoDelete, " +
+    s"internal=$internal, " +
+    s"arguments=$arguments" +
+    ")"
 }
 
 object ExchangeDeclaration {

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpSourceStage.scala
@@ -160,13 +160,12 @@ private[amqp] final class AmqpSourceStage(settings: AmqpSourceSettings, bufferSi
               pushMessage(queue.dequeue())
             }
 
-          override def onDownstreamFinish(): Unit = {
+          override def onDownstreamFinish(): Unit =
             if (finishWithOutstandingAcks || unackedMessages == 0) super.onDownstreamFinish()
             else {
               setKeepGoing(true)
               log.debug("Awaiting {} acks before finishing.", unackedMessages)
             }
-          }
         }
       )
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpRpcFlow.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpRpcFlow.scala
@@ -6,6 +6,7 @@ package akka.stream.alpakka.amqp.javadsl
 
 import java.util.concurrent.CompletionStage
 
+import akka.annotation.ApiMayChange
 import akka.stream.alpakka.amqp._
 import akka.stream.javadsl.Flow
 import akka.util.ByteString
@@ -36,6 +37,7 @@ object AmqpRpcFlow {
    * Convenience for "at-most once delivery" semantics. Each message is acked to RabbitMQ
    * before it is emitted downstream.
    */
+  @ApiMayChange // https://github.com/akka/alpakka/issues/1513
   def atMostOnceFlow(settings: AmqpSinkSettings,
                      bufferSize: Int): Flow[OutgoingMessage, IncomingMessage, CompletionStage[String]] =
     akka.stream.alpakka.amqp.scaladsl.AmqpRpcFlow
@@ -48,6 +50,7 @@ object AmqpRpcFlow {
    * Convenience for "at-most once delivery" semantics. Each message is acked to RabbitMQ
    * before it is emitted downstream.
    */
+  @ApiMayChange // https://github.com/akka/alpakka/issues/1513
   def atMostOnceFlow(settings: AmqpSinkSettings,
                      bufferSize: Int,
                      repliesPerMessage: Int): Flow[OutgoingMessage, IncomingMessage, CompletionStage[String]] =
@@ -67,6 +70,7 @@ object AmqpRpcFlow {
    *
    * Compared to auto-commit, this gives exact control over when a message is considered consumed.
    */
+  @ApiMayChange // https://github.com/akka/alpakka/issues/1513
   def committableFlow(
       settings: AmqpSinkSettings,
       bufferSize: Int,

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSink.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSink.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletionStage
 
 import scala.compat.java8.FutureConverters._
 import akka.Done
+import akka.annotation.ApiMayChange
 import akka.stream.alpakka.amqp._
 import akka.util.ByteString
 
@@ -19,6 +20,7 @@ object AmqpSink {
    * This stage materializes to a CompletionStage<Done>, which can be used to know when the Sink completes, either normally
    * or because of an amqp failure
    */
+  @ApiMayChange // https://github.com/akka/alpakka/issues/1513
   def create(settings: AmqpSinkSettings): akka.stream.javadsl.Sink[OutgoingMessage, CompletionStage[Done]] =
     akka.stream.alpakka.amqp.scaladsl.AmqpSink(settings).mapMaterializedValue(f => f.toJava).asJava
 
@@ -32,6 +34,7 @@ object AmqpSink {
    * This stage materializes to a CompletionStage<Done>, which can be used to know when the Sink completes, either normally
    * or because of an amqp failure
    */
+  @ApiMayChange // https://github.com/akka/alpakka/issues/1513
   def createReplyTo(
       settings: AmqpReplyToSinkSettings
   ): akka.stream.javadsl.Sink[OutgoingMessage, CompletionStage[Done]] =

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpSource.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.amqp.javadsl
 
 import akka.NotUsed
+import akka.annotation.ApiMayChange
 import akka.stream.alpakka.amqp.{AmqpSourceSettings, IncomingMessage}
 import akka.stream.javadsl.Source
 
@@ -14,6 +15,7 @@ object AmqpSource {
    * Java API: Convenience for "at-most once delivery" semantics. Each message is acked to RabbitMQ
    * before it is emitted downstream.
    */
+  @ApiMayChange // https://github.com/akka/alpakka/issues/1513
   def atMostOnceSource(settings: AmqpSourceSettings, bufferSize: Int): Source[IncomingMessage, NotUsed] =
     akka.stream.alpakka.amqp.scaladsl.AmqpSource
       .atMostOnceSource(settings, bufferSize)
@@ -30,6 +32,7 @@ object AmqpSource {
    *
    * Compared to auto-commit, this gives exact control over when a message is considered consumed.
    */
+  @ApiMayChange // https://github.com/akka/alpakka/issues/1513
   def committableSource(settings: AmqpSourceSettings, bufferSize: Int): Source[CommittableIncomingMessage, NotUsed] =
     akka.stream.alpakka.amqp.scaladsl.AmqpSource
       .committableSource(settings, bufferSize)

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/CommittableIncomingMessage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/CommittableIncomingMessage.scala
@@ -7,8 +7,10 @@ package akka.stream.alpakka.amqp.javadsl
 import java.util.concurrent.CompletionStage
 
 import akka.Done
+import akka.annotation.ApiMayChange
 import akka.stream.alpakka.amqp.IncomingMessage
 
+@ApiMayChange // https://github.com/akka/alpakka/issues/1513
 trait CommittableIncomingMessage {
   val message: IncomingMessage
   def ack(multiple: Boolean = false): CompletionStage[Done]

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
@@ -9,7 +9,7 @@ import akka.util.ByteString
 import com.rabbitmq.client.AMQP.BasicProperties
 import com.rabbitmq.client.Envelope
 
-@ApiMayChange
+@ApiMayChange // https://github.com/akka/alpakka/issues/1513
 final class IncomingMessage private (
     val bytes: ByteString,
     val envelope: Envelope,
@@ -19,7 +19,7 @@ final class IncomingMessage private (
     s"IncomingMessage(bytes=$bytes, envelope=$envelope, properties=$properties)"
 }
 
-@ApiMayChange
+@ApiMayChange // https://github.com/akka/alpakka/issues/1513
 object IncomingMessage {
   def apply(bytes: ByteString, envelope: Envelope, properties: BasicProperties): IncomingMessage =
     new IncomingMessage(bytes, envelope, properties)
@@ -31,7 +31,7 @@ object IncomingMessage {
     IncomingMessage(bytes, envelope, properties)
 }
 
-@ApiMayChange
+@ApiMayChange // https://github.com/akka/alpakka/issues/1513
 final class OutgoingMessage private (val bytes: ByteString,
                                      val immediate: Boolean,
                                      val mandatory: Boolean,
@@ -51,7 +51,7 @@ final class OutgoingMessage private (val bytes: ByteString,
     s"OutgoingMessage(bytes=$bytes, immediate=$immediate, mandatory=$mandatory, properties=$properties, routingKey=$routingKey)"
 }
 
-@ApiMayChange
+@ApiMayChange // https://github.com/akka/alpakka/issues/1513
 object OutgoingMessage {
   def apply(bytes: ByteString, immediate: Boolean, mandatory: Boolean): OutgoingMessage =
     new OutgoingMessage(bytes, immediate, mandatory)

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
@@ -4,10 +4,12 @@
 
 package akka.stream.alpakka.amqp
 
+import akka.annotation.ApiMayChange
 import akka.util.ByteString
 import com.rabbitmq.client.AMQP.BasicProperties
 import com.rabbitmq.client.Envelope
 
+@ApiMayChange
 final class IncomingMessage private (
     val bytes: ByteString,
     val envelope: Envelope,
@@ -17,6 +19,7 @@ final class IncomingMessage private (
     s"IncomingMessage(bytes=$bytes, envelope=$envelope, properties=$properties)"
 }
 
+@ApiMayChange
 object IncomingMessage {
   def apply(bytes: ByteString, envelope: Envelope, properties: BasicProperties): IncomingMessage =
     new IncomingMessage(bytes, envelope, properties)
@@ -28,6 +31,7 @@ object IncomingMessage {
     IncomingMessage(bytes, envelope, properties)
 }
 
+@ApiMayChange
 final class OutgoingMessage private (val bytes: ByteString,
                                      val immediate: Boolean,
                                      val mandatory: Boolean,
@@ -47,6 +51,7 @@ final class OutgoingMessage private (val bytes: ByteString,
     s"OutgoingMessage(bytes=$bytes, immediate=$immediate, mandatory=$mandatory, properties=$properties, routingKey=$routingKey)"
 }
 
+@ApiMayChange
 object OutgoingMessage {
   def apply(bytes: ByteString, immediate: Boolean, mandatory: Boolean): OutgoingMessage =
     new OutgoingMessage(bytes, immediate, mandatory)

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpRpcFlow.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpRpcFlow.scala
@@ -4,6 +4,7 @@
 
 package akka.stream.alpakka.amqp.scaladsl
 
+import akka.annotation.ApiMayChange
 import akka.dispatch.ExecutionContexts
 import akka.stream.alpakka.amqp._
 import akka.stream.scaladsl.{Flow, Keep}
@@ -35,6 +36,7 @@ object AmqpRpcFlow {
    * Convenience for "at-most once delivery" semantics. Each message is acked to RabbitMQ
    * before it is emitted downstream.
    */
+  @ApiMayChange // https://github.com/akka/alpakka/issues/1513
   def atMostOnceFlow(settings: AmqpSinkSettings,
                      bufferSize: Int,
                      repliesPerMessage: Int = 1): Flow[OutgoingMessage, IncomingMessage, Future[String]] =
@@ -52,6 +54,7 @@ object AmqpRpcFlow {
    *
    * Compared to auto-commit, this gives exact control over when a message is considered consumed.
    */
+  @ApiMayChange // https://github.com/akka/alpakka/issues/1513
   def committableFlow(settings: AmqpSinkSettings,
                       bufferSize: Int,
                       repliesPerMessage: Int = 1): Flow[OutgoingMessage, CommittableIncomingMessage, Future[String]] =

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpSink.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpSink.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.amqp.scaladsl
 
 import akka.Done
+import akka.annotation.ApiMayChange
 import akka.stream.alpakka.amqp._
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
@@ -32,6 +33,7 @@ object AmqpSink {
    * This stage materializes to a `Future[Done]`, which can be used to know when the Sink completes, either normally
    * or because of an amqp failure
    */
+  @ApiMayChange // https://github.com/akka/alpakka/issues/1513
   def replyTo(settings: AmqpReplyToSinkSettings): Sink[OutgoingMessage, Future[Done]] =
     Sink.fromGraph(new impl.AmqpReplyToSinkStage(settings))
 
@@ -45,6 +47,7 @@ object AmqpSink {
    * This stage materializes to a Future[Done], which can be used to know when the Sink completes, either normally
    * or because of an amqp failure
    */
+  @ApiMayChange // https://github.com/akka/alpakka/issues/1513
   def apply(settings: AmqpSinkSettings): Sink[OutgoingMessage, Future[Done]] =
     Sink.fromGraph(new impl.AmqpSinkStage(settings))
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpSource.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpSource.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.amqp.scaladsl
 
 import akka.NotUsed
+import akka.annotation.ApiMayChange
 import akka.dispatch.ExecutionContexts
 import akka.stream.alpakka.amqp.impl
 import akka.stream.alpakka.amqp.{AmqpSourceSettings, IncomingMessage}
@@ -17,6 +18,7 @@ object AmqpSource {
    * Scala API: Convenience for "at-most once delivery" semantics. Each message is acked to RabbitMQ
    * before it is emitted downstream.
    */
+  @ApiMayChange // https://github.com/akka/alpakka/issues/1513
   def atMostOnceSource(settings: AmqpSourceSettings, bufferSize: Int): Source[IncomingMessage, NotUsed] =
     committableSource(settings, bufferSize)
       .mapAsync(1)(cm => cm.ack().map(_ => cm.message))
@@ -32,6 +34,7 @@ object AmqpSource {
    *
    * Compared to auto-commit, this gives exact control over when a message is considered consumed.
    */
+  @ApiMayChange // https://github.com/akka/alpakka/issues/1513
   def committableSource(settings: AmqpSourceSettings, bufferSize: Int): Source[CommittableIncomingMessage, NotUsed] =
     Source.fromGraph(new impl.AmqpSourceStage(settings, bufferSize))
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/CommittableIncomingMessage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/CommittableIncomingMessage.scala
@@ -5,10 +5,12 @@
 package akka.stream.alpakka.amqp.scaladsl
 
 import akka.Done
+import akka.annotation.ApiMayChange
 import akka.stream.alpakka.amqp.IncomingMessage
 
 import scala.concurrent.Future
 
+@ApiMayChange // https://github.com/akka/alpakka/issues/1513
 trait CommittableIncomingMessage {
   val message: IncomingMessage
   def ack(multiple: Boolean = false): Future[Done]

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -11,6 +11,7 @@ import akka.stream._
 import akka.stream.alpakka.amqp._
 import akka.stream.scaladsl.{GraphDSL, Keep, Merge, Sink, Source}
 import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.{TestPublisher, TestSubscriber}
 import akka.util.ByteString
 import com.rabbitmq.client.AuthenticationFailureException
@@ -30,9 +31,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
 
     val connectionProvider = AmqpLocalConnectionProvider
 
-    // see AmqpDocsSpec "publish and consume elements through a simple queue again in the same JVM"
-
-    "connection should fail to wrong broker" in {
+    "connection should fail to wrong broker" in assertAllStagesStopped {
       val connectionProvider = AmqpDetailsConnectionProvider("localhost", 5673)
 
       val queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis()
@@ -49,7 +48,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       result.failed.futureValue shouldBe an[ConnectException]
     }
 
-    "connection should fail with wrong credentials" in {
+    "connection should fail with wrong credentials" in assertAllStagesStopped {
       val connectionProvider =
         AmqpDetailsConnectionProvider("invalid", 5673)
           .withHostsAndPorts(immutable.Seq("localhost" -> 5672))
@@ -69,9 +68,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       result.failed.futureValue shouldBe an[AuthenticationFailureException]
     }
 
-    // see AmqpDocsSpec "publish via RPC and then consume through a simple queue again in the same JVM"
-
-    "publish via RPC which expects 2 responses per message and then consume through a simple queue again in the same JVM" in {
+    "publish via RPC which expects 2 responses per message and then consume through a simple queue again in the same JVM" in assertAllStagesStopped {
       val queueName = "amqp-conn-it-spec-rpc-queue-" + System.currentTimeMillis()
       val queueDeclaration = QueueDeclaration(queueName)
 
@@ -96,22 +93,26 @@ class AmqpConnectorsSpec extends AmqpSpec {
         AmqpReplyToSinkSettings(connectionProvider)
       )
 
-      amqpSource
+      val sourceToSink = amqpSource
+        .viaMat(KillSwitches.single)(Keep.right)
         .mapConcat { b =>
           List(
             OutgoingMessage(b.bytes.concat(ByteString("a")), false, false).withProperties(b.properties),
             OutgoingMessage(b.bytes.concat(ByteString("aa")), false, false).withProperties(b.properties)
           )
         }
-        .runWith(amqpSink)
+        .to(amqpSink)
+        .run()
 
       probe
         .request(10)
         .expectNextUnorderedN(input.flatMap(s => List(ByteString(s.concat("a")), ByteString(s.concat("aa")))))
         .expectComplete()
+
+      sourceToSink.shutdown()
     }
 
-    "correctly close a AmqpRpcFlow when stream is closed without passing any elements" in {
+    "correctly close a AmqpRpcFlow when stream is closed without passing any elements" in assertAllStagesStopped {
 
       Source
         .empty[ByteString]
@@ -122,7 +123,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
 
     }
 
-    "handle missing reply-to header correctly" in {
+    "handle missing reply-to header correctly" in assertAllStagesStopped {
 
       val outgoingMessage = OutgoingMessage(ByteString.empty, false, false)
 
@@ -147,7 +148,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
 
     }
 
-    "publish from one source and consume elements with multiple sinks" in {
+    "publish from one source and consume elements with multiple sinks" in assertAllStagesStopped {
       val queueName = "amqp-conn-it-spec-work-queues-" + System.currentTimeMillis()
       val queueDeclaration = QueueDeclaration(queueName)
       val amqpSink = AmqpSink.simple(
@@ -182,7 +183,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       result.futureValue.sorted shouldEqual input.sorted
     }
 
-    "not fail on a fast producer and a slow consumer" in {
+    "not fail on a fast producer and a slow consumer" in assertAllStagesStopped {
       val queueName = "amqp-conn-it-spec-simple-queue-2-" + System.currentTimeMillis()
       val queueDeclaration = QueueDeclaration(queueName)
       val amqpSource = AmqpSource.atMostOnceSource(
@@ -234,13 +235,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       succeed
     }
 
-    // see AmqpDocsSpec "pub-sub from one source with multiple sinks"
-
-    // see AmqpDocsSpec "publish and consume elements through a simple queue again in the same JVM without autoAck"
-
-    // "republish message without autoAck if nack is sent"
-
-    "keep connection open if downstream closes and there are pending acks" in {
+    "keep connection open if downstream closes and there are pending acks" in assertAllStagesStopped {
       val connectionSettings = AmqpDetailsConnectionProvider("localhost", 5672)
 
       val queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis()
@@ -269,7 +264,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       })
     }
 
-    "not republish message without autoAck(false) if nack is sent" in {
+    "not republish message without autoAck(false) if nack is sent" in assertAllStagesStopped {
       val queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis()
       val queueDeclaration = QueueDeclaration(queueName)
 
@@ -287,6 +282,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       )
 
       val result1 = amqpSource
+        .named("result1")
         .mapAsync(1)(cm => cm.nack(requeue = false).map(_ => cm))
         .take(input.size)
         .runWith(Sink.seq)
@@ -294,14 +290,16 @@ class AmqpConnectorsSpec extends AmqpSpec {
       Await.ready(result1, 3.seconds)
 
       val result2 = amqpSource
+        .named("result2")
         .mapAsync(1)(cm => cm.ack().map(_ => cm))
         .take(input.size)
         .runWith(Sink.seq)
 
       result2.isReadyWithin(1.second) shouldEqual false
+      Await.ready(result2, 3.seconds)
     }
 
-    "publish via RPC and then consume through a simple queue again in the same JVM without autoAck" in {
+    "publish via RPC and then consume through a simple queue again in the same JVM without autoAck" in assertAllStagesStopped {
 
       val queueName = "amqp-conn-it-spec-rpc-queue-" + System.currentTimeMillis()
       val queueDeclaration = QueueDeclaration(queueName)
@@ -332,14 +330,17 @@ class AmqpConnectorsSpec extends AmqpSpec {
         NamedQueueSourceSettings(connectionProvider, queueName),
         bufferSize = 1
       )
-      amqpSource
+      val sourceToSink = amqpSource
+        .viaMat(KillSwitches.single)(Keep.right)
         .map(b => OutgoingMessage(b.bytes, false, false).withProperties(b.properties))
-        .runWith(amqpSink)
+        .to(amqpSink)
+        .run()
 
       probe.toStrict(3.second).map(_.bytes.utf8String) shouldEqual input
+      sourceToSink.shutdown()
     }
 
-    "set routing key per message and consume them in the same JVM" in {
+    "set routing key per message and consume them in the same JVM" in assertAllStagesStopped {
       def getRoutingKey(s: String) = s"key.${s}"
 
       val exchangeName = "amqp.topic." + System.currentTimeMillis()
@@ -376,7 +377,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       result.map(_.bytes.utf8String) shouldEqual input
     }
 
-    "declare connection that does not require server acks" in {
+    "declare connection that does not require server acks" in assertAllStagesStopped {
       val connectionProvider =
         AmqpDetailsConnectionProvider("localhost", 5672)
 
@@ -400,9 +401,10 @@ class AmqpConnectorsSpec extends AmqpSpec {
       val input = Vector("one", "two", "three", "four", "five")
       Source(input).map(s => ByteString(s)).runWith(amqpSink).futureValue shouldEqual Done
 
-      val result = amqpSource.take(input.size).runWith(Sink.seq)
+      val result = amqpSource.named("result").take(input.size).runWith(Sink.seq)
 
       result.futureValue.map(_.message.bytes.utf8String) shouldEqual input
+      Await.result(result, 2.seconds)
     }
   }
 }

--- a/docs/src/main/paradox/amqp.md
+++ b/docs/src/main/paradox/amqp.md
@@ -32,6 +32,12 @@ There are several types of @scaladoc[AmqpConnectionProvider](akka.stream.alpakka
 
 ## Sending messages
 
+@@@warning
+
+The Alpakka AMQP API is likely to change a bit in future releases, as discussed in @github[#1513](#1513).
+
+@@@
+
 First define a queue name and the declaration of the queue that the messages will be sent to.
 
 Scala
@@ -61,6 +67,12 @@ Java
 : @@snip [snip](/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java) { #run-sink }
 
 ## Receiving messages
+
+@@@warning
+
+The Alpakka AMQP API is likely to change a bit in future releases, as discussed in @github[#1513](#1513).
+
+@@@
 
 Create a source using the same queue declaration as before.
 


### PR DESCRIPTION
## Fixes

Fixes #1500 

Part of #1223 

## Purpose

Make use of `assertAllStagesStopped` to ensure proper stream shutdown in test cases.
Add `ApiMayChange` on stream element classes as they have unfortunate names.
