### PR TITLE
AvroParquet: Assert all stages stopped, stop actor systems, bridge log4j

### DIFF
--- a/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
@@ -7,6 +7,7 @@ import java.io.File
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
 import org.apache.hadoop.conf.Configuration
@@ -33,11 +34,11 @@ trait AbstractAvroParquet {
   val folder: String = "./" + Random.alphanumeric.take(8).mkString("")
 
   def afterAll(): Unit = {
-    import scala.reflect.io.Directory
+    TestKit.shutdownActorSystem(system)
 
+    import scala.reflect.io.Directory
     val directory = new Directory(new File(folder))
     directory.deleteRecursively()
-
   }
 
   def docToRecord(document: Document): GenericRecord =

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit
 
 import akka.stream.alpakka.avroparquet.scaladsl.AvroParquetFlow
 import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.{Done, NotUsed}
 import org.apache.avro.generic.GenericRecord
 import org.apache.hadoop.conf.Configuration
@@ -16,16 +17,17 @@ import org.apache.parquet.avro.{AvroParquetReader, AvroParquetWriter, AvroReadSu
 import org.apache.parquet.hadoop.ParquetWriter
 import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.specs2.mutable.Specification
+import org.specs2.specification.AfterAll
 
 import scala.collection.mutable
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class AvroParquetFlowSpec extends Specification with AbstractAvroParquet {
+class AvroParquetFlowSpec extends Specification with AbstractAvroParquet with AfterAll {
 
   "AvroParquet" should {
 
-    "insert records in parquet as part of Flow stage" in {
+    "insert records in parquet as part of Flow stage" in assertAllStagesStopped {
 
       val docs = List[Document](Document("id1", "sdaada"), Document("id1", "sdaada"), Document("id3", " fvrfecefedfww"))
 

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit
 import akka.Done
 import akka.stream.alpakka.avroparquet.scaladsl.AvroParquetSink
 import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.apache.parquet.avro.AvroParquetReader
 import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
@@ -25,11 +26,11 @@ import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.apache.parquet.avro.{AvroParquetWriter, AvroReadSupport}
 //#init-writer
 
-class AvroParquetSinkSpec extends Specification with AfterAll with AbstractAvroParquet {
+class AvroParquetSinkSpec extends Specification with AbstractAvroParquet with AfterAll {
 
   "ParquetSing Sink" should {
 
-    "create new Parquet file" in {
+    "create new Parquet file" in assertAllStagesStopped {
       val docs = List[Document](Document("id1", "sdaada"), Document("id1", "sdaada"), Document("id3", " fvrfecefedfww"))
 
       val source = Source.fromIterator(() => docs.iterator)

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
@@ -8,13 +8,14 @@ import java.util.concurrent.TimeUnit
 
 import akka.stream.alpakka.avroparquet.scaladsl.{AvroParquetSink, AvroParquetSource}
 import akka.stream.scaladsl.{Keep, Source}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
 import akka.{Done, NotUsed}
-
 import org.apache.parquet.avro.AvroParquetWriter
 import org.apache.parquet.hadoop.ParquetWriter
 import org.specs2.mutable.Specification
 import org.specs2.specification.{AfterAll, BeforeAll}
+
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
@@ -28,11 +29,11 @@ import org.apache.parquet.hadoop.ParquetReader
 import org.apache.parquet.avro.AvroReadSupport
 //#init-reader
 
-class AvroParquetSourceSpec extends Specification with AbstractAvroParquet with AfterAll with BeforeAll {
+class AvroParquetSourceSpec extends Specification with AbstractAvroParquet with BeforeAll with AfterAll {
 
   "AvroParquetSource" should {
 
-    "read from parquet file" in {
+    "read from parquet file" in assertAllStagesStopped {
 
       //#init-reader
       val file = folder + "/test.parquet"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -131,10 +131,10 @@ object Dependencies {
   val AvroParquet = Seq(
     libraryDependencies ++= Seq(
       "org.apache.parquet" % "parquet-avro" % "1.10.0", //Apache2
-      "org.apache.hadoop" % "hadoop-client" % "3.1.0" % Test, //Apache2
-      "org.apache.hadoop" % "hadoop-common" % "2.2.0" % Test, //Apache2
+      "org.apache.hadoop" % "hadoop-client" % "3.1.0" % Test exclude ("log4j", "log4j"), //Apache2
+      "org.apache.hadoop" % "hadoop-common" % "2.2.0" % Test exclude ("log4j", "log4j"), //Apache2
       "org.specs2" %% "specs2-core" % "4.3.2" % Test, //MIT like: https://github.com/etorreborre/specs2/blob/master/LICENSE.txt
-      "junit" % "junit" % "4.12" % Test // Eclipse Public License 1.0
+      "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % Test, // MIT like: http://www.slf4j.org/license.html
     )
   )
 


### PR DESCRIPTION
## Fixes

Part of #1223 

## Purpose

Assure proper stopping of stages in tests.
Improve cleanup after test runs (shut down actor systems, store temporary files in `target` instead).