### PR TITLE
Do not apply scalac compiler plugin flags when generating API doc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,7 +141,7 @@ lazy val googleCloudPubSubGrpc = alpakkaProject(
   javaAgents += Dependencies.GooglePubSubGrpcAlpnAgent % "test",
   // for the ExampleApp in the tests
   connectInput in run := true,
-  scalacOptions += "-P:silencer:pathFilters=src_managed"
+  Compile / compile / scalacOptions += "-P:silencer:pathFilters=src_managed"
 ).enablePlugins(AkkaGrpcPlugin, JavaAgent)
 
 lazy val googleFcm = alpakkaProject(


### PR DESCRIPTION
Flags for scalac compiler plugin introduced in #1486 should not be set when generating API docs.