### PR TITLE
Elasticsearch: Add CreteCreateMessage which supports Elasticsearch op_type 'create'

### DIFF
--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -73,6 +73,7 @@ In the above examples, `WriteMessage` is used as the input to `ElasticsearchSink
 | Message factory           | Description                                                                                          |
 | ---------------------- | ---------------------------------------------------------------------------------------------------- |
 | WriteMessage.createIndexMessage   | Create a new document. If `id` is specified and it already exists, do nothing.                       |
+| WriteMessage.createCreateMessage  | Create a new document. If `id` is already exists, an error will be raised.                           |
 | WriteMessage.createUpdateMessage  | Update an existing document. If there is no document with the specified `id`, do nothing.            |
 | WriteMessage.createUpsertMessage  | Update an existing document. If there is no document with the specified `id`, create a new document. |
 | WriteMessage.createDeleteMessage  | Delete an existing document. If there is no document with the specified `id`, do nothing.            |

--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -73,7 +73,7 @@ In the above examples, `WriteMessage` is used as the input to `ElasticsearchSink
 | Message factory           | Description                                                                                          |
 | ---------------------- | ---------------------------------------------------------------------------------------------------- |
 | WriteMessage.createIndexMessage   | Create a new document. If `id` is specified and it already exists, do nothing.                       |
-| WriteMessage.createCreateMessage  | Create a new document. If `id` is already exists, an error will be raised.                           |
+| WriteMessage.createCreateMessage  | Create a new document. If `id` already exists, the `WriteResult` will contain an error.                  |
 | WriteMessage.createUpdateMessage  | Update an existing document. If there is no document with the specified `id`, do nothing.            |
 | WriteMessage.createUpsertMessage  | Update an existing document. If there is no document with the specified `id`, create a new document. |
 | WriteMessage.createDeleteMessage  | Delete an existing document. If there is no document with the specified `id`, do nothing.            |

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/WriteMessage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/WriteMessage.scala
@@ -22,6 +22,7 @@ private[elasticsearch] sealed abstract class Operation(val command: String)
 @InternalApi
 private[elasticsearch] object Operation {
   object Index extends Operation("index")
+  object Create extends Operation("create")
   object Update extends Operation("update")
   object Upsert extends Operation("update")
   object Delete extends Operation("delete")
@@ -109,6 +110,9 @@ object WriteMessage {
 
   def createIndexMessage[T](id: String, source: T): WriteMessage[T, NotUsed] =
     new WriteMessage(Index, id = Option(id), source = Option(source))
+
+  def createCreateMessage[T](id: String, source: T): WriteMessage[T, NotUsed] =
+    new WriteMessage(Create, id = Option(id), source = Option(source))
 
   def createUpdateMessage[T](id: String, source: T): WriteMessage[T, NotUsed] =
     new WriteMessage(Update, id = Option(id), source = Option(source))

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
@@ -167,6 +167,16 @@ private[elasticsearch] final class ElasticsearchFlowStage[T, C](
                     }
                   ).flatten ++ additionalMetadata): _*
                 )
+              case Create =>
+                "create" -> JsObject(
+                  (Seq(
+                    Option("_index" -> JsString(indexNameToUse)),
+                    Option("_type" -> JsString(typeName)),
+                    message.id.map { id =>
+                      "_id" -> JsString(id)
+                    }
+                  ).flatten ++ additionalMetadata): _*
+                )
               case Update | Upsert =>
                 "update" -> JsObject(
                   (Seq(
@@ -218,7 +228,7 @@ private[elasticsearch] final class ElasticsearchFlowStage[T, C](
 
       private def messageToJsonString(message: WriteMessage[T, C]): String =
         message.operation match {
-          case Index =>
+          case Index | Create =>
             "\n" + writer.convert(message.source.get)
           case Upsert =>
             "\n" + JsObject(


### PR DESCRIPTION
op_type that can be used to force a create operation, allowing for "put-if-absent" behavior. When create is used, the index operation will fail if a document by that id already exists in the index.

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/akka/alpakka/tree/master/CONTRIBUTING.md) and [contributor advice](https://github.com/akka/alpakka/blob/master/contributor-advice.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #xxxx

## Purpose

Add op_type 'create' which index only if not exists.

## Background Context

Adding missing Elasticsearch supported option to create a document only if not exists.

## References

https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html

