### PR TITLE
Elasticsearch: Make flows type signature simpler to prepare for `withContext`

### DIFF
--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -118,7 +118,7 @@ Java
 
 | Parameter           | Default | Description                                                                                            |
 | ------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| bufferSize          | 10      | `ElasticsearchSink` puts messages by one bulk request per messages of this buffer size.                |
+| bufferSize          | 10      | Flow and Sink batche messages to bulk requests when back-pressure applies.                             |
 | versionType         | None    | If set, `ElasticsearchSink` uses the chosen versionType to index documents. See [Version types](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types) for accepted settings. |
 | retryLogic | No retries | See below |
 
@@ -126,7 +126,7 @@ Java
 A bulk request might fail partially for some reason. To retry failed writes to Elasticsearch, a `RetryLogic` can be specified. The provided implementation is `RetryAtFixedRate`.
 
 @@@ warning
-If using retries, you will receive messages out of order downstream in cases where elastic returns an error one some of the documents in a bulk request.
+If using retries, you will receive messages **out of order downstream** in cases when Elasticsearch returns an error on some of the documents in a bulk request.
 @@@
 
 

--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -118,7 +118,7 @@ Java
 
 | Parameter           | Default | Description                                                                                            |
 | ------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| bufferSize          | 10      | Flow and Sink batche messages to bulk requests when back-pressure applies.                             |
+| bufferSize          | 10      | Flow and Sink batch messages to bulk requests when back-pressure applies.                             |
 | versionType         | None    | If set, `ElasticsearchSink` uses the chosen versionType to index documents. See [Version types](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types) for accepted settings. |
 | retryLogic | No retries | See below |
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/WriteMessage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/WriteMessage.scala
@@ -14,7 +14,9 @@ import scala.compat.java8.OptionConverters._
  * INTERNAL API
  */
 @InternalApi
-private[elasticsearch] sealed abstract class Operation(val command: String)
+private[elasticsearch] sealed abstract class Operation(val command: String) {
+  override def toString: String = command
+}
 
 /**
  * INTERNAL API

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/WriteMessage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/WriteMessage.scala
@@ -134,11 +134,21 @@ object WriteMessage {
  * [[akka.stream.alpakka.elasticsearch.testkit.MessageFactory]].
  */
 final class WriteResult[T2, C2] @InternalApi private[elasticsearch] (val message: WriteMessage[T2, C2],
+                                                                     /** JSON structure of the Elasticsearch error. */
                                                                      val error: Option[String]) {
   val success: Boolean = error.isEmpty
 
-  /** Java API */
+  /** Java API: JSON structure of the Elasticsearch error. */
   def getError: java.util.Optional[String] = error.asJava
+
+  /** `reason` field value of the Elasticsearch error. */
+  def errorReason: Option[String] = {
+    import spray.json._
+    error.flatMap(_.parseJson.asJsObject.fields.get("reason").map(_.asInstanceOf[JsString].value))
+  }
+
+  /** Java API: `reason` field value from the Elasticsearch error */
+  def getErrorReason: java.util.Optional[String] = errorReason.asJava
 
   override def toString =
     s"""WriteResult(message=$message,error=$error)"""

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
@@ -18,8 +18,7 @@ import org.apache.http.util.EntityUtils
 import org.elasticsearch.client.{Response, ResponseListener, RestClient}
 import spray.json._
 
-import scala.collection.mutable
-import scala.concurrent.Future
+import scala.collection.immutable
 
 /**
  * INTERNAL API
@@ -31,252 +30,218 @@ private[elasticsearch] final class ElasticsearchFlowStage[T, C](
     client: RestClient,
     settings: ElasticsearchWriteSettings,
     writer: MessageWriter[T]
-) extends GraphStage[FlowShape[WriteMessage[T, C], Future[Seq[WriteResult[T, C]]]]] {
+) extends GraphStage[FlowShape[immutable.Seq[WriteMessage[T, C]], immutable.Seq[WriteResult[T, C]]]] {
   require(indexName != null, "You must define an index name")
   require(typeName != null, "You must define a type name")
 
-  private val in = Inlet[WriteMessage[T, C]]("messages")
-  private val out = Outlet[Future[Seq[WriteResult[T, C]]]]("result")
+  private val in = Inlet[immutable.Seq[WriteMessage[T, C]]]("messages")
+  private val out = Outlet[immutable.Seq[WriteResult[T, C]]]("result")
   override val shape = FlowShape(in, out)
 
-  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
-    new TimerGraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new StageLogic()
 
-      private var state: State = Idle
-      private val queue = new mutable.Queue[WriteMessage[T, C]]()
-      private val failureHandler = getAsyncCallback[(Seq[WriteMessage[T, C]], Throwable)](handleFailure)
-      private val responseHandler = getAsyncCallback[(Seq[WriteMessage[T, C]], Response)](handleResponse)
-      private var failedMessages: Seq[WriteMessage[T, C]] = Nil
-      private var retryCount: Int = 0
+  private class StageLogic extends TimerGraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
 
-      override def preStart(): Unit =
+    private var upstreamFinished = false
+    private var inflight = 0
+
+    private val failureHandler = getAsyncCallback[(immutable.Seq[WriteMessage[T, C]], Throwable)](handleFailure)
+    private val responseHandler = getAsyncCallback[(immutable.Seq[WriteMessage[T, C]], Response)](handleResponse)
+    private var failedMessages: immutable.Seq[WriteMessage[T, C]] = Nil
+    private var retryCount: Int = 0
+
+    private def tryPull(): Unit =
+      if (!isClosed(in) && !hasBeenPulled(in)) {
         pull(in)
-
-      private def tryPull(): Unit =
-        if (queue.size < settings.bufferSize && !isClosed(in) && !hasBeenPulled(in)) {
-          pull(in)
-        }
-
-      override def onTimer(timerKey: Any): Unit = {
-        sendBulkUpdateRequest(failedMessages)
-        failedMessages = Nil
       }
 
-      private def handleFailure(args: (Seq[WriteMessage[T, C]], Throwable)): Unit = {
-        val (messages, exception) = args
-        if (!settings.retryLogic.shouldRetry(retryCount, List(exception.toString))) {
-          log.error("Received error from elastic. Giving up after {} tries. {}, Error: {}",
+    override def onTimer(timerKey: Any): Unit = {
+      if (log.isDebugEnabled) log.debug("retrying inflight={} {}", inflight, failedMessages)
+      sendBulkUpdateRequest(failedMessages)
+      failedMessages = Nil
+    }
+
+    private def handleFailure(args: (immutable.Seq[WriteMessage[T, C]], Throwable)): Unit = {
+      val (messages, exception) = args
+      if (!settings.retryLogic.shouldRetry(retryCount, List(exception.toString))) {
+        log.error("Received error from elastic. Giving up after {} tries. {}, Error: {}",
+                  retryCount,
+                  settings.retryLogic,
+                  exception)
+        failStage(exception)
+      } else {
+        log.warning("Received error from elastic. Try number {}. {}, Error: {}",
                     retryCount,
                     settings.retryLogic,
                     exception)
-          failStage(exception)
-        } else {
-          log.warning("Received error from elastic. Try number {}. {}, Error: {}",
-                      retryCount,
-                      settings.retryLogic,
-                      exception)
-          retryCount = retryCount + 1
-          failedMessages = messages
-          scheduleOnce(RetrySend, settings.retryLogic.nextRetry(retryCount))
-        }
-      }
-
-      private def handleSuccess(): Unit =
-        completeStage()
-
-      private def handleResponse(args: (Seq[WriteMessage[T, C]], Response)): Unit = {
-        val (messages, response) = args
-        val responseJson = EntityUtils.toString(response.getEntity).parseJson
-
-        // If some commands in bulk request failed, pass failed messages to follows.
-        val items = responseJson.asJsObject.fields("items").asInstanceOf[JsArray]
-        val messageResults: Seq[WriteResult[T, C]] = items.elements.zip(messages).map {
-          case (item, message) =>
-            val command = message.operation.command
-            val res = item.asJsObject.fields(command).asJsObject
-            val error: Option[String] = res.fields.get("error").map(_.toString())
-            new WriteResult(message, error)
-        }
-
-        val failedMsgs = messageResults.filterNot(_.error.isEmpty)
-
-        if (failedMsgs.nonEmpty && settings.retryLogic.shouldRetry(retryCount, failedMsgs.map(_.error.get).toList)) {
-          retryPartialFailedMessages(messageResults, failedMsgs)
-        } else {
-          forwardAllResults(messageResults)
-        }
-      }
-
-      private def retryPartialFailedMessages(
-          messageResults: Seq[WriteResult[T, C]],
-          failedMsgs: Seq[WriteResult[T, C]]
-      ): Unit = {
-        // Retry partial failed messages
-        // NOTE: When we partially return message like this, message will arrive out of order downstream
-        // and it can break commit-logic when using Kafka
         retryCount = retryCount + 1
-        failedMessages = failedMsgs.map(_.message) // These are the messages we're going to retry
+        failedMessages = messages
         scheduleOnce(RetrySend, settings.retryLogic.nextRetry(retryCount))
-
-        val successMsgs = messageResults.filter(_.error.isEmpty)
-        if (successMsgs.nonEmpty) {
-          // push the messages that DID succeed
-          emit(out, Future.successful(successMsgs))
-        }
       }
-
-      private def forwardAllResults(messageResults: Seq[WriteResult[T, C]]): Unit = {
-        retryCount = 0 // Clear retryCount
-
-        // Push result
-        emit(out, Future.successful(messageResults))
-
-        // Fetch next messages from queue and send them
-        val nextMessages = (1 to settings.bufferSize).flatMap { _ =>
-          queue.dequeueFirst(_ => true)
-        }
-
-        if (nextMessages.isEmpty) {
-          state match {
-            case Finished => handleSuccess()
-            case _ => state = Idle
-          }
-        } else {
-          sendBulkUpdateRequest(nextMessages)
-        }
-      }
-
-      private def sendBulkUpdateRequest(messages: Seq[WriteMessage[T, C]]): Unit = {
-        val json = messages
-          .map { message =>
-            val indexNameToUse: String = message.indexName.getOrElse(indexName)
-            val additionalMetadata = message.customMetadata.map { case (field, value) => field -> JsString(value) }
-
-            JsObject(message.operation match {
-              case Index =>
-                "index" -> JsObject(
-                  (Seq(
-                    Option("_index" -> JsString(indexNameToUse)),
-                    Option("_type" -> JsString(typeName)),
-                    message.version.map { version =>
-                      "_version" -> JsNumber(version)
-                    },
-                    settings.versionType.map { versionType =>
-                      "version_type" -> JsString(versionType)
-                    },
-                    message.id.map { id =>
-                      "_id" -> JsString(id)
-                    }
-                  ).flatten ++ additionalMetadata): _*
-                )
-              case Create =>
-                "create" -> JsObject(
-                  (Seq(
-                    Option("_index" -> JsString(indexNameToUse)),
-                    Option("_type" -> JsString(typeName)),
-                    message.id.map { id =>
-                      "_id" -> JsString(id)
-                    }
-                  ).flatten ++ additionalMetadata): _*
-                )
-              case Update | Upsert =>
-                "update" -> JsObject(
-                  (Seq(
-                    Option("_index" -> JsString(indexNameToUse)),
-                    Option("_type" -> JsString(typeName)),
-                    message.version.map { version =>
-                      "_version" -> JsNumber(version)
-                    },
-                    settings.versionType.map { versionType =>
-                      "version_type" -> JsString(versionType)
-                    },
-                    Option("_id" -> JsString(message.id.get))
-                  ).flatten ++ additionalMetadata): _*
-                )
-              case Delete =>
-                "delete" -> JsObject(
-                  (Seq(
-                    Option("_index" -> JsString(indexNameToUse)),
-                    Option("_type" -> JsString(typeName)),
-                    message.version.map { version =>
-                      "_version" -> JsNumber(version)
-                    },
-                    settings.versionType.map { versionType =>
-                      "version_type" -> JsString(versionType)
-                    },
-                    Option("_id" -> JsString(message.id.get))
-                  ).flatten ++ additionalMetadata): _*
-                )
-            }).toString + messageToJsonString(message)
-          }
-          .mkString("", "\n", "\n")
-
-        log.debug("Posting data to Elasticsearch: {}", json)
-
-        client.performRequestAsync(
-          "POST",
-          "/_bulk",
-          java.util.Collections.emptyMap[String, String](),
-          new StringEntity(json, StandardCharsets.UTF_8),
-          new ResponseListener() {
-            override def onFailure(exception: Exception): Unit =
-              failureHandler.invoke((messages, exception))
-            override def onSuccess(response: Response): Unit =
-              responseHandler.invoke((messages, response))
-          },
-          new BasicHeader("Content-Type", "application/x-ndjson")
-        )
-      }
-
-      private def messageToJsonString(message: WriteMessage[T, C]): String =
-        message.operation match {
-          case Index | Create =>
-            "\n" + writer.convert(message.source.get)
-          case Upsert =>
-            "\n" + JsObject(
-              "doc" -> writer.convert(message.source.get).parseJson,
-              "doc_as_upsert" -> JsTrue
-            ).toString
-          case Update =>
-            "\n" + JsObject(
-              "doc" -> writer.convert(message.source.get).parseJson
-            ).toString
-          case Delete =>
-            ""
-        }
-
-      setHandlers(in, out, this)
-
-      override def onPull(): Unit = tryPull()
-
-      override def onPush(): Unit = {
-        val message = grab(in)
-        queue.enqueue(message)
-
-        state match {
-          case Idle => {
-            state = Sending
-            val messages = (1 to settings.bufferSize).flatMap { _ =>
-              queue.dequeueFirst(_ => true)
-            }
-            sendBulkUpdateRequest(messages)
-          }
-          case _ => ()
-        }
-
-        tryPull()
-      }
-
-      override def onUpstreamFailure(exception: Throwable): Unit =
-        failStage(exception)
-
-      override def onUpstreamFinish(): Unit =
-        state match {
-          case Idle => handleSuccess()
-          case Sending => state = Finished
-          case Finished => ()
-        }
     }
+
+    private def handleResponse(args: (immutable.Seq[WriteMessage[T, C]], Response)): Unit = {
+      val (messages, response) = args
+      val responseJson = EntityUtils.toString(response.getEntity).parseJson
+      if (log.isDebugEnabled) log.debug("response {}", responseJson.prettyPrint)
+
+      // If some commands in bulk request failed, pass failed messages to follows.
+      val items = responseJson.asJsObject.fields("items").asInstanceOf[JsArray]
+      val messageResults: immutable.Seq[WriteResult[T, C]] = items.elements.zip(messages).map {
+        case (item, message) =>
+          val command = message.operation.command
+          val res = item.asJsObject.fields(command).asJsObject
+          val error: Option[String] = res.fields.get("error").map(_.toString())
+          new WriteResult(message, error)
+      }
+
+      val failedMsgs = messageResults.filterNot(_.error.isEmpty)
+
+      if (failedMsgs.nonEmpty && settings.retryLogic.shouldRetry(retryCount, failedMsgs.map(_.error.get).toList)) {
+        retryPartialFailedMessages(messageResults, failedMsgs)
+      } else {
+        retryCount = 0
+        emitResults(messageResults)
+      }
+    }
+
+    private def retryPartialFailedMessages(
+        messageResults: immutable.Seq[WriteResult[T, C]],
+        failedMsgs: immutable.Seq[WriteResult[T, C]]
+    ): Unit = {
+      if (log.isDebugEnabled) log.debug("retryPartialFailedMessages inflight={} {}", inflight, failedMsgs)
+      // Retry partial failed messages
+      // NOTE: When we partially return message like this, message will arrive out of order downstream
+      // and it can break commit-logic when using Kafka
+      retryCount = retryCount + 1
+      failedMessages = failedMsgs.map(_.message) // These are the messages we're going to retry
+      scheduleOnce(RetrySend, settings.retryLogic.nextRetry(retryCount))
+
+      val successMsgs = messageResults.filter(_.error.isEmpty)
+      if (successMsgs.nonEmpty) {
+        // push the messages that DID succeed
+        emitResults(successMsgs)
+      }
+    }
+
+    private def emitResults(successMsgs: immutable.Seq[WriteResult[T, C]]): Unit = {
+      emit(out, successMsgs)
+      tryPull()
+      inflight -= successMsgs.size
+      if (upstreamFinished && inflight == 0) completeStage()
+    }
+
+    private def sendBulkUpdateRequest(messages: immutable.Seq[WriteMessage[T, C]]): Unit = {
+      val json = messages
+        .map { message =>
+          val indexNameToUse: String = message.indexName.getOrElse(indexName)
+          val additionalMetadata = message.customMetadata.map { case (field, value) => field -> JsString(value) }
+
+          JsObject(message.operation match {
+            case Index =>
+              "index" -> JsObject(
+                (Seq(
+                  Option("_index" -> JsString(indexNameToUse)),
+                  Option("_type" -> JsString(typeName)),
+                  message.version.map { version =>
+                    "_version" -> JsNumber(version)
+                  },
+                  settings.versionType.map { versionType =>
+                    "version_type" -> JsString(versionType)
+                  },
+                  message.id.map { id =>
+                    "_id" -> JsString(id)
+                  }
+                ).flatten ++ additionalMetadata): _*
+              )
+            case Create =>
+              "create" -> JsObject(
+                (Seq(
+                  Option("_index" -> JsString(indexNameToUse)),
+                  Option("_type" -> JsString(typeName)),
+                  message.id.map { id =>
+                    "_id" -> JsString(id)
+                  }
+                ).flatten ++ additionalMetadata): _*
+              )
+            case Update | Upsert =>
+              "update" -> JsObject(
+                (Seq(
+                  Option("_index" -> JsString(indexNameToUse)),
+                  Option("_type" -> JsString(typeName)),
+                  message.version.map { version =>
+                    "_version" -> JsNumber(version)
+                  },
+                  settings.versionType.map { versionType =>
+                    "version_type" -> JsString(versionType)
+                  },
+                  Option("_id" -> JsString(message.id.get))
+                ).flatten ++ additionalMetadata): _*
+              )
+            case Delete =>
+              "delete" -> JsObject(
+                (Seq(
+                  Option("_index" -> JsString(indexNameToUse)),
+                  Option("_type" -> JsString(typeName)),
+                  message.version.map { version =>
+                    "_version" -> JsNumber(version)
+                  },
+                  settings.versionType.map { versionType =>
+                    "version_type" -> JsString(versionType)
+                  },
+                  Option("_id" -> JsString(message.id.get))
+                ).flatten ++ additionalMetadata): _*
+              )
+          }).toString + messageToJsonString(message)
+        }
+        .mkString("", "\n", "\n")
+
+      log.debug("Posting data to Elasticsearch: {}", json)
+
+      client.performRequestAsync(
+        "POST",
+        "/_bulk",
+        java.util.Collections.emptyMap[String, String](),
+        new StringEntity(json, StandardCharsets.UTF_8),
+        new ResponseListener() {
+          override def onFailure(exception: Exception): Unit = failureHandler.invoke((messages, exception))
+          override def onSuccess(response: Response): Unit = responseHandler.invoke((messages, response))
+        },
+        new BasicHeader("Content-Type", "application/x-ndjson")
+      )
+    }
+
+    private def messageToJsonString(message: WriteMessage[T, C]): String =
+      message.operation match {
+        case Index | Create =>
+          "\n" + writer.convert(message.source.get)
+        case Upsert =>
+          "\n" + JsObject(
+            "doc" -> writer.convert(message.source.get).parseJson,
+            "doc_as_upsert" -> JsTrue
+          ).toString
+        case Update =>
+          "\n" + JsObject(
+            "doc" -> writer.convert(message.source.get).parseJson
+          ).toString
+        case Delete =>
+          ""
+      }
+
+    setHandlers(in, out, this)
+
+    override def onPull(): Unit = tryPull()
+
+    override def onPush(): Unit = {
+      val messages = grab(in)
+      inflight += messages.size
+      sendBulkUpdateRequest(messages)
+    }
+
+    override def onUpstreamFinish(): Unit =
+      if (inflight == 0) completeStage()
+      else upstreamFinished = true
+  }
 }
 
 /**
@@ -286,10 +251,4 @@ private[elasticsearch] final class ElasticsearchFlowStage[T, C](
 private[elasticsearch] object ElasticsearchFlowStage {
 
   private object RetrySend
-
-  private sealed trait State
-  private case object Idle extends State
-  private case object Sending extends State
-  private case object Finished extends State
-
 }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSink.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSink.scala
@@ -18,7 +18,7 @@ import org.elasticsearch.client.RestClient
 object ElasticsearchSink {
 
   /**
-   * Creates a [[akka.stream.javadsl.Sink]] to Elasticsearch for [[WriteMessage]] containing type `T`.
+   * Create a sink to update Elasticsearch with [[akka.stream.alpakka.elasticsearch.WriteMessage WriteMessage]]s containing type `T`.
    */
   def create[T](
       indexName: String,
@@ -29,6 +29,6 @@ object ElasticsearchSink {
   ): akka.stream.javadsl.Sink[WriteMessage[T, NotUsed], CompletionStage[Done]] =
     ElasticsearchFlow
       .create(indexName, typeName, settings, client, objectMapper)
-      .toMat(Sink.ignore[java.util.List[WriteResult[T, NotUsed]]], Keep.right[NotUsed, CompletionStage[Done]])
+      .toMat(Sink.ignore[WriteResult[T, NotUsed]], Keep.right[NotUsed, CompletionStage[Done]])
 
 }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSink.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSink.scala
@@ -18,7 +18,7 @@ import scala.concurrent.Future
 object ElasticsearchSink {
 
   /**
-   * Creates a [[akka.stream.scaladsl.Sink]] to Elasticsearch for [[WriteMessage]] containing type `T`.
+   * Create a sink to update Elasticsearch with [[akka.stream.alpakka.elasticsearch.WriteMessage WriteMessage]]s containing type `T`.
    */
   def create[T](indexName: String,
                 typeName: String,

--- a/elasticsearch/src/test/resources/application.conf
+++ b/elasticsearch/src/test/resources/application.conf
@@ -1,4 +1,4 @@
-akka.stream.akka {
+akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   loglevel = "DEBUG"

--- a/elasticsearch/src/test/resources/log4j2-test.xml
+++ b/elasticsearch/src/test/resources/log4j2-test.xml
@@ -3,7 +3,7 @@
 <Configuration status="WARN">
     <Appenders>
         <File name="File1" fileName="target/elasticsearch-cluster.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+            <PatternLayout pattern="%d{ISO8601} %-5level [%thread] [%logger{36}]  %msg%n"/>
         </File>
     </Appenders>
     <Loggers>

--- a/elasticsearch/src/test/resources/logback-test.xml
+++ b/elasticsearch/src/test/resources/logback-test.xml
@@ -7,6 +7,12 @@
         </encoder>
     </appender>
 
+    <logger name="akka" level="info"/>
+    <logger name="akka.stream.alpakka" level="debug"/>
+    <logger name="org.apache.http" level="info"/>
+    <logger name="org.apache.http.impl" level="info"/>
+    <logger name="org.elasticsearch.client" level="info"/>
+
     <root level="debug">
         <appender-ref ref="FILE" />
     </root>


### PR DESCRIPTION
## Purpose

Change Elasticsearch flow signatures to single element flows.

## Background Context

Akka has introduced a new type of flow `withContext` which supports `passThrough`s to be passed hidden from the user.
Elasticsearch flows used to do have internal logic for batching which made them consume `WriteMessage`s but emit `Seq[WriteResult]`s which does not work together with context promotion.

The retry logic in `ElasticsearchFlowStage` does not work with context promotion, either.

This ended up in a major rewrite of `ElasticsearchFlowStage`.

## References

https://github.com/akka/akka/pull/25951