### PR TITLE
WIP Sagemaker, shared AWS module

### DIFF
--- a/aws-sagemaker/src/main/scala/akka/stream/alpakka/aws/sagemaker/impl/SagemakerInvokeFlowStage.scala
+++ b/aws-sagemaker/src/main/scala/akka/stream/alpakka/aws/sagemaker/impl/SagemakerInvokeFlowStage.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.aws.sagemaker.impl
+
+import akka.annotation.InternalApi
+import akka.stream.alpakka.aws.AsyncHandlerFlowStage
+
+import java.util.concurrent.CompletableFuture
+
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeAsyncClient
+import software.amazon.awssdk.services.sagemakerruntime.model.{InvokeEndpointRequest, InvokeEndpointResponse}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[sagemaker] final class SagemakerInvokeFlowStage(sagemakerClient: SageMakerRuntimeAsyncClient)(
+    parallelism: Int
+) extends AsyncHandlerFlowStage[InvokeEndpointRequest, InvokeEndpointResponse](parallelism) {
+
+  /**
+   *
+   * @param request
+   * @return
+   */
+  override def clientInvoke(request: InvokeEndpointRequest): CompletableFuture[InvokeEndpointResponse] =
+    sagemakerClient.invokeEndpoint(request)
+}

--- a/aws-sagemaker/src/main/scala/akka/stream/alpakka/aws/sagemaker/javadsl/SagemakerInvokeFlow.scala
+++ b/aws-sagemaker/src/main/scala/akka/stream/alpakka/aws/sagemaker/javadsl/SagemakerInvokeFlow.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.aws.sagemaker.javadsl
+
+import akka.NotUsed
+import akka.stream.alpakka.aws.sagemaker.impl.SagemakerInvokeFlowStage
+import akka.stream.javadsl.Flow
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeAsyncClient
+import software.amazon.awssdk.services.sagemakerruntime.model.{InvokeEndpointRequest, InvokeEndpointResponse}
+
+object SagemakerInvokeFlow {
+
+  /**
+   * Java API: creates a [[SagemakerInvokeFlowStage]] for a AWS Lambda function invocation
+   * using [[software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeAsyncClient]]
+   */
+  def apply(parallelism: Int)(
+      implicit sagemakerRuntimeClient: SageMakerRuntimeAsyncClient
+  ): Flow[InvokeEndpointRequest, InvokeEndpointResponse, NotUsed] =
+    Flow.fromGraph(new SagemakerInvokeFlowStage(sagemakerRuntimeClient)(parallelism))
+
+}

--- a/aws-sagemaker/src/main/scala/akka/stream/alpakka/aws/sagemaker/scaladsl/SagemakerInvokeFlow.scala
+++ b/aws-sagemaker/src/main/scala/akka/stream/alpakka/aws/sagemaker/scaladsl/SagemakerInvokeFlow.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.aws.sagemaker.scaladsl
+
+import akka.NotUsed
+import akka.stream.alpakka.aws.sagemaker.impl.SagemakerInvokeFlowStage
+import akka.stream.scaladsl.Flow
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeAsyncClient
+import software.amazon.awssdk.services.sagemakerruntime.model.{InvokeEndpointRequest, InvokeEndpointResponse}
+
+object SagemakerInvokeFlow {
+
+  /**
+   * Scala API: creates a [[SagemakerInvokeFlowStage]] for a AWS Lambda function invocation
+   * using [[software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeAsyncClient]]
+   */
+  def apply(parallelism: Int)(
+      implicit sagemakerRuntimeClient: SageMakerRuntimeAsyncClient
+  ): Flow[InvokeEndpointRequest, InvokeEndpointResponse, NotUsed] =
+    Flow.fromGraph(new SagemakerInvokeFlowStage(sagemakerRuntimeClient)(parallelism))
+
+}

--- a/aws-shared/src/main/scala/akka/stream/alpakka/aws/AsyncHandlerFlowStage.scala
+++ b/aws-shared/src/main/scala/akka/stream/alpakka/aws/AsyncHandlerFlowStage.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.aws
+
+import akka.annotation.InternalApi
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+
+import java.util.concurrent.CompletableFuture
+
+import scala.util.{Failure, Success}
+import scala.compat.java8.FutureConverters._
+@InternalApi private[aws] abstract class AsyncHandlerFlowStage[In, Out](parallelism: Int)
+    extends GraphStage[FlowShape[In, Out]] {
+
+  val in: Inlet[In] = Inlet[In](s"${this.getClass.getSimpleName}.in")
+  val out: Outlet[Out] = Outlet[Out](s"${this.getClass.getSimpleName}.out")
+
+  /**
+   * Client async invocation method
+   * @param request
+   * @param handler
+   * @return
+   */
+  def clientInvoke(request: In): CompletableFuture[Out]
+  @scala.throws[Exception](classOf[Exception])
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+
+      private var inFlight = 0
+
+      private def invokeComplete(result: Out): Unit = {
+        inFlight -= 1
+        if (isAvailable(out)) {
+          if (!hasBeenPulled(in)) tryPull(in)
+          push(out, result)
+        }
+      }
+
+      private def invokeFailed(ex: Throwable): Unit =
+        failStage(ex)
+
+      override def onPush(): Unit = {
+        inFlight += 1
+        implicit val ec = scala.concurrent.ExecutionContext.global
+        clientInvoke(grab(in)).toScala.onComplete {
+          case Success(response) => invokeComplete(response)
+          case Failure(t) => invokeFailed(t)
+        }
+        if (inFlight < parallelism && !hasBeenPulled(in)) tryPull(in)
+      }
+
+      override def onUpstreamFinish(): Unit =
+        if (inFlight == 0) completeStage()
+
+      override def onPull(): Unit = {
+        if (isClosed(in) && inFlight == 0) completeStage()
+        if (inFlight < parallelism && !hasBeenPulled(in)) tryPull(in)
+      }
+
+      setHandlers(in, out, this)
+
+    }
+
+  override val shape: FlowShape[In, Out] = FlowShape.of(in, out)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 lazy val modules: Seq[ProjectReference] = Seq(
   amqp,
   avroparquet,
+  awsShared,
+  awsSagemaker,
   awslambda,
   azureStorageQueue,
   cassandra,
@@ -85,6 +87,20 @@ lazy val awslambda = alpakkaProject("awslambda",
                                     Dependencies.AwsLambda,
                                     // For mockito https://github.com/akka/alpakka/issues/390
                                     parallelExecution in Test := false)
+
+lazy val awsShared = alpakkaProject(
+  "aws-shared",
+  "aws",
+  Dependencies.AwsShared,
+  parallelExecution in Test := false)
+
+lazy val awsSagemaker = alpakkaProject(
+  "aws-sagemaker",
+  "aws.sagemaker",
+  Dependencies.AwsSagemaker,
+  parallelExecution in Test := false)
+  .dependsOn(awsShared)
+
 
 lazy val azureStorageQueue = alpakkaProject("azure-storage-queue", "azure.storagequeue", Dependencies.AzureStorageQueue)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   val AwsSdk2Version = "2.3.9"
 
   val AkkaHttpVersion = "10.1.7"
-  
+
   val CouchbaseVersion = "2.7.2"
   val CouchbaseVersionForDocs = "2.7"
 
@@ -45,6 +45,18 @@ object Dependencies {
   val Amqp = Seq(
     libraryDependencies ++= Seq(
       "com.rabbitmq" % "amqp-client" % "5.3.0" // APLv2
+    )
+  )
+
+  val AwsShared = Seq(
+    libraryDependencies ++= Seq(
+      "software.amazon.awssdk" % "sagemakerruntime" % AwsSdk2Version // ApacheV2
+    )
+  )
+
+  val AwsSagemaker = Seq(
+    libraryDependencies ++= Seq(
+      "software.amazon.awssdk" % "sagemakerruntime" % AwsSdk2Version // ApacheV2
     )
   )
 


### PR DESCRIPTION
This follows #1456 and the existing Lambda module. Since the general flow is almost identical, I've created an `aws-shared` module with an abstract flow stage that can be used in multiple AWS connectors. It has an abstract def for

```
  /**
    * Client async invocation method
    * @param request
    * @param handler
    * @return
    */
  def clientInvoke(request: In): CompletableFuture[Out]
```
this makes the Sagemaker integration small:

```
@InternalApi private[sagemaker]
final class SagemakerInvokeFlowStage(sagemakerClient: SageMakerRuntimeAsyncClient)(parallelism: Int)
  extends AsyncHandlerFlowStage[InvokeEndpointRequest, InvokeEndpointResponse](parallelism) {
  /**
    *
    * @param request
    * @return
    */
  override def clientInvoke(request: InvokeEndpointRequest): CompletableFuture[InvokeEndpointResponse] =
    sagemakerClient.invokeEndpoint(request)
}
```

Similarly, Lambda (and probably other AWS modules) could benefit from a shared flow stage.

* [ x ] Have you read through the [contributor guidelines]
* [ x ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ no ] Have you updated the documentation?
* [ no ] Have you added tests for any changed functionality?

I can work towards docs and tests; but wanted to drop this here first in case someone could provide feedback.