### PR TITLE
Elasticsearch: introduce `withContext` flow

### DIFF
--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSink.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSink.scala
@@ -24,11 +24,11 @@ object ElasticsearchSink {
       indexName: String,
       typeName: String,
       settings: ElasticsearchWriteSettings,
-      client: RestClient,
+      elasticsearchClient: RestClient,
       objectMapper: ObjectMapper
   ): akka.stream.javadsl.Sink[WriteMessage[T, NotUsed], CompletionStage[Done]] =
     ElasticsearchFlow
-      .create(indexName, typeName, settings, client, objectMapper)
+      .create(indexName, typeName, settings, elasticsearchClient, objectMapper)
       .toMat(Sink.ignore[WriteResult[T, NotUsed]], Keep.right[NotUsed, CompletionStage[Done]])
 
 }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSource.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSource.scala
@@ -29,8 +29,8 @@ object ElasticsearchSource {
              typeName: String,
              query: String,
              settings: ElasticsearchSourceSettings,
-             client: RestClient): Source[ReadResult[java.util.Map[String, Object]], NotUsed] =
-    create(indexName, typeName, query, settings, client, new ObjectMapper())
+             elasticsearchClient: RestClient): Source[ReadResult[java.util.Map[String, Object]], NotUsed] =
+    create(indexName, typeName, query, settings, elasticsearchClient, new ObjectMapper())
 
   /**
    * Creates a [[akka.stream.javadsl.Source]] from Elasticsearch that streams [[ReadResult]]s of [[java.util.Map]].
@@ -40,14 +40,14 @@ object ElasticsearchSource {
              typeName: String,
              query: String,
              settings: ElasticsearchSourceSettings,
-             client: RestClient,
+             elasticsearchClient: RestClient,
              objectMapper: ObjectMapper): Source[ReadResult[java.util.Map[String, Object]], NotUsed] =
     Source.fromGraph(
       new impl.ElasticsearchSourceStage(
         indexName,
         Option(typeName),
         Map("query" -> query),
-        client,
+        elasticsearchClient,
         settings,
         new JacksonReader[java.util.Map[String, Object]](objectMapper, classOf[java.util.Map[String, Object]])
       )
@@ -67,14 +67,14 @@ object ElasticsearchSource {
              typeName: String,
              searchParams: JMap[String, String],
              settings: ElasticsearchSourceSettings,
-             client: RestClient,
+             elasticsearchClient: RestClient,
              objectMapper: ObjectMapper): Source[ReadResult[java.util.Map[String, Object]], NotUsed] =
     Source.fromGraph(
       new impl.ElasticsearchSourceStage(
         indexName,
         Option(typeName),
         searchParams.asScala.toMap,
-        client,
+        elasticsearchClient,
         settings,
         new JacksonReader[java.util.Map[String, Object]](objectMapper, classOf[java.util.Map[String, Object]])
       )
@@ -88,9 +88,9 @@ object ElasticsearchSource {
                typeName: String,
                query: String,
                settings: ElasticsearchSourceSettings,
-               client: RestClient,
+               elasticsearchClient: RestClient,
                clazz: Class[T]): Source[ReadResult[T], NotUsed] =
-    typed[T](indexName, typeName, query, settings, client, clazz, new ObjectMapper())
+    typed[T](indexName, typeName, query, settings, elasticsearchClient, clazz, new ObjectMapper())
 
   /**
    * Creates a [[akka.stream.javadsl.Source]] from Elasticsearch that streams [[ReadResult]]s of type `T`.
@@ -100,7 +100,7 @@ object ElasticsearchSource {
                typeName: String,
                query: String,
                settings: ElasticsearchSourceSettings,
-               client: RestClient,
+               elasticsearchClient: RestClient,
                clazz: Class[T],
                objectMapper: ObjectMapper): Source[ReadResult[T], NotUsed] =
     Source.fromGraph(
@@ -108,7 +108,7 @@ object ElasticsearchSource {
         indexName,
         Option(typeName),
         Map("query" -> query),
-        client,
+        elasticsearchClient,
         settings,
         new JacksonReader[T](objectMapper, clazz)
       )
@@ -128,7 +128,7 @@ object ElasticsearchSource {
                typeName: String,
                searchParams: JMap[String, String],
                settings: ElasticsearchSourceSettings,
-               client: RestClient,
+               elasticsearchClient: RestClient,
                clazz: Class[T],
                objectMapper: ObjectMapper): Source[ReadResult[T], NotUsed] =
     Source.fromGraph(
@@ -136,7 +136,7 @@ object ElasticsearchSource {
         indexName,
         Option(typeName),
         searchParams.asScala.toMap,
-        client,
+        elasticsearchClient,
         settings,
         new JacksonReader[T](objectMapper, clazz)
       )

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchFlow.scala
@@ -5,11 +5,13 @@
 package akka.stream.alpakka.elasticsearch.scaladsl
 
 import akka.NotUsed
+import akka.annotation.ApiMayChange
 import akka.stream.alpakka.elasticsearch._
 import akka.stream.alpakka.elasticsearch.impl
 import akka.stream.scaladsl.Flow
 import org.elasticsearch.client.RestClient
 import spray.json._
+
 import scala.collection.immutable
 
 /**
@@ -22,15 +24,17 @@ object ElasticsearchFlow {
    * The result status is port of the [[akka.stream.alpakka.elasticsearch.WriteResult WriteResult]] and must be checked for
    * successful execution.
    *
+   * This factory method requires an implicit Spray JSON writer for `T`.
+   *
    * Warning: When settings configure retrying, messages are emitted out-of-order when errors are detected.
    */
   def create[T](indexName: String,
                 typeName: String,
                 settings: ElasticsearchWriteSettings = ElasticsearchWriteSettings.Default)(
-      implicit client: RestClient,
-      writer: JsonWriter[T]
+      implicit elasticsearchClient: RestClient,
+      sprayJsonWriter: JsonWriter[T]
   ): Flow[WriteMessage[T, NotUsed], WriteResult[T, NotUsed], NotUsed] =
-    create[T](indexName, typeName, settings, new SprayJsonWriter[T]()(writer))
+    create[T](indexName, typeName, settings, new SprayJsonWriter[T]()(sprayJsonWriter))
 
   /**
    * Create a flow to update Elasticsearch with [[akka.stream.alpakka.elasticsearch.WriteMessage WriteMessage]]s containing type `T`.
@@ -40,7 +44,7 @@ object ElasticsearchFlow {
    * Warning: When settings configure retrying, messages are emitted out-of-order when errors are detected.
    */
   def create[T](indexName: String, typeName: String, settings: ElasticsearchWriteSettings, writer: MessageWriter[T])(
-      implicit client: RestClient
+      implicit elasticsearchClient: RestClient
   ): Flow[WriteMessage[T, NotUsed], WriteResult[T, NotUsed], NotUsed] =
     Flow[WriteMessage[T, NotUsed]]
       .batch(settings.bufferSize, immutable.Seq(_)) { case (seq, wm) => seq :+ wm }
@@ -48,7 +52,7 @@ object ElasticsearchFlow {
         new impl.ElasticsearchFlowStage[T, NotUsed](
           indexName,
           typeName,
-          client,
+          elasticsearchClient,
           settings,
           writer
         )
@@ -58,23 +62,25 @@ object ElasticsearchFlow {
   /**
    * Create a flow to update Elasticsearch with [[akka.stream.alpakka.elasticsearch.WriteMessage WriteMessage]]s containing type `T`
    * with `passThrough` of type `C`.
-   * The result status is port of the [[akka.stream.alpakka.elasticsearch.WriteResult WriteResult]] and must be checked for
+   * The result status is part of the [[akka.stream.alpakka.elasticsearch.WriteResult WriteResult]] and must be checked for
    * successful execution.
+   *
+   * This factory method requires an implicit Spray JSON writer for `T`.
    *
    * Warning: When settings configure retrying, messages are emitted out-of-order when errors are detected.
    */
   def createWithPassThrough[T, C](indexName: String,
                                   typeName: String,
                                   settings: ElasticsearchWriteSettings = ElasticsearchWriteSettings.Default)(
-      implicit client: RestClient,
-      writer: JsonWriter[T]
+      implicit elasticsearchClient: RestClient,
+      sprayJsonWriter: JsonWriter[T]
   ): Flow[WriteMessage[T, C], WriteResult[T, C], NotUsed] =
-    createWithPassThrough[T, C](indexName, typeName, settings, new SprayJsonWriter[T]()(writer))
+    createWithPassThrough[T, C](indexName, typeName, settings, new SprayJsonWriter[T]()(sprayJsonWriter))
 
   /**
    * Create a flow to update Elasticsearch with [[akka.stream.alpakka.elasticsearch.WriteMessage WriteMessage]]s containing type `T`
    * with `passThrough` of type `C`.
-   * The result status is port of the [[akka.stream.alpakka.elasticsearch.WriteResult WriteResult]] and must be checked for
+   * The result status is part of the [[akka.stream.alpakka.elasticsearch.WriteResult WriteResult]] and must be checked for
    * successful execution.
    *
    * Warning: When settings configure retrying, messages are emitted out-of-order when errors are detected.
@@ -83,7 +89,7 @@ object ElasticsearchFlow {
                                   typeName: String,
                                   settings: ElasticsearchWriteSettings,
                                   writer: MessageWriter[T])(
-      implicit client: RestClient
+      implicit elasticsearchClient: RestClient
   ): Flow[WriteMessage[T, C], WriteResult[T, C], NotUsed] =
     Flow[WriteMessage[T, C]]
       .batch(settings.bufferSize, immutable.Seq(_)) { case (seq, wm) => seq :+ wm }
@@ -91,12 +97,59 @@ object ElasticsearchFlow {
         new impl.ElasticsearchFlowStage[T, C](
           indexName,
           typeName,
-          client,
+          elasticsearchClient,
           settings,
           writer
         )
       )
       .mapConcat(identity)
+
+  /**
+   * Create a flow to update Elasticsearch with [[akka.stream.alpakka.elasticsearch.WriteMessage WriteMessage]]s containing type `T`
+   * with `context` of type `C`.
+   * The result status is part of the [[akka.stream.alpakka.elasticsearch.WriteResult WriteResult]] and must be checked for
+   * successful execution.
+   *
+   * This factory method requires an implicit Spray JSON writer for `T`.
+   *
+   * @throws IllegalArgumentException When settings configure retrying.
+   */
+  @ApiMayChange
+  def createWithContext[T, C](indexName: String,
+                              typeName: String,
+                              settings: ElasticsearchWriteSettings = ElasticsearchWriteSettings())(
+      implicit elasticsearchClient: RestClient,
+      sprayJsonWriter: JsonWriter[T]
+  ): Flow[(WriteMessage[T, NotUsed], C), (WriteResult[T, C], C), NotUsed] =
+    createWithContext[T, C](indexName, typeName, settings, new SprayJsonWriter[T]()(sprayJsonWriter))
+
+  /**
+   * Create a flow to update Elasticsearch with [[akka.stream.alpakka.elasticsearch.WriteMessage WriteMessage]]s containing type `T`
+   * with `context` of type `C`.
+   * The result status is part of the [[akka.stream.alpakka.elasticsearch.WriteResult WriteResult]] and must be checked for
+   * successful execution.
+   *
+   * @throws IllegalArgumentException When settings configure retrying.
+   */
+  @ApiMayChange
+  def createWithContext[T, C](indexName: String,
+                              typeName: String,
+                              settings: ElasticsearchWriteSettings,
+                              writer: MessageWriter[T])(
+      implicit elasticsearchClient: RestClient
+  ): Flow[(WriteMessage[T, NotUsed], C), (WriteResult[T, C], C), NotUsed] = {
+    require(settings.retryLogic == RetryNever,
+            "`withContext` may not be used with retrying enabled, as it disturbs element order")
+    Flow[(WriteMessage[T, NotUsed], C)]
+      .map {
+        case (wm, pt) =>
+          wm.withPassThrough(pt)
+      }
+      .via(createWithPassThrough(indexName, typeName, settings, writer))
+      .map { wr =>
+        (wr, wr.message.passThrough)
+      }
+  }
 
   private final class SprayJsonWriter[T](implicit writer: JsonWriter[T]) extends MessageWriter[T] {
     override def convert(message: T): String = message.toJson.toString()

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSink.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSink.scala
@@ -23,8 +23,8 @@ object ElasticsearchSink {
   def create[T](indexName: String,
                 typeName: String,
                 settings: ElasticsearchWriteSettings = ElasticsearchWriteSettings.Default)(
-      implicit client: RestClient,
-      writer: JsonWriter[T]
+      implicit elasticsearchClient: RestClient,
+      sprayJsonWriter: JsonWriter[T]
   ): Sink[WriteMessage[T, NotUsed], Future[Done]] =
     ElasticsearchFlow.create[T](indexName, typeName, settings).toMat(Sink.ignore)(Keep.right)
 


### PR DESCRIPTION
Introduce a new factory method for Elasticsearch writing that takes and emits tuples so that it can be used with Akka's new `withContext`.
