### PR TITLE
Update to the latest jwt-core

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -174,7 +174,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
       "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-      "com.pauldijou" %% "jwt-core" % "0.16.0", //ApacheV2
+      "com.pauldijou" %% "jwt-core" % "2.1.0", //ApacheV2
       "org.mockito" % "mockito-core" % "2.23.4" % Test, // MIT
       "com.github.tomakehurst" % "wiremock" % "2.18.0" % Test // ApacheV2
     )
@@ -194,7 +194,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
       "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-      "com.pauldijou" %% "jwt-core" % "0.16.0", //ApacheV2
+      "com.pauldijou" %% "jwt-core" % "2.1.0", //ApacheV2
       "org.mockito" % "mockito-core" % "2.23.4" % Test // MIT
     )
   )


### PR DESCRIPTION
## Fixes

A step towards #828

## Purpose

Updates to the latest jwt-core and scalatest which have Scala 2.13.0-M5 artifacts published.