### PR TITLE
Fix paradox docs compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -268,7 +268,7 @@ lazy val docs = project
     ),
     Paradox / siteSubdirName := s"docs/alpakka/${if (isSnapshot.value) "snapshot" else version.value}",
     Paradox / sourceDirectory := sourceDirectory.value / "main" / "paradox",
-    Paradox / paradoxProperties ++= Map(
+    paradoxProperties ++= Map(
       "project.url" -> "https://doc.akka.io/docs/alpakka/current/",
       "akka.version" -> Dependencies.AkkaVersion,
       "akka-http.version" -> Dependencies.AkkaHttpVersion,
@@ -308,7 +308,7 @@ lazy val docs = project
         s"$docsHost/api/alpakka/${if (isSnapshot.value) "snapshot" else version.value}/"
       }
     ),
-    Paradox / paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
+    paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
     resolvers += Resolver.jcenterRepo,
     publishRsyncArtifact := makeSite.value -> "www/",
     publishRsyncHost := "akkarepo@gustav.akka.io"


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](https://github.com/akka/alpakka/tree/master/CONTRIBUTING.md) and [contributor advice](https://github.com/akka/alpakka/blob/master/contributor-advice.md)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you updated the documentation?
* [X] Have you added tests for any changed functionality?

## Fixes

Fix the local compilation of paradox documentation.

## Purpose

Right now from master trying to run `sbt docs/paradox` result in this error:
```
[error] java.lang.RuntimeException: Error writing content for page overview.html: Failed to resolve [akka-docs:stream/index.html] referenced from [overview.html] because property [extref.akka-docs.base_url] is not defined
[error] 	at com.lightbend.paradox.ParadoxProcessor$PageContents.liftedTree1$1(ParadoxProcessor.scala:102)
[error] 	at com.lightbend.paradox.ParadoxProcessor$PageContents.<init>(ParadoxProcessor.scala:100)
[error] 	at com.lightbend.paradox.ParadoxProcessor.render$1(ParadoxProcessor.scala:66)
[error] 	at com.lightbend.paradox.ParadoxProcessor.$anonfun$process$6(ParadoxProcessor.scala:74)
[error] 	at scala.collection.immutable.List.flatMap(List.scala:334)
[error] 	at com.lightbend.paradox.ParadoxProcessor.process(ParadoxProcessor.scala:74)
[error] 	at com.lightbend.paradox.sbt.ParadoxPlugin$.$anonfun$baseParadoxSettings$38(ParadoxPlugin.scala:160)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:40)
[error] 	at sbt.std.Transform$$anon$4.work(System.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:269)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error] 	at sbt.Execute.work(Execute.scala:278)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:269)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error] Caused by: com.lightbend.paradox.markdown.ExternalLinkDirective$LinkException: Failed to resolve [akka-docs:stream/index.html] referenced from [overview.html] because property [extref.akka-docs.base_url] is not defined
[error] 	at com.lightbend.paradox.markdown.ExternalLinkDirective.resolvedSource(Directive.scala:175)
[error] 	at com.lightbend.paradox.markdown.ExternalLinkDirective.render(Directive.scala:166)
[error] 	at com.lightbend.paradox.markdown.DirectiveSerializer.visit(Directive.scala:40)
[error] 	at org.pegdown.ToHtmlSerializer.visit(ToHtmlSerializer.java:386)
[error] 	at org.pegdown.ast.DirectiveNode.accept(DirectiveNode.java:59)
[error] 	at org.pegdown.ToHtmlSerializer.visitChildren(ToHtmlSerializer.java:397)
[error] 	at org.pegdown.ToHtmlSerializer.visit(ToHtmlSerializer.java:381)
[error] 	at org.pegdown.ast.SuperNode.accept(SuperNode.java:43)
[error] 	at org.pegdown.ToHtmlSerializer.visitChildren(ToHtmlSerializer.java:397)
[error] 	at org.pegdown.ToHtmlSerializer.visit(ToHtmlSerializer.java:89)
[error] 	at org.pegdown.ast.RootNode.accept(RootNode.java:51)
[error] 	at org.pegdown.ToHtmlSerializer.visitChildren(ToHtmlSerializer.java:397)
[error] 	at org.pegdown.ToHtmlSerializer.printConditionallyIndentedTag(ToHtmlSerializer.java:444)
[error] 	at org.pegdown.ToHtmlSerializer.visit(ToHtmlSerializer.java:177)
[error] 	at org.pegdown.ast.ListItemNode.accept(ListItemNode.java:29)
[error] 	at org.pegdown.ToHtmlSerializer.visitChildren(ToHtmlSerializer.java:397)
[error] 	at org.pegdown.ToHtmlSerializer.printIndentedTag(ToHtmlSerializer.java:431)
[error] 	at org.pegdown.ToHtmlSerializer.visit(ToHtmlSerializer.java:108)
[error] 	at org.pegdown.ast.BulletListNode.accept(BulletListNode.java:29)
[error] 	at org.pegdown.ToHtmlSerializer.visitChildren(ToHtmlSerializer.java:397)
[error] 	at org.pegdown.ToHtmlSerializer.visit(ToHtmlSerializer.java:89)
[error] 	at org.pegdown.ast.RootNode.accept(RootNode.java:51)
[error] 	at org.pegdown.ToHtmlSerializer.visitChildren(ToHtmlSerializer.java:397)
[error] 	at org.pegdown.ToHtmlSerializer.visit(ToHtmlSerializer.java:89)
[error] 	at org.pegdown.ast.RootNode.accept(RootNode.java:51)
[error] 	at org.pegdown.ToHtmlSerializer.toHtml(ToHtmlSerializer.java:70)
[error] 	at com.lightbend.paradox.markdown.Writer.write(Writer.scala:73)
[error] 	at com.lightbend.paradox.markdown.Writer.writeFragment(Writer.scala:82)
[error] 	at com.lightbend.paradox.markdown.Writer.writeContent(Writer.scala:43)
[error] 	at com.lightbend.paradox.ParadoxProcessor$PageContents.liftedTree1$1(ParadoxProcessor.scala:100)
[error] 	at com.lightbend.paradox.ParadoxProcessor$PageContents.<init>(ParadoxProcessor.scala:100)
[error] 	at com.lightbend.paradox.ParadoxProcessor.render$1(ParadoxProcessor.scala:66)
[error] 	at com.lightbend.paradox.ParadoxProcessor.$anonfun$process$6(ParadoxProcessor.scala:74)
[error] 	at scala.collection.immutable.List.flatMap(List.scala:334)
[error] 	at com.lightbend.paradox.ParadoxProcessor.process(ParadoxProcessor.scala:74)
[error] 	at com.lightbend.paradox.sbt.ParadoxPlugin$.$anonfun$baseParadoxSettings$38(ParadoxPlugin.scala:160)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:40)
[error] 	at sbt.std.Transform$$anon$4.work(System.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:269)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error] 	at sbt.Execute.work(Execute.scala:278)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:269)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error] (Compile / paradoxMarkdownToHtml) Error writing content for page overview.html: Failed to resolve [akka-docs:stream/index.html] referenced from [overview.html] because property [extref.akka-docs.base_url] is not defined
```
