### PR TITLE
Add maxOpenRequests param in DynamoConfig

### DIFF
--- a/dynamodb/src/main/resources/reference.conf
+++ b/dynamodb/src/main/resources/reference.conf
@@ -14,6 +14,10 @@ akka.stream.alpakka.dynamodb {
   # Max number of in flight requests from the AwsClient - must be a power of 2
   parallelism = 32
 
+  # Optional max number of outstanding requests to the underlying host connection pool.
+  # If unspecified, will be the same as the parallelism value. Must be a power of 2
+  #maxOpenRequests =
+
   # Optional Credentials. Used to define static credentials rather than use the DefaultAWSCredentialsProviderChain
   #credentials {
   #  access-key-id = "dummy-access-key"

--- a/dynamodb/src/main/resources/reference.conf
+++ b/dynamodb/src/main/resources/reference.conf
@@ -16,7 +16,7 @@ akka.stream.alpakka.dynamodb {
 
   # Optional max number of outstanding requests to the underlying host connection pool.
   # If unspecified, will be the same as the parallelism value. Must be a power of 2
-  #maxOpenRequests =
+  #max-open-requests =
 
   # Optional Credentials. Used to define static credentials rather than use the DefaultAWSCredentialsProviderChain
   #credentials {

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/DynamoSettings.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/DynamoSettings.scala
@@ -14,6 +14,7 @@ final class DynamoSettings private (
     val port: Int,
     val tls: Boolean,
     val parallelism: Int,
+    val maxOpenRequests: Option[Int],
     val credentialsProvider: com.amazonaws.auth.AWSCredentialsProvider
 ) extends AwsClientSettings {
 
@@ -27,6 +28,8 @@ final class DynamoSettings private (
   def withTls(value: Boolean): DynamoSettings =
     if (value == tls) this else copy(tls = value)
   def withParallelism(value: Int): DynamoSettings = copy(parallelism = value)
+  def withMaxOpenRequests(value: Int): DynamoSettings = copy(maxOpenRequests = Option(value))
+  def withoutMaxOpenRequests(): DynamoSettings = copy(maxOpenRequests = None)
   def withCredentialsProvider(value: com.amazonaws.auth.AWSCredentialsProvider): DynamoSettings =
     copy(credentialsProvider = value)
 
@@ -36,6 +39,7 @@ final class DynamoSettings private (
       port: Int = port,
       tls: Boolean = tls,
       parallelism: Int = parallelism,
+      maxOpenRequests: Option[Int] = maxOpenRequests,
       credentialsProvider: com.amazonaws.auth.AWSCredentialsProvider = credentialsProvider
   ): DynamoSettings = new DynamoSettings(
     region = region,
@@ -43,11 +47,12 @@ final class DynamoSettings private (
     port = port,
     tls = tls,
     parallelism = parallelism,
+    maxOpenRequests = maxOpenRequests,
     credentialsProvider = credentialsProvider
   )
 
   override def toString =
-    s"""DynamoSettings(region=$region,host=$host,port=$port,parallelism=$parallelism,credentialsProvider=$credentialsProvider)"""
+    s"""DynamoSettings(region=$region,host=$host,port=$port,parallelism=$parallelism,maxOpenRequests=$maxOpenRequests,credentialsProvider=$credentialsProvider)"""
 }
 
 object DynamoSettings {
@@ -70,6 +75,8 @@ object DynamoSettings {
     val port = c.getInt("port")
     val tls = c.getBoolean("tls")
     val parallelism = c.getInt("parallelism")
+    val maxOpenRequests = if (c.hasPath("maxOpenRequests")) Option(c.getInt("maxOpenRequests")) else None
+
     val awsCredentialsProvider = {
       if (c.hasPath("credentials.access-key-id") &&
           c.hasPath("credentials.secret-key-id")) {
@@ -84,6 +91,7 @@ object DynamoSettings {
       port,
       tls,
       parallelism,
+      maxOpenRequests,
       awsCredentialsProvider
     )
   }
@@ -109,6 +117,7 @@ object DynamoSettings {
     port = 443,
     tls = true,
     parallelism = 4,
+    maxOpenRequests = None,
     new DefaultAWSCredentialsProviderChain()
   )
 

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/DynamoSettings.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/DynamoSettings.scala
@@ -31,9 +31,11 @@ final class DynamoSettings private (
     if (value == tls) this else copy(tls = value)
   def withParallelism(value: Int): DynamoSettings = copy(parallelism = value)
   def withMaxOpenRequests(value: Option[Int]): DynamoSettings = copy(maxOpenRequests = value)
-  def withMaxOpenRequests(value: Optional[Int]): DynamoSettings = copy(maxOpenRequests = value.asScala)
   def withCredentialsProvider(value: com.amazonaws.auth.AWSCredentialsProvider): DynamoSettings =
     copy(credentialsProvider = value)
+
+  /** Java Api */
+  def withMaxOpenRequests(value: Optional[Int]): DynamoSettings = copy(maxOpenRequests = value.asScala)
 
   /** Java Api */
   def getMaxOpenRequests(): Optional[Int] = maxOpenRequests.asJava

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoClientImpl.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoClientImpl.scala
@@ -36,7 +36,7 @@ private[dynamodb] class DynamoClientImpl(
   override protected val connection: AwsConnect = {
     val poolSettings = ConnectionPoolSettings(system)
       .withMaxConnections(settings.parallelism)
-      .withMaxOpenRequests(settings.parallelism)
+      .withMaxOpenRequests(settings.maxOpenRequests.getOrElse(settings.parallelism))
     if (settings.tls)
       Http().cachedHostConnectionPoolHttps[AwsRequestMetadata](settings.host, settings = poolSettings)
     else

--- a/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
@@ -100,7 +100,7 @@ public class ExampleTest {
         tableArnSource.runWith(Sink.seq(), materializer);
     try {
       List<String> strings = streamCompletion.toCompletableFuture().get(5, TimeUnit.SECONDS);
-      fail("expeced missing schema");
+      fail("expected missing schema");
     } catch (ExecutionException expected) {
       // expected
     }
@@ -116,7 +116,7 @@ public class ExampleTest {
         scanPages.runWith(Sink.seq(), materializer);
     try {
       List<ScanResult> strings = streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS);
-      fail("expeced missing schema");
+      fail("expected missing schema");
     } catch (ExecutionException expected) {
       // expected
     }

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/DynamoSettingsSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/DynamoSettingsSpec.scala
@@ -16,6 +16,7 @@ import org.scalatest.{Matchers, WordSpecLike}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import java.util.Optional
 
 class DynamoSettingsSpec extends WordSpecLike with Matchers {
 
@@ -62,10 +63,16 @@ class DynamoSettingsSpec extends WordSpecLike with Matchers {
         """.stripMargin)
 
       val settings = DynamoSettings(config)
-      settings.maxOpenRequests shouldBe Some(64)
 
+      // Test Scala API
+      settings.maxOpenRequests shouldBe Some(64)
       settings.withMaxOpenRequests(None).maxOpenRequests shouldBe None
       settings.withMaxOpenRequests(Some(32)).maxOpenRequests shouldBe Some(32)
+
+      // Test Java API
+      settings.getMaxOpenRequests shouldBe Optional.of(64)
+      settings.withMaxOpenRequests(Optional.empty[Int]).getMaxOpenRequests shouldBe Optional.empty[Int]
+      settings.withMaxOpenRequests(Optional.of(32)).getMaxOpenRequests shouldBe Optional.of(32)
     }
 
     "use the DefaultAWSCredentialsProviderChain if the config defines an incomplete akka.stream.alpakka.dynamodb.credentials" in {

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/DynamoSettingsSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/DynamoSettingsSpec.scala
@@ -34,6 +34,7 @@ class DynamoSettingsSpec extends WordSpecLike with Matchers {
       settings.host should be("host")
       settings.port should be(443)
       settings.parallelism should be(4)
+      settings.maxOpenRequests should be(None)
       settings.credentialsProvider shouldBe a[AWSStaticCredentialsProvider]
     }
 
@@ -45,8 +46,24 @@ class DynamoSettingsSpec extends WordSpecLike with Matchers {
       settings.host should be("localhost")
       settings.port should be(8001)
       settings.parallelism should be(4)
+      settings.maxOpenRequests should be(None)
       settings.credentialsProvider shouldBe a[DefaultAWSCredentialsProviderChain]
       Await.result(system.terminate(), 1.second)
+    }
+
+    "read optional value for maxOpenRequests" in {
+      val config = ConfigFactory.parseString("""
+          |region = "eu-west-1"
+          |host = "localhost"
+          |port = 443
+          |tls = true
+          |parallelism = 32
+          |maxOpenRequests = 64
+        """.stripMargin)
+
+      val settings = DynamoSettings(config)
+      settings.maxOpenRequests shouldBe Some(64)
+      settings.withoutMaxOpenRequests.maxOpenRequests shouldBe None
     }
 
     "use the DefaultAWSCredentialsProviderChain if the config defines an incomplete akka.stream.alpakka.dynamodb.credentials" in {

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/DynamoSettingsSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/DynamoSettingsSpec.scala
@@ -51,19 +51,21 @@ class DynamoSettingsSpec extends WordSpecLike with Matchers {
       Await.result(system.terminate(), 1.second)
     }
 
-    "read optional value for maxOpenRequests" in {
+    "allow configuring optional maxOpenRequests" in {
       val config = ConfigFactory.parseString("""
           |region = "eu-west-1"
           |host = "localhost"
           |port = 443
           |tls = true
           |parallelism = 32
-          |maxOpenRequests = 64
+          |max-open-requests = 64
         """.stripMargin)
 
       val settings = DynamoSettings(config)
       settings.maxOpenRequests shouldBe Some(64)
-      settings.withoutMaxOpenRequests.maxOpenRequests shouldBe None
+
+      settings.withMaxOpenRequests(None).maxOpenRequests shouldBe None
+      settings.withMaxOpenRequests(Some(32)).maxOpenRequests shouldBe Some(32)
     }
 
     "use the DefaultAWSCredentialsProviderChain if the config defines an incomplete akka.stream.alpakka.dynamodb.credentials" in {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/akka/alpakka/tree/master/CONTRIBUTING.md) and [contributor advice](https://github.com/akka/alpakka/blob/master/contributor-advice.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #1542

## Purpose

Allows the `maxOpenRequests` of the underlying host connection pool to
be configured separately from the `maxConnections` value (as specified
by the `parallelism` value in the config).

## Background Context

To preserve old behavior, I made it an optional field, where if it's
absent, then it will use the `parallelism` value as before. However the
one thing I'm not sure of is whether I should have the `Option` exposed
in the public interface (since this is meant to be used in Java as
well). Glad to accept any suggestions on how to handle optional values
like this.

## References

#1542 - Can't specify maxOpenRequests in DynamoClient
