### PR TITLE
Change mat value to Future in multiPartUpload/Copy

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -8,6 +8,7 @@ import java.time.{Instant, LocalDate}
 
 import akka.actor.ActorSystem
 import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
@@ -261,7 +262,7 @@ import akka.util.ByteString
       s3Headers: S3Headers,
       chunkSize: Int = MinChunkSize,
       chunkingParallelism: Int = 4
-  ): Sink[ByteString, Source[MultipartUploadResult, NotUsed]] =
+  ): Sink[ByteString, Future[MultipartUploadResult]] =
     chunkAndRequest(s3Location, contentType, s3Headers, chunkSize)(chunkingParallelism)
       .toMat(completionSink(s3Location, s3Headers.serverSideEncryption))(Keep.right)
 
@@ -297,7 +298,7 @@ import akka.util.ByteString
       s3Headers: S3Headers,
       chunkSize: Int = MinChunkSize,
       chunkingParallelism: Int = 4
-  ): RunnableGraph[Source[MultipartUploadResult, NotUsed]] = {
+  ): RunnableGraph[Future[MultipartUploadResult]] = {
 
     // Pre step get source meta to get content length (size of the object)
     val eventualMaybeObjectSize =
@@ -343,7 +344,7 @@ import akka.util.ByteString
                                       sse: Option[ServerSideEncryption])(
       implicit mat: ActorMaterializer,
       attr: Attributes
-  ): Source[CompleteMultipartUploadResult, NotUsed] = {
+  ): Future[CompleteMultipartUploadResult] = {
     def populateResult(result: CompleteMultipartUploadResult,
                        headers: Seq[HttpHeader]): CompleteMultipartUploadResult = {
       val versionId = headers.find(_.lowercaseName() == "x-amz-version-id").map(_.value())
@@ -361,6 +362,7 @@ import akka.util.ByteString
         completeMultipartUploadRequest(parts.head.multipartUpload, parts.map(p => p.index -> p.etag), headers)
       )
       .flatMapConcat(signAndGetAs[CompleteMultipartUploadResult](_, populateResult(_, _)))
+      .runWith(Sink.head)
   }
 
   /**
@@ -476,30 +478,31 @@ import akka.util.ByteString
   private def completionSink(
       s3Location: S3Location,
       sse: Option[ServerSideEncryption]
-  ): Sink[UploadPartResponse, Source[MultipartUploadResult, NotUsed]] =
+  ): Sink[UploadPartResponse, Future[MultipartUploadResult]] =
     Setup
       .sink { implicit mat => implicit attr =>
+        val sys = mat.system
+        import sys.dispatcher
         Sink
           .seq[UploadPartResponse]
           .mapMaterializedValue { responseFuture: Future[Seq[UploadPartResponse]] =>
-            Source
-              .fromFuture(responseFuture)
-              .flatMapConcat { responses: Seq[UploadPartResponse] =>
+            responseFuture
+              .flatMap { responses: Seq[UploadPartResponse] =>
                 val successes = responses.collect { case r: SuccessfulUploadPart => r }
                 val failures = responses.collect { case r: FailedUploadPart => r }
                 if (responses.isEmpty) {
-                  Source.failed(new RuntimeException("No Responses"))
+                  Future.failed(new RuntimeException("No Responses"))
                 } else if (failures.isEmpty) {
-                  Source.single(successes.sortBy(_.index))
+                  Future.successful(successes.sortBy(_.index))
                 } else {
-                  Source.failed(FailedUpload(failures.map(_.exception)))
+                  Future.failed(FailedUpload(failures.map(_.exception)))
                 }
               }
-              .flatMapConcat(completeMultipartUpload(s3Location, _, sse))
+              .flatMap(completeMultipartUpload(s3Location, _, sse))
           }
           .mapMaterializedValue(_.map(r => MultipartUploadResult(r.location, r.bucket, r.key, r.etag, r.versionId)))
       }
-      .mapMaterializedValue(s => Source.fromFuture(s).flatMapConcat(identity))
+      .mapMaterializedValue(_.flatMap(identity)(ExecutionContexts.sameThreadExecutionContext))
 
   private def signAndGetAs[T](
       request: HttpRequest

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
@@ -4,6 +4,7 @@
 
 package akka.stream.alpakka.s3.javadsl
 import java.util.Optional
+import java.util.concurrent.CompletionStage
 
 import akka.japi.{Pair => JPair}
 import akka.{Done, NotUsed}
@@ -18,6 +19,7 @@ import akka.stream.javadsl.{RunnableGraph, Sink, Source}
 import akka.util.ByteString
 
 import scala.compat.java8.OptionConverters._
+import scala.compat.java8.FutureConverters._
 
 /**
  * Java API
@@ -301,15 +303,15 @@ object S3 {
    * @param key the s3 object key
    * @param contentType an optional [[akka.http.javadsl.model.ContentType ContentType]]
    * @param s3Headers any headers you want to add
-   * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.util.ByteString ByteString]]'s and materializes to a [[akka.stream.javadsl.Source Source]] of [[MultipartUploadResult]]
+   * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.util.ByteString ByteString]]'s and materializes to a [[ava.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUpload(bucket: String,
                       key: String,
                       contentType: ContentType,
-                      s3Headers: S3Headers): Sink[ByteString, Source[MultipartUploadResult, NotUsed]] =
+                      s3Headers: S3Headers): Sink[ByteString, CompletionStage[MultipartUploadResult]] =
     S3Stream
       .multipartUpload(S3Location(bucket, key), contentType.asInstanceOf[ScalaContentType], s3Headers)
-      .mapMaterializedValue(_.asJava)
+      .mapMaterializedValue(_.toJava)
       .asJava
 
   /**
@@ -318,11 +320,11 @@ object S3 {
    * @param bucket the s3 bucket name
    * @param key the s3 object key
    * @param contentType an optional [[akka.http.javadsl.model.ContentType ContentType]]
-   * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.util.ByteString ByteString]]'s and materializes to a [[akka.stream.javadsl.Source Source]] of [[MultipartUploadResult]]
+   * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.util.ByteString ByteString]]'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUpload(bucket: String,
                       key: String,
-                      contentType: ContentType): Sink[ByteString, Source[MultipartUploadResult, NotUsed]] =
+                      contentType: ContentType): Sink[ByteString, CompletionStage[MultipartUploadResult]] =
     multipartUpload(bucket, key, contentType, S3Headers().withCannedAcl(CannedAcl.Private))
 
   /**
@@ -330,9 +332,9 @@ object S3 {
    *
    * @param bucket the s3 bucket name
    * @param key the s3 object key
-   * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.util.ByteString ByteString]]'s and materializes to a [[akka.stream.javadsl.Source Source]] of [[MultipartUploadResult]]
+   * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.util.ByteString ByteString]]'s and materializes to a [[ava.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
    */
-  def multipartUpload(bucket: String, key: String): Sink[ByteString, Source[MultipartUploadResult, NotUsed]] =
+  def multipartUpload(bucket: String, key: String): Sink[ByteString, CompletionStage[MultipartUploadResult]] =
     multipartUpload(bucket, key, ContentTypes.APPLICATION_OCTET_STREAM)
 
   /**
@@ -345,7 +347,7 @@ object S3 {
    * @param sourceVersionId version id of source object, if the versioning is enabled in source bucket
    * @param contentType an optional [[akka.http.javadsl.model.ContentType ContentType]]
    * @param s3Headers any headers you want to add
-   * @return a [[akka.stream.javadsl.Source Source]] containing the [[akka.stream.alpakka.s3.MultipartUploadResult MultipartUploadResult]] of the uploaded S3 Object
+   * @return the [[akka.stream.alpakka.s3.MultipartUploadResult MultipartUploadResult]] of the uploaded S3 Object
    */
   def multipartCopy(sourceBucket: String,
                     sourceKey: String,
@@ -353,7 +355,7 @@ object S3 {
                     targetKey: String,
                     sourceVersionId: Optional[String],
                     contentType: ContentType,
-                    s3Headers: S3Headers): RunnableGraph[Source[MultipartUploadResult, NotUsed]] =
+                    s3Headers: S3Headers): RunnableGraph[CompletionStage[MultipartUploadResult]] =
     RunnableGraph
       .fromGraph {
         S3Stream
@@ -365,7 +367,7 @@ object S3 {
             s3Headers
           )
       }
-      .mapMaterializedValue(func(_.asJava))
+      .mapMaterializedValue(func(_.toJava))
 
   /**
    * Copy a S3 Object by making multiple requests.
@@ -376,14 +378,14 @@ object S3 {
    * @param targetKey the target s3 key
    * @param sourceVersionId version id of source object, if the versioning is enabled in source bucket
    * @param s3Headers any headers you want to add
-   * @return a [[akka.stream.javadsl.Source Source]] containing the [[akka.stream.alpakka.s3.MultipartUploadResult MultipartUploadResult]] of the uploaded S3 Object
+   * @return the [[akka.stream.alpakka.s3.MultipartUploadResult MultipartUploadResult]] of the uploaded S3 Object
    */
   def multipartCopy(sourceBucket: String,
                     sourceKey: String,
                     targetBucket: String,
                     targetKey: String,
                     sourceVersionId: Optional[String],
-                    s3Headers: S3Headers): RunnableGraph[Source[MultipartUploadResult, NotUsed]] =
+                    s3Headers: S3Headers): RunnableGraph[CompletionStage[MultipartUploadResult]] =
     multipartCopy(sourceBucket,
                   sourceKey,
                   targetBucket,
@@ -401,14 +403,14 @@ object S3 {
    * @param targetKey the target s3 key
    * @param contentType an optional [[akka.http.javadsl.model.ContentType ContentType]]
    * @param s3Headers any headers you want to add
-   * @return a [[akka.stream.javadsl.Source Source]] containing the [[akka.stream.alpakka.s3.MultipartUploadResult MultipartUploadResult]] of the uploaded S3 Object
+   * @return the [[akka.stream.alpakka.s3.MultipartUploadResult MultipartUploadResult]] of the uploaded S3 Object
    */
   def multipartCopy(sourceBucket: String,
                     sourceKey: String,
                     targetBucket: String,
                     targetKey: String,
                     contentType: ContentType,
-                    s3Headers: S3Headers): RunnableGraph[Source[MultipartUploadResult, NotUsed]] =
+                    s3Headers: S3Headers): RunnableGraph[CompletionStage[MultipartUploadResult]] =
     multipartCopy(sourceBucket, sourceKey, targetBucket, targetKey, Optional.empty(), contentType, s3Headers)
 
   /**
@@ -419,13 +421,13 @@ object S3 {
    * @param targetBucket the target s3 bucket name
    * @param targetKey the target s3 key
    * @param s3Headers any headers you want to add
-   * @return a [[akka.stream.javadsl.Source Source]] containing the [[akka.stream.alpakka.s3.MultipartUploadResult MultipartUploadResult]] of the uploaded S3 Object
+   * @return the [[akka.stream.alpakka.s3.MultipartUploadResult MultipartUploadResult]] of the uploaded S3 Object
    */
   def multipartCopy(sourceBucket: String,
                     sourceKey: String,
                     targetBucket: String,
                     targetKey: String,
-                    s3Headers: S3Headers): RunnableGraph[Source[MultipartUploadResult, NotUsed]] =
+                    s3Headers: S3Headers): RunnableGraph[CompletionStage[MultipartUploadResult]] =
     multipartCopy(sourceBucket, sourceKey, targetBucket, targetKey, ContentTypes.APPLICATION_OCTET_STREAM, s3Headers)
 
   /**
@@ -435,12 +437,12 @@ object S3 {
    * @param sourceKey the source s3 key
    * @param targetBucket the target s3 bucket name
    * @param targetKey the target s3 key
-   * @return a [[akka.stream.javadsl.Source Source]] containing the [[akka.stream.alpakka.s3.MultipartUploadResult MultipartUploadResult]] of the uploaded S3 Object
+   * @return the [[akka.stream.alpakka.s3.MultipartUploadResult MultipartUploadResult]] of the uploaded S3 Object
    */
   def multipartCopy(sourceBucket: String,
                     sourceKey: String,
                     targetBucket: String,
-                    targetKey: String): RunnableGraph[Source[MultipartUploadResult, NotUsed]] =
+                    targetKey: String): RunnableGraph[CompletionStage[MultipartUploadResult]] =
     multipartCopy(sourceBucket, sourceKey, targetBucket, targetKey, ContentTypes.APPLICATION_OCTET_STREAM, S3Headers())
 
   private def func[T, R](f: T => R) = new akka.japi.function.Function[T, R] {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
@@ -12,6 +12,8 @@ import akka.stream.alpakka.s3.impl._
 import akka.stream.scaladsl.{RunnableGraph, Sink, Source}
 import akka.util.ByteString
 
+import scala.concurrent.Future
+
 /**
  * Factory of S3 operations.
  */
@@ -126,7 +128,7 @@ object S3 {
    * @param cannedAcl a [[CannedAcl]], defaults to [[CannedAcl.Private]]
    * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
    * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4
-   * @return a [[akka.stream.scaladsl.Sink Sink]] that accepts [[ByteString]]'s and materializes to a [[akka.stream.scaladsl.Source]] of [[MultipartUploadResult]]
+   * @return a [[akka.stream.scaladsl.Sink Sink]] that accepts [[ByteString]]'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
    */
   def multipartUpload(
       bucket: String,
@@ -137,7 +139,7 @@ object S3 {
       chunkSize: Int = MinChunkSize,
       chunkingParallelism: Int = 4,
       sse: Option[ServerSideEncryption] = None
-  ): Sink[ByteString, Source[MultipartUploadResult, NotUsed]] = {
+  ): Sink[ByteString, Future[MultipartUploadResult]] = {
     val s3Headers = S3Headers().withCannedAcl(cannedAcl).withMetaHeaders(metaHeaders)
     S3Stream
       .multipartUpload(
@@ -158,7 +160,7 @@ object S3 {
    * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
    * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4
    * @param s3Headers any headers you want to add
-   * @return a [[akka.stream.scaladsl.Sink Sink]] that accepts [[akka.util.ByteString ByteString]]'s and materializes to a [[akka.stream.scaladsl.Source]] of [[MultipartUploadResult]]
+   * @return a [[akka.stream.scaladsl.Sink Sink]] that accepts [[akka.util.ByteString ByteString]]'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
    */
   def multipartUploadWithHeaders(
       bucket: String,
@@ -167,7 +169,7 @@ object S3 {
       chunkSize: Int = MinChunkSize,
       chunkingParallelism: Int = 4,
       s3Headers: S3Headers = S3Headers()
-  ): Sink[ByteString, Source[MultipartUploadResult, NotUsed]] =
+  ): Sink[ByteString, Future[MultipartUploadResult]] =
     S3Stream
       .multipartUpload(
         S3Location(bucket, key),
@@ -190,7 +192,7 @@ object S3 {
    * @param sse an optional server side encryption key
    * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
    * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4
-   * @return a runnable graph which upon materialization will return a source containing the results of the copy operation.
+   * @return a runnable graph which upon materialization will return a [[scala.concurrent.Future Future ]] containing the results of the copy operation.
    */
   def multipartCopy(
       sourceBucket: String,
@@ -202,7 +204,7 @@ object S3 {
       s3Headers: S3Headers = S3Headers(),
       chunkSize: Int = MinChunkSize,
       chunkingParallelism: Int = 4
-  ): RunnableGraph[Source[MultipartUploadResult, NotUsed]] =
+  ): RunnableGraph[Future[MultipartUploadResult]] =
     S3Stream
       .multipartCopy(
         S3Location(sourceBucket, sourceKey),

--- a/s3/src/test/java/docs/javadsl/S3Test.java
+++ b/s3/src/test/java/docs/javadsl/S3Test.java
@@ -42,18 +42,15 @@ public class S3Test extends S3WireMockBase {
     // #upload
     final Source<ByteString, NotUsed> file = Source.single(ByteString.fromString(body()));
 
-    final Sink<ByteString, Source<MultipartUploadResult, NotUsed>> sink =
+    final Sink<ByteString, CompletionStage<MultipartUploadResult>> sink =
         S3.multipartUpload(bucket(), bucketKey());
 
-    final Source<MultipartUploadResult, NotUsed> resultCompletionStage =
+    final CompletionStage<MultipartUploadResult> resultCompletionStage =
         file.runWith(sink, materializer);
     // #upload
 
     MultipartUploadResult result =
-        resultCompletionStage
-            .runWith(Sink.head(), materializer)
-            .toCompletableFuture()
-            .get(5, TimeUnit.SECONDS);
+        resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
     assertEquals(
         MultipartUploadResult.create(
@@ -66,21 +63,18 @@ public class S3Test extends S3WireMockBase {
 
     mockUploadSSE();
 
-    final Sink<ByteString, Source<MultipartUploadResult, NotUsed>> sink =
+    final Sink<ByteString, CompletionStage<MultipartUploadResult>> sink =
         S3.multipartUpload(
             bucket(),
             bucketKey(),
             ContentTypes.APPLICATION_OCTET_STREAM,
             S3Headers.create().withServerSideEncryption(sseCustomerKeys()));
 
-    final Source<MultipartUploadResult, NotUsed> resultCompletionStage =
+    final CompletionStage<MultipartUploadResult> resultCompletionStage =
         Source.single(ByteString.fromString(body())).runWith(sink, materializer);
 
     MultipartUploadResult result =
-        resultCompletionStage
-            .runWith(Sink.head(), materializer)
-            .toCompletableFuture()
-            .get(5, TimeUnit.SECONDS);
+        resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
     assertEquals(
         MultipartUploadResult.create(
@@ -346,15 +340,12 @@ public class S3Test extends S3WireMockBase {
     String targetBucket = targetBucket();
     String targetKey = targetBucketKey();
     // #multipart-copy
-    final Source<MultipartUploadResult, NotUsed> resultCompletionStage =
+    final CompletionStage<MultipartUploadResult> resultCompletionStage =
         S3.multipartCopy(bucket, sourceKey, targetBucket, targetKey).run(materializer);
     // #multipart-copy
 
     final MultipartUploadResult result =
-        resultCompletionStage
-            .runWith(Sink.head(), materializer)
-            .toCompletableFuture()
-            .get(5, TimeUnit.SECONDS);
+        resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
     assertEquals(
         result,
@@ -373,7 +364,7 @@ public class S3Test extends S3WireMockBase {
 
     // #multipart-copy-with-source-version
     String sourceVersionId = "3/L4kqtJlcpXroDTDmJ+rmSpXd3dIbrHY+MTRCxf3vjVBH40Nr8X8gdRQBpUMLUo";
-    final Source<MultipartUploadResult, NotUsed> resultCompletionStage =
+    final CompletionStage<MultipartUploadResult> resultCompletionStage =
         S3.multipartCopy(
                 bucket,
                 sourceKey,
@@ -385,10 +376,7 @@ public class S3Test extends S3WireMockBase {
     // #multipart-copy-with-source-version
 
     final MultipartUploadResult result =
-        resultCompletionStage
-            .runWith(Sink.head(), materializer)
-            .toCompletableFuture()
-            .get(5, TimeUnit.SECONDS);
+        resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
     assertEquals(
         result,
@@ -404,14 +392,11 @@ public class S3Test extends S3WireMockBase {
   public void copyUploadWithContentLengthEqualToChunkSize() throws Exception {
     mockCopy(5242880);
 
-    final Source<MultipartUploadResult, NotUsed> resultCompletionStage =
+    final CompletionStage<MultipartUploadResult> resultCompletionStage =
         S3.multipartCopy(bucket(), bucketKey(), targetBucket(), targetBucketKey())
             .run(materializer);
     final MultipartUploadResult result =
-        resultCompletionStage
-            .runWith(Sink.head(), materializer)
-            .toCompletableFuture()
-            .get(5, TimeUnit.SECONDS);
+        resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
     assertEquals(
         result,
@@ -423,14 +408,11 @@ public class S3Test extends S3WireMockBase {
   public void copyUploadWithContentLengthGreaterThenChunkSize() throws Exception {
     mockCopyMulti();
 
-    final Source<MultipartUploadResult, NotUsed> resultCompletionStage =
+    final CompletionStage<MultipartUploadResult> resultCompletionStage =
         S3.multipartCopy(bucket(), bucketKey(), targetBucket(), targetBucketKey())
             .run(materializer);
     final MultipartUploadResult result =
-        resultCompletionStage
-            .runWith(Sink.head(), materializer)
-            .toCompletableFuture()
-            .get(5, TimeUnit.SECONDS);
+        resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
     assertEquals(
         result,
@@ -442,14 +424,11 @@ public class S3Test extends S3WireMockBase {
   public void copyUploadEmptyFile() throws Exception {
     mockCopy(0);
 
-    final Source<MultipartUploadResult, NotUsed> resultCompletionStage =
+    final CompletionStage<MultipartUploadResult> resultCompletionStage =
         S3.multipartCopy(bucket(), bucketKey(), targetBucket(), targetBucketKey())
             .run(materializer);
     final MultipartUploadResult result =
-        resultCompletionStage
-            .runWith(Sink.head(), materializer)
-            .toCompletableFuture()
-            .get(5, TimeUnit.SECONDS);
+        resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
     assertEquals(
         result,
@@ -465,7 +444,7 @@ public class S3Test extends S3WireMockBase {
     final CustomerKeys keys =
         ServerSideEncryption.customerKeys(sseCustomerKey()).withMd5(sseCustomerMd5Key());
 
-    final Source<MultipartUploadResult, NotUsed> resultCompletionStage =
+    final CompletionStage<MultipartUploadResult> resultCompletionStage =
         S3.multipartCopy(
                 bucket(),
                 bucketKey(),
@@ -476,10 +455,7 @@ public class S3Test extends S3WireMockBase {
     // #multipart-copy-sse
 
     final MultipartUploadResult result =
-        resultCompletionStage
-            .runWith(Sink.head(), materializer)
-            .toCompletableFuture()
-            .get(5, TimeUnit.SECONDS);
+        resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
     assertEquals(
         result,
@@ -491,7 +467,7 @@ public class S3Test extends S3WireMockBase {
   public void copyUploadWithCustomHeader() throws Exception {
     mockCopy();
 
-    final Source<MultipartUploadResult, NotUsed> resultCompletionStage =
+    final CompletionStage<MultipartUploadResult> resultCompletionStage =
         S3.multipartCopy(
                 bucket(),
                 bucketKey(),
@@ -501,10 +477,7 @@ public class S3Test extends S3WireMockBase {
             .run(materializer);
 
     final MultipartUploadResult result =
-        resultCompletionStage
-            .runWith(Sink.head(), materializer)
-            .toCompletableFuture()
-            .get(5, TimeUnit.SECONDS);
+        resultCompletionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
     assertEquals(
         result,

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -143,7 +143,6 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
         .runWith(
           S3.multipartUpload(defaultRegionBucket, objectKey, metaHeaders = MetaHeaders(metaHeaders))
         )
-        .runWith(Sink.head)
 
     val multipartUploadResult = Await.ready(result, 90.seconds).futureValue
     multipartUploadResult.bucket shouldBe defaultRegionBucket
@@ -179,7 +178,6 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
         .runWith(
           S3.multipartUpload(defaultRegionBucket, objectKey, metaHeaders = MetaHeaders(metaHeaders))
         )
-        .runWith(Sink.head)
       download <- S3.download(defaultRegionBucket, objectKey).runWith(Sink.head).flatMap {
         case Some((downloadSource, _)) =>
           downloadSource
@@ -207,7 +205,6 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
         .runWith(
           S3.multipartUpload(defaultRegionBucket, objectKey, metaHeaders = MetaHeaders(metaHeaders))
         )
-        .runWith(Sink.head)
       download <- S3.download(defaultRegionBucket, objectKey).runWith(Sink.head).flatMap {
         case Some((downloadSource, _)) =>
           downloadSource
@@ -236,7 +233,6 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
           S3.multipartUpload(otherRegionBucket, objectKey, metaHeaders = MetaHeaders(metaHeaders))
             .withAttributes(S3Attributes.settings(otherRegionSettings))
         )
-        .runWith(Sink.head)
       download <- S3
         .download(otherRegionBucket, objectKey)
         .withAttributes(S3Attributes.settings(otherRegionSettings))
@@ -273,7 +269,6 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
           S3.multipartUpload(otherRegionBucket, objectKey, metaHeaders = MetaHeaders(metaHeaders))
             .withAttributes(S3Attributes.settings(otherRegionSettings))
         )
-        .runWith(Sink.head)
       download <- S3
         .download(otherRegionBucket, objectKey)
         .withAttributes(S3Attributes.settings(otherRegionSettings))
@@ -305,8 +300,8 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
     val source: Source[ByteString, Any] = Source(ByteString(objectValue) :: Nil)
 
     val results = for {
-      upload <- source.runWith(S3.multipartUpload(defaultRegionBucket, sourceKey)).runWith(Sink.head)
-      copy <- S3.multipartCopy(defaultRegionBucket, sourceKey, defaultRegionBucket, targetKey).run().runWith(Sink.head)
+      upload <- source.runWith(S3.multipartUpload(defaultRegionBucket, sourceKey))
+      copy <- S3.multipartCopy(defaultRegionBucket, sourceKey, defaultRegionBucket, targetKey).run()
       download <- S3.download(defaultRegionBucket, targetKey).runWith(Sink.head).flatMap {
         case Some((downloadSource, _)) =>
           downloadSource

--- a/s3/src/test/scala/docs/scaladsl/S3SinkSpec.scala
+++ b/s3/src/test/scala/docs/scaladsl/S3SinkSpec.scala
@@ -11,6 +11,8 @@ import akka.stream.alpakka.s3.{MultipartUploadResult, S3Headers}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 
+import scala.concurrent.Future
+
 class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
 
   override protected def afterEach(): Unit =
@@ -19,13 +21,13 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
   it should "succeed uploading an empty file" in {
     mockUpload(expectedBody = "")
 
-    val s3Sink: Sink[ByteString, Source[MultipartUploadResult, NotUsed]] = S3.multipartUpload(bucket, bucketKey)
+    val s3Sink: Sink[ByteString, Future[MultipartUploadResult]] = S3.multipartUpload(bucket, bucketKey)
 
     val src = Source.empty[ByteString]
 
-    val result: Source[MultipartUploadResult, NotUsed] = src.runWith(s3Sink)
+    val result: Future[MultipartUploadResult] = src.runWith(s3Sink)
 
-    result.runWith(Sink.head).futureValue shouldBe MultipartUploadResult(url, bucket, bucketKey, etag, None)
+    result.futureValue shouldBe MultipartUploadResult(url, bucket, bucketKey, etag, None)
   }
 
   "S3Sink" should "upload a stream of bytes to S3" in {
@@ -36,39 +38,39 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     val file: Source[ByteString, NotUsed] =
       Source.single(ByteString(body))
 
-    val s3Sink: Sink[ByteString, Source[MultipartUploadResult, NotUsed]] =
+    val s3Sink: Sink[ByteString, Future[MultipartUploadResult]] =
       S3.multipartUpload(bucket, bucketKey)
 
-    val result: Source[MultipartUploadResult, NotUsed] =
+    val result: Future[MultipartUploadResult] =
       file.runWith(s3Sink)
     //#upload
 
-    result.runWith(Sink.head).futureValue shouldBe MultipartUploadResult(url, bucket, bucketKey, etag, None)
+    result.futureValue shouldBe MultipartUploadResult(url, bucket, bucketKey, etag, None)
   }
 
   "S3Sink" should "retry upload after internal server error" in {
 
     mockUploadWithInternalError(body)
 
-    val s3Sink: Sink[ByteString, Source[MultipartUploadResult, NotUsed]] = S3.multipartUpload(bucket, bucketKey)
+    val s3Sink: Sink[ByteString, Future[MultipartUploadResult]] = S3.multipartUpload(bucket, bucketKey)
 
-    val result: Source[MultipartUploadResult, NotUsed] = Source.single(ByteString(body)).runWith(s3Sink)
+    val result: Future[MultipartUploadResult] = Source.single(ByteString(body)).runWith(s3Sink)
 
-    result.runWith(Sink.head).futureValue shouldBe MultipartUploadResult(url, bucket, bucketKey, etag, None)
+    result.futureValue shouldBe MultipartUploadResult(url, bucket, bucketKey, etag, None)
   }
 
   it should "upload a stream of bytes to S3 with custom headers" in {
 
     mockUpload()
 
-    val s3Sink: Sink[ByteString, Source[MultipartUploadResult, NotUsed]] =
+    val s3Sink: Sink[ByteString, Future[MultipartUploadResult]] =
       S3.multipartUploadWithHeaders(bucket,
                                     bucketKey,
                                     s3Headers = S3Headers().withCannedAcl(CannedAcl.AuthenticatedRead))
 
-    val result: Source[MultipartUploadResult, NotUsed] = Source.single(ByteString(body)).runWith(s3Sink)
+    val result: Future[MultipartUploadResult] = Source.single(ByteString(body)).runWith(s3Sink)
 
-    result.runWith(Sink.head).futureValue shouldBe MultipartUploadResult(url, bucket, bucketKey, etag, None)
+    result.futureValue shouldBe MultipartUploadResult(url, bucket, bucketKey, etag, None)
   }
 
   it should "fail if request returns 404" in {
@@ -78,7 +80,6 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     val result = Source
       .single(ByteString("some contents"))
       .runWith(S3.multipartUpload("nonexisting_bucket", "nonexisting_file.xml"))
-      .runWith(Sink.head)
 
     result.failed.futureValue.getMessage shouldBe "No key found"
   }
@@ -87,37 +88,25 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     mockCopy()
 
     //#multipart-copy
-    val result: Source[MultipartUploadResult, NotUsed] =
+    val result: Future[MultipartUploadResult] =
       S3.multipartCopy(bucket, bucketKey, targetBucket, targetBucketKey).run()
     //#multipart-copy
 
-    result.runWith(Sink.head).futureValue shouldBe MultipartUploadResult(targetUrl,
-                                                                         targetBucket,
-                                                                         targetBucketKey,
-                                                                         etag,
-                                                                         None)
+    result.futureValue shouldBe MultipartUploadResult(targetUrl, targetBucket, targetBucketKey, etag, None)
   }
 
   it should "copy a file from source bucket to target bucket when expected content length is equal to chunk size" in {
     mockCopyMinChunkSize()
 
     val result = S3.multipartCopy(bucket, bucketKey, targetBucket, targetBucketKey).run()
-    result.runWith(Sink.head).futureValue shouldBe MultipartUploadResult(targetUrl,
-                                                                         targetBucket,
-                                                                         targetBucketKey,
-                                                                         etag,
-                                                                         None)
+    result.futureValue shouldBe MultipartUploadResult(targetUrl, targetBucket, targetBucketKey, etag, None)
   }
 
   it should "copy an empty file from source bucket to target bucket" in {
     mockCopy(expectedContentLength = 0)
 
     val result = S3.multipartCopy(bucket, bucketKey, targetBucket, targetBucketKey).run()
-    result.runWith(Sink.head).futureValue shouldBe MultipartUploadResult(targetUrl,
-                                                                         targetBucket,
-                                                                         targetBucketKey,
-                                                                         etag,
-                                                                         None)
+    result.futureValue shouldBe MultipartUploadResult(targetUrl, targetBucket, targetBucketKey, etag, None)
   }
 
   it should "copy a file from source bucket to target bucket with SSE" in {
@@ -128,7 +117,7 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
       .customerKeys(sseCustomerKey)
       .withMd5(sseCustomerMd5Key)
 
-    val result: Source[MultipartUploadResult, NotUsed] =
+    val result: Future[MultipartUploadResult] =
       S3.multipartCopy(bucket,
                        bucketKey,
                        targetBucket,
@@ -137,11 +126,7 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
         .run()
     //#multipart-copy-sse
 
-    result.runWith(Sink.head).futureValue shouldBe MultipartUploadResult(targetUrl,
-                                                                         targetBucket,
-                                                                         targetBucketKey,
-                                                                         etag,
-                                                                         None)
+    result.futureValue shouldBe MultipartUploadResult(targetUrl, targetBucket, targetBucketKey, etag, None)
   }
 
   it should "copy a file from source bucket to target bucket with custom header" in {
@@ -154,29 +139,21 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
                        targetBucketKey,
                        s3Headers = S3Headers().withServerSideEncryption(ServerSideEncryption.aes256()))
         .run()
-    result.runWith(Sink.head).futureValue shouldBe MultipartUploadResult(targetUrl,
-                                                                         targetBucket,
-                                                                         targetBucketKey,
-                                                                         etag,
-                                                                         None)
+    result.futureValue shouldBe MultipartUploadResult(targetUrl, targetBucket, targetBucketKey, etag, None)
   }
 
   it should "copy a file from source bucket to target bucket when expected content length is greater then chunk size" in {
     mockCopyMulti()
 
     val result = S3.multipartCopy(bucket, bucketKey, targetBucket, targetBucketKey).run()
-    result.runWith(Sink.head).futureValue shouldBe MultipartUploadResult(targetUrl,
-                                                                         targetBucket,
-                                                                         targetBucketKey,
-                                                                         etag,
-                                                                         None)
+    result.futureValue shouldBe MultipartUploadResult(targetUrl, targetBucket, targetBucketKey, etag, None)
   }
 
   it should "copy a file from source bucket to target bucket with source version id provided" in {
     mockCopyVersioned()
 
     //#multipart-copy-with-source-version
-    val result: Source[MultipartUploadResult, NotUsed] =
+    val result: Future[MultipartUploadResult] =
       S3.multipartCopy(bucket,
                        bucketKey,
                        targetBucket,
@@ -185,7 +162,7 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec {
         .run()
     //#multipart-copy-with-source-version
 
-    result.runWith(Sink.head).futureValue shouldBe MultipartUploadResult(
+    result.futureValue shouldBe MultipartUploadResult(
       targetUrl,
       targetBucket,
       targetBucketKey,


### PR DESCRIPTION
## Fixes

Fixes #1543

## Purpose

Changes the wrapper for the materialized value of the multiPartUpload/multiPartCopy from `Source` to `Future`. This fixed the API inconsistency where the stream needs to be run twice in order for the upload to start.

## Background Context

In #1395 the materialized value was changed from `Future` to `Source` because all of the S3 internals where changed to support blue-print-like-usage of S3 factories. `multiPartUpload/multiPartCopy` use the same machinery for materialized value transformations so the changes propagated here as well. Since the stream is already running when the materialized value is transformed, it is okay to have the `Future` as the wrapper in `multiPartUpload/multiPartCopy` materialized value. In other words, that will not brake the blueprint nature of the stream operators returned by these factories.

## References

This was discussed here https://gitter.im/akka/akka?at=5c7691a4d2d62067b715a518

//cc @jypma 