### PR TITLE
Scala 2.13; links to snapshots page from data-transformations

### DIFF
--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -13,7 +13,7 @@ There are a few blog posts and presentations about Alpakka out there, we've @ref
 The code in this documentation is compiled against
 
 * Alpakka $project.version$ ([Github](https://github.com/akka/alpakka), [API docs](https://doc.akka.io/api/alpakka/current/akka/stream/alpakka/index.html))
-* Scala $scala.binary.version$ (also available for Scala 2.11)
+* Scala $scala.binary.version$ (most modules are available for Scala 2.13, and all are available for Scala 2.11)
 * Akka Streams $akka.version$ (@extref[Docs](akka-docs:stream/index.html), [Github](https://github.com/akka/akka))
 * Akka Http $akka-http.version$ (@extref[Docs Scala](akka-http-docs:scala.html), @extref[Docs Java](akka-http-docs:java.html), [Github](https://github.com/akka/akka-http))
 

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -141,6 +141,9 @@ project-info {
     title: "Alpakka CSV"
     jpms-name: "akka.stream.alpakka.csv"
     issues.url: ${project-info.labels}"csv"
+    snapshots: {
+      url: "../other-docs/snapshots.html"
+    }
     levels: [
       {
         readiness: CommunityDriven
@@ -375,6 +378,9 @@ project-info {
     title: "Alpakka JSON Streaming"
     jpms-name: "akka.stream.alpakka.json.streaming"
     issues.url: ${project-info.labels}"json-streaming"
+    snapshots: {
+      url: "../other-docs/snapshots.html"
+    }
     levels: [
       {
         readiness: CommunityDriven
@@ -519,6 +525,9 @@ project-info {
     title: "Alpakka Simple Codecs (RecordIO)"
     jpms-name: "akka.stream.alpakka.simplecodecs"
     issues.url: ${project-info.labels}"recordio"
+    snapshots: {
+      url: "../other-docs/snapshots.html"
+    }
     levels: [
       {
         readiness: CommunityDriven
@@ -645,6 +654,9 @@ project-info {
     title: "Alpakka Text"
     jpms-name: "akka.stream.alpakka.text"
     issues.url: ${project-info.labels}"text"
+    snapshots: {
+      url: "../other-docs/snapshots.html"
+    }
     levels: [
       {
         readiness: CommunityDriven
@@ -699,6 +711,9 @@ project-info {
     title: "Alpakka XML"
     jpms-name: "akka.stream.alpakka.xml"
     issues.url: ${project-info.labels}"xml"
+    snapshots: {
+      url: "../other-docs/snapshots.html"
+    }
     levels: [
       {
         readiness: CommunityDriven


### PR DESCRIPTION
* List Scala 2.13 availability
* Fix dead links
