### PR TITLE
Update akka-grpc to 0.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ lazy val alpakka = project
     ScalaUnidoc / unidoc / fullClasspath := {
       (ScalaUnidoc / unidoc / fullClasspath).value
         .filterNot(_.data.getAbsolutePath.contains("protobuf-java-2.5.0.jar"))
-	.filterNot(_.data.getAbsolutePath.contains("guava-26.0-android.jar"))
+        .filterNot(_.data.getAbsolutePath.contains("guava-26.0-android.jar"))
     },
     ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(`doc-examples`),
     crossScalaVersions := List() // workaround for https://github.com/sbt/sbt/issues/3465

--- a/build.sbt
+++ b/build.sbt
@@ -321,6 +321,9 @@ lazy val `doc-examples` = project
     name := s"akka-stream-alpakka-doc-examples",
     publish / skip := true,
     whitesourceIgnore := true,
+    // Google Cloud Pub/Sub gRPC is not available for Scala 2.11
+    crossScalaVersions -= Dependencies.Scala211,
+    // More projects are not available for Scala 2.13
     crossScalaVersions -= Dependencies.Scala213,
     Dependencies.`Doc-examples`
   )

--- a/build.sbt
+++ b/build.sbt
@@ -65,12 +65,13 @@ lazy val alpakka = project
         |    is binary compatible with the released version
       """.stripMargin,
     // unidoc combines sources and jars from all connectors and that
-    // includes two incompatible versions of protobuf. Depending on the
+    // might include some incompatible ones. Depending on the
     // classpath order that might lead to scaladoc compilation errors.
-    // Therefore the older version is exlcuded here.
+    // Therefore some versions are exlcuded here.
     ScalaUnidoc / unidoc / fullClasspath := {
       (ScalaUnidoc / unidoc / fullClasspath).value
         .filterNot(_.data.getAbsolutePath.contains("protobuf-java-2.5.0.jar"))
+	.filterNot(_.data.getAbsolutePath.contains("guava-26.0-android.jar"))
     },
     ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(`doc-examples`),
     crossScalaVersions := List() // workaround for https://github.com/sbt/sbt/issues/3465

--- a/build.sbt
+++ b/build.sbt
@@ -157,7 +157,7 @@ lazy val googleCloudPubSubGrpc = alpakkaProject(
   // for the ExampleApp in the tests
   connectInput in run := true,
   Compile / compile / scalacOptions += "-P:silencer:pathFilters=src_managed",
-  crossScalaVersions -= Dependencies.Scala213
+  crossScalaVersions --= Seq(Dependencies.Scala211, Dependencies.Scala213)
 ).enablePlugins(AkkaGrpcPlugin, JavaAgent)
 
 lazy val googleFcm = alpakkaProject(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -186,7 +186,7 @@ object Dependencies {
   val GooglePubSubGrpc = Seq(
     libraryDependencies ++= Seq(
       "com.google.api.grpc" % "grpc-google-cloud-pubsub-v1" % "0.12.0" % "protobuf", // ApacheV2
-      "io.grpc" % "grpc-auth" % "1.14.0", // ApacheV2
+      "io.grpc" % "grpc-auth" % "1.16.1", // ApacheV2
       "com.google.auth" % "google-auth-library-oauth2-http" % "0.10.0" // BSD 3-clause
     ) ++ Silencer
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,22 +1,22 @@
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.1.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.0-RC5")
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.1.0")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.3.0")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.4.3")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.1")
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "1.1")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "1.1.1")
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.14")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.1.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
-addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.13")
+addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.14")
 // has following PRs merged in:
 // * https://github.com/sbt/sbt-site/pull/141
 // * https://github.com/sbt/sbt-site/pull/139
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.2+24-b76fdbbe")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
-addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.1")
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.4")
+addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.6.0")
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
 // depend directly on the patched version see https://github.com/akka/alpakka/issues/1388


### PR DESCRIPTION
## Purpose

Updates to the just released akka-grpc 0.6.

Had to drop 2.11 for Google Pub/Sub gRPC because akka-grpc does not support it anymore https://github.com/akka/akka-grpc/issues/520