### PR TITLE
Cassandra: API may change

### DIFF
--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraFlow.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraFlow.scala
@@ -8,6 +8,7 @@ import java.util.function.BiFunction
 import java.util.function.Function
 
 import akka.NotUsed
+import akka.annotation.ApiMayChange
 import akka.stream.alpakka.cassandra.CassandraBatchSettings
 import com.datastax.driver.core.{BoundStatement, PreparedStatement, Session}
 import akka.stream.alpakka.cassandra.scaladsl.{CassandraFlow => ScalaCFlow}
@@ -15,6 +16,7 @@ import akka.stream.javadsl.Flow
 
 import scala.concurrent.ExecutionContext
 
+@ApiMayChange // https://github.com/akka/alpakka/issues/1213
 object CassandraFlow {
   def createWithPassThrough[T](parallelism: Int,
                                statement: PreparedStatement,

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraSink.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraSink.scala
@@ -8,12 +8,14 @@ import java.util.concurrent.CompletionStage
 import java.util.function.BiFunction
 
 import akka.Done
+import akka.annotation.ApiMayChange
 import akka.stream.alpakka.cassandra.scaladsl.{CassandraSink => ScalaCSink}
 import akka.stream.javadsl.Sink
 import com.datastax.driver.core.{BoundStatement, PreparedStatement, Session}
 
 import scala.compat.java8.FutureConverters._
 
+@ApiMayChange // https://github.com/akka/alpakka/issues/1213
 object CassandraSink {
 
   def create[T](parallelism: Int,

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraSource.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraSource.scala
@@ -7,12 +7,14 @@ package akka.stream.alpakka.cassandra.javadsl
 import java.util.concurrent.CompletableFuture
 
 import akka.NotUsed
+import akka.annotation.ApiMayChange
 import akka.stream.alpakka.cassandra.impl.CassandraSourceStage
 import akka.stream.javadsl.Source
 import com.datastax.driver.core.{Row, Session, Statement}
 
 import scala.concurrent.Future
 
+@ApiMayChange // https://github.com/akka/alpakka/issues/1213
 object CassandraSource {
 
   /**

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraFlow.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraFlow.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.cassandra.scaladsl
 
 import akka.NotUsed
+import akka.annotation.ApiMayChange
 import akka.dispatch.ExecutionContexts
 import akka.stream.FlowShape
 import akka.stream.alpakka.cassandra.CassandraBatchSettings
@@ -17,6 +18,7 @@ import scala.collection.JavaConverters._
 /**
  * Scala API to create Cassandra flows.
  */
+@ApiMayChange // https://github.com/akka/alpakka/issues/1213
 object CassandraFlow {
   def createWithPassThrough[T](
       parallelism: Int,

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSink.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSink.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.cassandra.scaladsl
 
 import akka.Done
+import akka.annotation.ApiMayChange
 import akka.stream.alpakka.cassandra.impl.GuavaFutures._
 import akka.stream.scaladsl.{Flow, Keep, Sink}
 import com.datastax.driver.core.{BoundStatement, PreparedStatement, Session}
@@ -14,6 +15,7 @@ import scala.concurrent.Future
 /**
  * Scala API to create Cassandra Sinks.
  */
+@ApiMayChange // https://github.com/akka/alpakka/issues/1213
 object CassandraSink {
   def apply[T](
       parallelism: Int,

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSource.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSource.scala
@@ -5,12 +5,14 @@
 package akka.stream.alpakka.cassandra.scaladsl
 
 import akka.NotUsed
+import akka.annotation.ApiMayChange
 import akka.stream.alpakka.cassandra.impl.CassandraSourceStage
 import akka.stream.scaladsl.Source
 import com.datastax.driver.core._
 
 import scala.concurrent.Future
 
+@ApiMayChange // https://github.com/akka/alpakka/issues/1213
 object CassandraSource {
 
   /**

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/settings.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/settings.scala
@@ -4,11 +4,13 @@
 
 package akka.stream.alpakka.cassandra
 
+import akka.annotation.ApiMayChange
+
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
-
 import akka.util.JavaDurationConverters._
 
+@ApiMayChange // https://github.com/akka/alpakka/issues/1213
 final class CassandraBatchSettings private (val maxGroupSize: Int, val maxGroupWait: FiniteDuration) {
   require(
     maxGroupSize > 0,
@@ -31,6 +33,7 @@ final class CassandraBatchSettings private (val maxGroupSize: Int, val maxGroupW
     s"CassandraBatchSettings(maxGroupSize=$maxGroupSize, maxGroupWait=$maxGroupWait)"
 }
 
+@ApiMayChange // https://github.com/akka/alpakka/issues/1213
 object CassandraBatchSettings {
 
   def apply(maxGroupSize: Int, maxGroupWait: FiniteDuration): CassandraBatchSettings =

--- a/docs/src/main/paradox/cassandra.md
+++ b/docs/src/main/paradox/cassandra.md
@@ -19,6 +19,14 @@ The table below shows direct dependencies of this module and the second tab show
 @@dependencies { projectId="cassandra" }
 
 
+@@@warning { title="API may change" }
+
+We intend to bring in the Cassandra client part of [Akka Persistence Cassandra](https://github.com/akka/akka-persistence-cassandra/) to Alpakka. This will mean changes to this API.
+
+See @github[issue #1213](#1213)
+
+@@@
+
 ## Source
 
 Sources provided by this connector need a prepared session to communicate with Cassandra cluster. First, let's initialize a Cassandra session.


### PR DESCRIPTION
## Purpose

Marks all Alpakka Cassandra APIs as "may change".

## Background Context

We might not be able to rework the API before we publish release candidates and want to be clear about anticipated API changes.

## References

See #1213 and https://github.com/akka/akka-persistence-cassandra/issues/390
Are there any relevant issues / PRs / mailing lists discussions?
