### PR TITLE
Fix sourceDirectory for paradoxTheme

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -264,7 +264,7 @@ lazy val docs = project
       ("\\.java\\.scala".r, _ => ".java")
     ),
     Paradox / siteSubdirName := s"docs/alpakka/${if (isSnapshot.value) "snapshot" else version.value}",
-    Paradox / sourceDirectory := sourceDirectory.value / "main" / "paradox",
+    Paradox / sourceDirectory := sourceDirectory.value / "main",
     Paradox / paradoxProperties ++= Map(
       "project.url" -> "https://doc.akka.io/docs/alpakka/current/",
       "akka.version" -> Dependencies.AkkaVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,10 @@ addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.1.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.13")
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.3-2m")
+// has following PRs merged in:
+// * https://github.com/sbt/sbt-site/pull/141
+// * https://github.com/sbt/sbt-site/pull/139
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.2+24-b76fdbbe")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.1")
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.4")


### PR DESCRIPTION
## Purpose

Updates to the updates sbt-site, which correctly uses overriden `Paradox / sourceDirectory` for both `paradox` and `paradoxTheme` settings.