### PR TITLE
support confirm amqp flow, resolve #1132

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpConfirmFlowStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpConfirmFlowStage.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.amqp.impl
+
+import akka.Done
+import akka.stream._
+import akka.stream.alpakka.amqp.{AmqpWriteSettings, ConfirmMessage, WriteMessage}
+import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, InHandler, OutHandler}
+import com.rabbitmq.client.ConfirmListener
+
+import scala.collection.mutable
+import scala.concurrent.{Future, Promise}
+
+class AmqpConfirmFlowStage(settings: AmqpWriteSettings)
+    extends GraphStageWithMaterializedValue[FlowShape[WriteMessage, ConfirmMessage], Future[Done]] {
+
+  private val in = Inlet[WriteMessage]("AmqpConfirmFlow.in")
+  private val out = Outlet[ConfirmMessage]("AmqpConfirmFlow.out")
+
+  val shape: FlowShape[WriteMessage, ConfirmMessage] = FlowShape.of(in, out)
+
+  def createLogicAndMaterializedValue(attributes: Attributes): (GraphStageLogic, Future[Done]) = {
+    val promise = Promise[Done]()
+
+    val exchange = settings.exchange.getOrElse("")
+    val routingKey = settings.routingKey.getOrElse("")
+
+    (new AmqpConnectorLogic(shape, settings) {
+
+      private val buffer = mutable.Queue[ConfirmMessage]()
+
+      private val callback = getAsyncCallback[ConfirmMessage] { elem =>
+        if (isAvailable(out)) {
+          push(out, elem)
+          if (!hasBeenPulled(in)) {
+            pull(in)
+          }
+        } else {
+          buffer.enqueue(elem)
+        }
+      }
+
+      def whenConnected(): Unit = {
+        channel.confirmSelect()
+        channel.addConfirmListener(new ConfirmListener {
+          def handleAck(deliveryTag: Long, multiple: Boolean): Unit =
+            callback.invoke(ConfirmMessage.Ack(deliveryTag, multiple))
+
+          def handleNack(deliveryTag: Long, multiple: Boolean): Unit =
+            callback.invoke(ConfirmMessage.Nack(deliveryTag, multiple))
+        })
+      }
+
+      override def postStop(): Unit = {
+        promise.tryFailure(new RuntimeException("stage stopped unexpectedly"))
+        super.postStop()
+      }
+
+      override def onFailure(ex: Throwable): Unit = {
+        promise.tryFailure(ex)
+        super.onFailure(ex)
+      }
+
+      setHandler(
+        in,
+        new InHandler {
+          def onPush(): Unit = {
+            val elem = grab(in)
+            channel.basicPublish(
+              exchange,
+              elem.routingKey.getOrElse(routingKey),
+              elem.mandatory,
+              elem.immediate,
+              elem.properties.orNull,
+              elem.bytes.toArray
+            )
+          }
+
+          override def onUpstreamFailure(ex: Throwable): Unit = {
+            promise.tryFailure(ex)
+            super.onUpstreamFailure(ex)
+          }
+
+          override def onUpstreamFinish(): Unit = {
+            promise.trySuccess(Done)
+            super.onUpstreamFinish()
+          }
+        }
+      )
+
+      setHandler(
+        out,
+        new OutHandler {
+          def onPull(): Unit = {
+            while (buffer.nonEmpty && isAvailable(out)) {
+              push(out, buffer.dequeue())
+            }
+            if (buffer.isEmpty && !hasBeenPulled(in)) {
+              pull(in)
+            }
+          }
+        }
+      )
+
+    }, promise.future)
+  }
+
+}

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpConnectorLogic.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpConnectorLogic.scala
@@ -4,13 +4,15 @@
 
 package akka.stream.alpakka.amqp.impl
 
+import akka.stream.Shape
 import akka.stream.alpakka.amqp.{AmqpConnectorSettings, BindingDeclaration, ExchangeDeclaration, QueueDeclaration}
 import akka.stream.stage.{AsyncCallback, GraphStageLogic}
 import com.rabbitmq.client._
 
 import scala.util.control.NonFatal
 
-private trait AmqpConnectorLogic { this: GraphStageLogic =>
+private abstract class AmqpConnectorLogic(shape: Shape, settings: AmqpConnectorSettings)
+    extends GraphStageLogic(shape) {
 
   private var connection: Connection = _
   protected var channel: Channel = _
@@ -20,7 +22,6 @@ private trait AmqpConnectorLogic { this: GraphStageLogic =>
     override def shutdownCompleted(cause: ShutdownSignalException): Unit = shutdownCallback.invoke(cause)
   }
 
-  def settings: AmqpConnectorSettings
   def whenConnected(): Unit
   def onFailure(ex: Throwable): Unit = failStage(ex)
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpReplyToSinkStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpReplyToSinkStage.scala
@@ -30,8 +30,7 @@ private[amqp] final class AmqpReplyToSinkStage(settings: AmqpReplyToSinkSettings
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Done]) = {
     val promise = Promise[Done]()
-    (new GraphStageLogic(shape) with AmqpConnectorLogic {
-      override val settings = stage.settings
+    (new AmqpConnectorLogic(shape, settings) {
 
       override def whenConnected(): Unit = pull(in)
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpRpcFlowStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpRpcFlowStage.scala
@@ -41,9 +41,8 @@ private[amqp] final class AmqpRpcFlowStage(settings: AmqpWriteSettings, bufferSi
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[String]) = {
     val promise = Promise[String]()
-    (new GraphStageLogic(shape) with AmqpConnectorLogic {
+    (new AmqpConnectorLogic(shape, settings) {
 
-      override val settings = stage.settings
       private val exchange = settings.exchange.getOrElse("")
       private val routingKey = settings.routingKey.getOrElse("")
       private val queue = mutable.Queue[CommittableReadResult]()

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpSinkStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpSinkStage.scala
@@ -29,8 +29,8 @@ private[amqp] final class AmqpSinkStage(settings: AmqpWriteSettings)
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Done]) = {
     val promise = Promise[Done]()
-    (new GraphStageLogic(shape) with AmqpConnectorLogic {
-      override val settings = stage.settings
+    (new AmqpConnectorLogic(shape, settings) {
+
       private val exchange = settings.exchange.getOrElse("")
       private val routingKey = settings.routingKey.getOrElse("")
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpSourceStage.scala
@@ -41,9 +41,7 @@ private[amqp] final class AmqpSourceStage(settings: AmqpSourceSettings, bufferSi
   override protected def initialAttributes: Attributes = Attributes.name("AmqpSource")
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
-    new GraphStageLogic(shape) with AmqpConnectorLogic with StageLogging {
-
-      override val settings: AmqpSourceSettings = stage.settings
+    new AmqpConnectorLogic(shape, settings) with StageLogging {
 
       private val queue = mutable.Queue[CommittableReadResult]()
       private var ackRequired = true

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpConfirmFlow.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/javadsl/AmqpConfirmFlow.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.amqp.javadsl
+
+import java.util.concurrent.CompletionStage
+
+import akka.Done
+import akka.stream.alpakka.amqp._
+
+import scala.compat.java8.FutureConverters._
+
+object AmqpConfirmFlow {
+
+  /**
+   * Java API: Creates an [[AmqpConfirmFlow]] that accepts [[akka.stream.alpakka.amqp.WriteMessage WriteMessage]] elements
+   * and sends  [[akka.stream.alpakka.amqp.ConfirmMessage ConfirmMessage]] to the out
+   *
+   * This stage materializes to a CompletionStage<Done>, which can be used to know when the Sink completes, either normally
+   * or because of an amqp failure
+   */
+  def create(
+      settings: AmqpWriteSettings
+  ): akka.stream.javadsl.Flow[WriteMessage, ConfirmMessage, CompletionStage[Done]] =
+    akka.stream.alpakka.amqp.scaladsl.AmqpConfirmFlow(settings).mapMaterializedValue(_.toJava).asJava
+
+}

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/model.scala
@@ -82,3 +82,13 @@ object WriteMessage {
   def create(bytes: ByteString, immediate: Boolean, mandatory: Boolean): WriteMessage =
     WriteMessage(bytes, immediate, mandatory)
 }
+
+sealed trait ConfirmMessage
+
+object ConfirmMessage {
+
+  final case class Ack(deliveryTag: Long, multiple: Boolean) extends ConfirmMessage
+
+  final case class Nack(deliveryTag: Long, multiple: Boolean) extends ConfirmMessage
+
+}

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConfirmFlow.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConfirmFlow.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.amqp.scaladsl
+
+import akka.Done
+import akka.stream.alpakka.amqp.{AmqpWriteSettings, ConfirmMessage, WriteMessage}
+import akka.stream.alpakka.amqp.impl.AmqpConfirmFlowStage
+import akka.stream.scaladsl.Flow
+
+import scala.concurrent.Future
+
+object AmqpConfirmFlow {
+
+  /**
+   * Scala API:
+   *
+   * Connects to an AMQP server upon materialization and sends incoming messages to the server.
+   * The flow sends ConfirmMessage with ack or nack to the out port.
+   *
+   * This stage materializes to a Future[Done], which can be used to know when the Sink completes, either normally
+   * or because of an amqp failure
+   */
+  def apply(settings: AmqpWriteSettings): Flow[WriteMessage, ConfirmMessage, Future[Done]] =
+    Flow.fromGraph(new AmqpConfirmFlowStage(settings))
+
+}


### PR DESCRIPTION
Sorry, didn't notice already existing PR #1330, but did some things on my free time, wanted to share.
But the implementation is a little bit different, it uses confirm listener instead of waiting. I would prefer this option.

Feel free to share your thoughts about this draft.