### PR TITLE
Termination signal handling

### DIFF
--- a/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -207,8 +207,7 @@ public class MqttFlowTest {
                                 JavaConverters.asJavaCollectionConverter(subscribe.topicFilters())
                                     .asJavaCollection();
                             List<Integer> flags =
-                                topicFilters
-                                    .stream()
+                                topicFilters.stream()
                                     .map(x -> x._2().underlying())
                                     .collect(Collectors.toList());
                             queue.offer(


### PR DESCRIPTION
There were a couple of behaviours that were not handling the termination signal where it was possible to receive it. This PR fixes that.

I recommend reviewing without white space changes as the formatter wants to format.