### PR TITLE
mqtt-streaming: Various fixes

### DIFF
--- a/mqtt-streaming-bench/src/main/scala/akka/stream/alpakka/mqtt/MqttPerf.scala
+++ b/mqtt-streaming-bench/src/main/scala/akka/stream/alpakka/mqtt/MqttPerf.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.stream.alpakka.mqtt

--- a/mqtt-streaming-bench/src/main/scala/akka/stream/alpakka/mqtt/streaming/MqttPerf.scala
+++ b/mqtt-streaming-bench/src/main/scala/akka/stream/alpakka/mqtt/streaming/MqttPerf.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.stream.alpakka.mqtt.streaming
@@ -107,7 +107,7 @@ class MqttPerf {
       .fromGraph(clientSource)
       .via(
         Mqtt
-          .clientSessionFlow(clientSession)
+          .clientSessionFlow(clientSession, ByteString("1"))
           .join(Tcp().outgoingConnection(host, port))
       )
       .wireTap(Sink.foreach[Either[DecodeError, Event[_]]] {

--- a/mqtt-streaming/src/main/mima-filters/1.0-RC1.backwards.excludes
+++ b/mqtt-streaming/src/main/mima-filters/1.0-RC1.backwards.excludes
@@ -1,2 +1,10 @@
 # Allow changes to impl
 ProblemFilters.exclude[Problem]("akka.stream.alpakka.mqtt.streaming.impl.*")
+# PR #1595
+# https://github.com/akka/alpakka/pull/1595
+# private[streaming]
+ProblemFilters.exclude[MissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.scaladsl.MqttClientSession.commandFlow")
+ProblemFilters.exclude[MissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.scaladsl.ActorMqttClientSession.commandFlow")
+# private[streaming]
+ProblemFilters.exclude[MissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.scaladsl.MqttClientSession.eventFlow")
+ProblemFilters.exclude[MissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.scaladsl.ActorMqttClientSession.eventFlow")

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/MqttSessionSettings.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/MqttSessionSettings.scala
@@ -34,8 +34,8 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
                                          val eventParallelism: Int = 10,
                                          val receiveConnectTimeout: FiniteDuration = 5.minutes,
                                          val receiveConnAckTimeout: FiniteDuration = 30.seconds,
-                                         val producerPubAckRecTimeout: FiniteDuration = 15.seconds,
-                                         val producerPubCompTimeout: FiniteDuration = 15.seconds,
+                                         val producerPubAckRecTimeout: FiniteDuration = 0.seconds,
+                                         val producerPubCompTimeout: FiniteDuration = 0.seconds,
                                          val consumerPubAckRecTimeout: FiniteDuration = 30.seconds,
                                          val consumerPubCompTimeout: FiniteDuration = 30.seconds,
                                          val consumerPubRelTimeout: FiniteDuration = 30.seconds,
@@ -105,7 +105,7 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
 
   /**
    * For producers of PUBLISH, the amount of time to wait to ack/receive a QoS 1/2 publish before retrying with
-   * the DUP flag set. Defaults to 15 seconds.
+   * the DUP flag set. Defaults to 0 seconds, which means republishing only occurs on reconnect.
    */
   def withProducerPubAckRecTimeout(producerPubAckRecTimeout: FiniteDuration): MqttSessionSettings =
     copy(producerPubAckRecTimeout = producerPubAckRecTimeout)
@@ -114,14 +114,14 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
    * JAVA API
    *
    * For producers of PUBLISH, the amount of time to wait to ack/receive a QoS 1/2 publish before retrying with
-   * the DUP flag set. Defaults to 15 seconds.
+   * the DUP flag set. Defaults to 0 seconds, which means republishing only occurs on reconnect.
    */
   def withProducerPubAckRecTimeout(producerPubAckRecTimeout: Duration): MqttSessionSettings =
     copy(producerPubAckRecTimeout = producerPubAckRecTimeout.asScala)
 
   /**
    * For producers of PUBLISH, the amount of time to wait for a server to complete a QoS 2 publish before retrying
-   * with another PUBREL. Defaults to 15 seconds.
+   * with another PUBREL. Defaults to 0 seconds, which means republishing only occurs on reconnect.
    */
   def withProducerPubCompTimeout(producerPubCompTimeout: FiniteDuration): MqttSessionSettings =
     copy(producerPubCompTimeout = producerPubCompTimeout)
@@ -130,7 +130,7 @@ final class MqttSessionSettings private (val maxPacketSize: Int = 4096,
    * JAVA API
    *
    * For producers of PUBLISH, the amount of time to wait for a server to complete a QoS 2 publish before retrying
-   * with another PUBREL. Defaults to 15 seconds.
+   * with another PUBREL. Defaults to 0 seconds, which means republishing only occurs on reconnect.
    */
   def withProducerPubCompTimeout(producerPubCompTimeout: Duration): MqttSessionSettings =
     copy(producerPubCompTimeout = producerPubCompTimeout.asScala)

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -257,6 +257,10 @@ import scala.util.{Failure, Success}
               )
             )
           } else {
+            data.activeProducers.values.foreach { producer =>
+              producer ! Producer.ReceiveConnect
+            }
+
             serverConnect(
               ConnectReceived(
                 connectionId,
@@ -411,7 +415,8 @@ import scala.util.{Failure, Success}
               if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 =>
             local.success(Consumer.ForwardPublish)
             serverConnected(data, resetPingReqTimer = false)
-          case (context, prfr @ PublishReceivedFromRemote(_, publish @ Publish(_, topicName, Some(packetId), _), local)) =>
+          case (context,
+                prfr @ PublishReceivedFromRemote(_, publish @ Publish(_, topicName, Some(packetId), _), local)) =>
             data.activeConsumers.get(topicName) match {
               case None =>
                 val consumerName = ActorName.mkName(ConsumerNamePrefix + topicName + "-" + context.children.size)

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -390,6 +390,9 @@ import scala.util.{Failure, Success}
             data.stash.foreach(context.self.tell)
             timer.cancel(ReceiveConnAck)
 
+            data.activeProducers.values
+              .foreach(_ ! Producer.ReceiveConnect)
+
             clientConnected(
               ConnAckReplied(
                 data.connect,

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/javadsl/Mqtt.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/javadsl/Mqtt.scala
@@ -20,13 +20,33 @@ object Mqtt {
    * an MQTT server.
    *
    * @param session the client session to use
+   * @param connectionId a identifier to distinguish the client connection so that the session
+   *                     can route the incoming requests
    * @return the bidirectional flow
    */
+  def clientSessionFlow[A](
+      session: MqttClientSession,
+      connectionId: ByteString
+  ): BidiFlow[Command[A], ByteString, ByteString, DecodeErrorOrEvent[A], NotUsed] =
+    inputOutputConverter
+      .atop(scaladsl.Mqtt.clientSessionFlow[A](session.underlying, connectionId))
+      .asJava
+
+  /**
+   * Create a bidirectional flow that maintains client session state with an MQTT endpoint.
+   * The bidirectional flow can be joined with an endpoint flow that receives
+   * [[ByteString]] payloads and independently produces [[ByteString]] payloads e.g.
+   * an MQTT server.
+   *
+   * @param session the client session to use
+   * @return the bidirectional flow
+   */
+  @deprecated("Provide a connectionId instead", "1.0-RC21")
   def clientSessionFlow[A](
       session: MqttClientSession
   ): BidiFlow[Command[A], ByteString, ByteString, DecodeErrorOrEvent[A], NotUsed] =
     inputOutputConverter
-      .atop(scaladsl.Mqtt.clientSessionFlow[A](session.underlying))
+      .atop(scaladsl.Mqtt.clientSessionFlow[A](session.underlying, ByteString("0")))
       .asJava
 
   /**
@@ -36,6 +56,8 @@ object Mqtt {
    * an MQTT server.
    *
    * @param session the server session to use
+   * @param connectionId a identifier to distinguish the client connection so that the session
+   *                     can route the incoming requests
    * @return the bidirectional flow
    */
   def serverSessionFlow[A](

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -152,7 +152,7 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
 
   private val pingReqBytes = PingReq.encode(ByteString.newBuilder).result()
 
-  override def commandFlow[A](connectionId: ByteString): CommandFlow[A] =
+  private[streaming] override def commandFlow[A](connectionId: ByteString): CommandFlow[A] =
     Flow
       .lazyInitAsync { () =>
         val killSwitch = KillSwitches.shared("command-kill-switch-" + clientSessionId)
@@ -249,7 +249,7 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
       }
       .mapMaterializedValue(_ => NotUsed)
 
-  override def eventFlow[A](connectionId: ByteString): EventFlow[A] =
+  private[streaming] override def eventFlow[A](connectionId: ByteString): EventFlow[A] =
     Flow[ByteString]
       .watch(clientConnector.toUntyped)
       .watchTermination() {

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -263,7 +263,6 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
       }
       .via(new MqttFrameStage(settings.maxPacketSize))
       .map(_.iterator.decodeControlPacket(settings.maxPacketSize))
-      .async
       .log("client-events")
       .mapAsync[Either[MqttCodec.DecodeError, Event[A]]](settings.eventParallelism) {
         case Right(cp: ConnAck) =>

--- a/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -107,7 +107,7 @@ public class MqttFlowTest {
         Tcp.get(system).outgoingConnection("localhost", 1883);
 
     Flow<Command<Object>, DecodeErrorOrEvent<Object>, NotUsed> mqttFlow =
-        Mqtt.clientSessionFlow(session).join(connection);
+        Mqtt.clientSessionFlow(session, ByteString.fromString("1")).join(connection);
     // #create-streaming-flow
 
     // #run-streaming-flow
@@ -247,7 +247,7 @@ public class MqttFlowTest {
     MqttClientSession clientSession = new ActorMqttClientSession(settings, materializer, system);
 
     Flow<Command<Object>, DecodeErrorOrEvent<Object>, NotUsed> mqttFlow =
-        Mqtt.clientSessionFlow(clientSession).join(connection);
+        Mqtt.clientSessionFlow(clientSession, ByteString.fromString("1")).join(connection);
 
     Pair<SourceQueueWithComplete<Command<Object>>, CompletionStage<Publish>> run =
         Source.<Command<Object>>queue(3, OverflowStrategy.fail())

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -47,7 +47,7 @@ class MqttFlowSpec
 
       val mqttFlow: Flow[Command[Nothing], Either[MqttCodec.DecodeError, Event[Nothing]], NotUsed] =
         Mqtt
-          .clientSessionFlow(session)
+          .clientSessionFlow(session, ByteString("1"))
           .join(connection)
       //#create-streaming-flow
 
@@ -143,7 +143,7 @@ class MqttFlowSpec
 
       val clientSession = ActorMqttClientSession(settings)
       val connection = Tcp().outgoingConnection(host, port)
-      val mqttFlow = Mqtt.clientSessionFlow(clientSession).join(connection)
+      val mqttFlow = Mqtt.clientSessionFlow(clientSession, ByteString("1")).join(connection)
       val (commands, events) =
         Source
           .queue(2, OverflowStrategy.fail)


### PR DESCRIPTION
A number of commits here that improve the resilience of the mqtt-streaming connector. #1577 remains important as well, but will require an Akka release.

##### mqtt-streaming: Require a connection id to be specified for client flows 

This allows the MQTT session to better track which events are relevant, given that there can be races when old connections are torn down and new ones are established.

##### mqtt-streaming: Fix a bug where actor state was closed over 

This could cause duplicate publications to never be sent to new connections

##### mqtt-streaming: Republish messages on reconnect only by default 

Previously, messages for QoS1/2 were only republished on an interval after not receiving an ack.

It is more conventional to instead republish everything only on connect, and indeed to be compliant for MQTT 5, that is the only time this is allowed.

To accommodate this, the timeouts default to 0, but the previous behavior can still be restored by changing the default producer timeout settings.
