### PR TITLE
FTP: fix default sftp overwrite behaviour

### DIFF
--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
@@ -104,7 +104,7 @@ private[ftp] trait SftpOperations { _: FtpLike[SSHClient, SftpSettings] =>
 
   def storeFileOutputStream(name: String, handler: Handler, append: Boolean): Try[OutputStream] = Try {
     import OpenMode._
-    val openModes = Set(WRITE, CREAT) ++ (if (append) Set(APPEND) else Set())
+    val openModes = Set(WRITE, CREAT) ++ (if (append) Set(APPEND) else Set(TRUNC))
     val remoteFile = handler.open(name, openModes.asJava)
     val os = new remoteFile.RemoteFileOutputStream() {
 

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
@@ -86,7 +86,7 @@ private[ftp] trait SftpOperations { _: FtpLike[SSHClient, SftpSettings] =>
   def listFiles(handler: Handler): immutable.Seq[FtpFile] = listFiles(".", handler)
 
   def retrieveFileInputStream(name: String, handler: Handler): Try[InputStream] = Try {
-    val remoteFile = handler.open(name, Set(OpenMode.READ).asJava)
+    val remoteFile = handler.open(name, java.util.EnumSet.of(OpenMode.READ))
     val is = new remoteFile.RemoteFileInputStream() {
 
       override def close(): Unit =
@@ -104,8 +104,9 @@ private[ftp] trait SftpOperations { _: FtpLike[SSHClient, SftpSettings] =>
 
   def storeFileOutputStream(name: String, handler: Handler, append: Boolean): Try[OutputStream] = Try {
     import OpenMode._
-    val openModes = Set(WRITE, CREAT) ++ (if (append) Set(APPEND) else Set(TRUNC))
-    val remoteFile = handler.open(name, openModes.asJava)
+    val openModes =
+      if (append) java.util.EnumSet.of(WRITE, CREAT, APPEND) else java.util.EnumSet.of(WRITE, CREAT, TRUNC)
+    val remoteFile = handler.open(name, openModes)
     val os = new remoteFile.RemoteFileOutputStream() {
 
       override def close(): Unit = {


### PR DESCRIPTION
## Fixes

Fixes #1599 

## Purpose

Add missing `TRUNC` mode if `append` is false.
It should overwrite file if exists.
 