### PR TITLE
Fix more links to API docs

### DIFF
--- a/docs/src/main/paradox/examples/mqtt-samples.md
+++ b/docs/src/main/paradox/examples/mqtt-samples.md
@@ -18,7 +18,7 @@ Java
 ### Restarting of the source
 
 The MQTT source gets wrapped by a `RestartSource` to mitigate the 
-@ref:[Paho initial connections problem](../mqtt.md#setup).
+@ref:[Paho initial connections problem](../mqtt.md#settings).
 
 Java
 : @@snip [snip](/doc-examples/src/main/java/mqtt/javasamples/MqttGroupedWithin.java) { #restarting }

--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -30,14 +30,14 @@ Scala
 Java
 : @@snip [snip](/ftp/src/test/java/docs/javadsl/FtpWritingTest.java) { #create-settings }
 
-The configuration above will create an anonymous connection with a remote FTP server in passive mode. For both FTPs and SFTP servers, you will need to provide the specialized versions of these settings: @scaladoc[FtpsSettings](akka.stream.alpakka.ftp.RemoteFileSettings$$FtpsSettings) or @scaladoc[SftpSettings](akka.stream.alpakka.ftp.RemoteFileSettings$$SftpSettings)
+The configuration above will create an anonymous connection with a remote FTP server in passive mode. For both FTPs and SFTP servers, you will need to provide the specialized versions of these settings: @scaladoc[FtpsSettings](akka.stream.alpakka.ftp.FtpsSettings) or @scaladoc[SftpSettings](akka.stream.alpakka.ftp.SftpSettings)
 respectively.
 
 The example demonstrates optional use of `configureConnection` option available on FTP and FTPs clients. Use it to configure any custom parameters the server may require, such as explicit or implicit data transfer encryption.
 
 For non-anonymous connection, please provide an instance of @scaladoc[NonAnonFtpCredentials](akka.stream.alpakka.ftp.FtpCredentials$$NonAnonFtpCredentials) instead.
 
-For connection using a private key, please provide an instance of @scaladoc[SftpIdentity](akka.stream.alpakka.ftp.SftpIdentity) to @scaladoc[SftpSettings](akka.stream.alpakka.ftp.RemoteFileSettings$$SftpSettings).
+For connection using a private key, please provide an instance of @scaladoc[SftpIdentity](akka.stream.alpakka.ftp.SftpIdentity) to @scaladoc[SftpSettings](akka.stream.alpakka.ftp.SftpSettings).
 
 In order to use a custom SSH client for SFTP please provide an instance of @scaladoc[SSHClient](net.schmizz.sshj.SSHClient).
 

--- a/docs/src/main/paradox/google-fcm.md
+++ b/docs/src/main/paradox/google-fcm.md
@@ -53,7 +53,7 @@ Java
 : @@snip [snip](/google-fcm/src/test/java/docs/javadsl/FcmExamples.java) { #imports #asFlow-send }
 
 With this type of send you can get responses from the server.
-These responses can be @scaladoc[`FcmSuccessResponse`](akka.stream.alpakka.google.firebase.fcm.FcmFlowModels.FcmSuccessResponse) or @scaladoc[`FcmErrorResponse`](akka.stream.alpakka.google.firebase.fcm.FcmFlowModels.FcmErrorResponse). 
+These responses can be @scaladoc[`FcmSuccessResponse`](akka.stream.alpakka.google.firebase.fcm.FcmSuccessResponse) or @scaladoc[`FcmErrorResponse`](akka.stream.alpakka.google.firebase.fcm.FcmErrorResponse). 
 You can choose what you want to do with this information, but keep in mind
 if you try to resend the failed messages you will need to use exponential backoff! (see [Akka docs `RestartFlow.onFailuresWithBackoff`](https://doc.akka.io/docs/akka/current/stream/operators/RestartFlow/onFailuresWithBackoff.html))
 

--- a/docs/src/main/paradox/release-notes/1.0-M2.md
+++ b/docs/src/main/paradox/release-notes/1.0-M2.md
@@ -65,7 +65,7 @@ New API frees the factory methods from these dependencies.
 All of the required resources are injected during the materialization time.
 
 If you are loading `S3Settings` from the `application.conf` then migration should be done by changing all method calls on `s3Client` instance to method calls on the @scala[@scaladoc[S3](akka.stream.alpakka.s3.scaladsl.S3$)]@java[@scaladoc[S3](akka.stream.alpakka.s3.javadsl.S3$)] factory.
-If you were using multiple `s3Client` instances with different configurations, then take a look at the new @ref:[documentation section](../s3.md#changing-s3-settings-for-part-of-the-stream) about how to use `S3Attributes` to apply different `S3Settings` to different parts of the same Akka Stream graph.
+If you were using multiple `s3Client` instances with different configurations, then take a look at the new @ref:[documentation section](../s3.md#apply-s3-settings-to-a-part-of-the-stream) about how to use `S3Attributes` to apply different `S3Settings` to different parts of the same Akka Stream graph.
 
 The configuration path has been shortened from `akka.stream.alpakka.s3` to `alpakka.s3`.
 Please update your `application.conf` files accordingly.


### PR DESCRIPTION
Fix links into API that has moved and some anchors that changed.
