### PR TITLE
AWS S3: put an upper limit on upload chunks

### DIFF
--- a/s3/src/main/mima-filters/1.0.x.backwards.excludes
+++ b/s3/src/main/mima-filters/1.0.x.backwards.excludes
@@ -1,0 +1,2 @@
+# Allow changes to impl
+ProblemFilters.exclude[Problem]("akka.stream.alpakka.s3.impl.*")

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/SplitAfterSize.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/SplitAfterSize.scala
@@ -17,35 +17,53 @@ import akka.stream.stage.OutHandler
 import akka.stream.stage.InHandler
 import akka.stream.scaladsl.Flow
 
+import scala.annotation.tailrec
+
 /**
  * Internal Api
  *
  * Splits up a byte stream source into sub-flows of a minimum size. Does not attempt to create chunks of an exact size.
  */
 @InternalApi private[impl] object SplitAfterSize {
-  def apply[I, M](minChunkSize: Long)(in: Flow[I, ByteString, M]): SubFlow[ByteString, M, in.Repr, in.Closed] =
-    in.via(insertMarkers(minChunkSize)).splitWhen(_ == NewStream).collect { case bs: ByteString => bs }
+  def apply[I, M](minChunkSize: Int,
+                  maxChunkSize: Int)(in: Flow[I, ByteString, M]): SubFlow[ByteString, M, in.Repr, in.Closed] = {
+    require(minChunkSize < maxChunkSize, "the min chunk size must be smaller than the max chunk size")
+    in.via(insertMarkers(minChunkSize, maxChunkSize)).splitWhen(_ == NewStream).collect { case bs: ByteString => bs }
+  }
 
   private case object NewStream
 
-  private def insertMarkers(minChunkSize: Long) = new GraphStage[FlowShape[ByteString, Any]] {
+  private def insertMarkers(minChunkSize: Long, maxChunkSize: Int) = new GraphStage[FlowShape[ByteString, Any]] {
     val in = Inlet[ByteString]("SplitAfterSize.in")
     val out = Outlet[Any]("SplitAfterSize.out")
     override val shape = FlowShape.of(in, out)
 
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
       new GraphStageLogic(shape) with OutHandler with InHandler {
-        var count: Long = 0
+        var count: Int = 0
         override def onPull(): Unit = pull(in)
 
         override def onPush(): Unit = {
           val elem = grab(in)
           count += elem.size
-          if (count >= minChunkSize) {
+          if (count > maxChunkSize) {
+            splitElement(elem, elem.size - (count - maxChunkSize))
+          } else if (count >= minChunkSize) {
             count = 0
             emitMultiple(out, elem :: NewStream :: Nil)
           } else emit(out, elem)
         }
+
+        @tailrec private def splitElement(elem: ByteString, splitPos: Int): Unit =
+          if (elem.size > splitPos) {
+            val (part1, rest) = elem.splitAt(splitPos)
+            emitMultiple(out, part1 :: NewStream :: Nil)
+            splitElement(rest, maxChunkSize)
+          } else {
+            count = elem.size
+            emit(out, elem)
+          }
+
         setHandlers(in, out, this)
       }
   }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/SplitAfterSizeSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/SplitAfterSizeSpec.scala
@@ -7,11 +7,12 @@ package akka.stream.alpakka.s3.impl
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
+import scala.concurrent.duration._
 
 class SplitAfterSizeSpec(_system: ActorSystem)
     extends TestKit(_system)
@@ -21,25 +22,28 @@ class SplitAfterSizeSpec(_system: ActorSystem)
     with ScalaFutures {
 
   def this() = this(ActorSystem("SplitAfterSizeSpec"))
-  implicit val defaultPatience =
-    PatienceConfig(timeout = Span(5, Seconds), interval = Span(30, Millis))
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(1.seconds, 5.millis)
 
   implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system).withDebugLogging(true))
 
-  "SplitAfterSize" should "yield a single empty substream on no input" in {
+  final val MaxChunkSize = 1024
+  "SplitAfterSize" should "yield a single empty substream on no input" in assertAllStagesStopped {
     Source
       .empty[ByteString]
       .via(
-        SplitAfterSize(10)(Flow[ByteString]).concatSubstreams
+        SplitAfterSize(10, MaxChunkSize)(Flow[ByteString]).concatSubstreams
       )
       .runWith(Sink.seq)
       .futureValue should be(Seq.empty)
   }
 
-  it should "start a new stream after the element that makes it reach a maximum, but not split the element itself" in {
+  it should "start a new stream after the element that makes it reach a maximum, but not split the element itself" in assertAllStagesStopped {
     Source(Vector(ByteString(1, 2, 3, 4, 5), ByteString(6, 7, 8, 9, 10, 11, 12), ByteString(13, 14)))
       .via(
-        SplitAfterSize(10)(Flow[ByteString]).prefixAndTail(10).map { case (prefix, tail) => prefix }.concatSubstreams
+        SplitAfterSize(10, MaxChunkSize)(Flow[ByteString])
+          .prefixAndTail(10)
+          .map { case (prefix, tail) => prefix }
+          .concatSubstreams
       )
       .runWith(Sink.seq)
       .futureValue should be(
@@ -49,5 +53,76 @@ class SplitAfterSizeSpec(_system: ActorSystem)
       )
     )
   }
+
+  it should "split large elements" in assertAllStagesStopped {
+    Source(Vector(ByteString(bytes(1, 16)), ByteString(17, 18)))
+      .via(
+        SplitAfterSize(10, maxChunkSize = 15)(Flow[ByteString])
+          .prefixAndTail(10)
+          .map { case (prefix, tail) => prefix }
+          .concatSubstreams
+      )
+      .runWith(Sink.seq)
+      .futureValue should be(
+      Seq(
+        Seq(ByteString(bytes(1, 15))),
+        Seq(ByteString(16), ByteString(17, 18))
+      )
+    )
+  }
+
+  it should "split large elements following a smaller element" in assertAllStagesStopped {
+    Source(Vector(ByteString(101, 102), ByteString(bytes(1, 16)), ByteString(17, 18)))
+      .via(
+        SplitAfterSize(10, maxChunkSize = 15)(Flow[ByteString])
+          .prefixAndTail(10)
+          .map { case (prefix, tail) => prefix }
+          .concatSubstreams
+      )
+      .runWith(Sink.seq)
+      .futureValue should be(
+      Seq(
+        Seq(ByteString(101, 102), ByteString(bytes(1, 13))),
+        Seq(ByteString(14, 15, 16), ByteString(17, 18))
+      )
+    )
+  }
+
+  it should "split large elements multiple times" in assertAllStagesStopped {
+    Source(Vector(ByteString(bytes(1, 32)), ByteString(1, 2)))
+      .via(
+        SplitAfterSize(10, maxChunkSize = 15)(Flow[ByteString])
+          .prefixAndTail(10)
+          .map { case (prefix, tail) => prefix }
+          .concatSubstreams
+      )
+      .runWith(Sink.seq)
+      .futureValue should be(
+      Seq(
+        Seq(ByteString(bytes(1, 15))),
+        Seq(ByteString(bytes(16, 30))),
+        Seq(ByteString(31, 32), ByteString(1, 2))
+      )
+    )
+  }
+
+  it should "split large elements that would overflow the max chunk size" in assertAllStagesStopped {
+    Source(Vector(ByteString(1, 2, 3, 4), ByteString(bytes(5, 16)), ByteString(17, 18)))
+      .via(
+        SplitAfterSize(10, maxChunkSize = 15)(Flow[ByteString])
+          .prefixAndTail(10)
+          .map { case (prefix, tail) => prefix }
+          .concatSubstreams
+      )
+      .runWith(Sink.seq)
+      .futureValue should be(
+      Seq(
+        Seq(ByteString(1, 2, 3, 4), ByteString(5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)),
+        Seq(ByteString(16), ByteString(17, 18))
+      )
+    )
+  }
+
+  def bytes(start: Byte, end: Byte): Array[Byte] = (start to end).map(_.toByte).toArray[Byte]
 
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -13,7 +13,6 @@ import akka.util.ByteString
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest._
 
 import scala.concurrent.{Await, Future}
@@ -29,8 +28,7 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
   implicit val materializer = ActorMaterializer()
   implicit val ec = materializer.executionContext
 
-  implicit val defaultPatience =
-    PatienceConfig(timeout = Span(5, Seconds), interval = Span(30, Millis))
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(90.seconds, 30.millis)
 
   val defaultRegionBucket = "my-test-us-east-1"
 
@@ -167,6 +165,21 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
   it should "delete with real credentials" in {
     val delete = S3.deleteObject(defaultRegionBucket, objectKey).runWith(Sink.head)
     delete.futureValue shouldEqual akka.Done
+  }
+
+  it should "upload huge multipart with real credentials" in {
+    val objectKey = "huge"
+    val hugeString = "0123456789abcdef" * 64 * 1024 * 11
+    val result =
+      Source
+        .single(ByteString(hugeString))
+        .runWith(
+          S3.multipartUpload(defaultRegionBucket, objectKey, metaHeaders = MetaHeaders(metaHeaders))
+        )
+
+    val multipartUploadResult = result.futureValue
+    multipartUploadResult.bucket shouldBe defaultRegionBucket
+    multipartUploadResult.key shouldBe objectKey
   }
 
   it should "upload, download and delete with spaces in the key" in {


### PR DESCRIPTION
## Fixes

Fixes #980 

## Purpose

Split data streams to be uploaded to S3 if the chunk size would exceed the limit of 10 MB.

## Background Context

AWS S3 has a lower and an upper size limit for chunks when uploading data. The lower limit of 5 MB is described in http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html
The upper limit is 10 MB.