### PR TITLE
SQS: try different timing for better test stability

### DIFF
--- a/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
@@ -56,15 +56,13 @@ public class SqsSourceTest extends BaseSqsTest {
                 .collect(Collectors.toList()))
         .get();
 
-    Thread.sleep(1000); // to let messages arrive (even on Travis)
-
     final CompletionStage<List<Message>> cs =
         // #run
         SqsSource.create(
                 queueUrl,
                 SqsSourceSettings.create()
                     .withCloseOnEmptyReceive(true)
-                    .withWaitTime(Duration.ofSeconds(0)),
+                    .withWaitTime(Duration.ofMillis(10)),
                 sqsClient)
             .runWith(Sink.seq(), materializer);
     // #run

--- a/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
@@ -56,6 +56,8 @@ public class SqsSourceTest extends BaseSqsTest {
                 .collect(Collectors.toList()))
         .get();
 
+    Thread.sleep(1000) // to let messages arrive (even on Travis)
+
     final CompletionStage<List<Message>> cs =
         // #run
         SqsSource.create(

--- a/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
@@ -56,7 +56,7 @@ public class SqsSourceTest extends BaseSqsTest {
                 .collect(Collectors.toList()))
         .get();
 
-    Thread.sleep(1000) // to let messages arrive (even on Travis)
+    Thread.sleep(1000); // to let messages arrive (even on Travis)
 
     final CompletionStage<List<Message>> cs =
         // #run

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -207,13 +207,11 @@ class SqsSourceSpec extends FlatSpec with ScalaFutures with Matchers with Defaul
 
     input.foreach(m => sqsClient.sendMessage(m).get())
 
-    Thread.sleep(1000) // to let messages arrive (even on Travis)
-
     val future =
       //#run
       SqsSource(
         queueUrl,
-        SqsSourceSettings().withCloseOnEmptyReceive(true).withWaitTime(0.second)
+        SqsSourceSettings().withCloseOnEmptyReceive(true).withWaitTime(10.millis)
       ).runWith(Sink.seq)
     //#run
 

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -207,6 +207,8 @@ class SqsSourceSpec extends FlatSpec with ScalaFutures with Matchers with Defaul
 
     input.foreach(m => sqsClient.sendMessage(m).get())
 
+    Thread.sleep(1000) // to let messages arrive (even on Travis)
+
     val future =
       //#run
       SqsSource(
@@ -245,7 +247,7 @@ class SqsSourceSpec extends FlatSpec with ScalaFutures with Matchers with Defaul
 
     sqsClient.sendMessage(sendMessageRequest).get()
 
-    val future = SqsSource(queueUrl, sqsSourceSettings.withVisibilityTimeout(5.seconds))
+    val future = SqsSource(queueUrl, sqsSourceSettings.withVisibilityTimeout(10.seconds))
       .takeWithin(500.milliseconds)
       .runWith(Sink.seq)
 


### PR DESCRIPTION
## Purpose

Trying to improve SQS tests on Travis with different timing.

## Background Context

SQS tests have been failing quite a lot recently, possibly because the timings have changed with the update to AWS client 2.0.