### PR TITLE
Mqtt streaming: Discontinue Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -201,8 +201,14 @@ lazy val mongodb =
 
 lazy val mqtt = alpakkaProject("mqtt", "mqtt", Dependencies.Mqtt)
 
-lazy val mqttStreaming = alpakkaProject("mqtt-streaming", "mqttStreaming", Dependencies.MqttStreaming)
-lazy val mqttStreamingBench = alpakkaProject("mqtt-streaming-bench", "mqttStreamingBench", publish / skip := true)
+lazy val mqttStreaming = alpakkaProject("mqtt-streaming",
+                                        "mqttStreaming",
+                                        Dependencies.MqttStreaming,
+                                        crossScalaVersions -= Dependencies.Scala211)
+lazy val mqttStreamingBench = alpakkaProject("mqtt-streaming-bench",
+                                             "mqttStreamingBench",
+                                             publish / skip := true,
+                                             crossScalaVersions -= Dependencies.Scala211)
   .enablePlugins(JmhPlugin)
   .disablePlugins(BintrayPlugin, MimaPlugin)
   .dependsOn(mqtt, mqttStreaming)

--- a/docs/src/main/paradox/release-notes/1.0.x/mqtt-streaming.md
+++ b/docs/src/main/paradox/release-notes/1.0.x/mqtt-streaming.md
@@ -34,7 +34,9 @@
 
 * mqtt-streaming: Prefer wrapping instead of reissuing packet ids [#1489](https://github.com/akka/alpakka/pull/1489)  
 
-* Parallel subscriptions/unsubscriptions and SubAck notifications [#1480](https://github.com/akka/alpakka/pull/1480)  
+* Parallel subscriptions/unsubscriptions and SubAck notifications [#1480](https://github.com/akka/alpakka/pull/1480)
+
+* Only publish for Scala 2.12 and 2.13 [#1613](https://github.com/akka/alpakka/issues/1631)  
 
 [*closed in 1.0.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.0.0+label%3Ap%3Amqtt-streaming)
 [*closed in 1.0-RC1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.0-RC1+label%3Ap%3Amqtt-streaming)


### PR DESCRIPTION
## Purpose

Remove Scala 2.11 from cross Scala versions for MQTT streaming.

## Background Context

As MQTT streaming is built on top of Akka Typed which is not published for Scala 2.11 anymore, Alpakka won't publish Scala 2.11 artifacts for this anymore.
