### PR TITLE
Google Cloud Pub/Sub gRPC: upgrade to google-auth-library-oauth2-http

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -187,7 +187,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
       "com.google.api.grpc" % "grpc-google-cloud-pubsub-v1" % "0.12.0" % "protobuf", // ApacheV2
       "io.grpc" % "grpc-auth" % "1.16.1", // ApacheV2
-      "com.google.auth" % "google-auth-library-oauth2-http" % "0.10.0" // BSD 3-clause
+      "com.google.auth" % "google-auth-library-oauth2-http" % "0.15.0" // BSD 3-clause
     ) ++ Silencer
   )
 


### PR DESCRIPTION
## Purpose

Upgrade to the latest google-auth-library-oauth2-http version 0.15.0 as the former version pulled in very old other libraries.
