### PR TITLE
Ignore the latest guava android from the dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val alpakka = project
     ScalaUnidoc / unidoc / fullClasspath := {
       (ScalaUnidoc / unidoc / fullClasspath).value
         .filterNot(_.data.getAbsolutePath.contains("protobuf-java-2.5.0.jar"))
-        .filterNot(_.data.getAbsolutePath.contains("guava-26.0-android.jar"))
+        .filterNot(_.data.getAbsolutePath.contains("guava-27.1-android.jar"))
     },
     ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(`doc-examples`),
     crossScalaVersions := List() // workaround for https://github.com/sbt/sbt/issues/3465


### PR DESCRIPTION
## Fixes

Fixed failure from https://travis-ci.com/akka/alpakka/jobs/190295310

## Purpose

Different connectors depend on different guava libraries. When all of the connector dependencies are pulled together, as it is done by unidoc, some of them get into binary incompatibilities. This change filters out the guava library that is causing incompatibility.