### PR TITLE
AWS  S3 - forward proxy support

### DIFF
--- a/s3/src/main/mima-filters/1.0.0.backwards.excludes
+++ b/s3/src/main/mima-filters/1.0.0.backwards.excludes
@@ -1,0 +1,3 @@
+# Forward proxy support https://github.com/akka/alpakka/pull/1639
+# constructor is private
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.alpakka.s3.S3Settings.this")

--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -5,6 +5,8 @@ alpakka.s3 {
   # location for temporary files, if buffer is set to "disk". If empty, uses the standard java temp path.
   disk-buffer-path = ""
 
+  # DEPRECATED since Alpakka 1.0.1
+  # Please use alpakka.s3.endpoint-url for setting custom scheme, host and port.
   proxy {
     # hostname of the proxy. If undefined ("") proxy is not enabled.
     host = ""
@@ -13,6 +15,16 @@ alpakka.s3 {
     # if "secure" is set to "true" then HTTPS will be used for all requests to S3, otherwise HTTP will be used
     secure = true
   }
+
+  # An address of a proxy that will be used for all connections using HTTP CONNECT tunnel.
+  # forward-proxy {
+  #   host = "proxy"
+  #   port = 8080
+  #   credentials {
+  #     username = "username"
+  #     password = "password"
+  #   }
+  # }
 
   # default values for AWS configuration
   aws {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -158,7 +158,8 @@ import scala.concurrent.{ExecutionContext, Future}
 
   @throws(classOf[IllegalUriException])
   private[this] def requestAuthority(bucket: String, region: String)(implicit conf: S3Settings): Authority =
-    conf.proxy match {
+    conf.endpointUrl match {
+      case Some(endpointUrl) => Uri(endpointUrl).authority
       case None =>
         if (!conf.pathStyleAccess) {
           val bucketRegex = "[^a-z0-9\\-\\.]{1,255}|[\\.]{2,}".r
@@ -167,16 +168,14 @@ import scala.concurrent.{ExecutionContext, Future}
               throw IllegalUriException(
                 "Bucket name contains non-LDH characters",
                 s"""The following character is not allowed: $illegalCharacter
-                   | This may be solved by setting alpakka.s3.path-style-access to true in the configuration.
+                       | This may be solved by setting alpakka.s3.path-style-access to true in the configuration.
                  """.stripMargin
               )
             case None => ()
           }
         }
-        (region, conf.endpointUrl) match {
-          case (_, Some(endpointUrl)) =>
-            Uri(endpointUrl).authority
-          case ("us-east-1", _) =>
+        region match {
+          case "us-east-1" =>
             if (conf.pathStyleAccess) {
               Authority(Uri.Host("s3.amazonaws.com"))
             } else {
@@ -189,7 +188,6 @@ import scala.concurrent.{ExecutionContext, Future}
               Authority(Uri.Host(s"$bucket.s3-$region.amazonaws.com"))
             }
         }
-      case Some(proxy) => Authority(Uri.Host(proxy.host))
     }
 
   private[this] def requestUri(bucket: String, key: Option[String])(implicit conf: S3Settings): Uri = {
@@ -202,15 +200,13 @@ import scala.concurrent.{ExecutionContext, Future}
       someKey.split("/").foldLeft(basePath)((acc, p) => acc / p)
     }
     val uri = Uri(path = path, authority = requestAuthority(bucket, conf.s3RegionProvider.getRegion))
+      .withHost(requestAuthority(bucket, conf.s3RegionProvider.getRegion).host)
 
-    (conf.proxy, conf.endpointUrl) match {
-      case (_, Some(endpointUri)) =>
-        uri
-          .withScheme(Uri(endpointUri).scheme)
-          .withHost(requestAuthority(bucket, conf.s3RegionProvider.getRegion).host)
-      case (None, _) =>
-        uri.withScheme("https").withHost(requestAuthority(bucket, conf.s3RegionProvider.getRegion).host)
-      case (Some(proxy), _) => uri.withPort(proxy.port).withScheme(proxy.scheme).withHost(proxy.host)
+    conf.endpointUrl match {
+      case Some(endpointUri) =>
+        uri.withScheme(Uri(endpointUri).scheme)
+      case None =>
+        uri.withScheme("https")
     }
   }
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -747,7 +747,7 @@ import akka.util.ByteString
       implicit val settings = resolveSettings()
 
       requests
-        .via(superPool[MultipartCopy](settings, sys))
+        .via(superPool[MultipartCopy])
         .map {
           case (Success(r), multipartCopy) =>
             val entity = r.entity

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -13,7 +13,7 @@ import akka.http.scaladsl.model.headers.{ByteRange, RawHeader}
 import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.s3.headers.{CannedAcl, ServerSideEncryption, StorageClass}
-import akka.stream.alpakka.s3.{ApiVersion, BufferType, MemoryBufferType, MetaHeaders, Proxy, S3Headers, S3Settings}
+import akka.stream.alpakka.s3.{ApiVersion, BufferType, MemoryBufferType, MetaHeaders, S3Headers, S3Settings}
 import akka.stream.scaladsl.Source
 import akka.testkit.{SocketUtil, TestProbe}
 import com.amazonaws.auth.{AWSCredentialsProvider, AWSStaticCredentialsProvider, AnonymousAWSCredentials}
@@ -26,25 +26,15 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   // test fixtures
   def getSettings(
       bufferType: BufferType = MemoryBufferType,
-      proxy: Option[Proxy] = None,
       awsCredentials: AWSCredentialsProvider = new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()),
       s3Region: String = "us-east-1",
-      pathStyleAccess: Boolean = false,
-      endpointUrl: Option[String] = None,
       listBucketApiVersion: ApiVersion = ApiVersion.ListBucketVersion2
   ) = {
     val regionProvider = new AwsRegionProvider {
       def getRegion = s3Region
     }
 
-    S3Settings(bufferType,
-               proxy,
-               awsCredentials,
-               regionProvider,
-               pathStyleAccess,
-               endpointUrl,
-               listBucketApiVersion,
-               None)
+    S3Settings(bufferType, awsCredentials, regionProvider, listBucketApiVersion)
   }
 
   val location = S3Location("bucket", "image-1024@2x")
@@ -94,7 +84,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "throw an error if path-style access is false and the bucket name contains non-LDH characters" in {
-    implicit val settings = getSettings(s3Region = "eu-west-1", pathStyleAccess = false)
+    implicit val settings = getSettings(s3Region = "eu-west-1").withPathStyleAccess(false)
 
     assertThrows[IllegalUriException](
       HttpRequests.getDownloadRequest(S3Location("invalid_bucket_name", "image-1024@2x"))
@@ -102,7 +92,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "initiate multipart upload with path-style access in region us-east-1" in {
-    implicit val settings = getSettings(s3Region = "us-east-1", pathStyleAccess = true)
+    implicit val settings = getSettings(s3Region = "us-east-1").withPathStyleAccess(true)
 
     val req =
       HttpRequests.initiateMultipartUploadRequest(
@@ -116,7 +106,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "support download requests with path-style access in region us-east-1" in {
-    implicit val settings = getSettings(s3Region = "us-east-1", pathStyleAccess = true)
+    implicit val settings = getSettings(s3Region = "us-east-1").withPathStyleAccess(true)
 
     val req = HttpRequests.getDownloadRequest(location)
 
@@ -126,7 +116,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "initiate multipart upload with path-style access in other regions" in {
-    implicit val settings = getSettings(s3Region = "us-west-2", pathStyleAccess = true)
+    implicit val settings = getSettings(s3Region = "us-west-2").withPathStyleAccess(true)
 
     val req =
       HttpRequests.initiateMultipartUploadRequest(
@@ -140,7 +130,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "support download requests with path-style access in other regions" in {
-    implicit val settings = getSettings(s3Region = "eu-west-1", pathStyleAccess = true)
+    implicit val settings = getSettings(s3Region = "eu-west-1").withPathStyleAccess(true)
 
     val req = HttpRequests.getDownloadRequest(location)
 
@@ -149,12 +139,14 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
     req.uri.rawQueryString shouldBe empty
   }
 
-  it should "support download requests via HTTP when such scheme configured for `proxy`" in {
-    implicit val settings = getSettings(s3Region = "region", proxy = Option(Proxy("localhost", 8080, "http")))
+  it should "support download requests via configured `endpointUrl`" in {
+    implicit val settings = getSettings(s3Region = "region").withEndpointUrl("http://localhost:8080")
 
     val req = HttpRequests.getDownloadRequest(location)
 
     req.uri.scheme shouldEqual "http"
+    req.uri.authority.host.address shouldEqual "localhost"
+    req.uri.authority.port shouldEqual 8080
   }
 
   it should "support download requests with keys starting with /" in {
@@ -186,7 +178,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "support download requests with keys containing spaces with path-style access in other regions" in {
-    implicit val settings = getSettings(s3Region = "eu-west-1", pathStyleAccess = true)
+    implicit val settings = getSettings(s3Region = "eu-west-1").withPathStyleAccess(true)
 
     val location = S3Location("bucket", "test folder/test file.txt")
 
@@ -198,7 +190,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "add versionId query parameter when provided" in {
-    implicit val settings = getSettings(pathStyleAccess = true)
+    implicit val settings = getSettings().withPathStyleAccess(true)
 
     val location = S3Location("bucket", "test/foo.txt")
     val versionId = "123456"
@@ -211,8 +203,8 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
     }
   }
 
-  it should "support multipart init upload requests via HTTP when such scheme configured for `proxy`" in {
-    implicit val settings = getSettings(s3Region = "region", proxy = Option(Proxy("localhost", 8080, "http")))
+  it should "support multipart init upload requests via configured `endpointUrl`" in {
+    implicit val settings = getSettings(s3Region = "region").withEndpointUrl("http://localhost:8080")
 
     val req =
       HttpRequests.initiateMultipartUploadRequest(
@@ -222,19 +214,23 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
       )
 
     req.uri.scheme shouldEqual "http"
+    req.uri.authority.host.address shouldEqual "localhost"
+    req.uri.authority.port shouldEqual 8080
   }
 
-  it should "support multipart upload part requests via HTTP when such scheme configured for `proxy`" in {
-    implicit val settings = getSettings(s3Region = "region", proxy = Option(Proxy("localhost", 8080, "http")))
+  it should "support multipart upload part requests via configured `endpointUrl`" in {
+    implicit val settings = getSettings(s3Region = "region").withEndpointUrl("http://localhost:8080")
 
     val req =
       HttpRequests.uploadPartRequest(multipartUpload, 1, Source.empty, 1)
 
     req.uri.scheme shouldEqual "http"
+    req.uri.authority.host.address shouldEqual "localhost"
+    req.uri.authority.port shouldEqual 8080
   }
 
   it should "properly multipart upload part request with customer keys server side encryption" in {
-    implicit val settings = getSettings(s3Region = "region", proxy = Option(Proxy("localhost", 8080, "http")))
+    implicit val settings = getSettings(s3Region = "region").withPathStyleAccess(true)
     val myKey = "my-key"
     val md5Key = "md5-key"
     val s3Headers = ServerSideEncryption.customerKeys(myKey).withMd5(md5Key).headersFor(UploadPart)
@@ -245,18 +241,20 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
     req.headers should contain(RawHeader("x-amz-server-side-encryption-customer-key-MD5", md5Key))
   }
 
-  it should "support multipart upload complete requests via HTTP when such scheme configured for `proxy`" in {
-    implicit val settings = getSettings(s3Region = "region", proxy = Option(Proxy("localhost", 8080, "http")))
+  it should "support multipart upload complete requests via configured `endpointUrl`" in {
+    implicit val settings = getSettings(s3Region = "region").withEndpointUrl("http://localhost:8080")
     implicit val executionContext = scala.concurrent.ExecutionContext.global
 
-    val reqFuture =
-      HttpRequests.completeMultipartUploadRequest(multipartUpload, (1, "part") :: Nil, Nil)
+    val req =
+      HttpRequests.completeMultipartUploadRequest(multipartUpload, (1, "part") :: Nil, Nil).futureValue
 
-    reqFuture.futureValue.uri.scheme shouldEqual "http"
+    req.uri.scheme shouldEqual "http"
+    req.uri.authority.host.address shouldEqual "localhost"
+    req.uri.authority.port shouldEqual 8080
   }
 
   it should "initiate multipart upload with AES-256 server side encryption" in {
-    implicit val settings = getSettings(s3Region = "us-east-2", proxy = Option(Proxy("localhost", 8080, "http")))
+    implicit val settings = getSettings(s3Region = "us-east-2")
     val s3Headers = ServerSideEncryption.aes256().headersFor(InitiateMultipartUpload)
     val req = HttpRequests.initiateMultipartUploadRequest(location, contentType, s3Headers)
 
@@ -302,7 +300,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "properly construct the list bucket request with no prefix or continuation token passed" in {
-    implicit val settings = getSettings(s3Region = "region", pathStyleAccess = true)
+    implicit val settings = getSettings(s3Region = "region").withPathStyleAccess(true)
 
     val req =
       HttpRequests.listBucket(location.bucket)
@@ -311,7 +309,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "properly construct the list bucket request with a prefix and token passed" in {
-    implicit val settings = getSettings(s3Region = "region", pathStyleAccess = true)
+    implicit val settings = getSettings(s3Region = "region").withPathStyleAccess(true)
 
     val req =
       HttpRequests.listBucket(location.bucket, Some("random/prefix"), Some("randomToken"))
@@ -323,7 +321,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
 
   it should "properly construct the list bucket request when using api version 1" in {
     implicit val settings =
-      getSettings(s3Region = "region", pathStyleAccess = true, listBucketApiVersion = ApiVersion.ListBucketVersion1)
+      getSettings(s3Region = "region", listBucketApiVersion = ApiVersion.ListBucketVersion1).withPathStyleAccess(true)
 
     val req =
       HttpRequests.listBucket(location.bucket)
@@ -333,7 +331,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
 
   it should "properly construct the list bucket request when using api version set to 1 and a continuation token" in {
     implicit val settings =
-      getSettings(s3Region = "region", pathStyleAccess = true, listBucketApiVersion = ApiVersion.ListBucketVersion1)
+      getSettings(s3Region = "region", listBucketApiVersion = ApiVersion.ListBucketVersion1).withPathStyleAccess(true)
 
     val req =
       HttpRequests.listBucket(location.bucket, continuationToken = Some("randomToken"))
@@ -357,7 +355,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
     }, address.getHostName, address.getPort)
 
     implicit val setting: S3Settings =
-      getSettings(endpointUrl = Some(s"http://${address.getHostName}:${address.getPort}/"))
+      getSettings().withEndpointUrl(s"http://${address.getHostName}:${address.getPort}/")
 
     val req =
       HttpRequests.listBucket(location.bucket, Some("random/prefix"), Some("randomToken"))

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -37,7 +37,14 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
       def getRegion = s3Region
     }
 
-    S3Settings(bufferType, proxy, awsCredentials, regionProvider, pathStyleAccess, endpointUrl, listBucketApiVersion)
+    S3Settings(bufferType,
+               proxy,
+               awsCredentials,
+               regionProvider,
+               pathStyleAccess,
+               endpointUrl,
+               listBucketApiVersion,
+               None)
   }
 
   val location = S3Location("bucket", "image-1024@2x")

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
@@ -54,7 +54,8 @@ class S3StreamSpec(_system: ActorSystem)
                  regionProvider,
                  false,
                  None,
-                 ApiVersion.ListBucketVersion2)
+                 ApiVersion.ListBucketVersion2,
+                 None)
 
     val result: HttpRequest = S3Stream invokePrivate requestHeaders(getDownloadRequest(location), None)
     result.headers.size shouldBe 1
@@ -85,7 +86,8 @@ class S3StreamSpec(_system: ActorSystem)
                  regionProvider,
                  false,
                  None,
-                 ApiVersion.ListBucketVersion2)
+                 ApiVersion.ListBucketVersion2,
+                 None)
 
     val result: HttpRequest = S3Stream invokePrivate requestHeaders(getDownloadRequest(location), Some(range))
     result.headers.size shouldBe 2

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
@@ -48,14 +48,7 @@ class S3StreamSpec(_system: ActorSystem)
     val location = S3Location("test-bucket", "test-key")
 
     implicit val settings =
-      S3Settings(MemoryBufferType,
-                 None,
-                 credentialsProvider,
-                 regionProvider,
-                 false,
-                 None,
-                 ApiVersion.ListBucketVersion2,
-                 None)
+      S3Settings(MemoryBufferType, credentialsProvider, regionProvider, ApiVersion.ListBucketVersion2)
 
     val result: HttpRequest = S3Stream invokePrivate requestHeaders(getDownloadRequest(location), None)
     result.headers.size shouldBe 1
@@ -80,14 +73,7 @@ class S3StreamSpec(_system: ActorSystem)
     val range = ByteRange(1, 4)
 
     implicit val settings =
-      S3Settings(MemoryBufferType,
-                 None,
-                 credentialsProvider,
-                 regionProvider,
-                 false,
-                 None,
-                 ApiVersion.ListBucketVersion2,
-                 None)
+      S3Settings(MemoryBufferType, credentialsProvider, regionProvider, ApiVersion.ListBucketVersion2)
 
     val result: HttpRequest = S3Stream invokePrivate requestHeaders(getDownloadRequest(location), Some(range))
     result.headers.size shouldBe 2

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ExtSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ExtSpec.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.s3.scaladsl
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{FlatSpecLike, Matchers}
-import akka.stream.alpakka.s3.{Proxy, S3Ext}
+import akka.stream.alpakka.s3.S3Ext
 
 import scala.collection.JavaConverters._
 
@@ -18,15 +18,13 @@ class S3ExtSpec extends FlatSpecLike with Matchers {
   it should "reuse application config from actor system" in {
     val config = ConfigFactory.parseMap(
       Map(
-        "alpakka.s3.proxy.host" -> "localhost",
-        "alpakka.s3.proxy.port" -> 8001,
-        "alpakka.s3.proxy.secure" -> false,
+        "alpakka.s3.endpoint-url" -> "http://localhost:8001",
         "alpakka.s3.path-style-access" -> true
       ).asJava
     )
     implicit val system = ActorSystem.create("s3", config)
     val ext = S3Ext(system)
-    ext.settings.proxy shouldBe Some(Proxy("localhost", 8001, "http"))
+    ext.settings.endpointUrl shouldBe Some("http://localhost:8001")
     ext.settings.pathStyleAccess shouldBe true
   }
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -800,11 +800,6 @@ private object S3WireMockBase {
 
   private def config(proxyPort: Int) = ConfigFactory.parseString(s"""
     |${S3Settings.ConfigPath} {
-    |  proxy {
-    |    host = localhost
-    |    port = $proxyPort
-    |    secure = false
-    |  }
     |  aws {
     |    credentials {
     |      provider = static
@@ -817,6 +812,7 @@ private object S3WireMockBase {
     |    }
     |  }
     |  path-style-access = false
+    |  endpoint-url = "http://localhost:$proxyPort"
     |}
     """.stripMargin)
 }


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Akka HTTP has support for forward proxies via its [Pluggable Client Transports](https://doc.akka.io/docs/akka-http/current/client-side/client-transport.html). The functionality is used in this update in order to support forward proxies when integrating with S3.


## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #1017 

## Changes

<!-- Bullets for important changes in this PR -->

## Background Context

<!-- Why did you take this approach? -->