### PR TITLE
Enable 2.13 for sqs and sns connectors.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -235,8 +235,7 @@ lazy val sns = alpakkaProject(
   "aws.sns",
   Dependencies.Sns,
   // For mockito https://github.com/akka/alpakka/issues/390
-  parallelExecution in Test := false,
-  crossScalaVersions -= Dependencies.Scala213
+  parallelExecution in Test := false
 )
 
 lazy val solr = alpakkaProject("solr", "solr", Dependencies.Solr, parallelExecution in Test := false)
@@ -246,8 +245,7 @@ lazy val sqs = alpakkaProject(
   "aws.sqs",
   Dependencies.Sqs,
   // For mockito https://github.com/akka/alpakka/issues/390
-  parallelExecution in Test := false,
-  crossScalaVersions -= Dependencies.Scala213
+  parallelExecution in Test := false
 )
 
 lazy val sse = alpakkaProject("sse", "sse", Dependencies.Sse)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -344,7 +344,7 @@ object Dependencies {
 
   val Sns = Seq(
     libraryDependencies ++= Seq(
-      "com.github.matsluni" %% "aws-spi-akka-http" % "0.0.4" excludeAll ExclusionRule(
+      "com.github.matsluni" %% "aws-spi-akka-http" % "0.0.5" excludeAll ExclusionRule(
         organization = "com.typesafe.akka"
       ), // ApacheV2
       "software.amazon.awssdk" % "sns" % AwsSdk2Version excludeAll (ExclusionRule(
@@ -373,7 +373,7 @@ object Dependencies {
 
   val Sqs = Seq(
     libraryDependencies ++= Seq(
-      "com.github.matsluni" %% "aws-spi-akka-http" % "0.0.4" excludeAll ExclusionRule(
+      "com.github.matsluni" %% "aws-spi-akka-http" % "0.0.5" excludeAll ExclusionRule(
         organization = "com.typesafe.akka"
       ), // ApacheV2
       "software.amazon.awssdk" % "sqs" % AwsSdk2Version excludeAll (ExclusionRule(

--- a/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
@@ -39,7 +39,7 @@ class SqsPublishSpec extends FlatSpec with Matchers with DefaultTestContext {
           .maxNumberOfMessages(maxNumberOfMessages)
           .build()
 
-      awsSqsClient.receiveMessage(request).get().messages().asScala
+      awsSqsClient.receiveMessage(request).get().messages().asScala.toSeq
     }
   }
 


### PR DESCRIPTION
## Purpose

Build sqs and sns connectors with Scala 2.13.0-M5.

## References

Aws Spi Akka Http was released for Scala 2.13.0-M5 recently: https://github.com/matsluni/aws-spi-akka-http/issues/3#issuecomment-481664687

Fixes #1537 and #1538
