### PR TITLE
Read from Kafka write to Elasticsearch example

### DIFF
--- a/doc-examples/src/main/java/elastic/KafkaToElasticInJava.java
+++ b/doc-examples/src/main/java/elastic/KafkaToElasticInJava.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package elastic;
+
+// #imports
+import akka.Done;
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.actor.Terminated;
+import akka.kafka.CommitterSettings;
+import akka.kafka.ConsumerSettings;
+import akka.kafka.ProducerSettings;
+import akka.kafka.Subscriptions;
+import akka.kafka.javadsl.Committer;
+import akka.kafka.javadsl.Consumer;
+import akka.kafka.javadsl.Producer;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.alpakka.elasticsearch.ElasticsearchSourceSettings;
+import akka.stream.alpakka.elasticsearch.ElasticsearchWriteSettings;
+import akka.stream.alpakka.elasticsearch.WriteMessage;
+import akka.stream.alpakka.elasticsearch.javadsl.ElasticsearchFlow;
+import akka.stream.alpakka.elasticsearch.javadsl.ElasticsearchSource;
+import akka.stream.javadsl.Keep;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.http.HttpHost;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.elasticsearch.client.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+// #imports
+
+public class KafkaToElasticInJava {
+
+  private static final Logger log = LoggerFactory.getLogger(KafkaToElasticInJava.class);
+  private final String elasticsearchAddress;
+  private final String kafkaBootstrapServers;
+
+  private final String topic = "movies-to-elasticsearch";
+  private final String groupId = "docs-group";
+
+  private final String indexName = "movies";
+
+  public KafkaToElasticInJava(String elasticsearchAddress, String kafkaBootstrapServers) {
+    this.elasticsearchAddress = elasticsearchAddress;
+    this.kafkaBootstrapServers = kafkaBootstrapServers;
+  }
+
+  public
+  // #es-setup
+
+  // Type in Elasticsearch (2)
+  static class Movie {
+    public final int id;
+    public final String title;
+
+    @JsonCreator
+    public Movie(@JsonProperty("id") int id, @JsonProperty("title") String title) {
+      this.id = id;
+      this.title = title;
+    }
+
+    @Override
+    public String toString() {
+      return "Movie(" + id + ", title=" + title + ")";
+    }
+  }
+
+  // Jackson conversion setup (3)
+  final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+  final ObjectWriter movieWriter = mapper.writerFor(Movie.class);
+  final ObjectReader movieReader = mapper.readerFor(Movie.class);
+
+  // #es-setup
+
+  private ActorSystem actorSystem;
+  private Materializer materializer;
+  private RestClient elasticsearchClient;
+
+  private Consumer.DrainingControl<Done> readFromKafkaToEleasticsearch() {
+    // #kafka-setup
+
+    // configure Kafka consumer (1)
+    ConsumerSettings<Integer, String> kafkaConsumerSettings =
+        ConsumerSettings.create(actorSystem, new IntegerDeserializer(), new StringDeserializer())
+            .withBootstrapServers(kafkaBootstrapServers)
+            .withGroupId(groupId)
+            .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+            .withStopTimeout(Duration.ofSeconds(5));
+    // #kafka-setup
+
+    // #flow
+
+    Consumer.DrainingControl<Done> control =
+        Consumer.committableSource(kafkaConsumerSettings, Subscriptions.topics(topic)) // (5)
+            .asSourceWithContext(cm -> cm.committableOffset()) // (6)
+            .map(cm -> cm.record())
+            .map(
+                consumerRecord -> { // (7)
+                  Movie movie = movieReader.readValue(consumerRecord.value());
+                  return WriteMessage.createUpsertMessage(String.valueOf(movie.id), movie);
+                })
+            .via(
+                ElasticsearchFlow.createWithContext(
+                    indexName,
+                    "_doc",
+                    ElasticsearchWriteSettings.create(),
+                    elasticsearchClient,
+                    mapper)) // (8)
+            .map(
+                writeResult -> { // (9)
+                  writeResult
+                      .getError()
+                      .ifPresent(
+                          errorJson -> {
+                            throw new RuntimeException(
+                                "Elasticsearch update failed "
+                                    + writeResult.getErrorReason().orElse(errorJson));
+                          });
+                  return NotUsed.notUsed();
+                })
+            .asSource() // (10)
+            .map(pair -> pair.second())
+            .toMat(Committer.sink(CommitterSettings.create(actorSystem)), Keep.both()) // (11)
+            .mapMaterializedValue(Consumer::createDrainingControl) // (12)
+            .run(materializer);
+    // #flow
+    return control;
+  }
+
+  private CompletionStage<Terminated> run() throws Exception {
+    actorSystem = ActorSystem.create();
+    materializer = ActorMaterializer.create(actorSystem);
+    // #es-setup
+
+    // Elasticsearch client setup (4)
+    elasticsearchClient = RestClient.builder(HttpHost.create(elasticsearchAddress)).build();
+    // #es-setup
+
+    List<Movie> movies = Arrays.asList(new Movie(23, "Psycho"), new Movie(423, "Citizen Kane"));
+    CompletionStage<Done> writing = writeToKafka(movies);
+    writing.toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+    Consumer.DrainingControl<Done> control = readFromKafkaToEleasticsearch();
+    TimeUnit.SECONDS.sleep(5);
+    CompletionStage<Done> copyingFinished = control.drainAndShutdown(actorSystem.dispatcher());
+    copyingFinished.toCompletableFuture().get(10, TimeUnit.SECONDS);
+    CompletionStage<List<Movie>> reading = readFromElasticsearch(elasticsearchClient);
+
+    return reading.thenCompose(
+        ms -> {
+          ms.forEach(m -> System.out.println("read " + m));
+          try {
+            elasticsearchClient.close();
+          } catch (IOException e) {
+            log.error(e.toString(), e);
+          }
+          actorSystem.terminate();
+          return actorSystem.getWhenTerminated();
+        });
+  }
+
+  private CompletionStage<Done> writeToKafka(List<Movie> movies) {
+    ProducerSettings<Integer, String> kafkaProducerSettings =
+        ProducerSettings.create(actorSystem, new IntegerSerializer(), new StringSerializer())
+            .withBootstrapServers(kafkaBootstrapServers);
+
+    CompletionStage<Done> producing =
+        Source.from(movies)
+            .map(
+                movie -> {
+                  log.debug("producing {}", movie);
+                  String json = movieWriter.writeValueAsString(movie);
+                  return new ProducerRecord<>(topic, movie.id, json);
+                })
+            .runWith(Producer.plainSink(kafkaProducerSettings), materializer);
+    producing.thenAccept(s -> log.info("Producing finished"));
+    return producing;
+  }
+
+  private CompletionStage<List<Movie>> readFromElasticsearch(RestClient elasticsearchClient) {
+    CompletionStage<List<Movie>> reading =
+        ElasticsearchSource.typed(
+                indexName,
+                "_doc",
+                "{\"match_all\": {}}",
+                ElasticsearchSourceSettings.create(),
+                elasticsearchClient,
+                Movie.class)
+            .map(readResult -> readResult.source())
+            .runWith(Sink.seq(), materializer);
+    reading.thenAccept(
+        non -> {
+          log.info("Reading finished");
+        });
+    return reading;
+  }
+
+  public static void main(String[] args) throws Exception {
+    ElasticsearchContainer elasticsearchContainer =
+        new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.3");
+    elasticsearchContainer.start();
+    String elasticsearchAddress = elasticsearchContainer.getHttpHostAddress();
+
+    KafkaContainer kafka = new KafkaContainer("5.1.2"); // contains Kafka 2.1.x
+    kafka.start();
+    String kafkaBootstrapServers = kafka.getBootstrapServers();
+
+    CompletionStage<Terminated> run =
+        new KafkaToElasticInJava(elasticsearchAddress, kafkaBootstrapServers).run();
+
+    run.thenAccept(
+        res -> {
+          kafka.stop();
+          elasticsearchContainer.stop();
+        });
+  }
+}

--- a/doc-examples/src/main/java/ftpsamples/FtpToFileExample.java
+++ b/doc-examples/src/main/java/ftpsamples/FtpToFileExample.java
@@ -68,8 +68,7 @@ public class FtpToFileExample extends ActorSystemAvailable {
     fetchedFiles
         .thenApply(
             files ->
-                files
-                    .stream()
+                files.stream()
                     .filter(pathResult -> !pathResult.second().wasSuccessful())
                     .collect(Collectors.toList()))
         .whenComplete(

--- a/doc-examples/src/main/resources/logback.xml
+++ b/doc-examples/src/main/resources/logback.xml
@@ -37,6 +37,9 @@
     <logger name="org.apache.kafka.clients.NetworkClient" level="ERROR"/>
     <logger name="org.I0Itec.zkclient" level="WARN"/>
 
+    <logger name="org.testcontainers" level="WARN"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+
     <!-- Log at the INFO level. Change the main loglevel here. -->
     <!-- Note that custom loggers obey their own levels. -->
     <root level="debug">

--- a/doc-examples/src/main/scala/elastic/KafkaToElastic.scala
+++ b/doc-examples/src/main/scala/elastic/KafkaToElastic.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package elastic
+
+import akka.actor.ActorSystem
+import akka.kafka._
+import akka.kafka.scaladsl.{Committer, Consumer, Producer}
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.alpakka.elasticsearch.WriteMessage
+import akka.stream.alpakka.elasticsearch.scaladsl.{ElasticsearchFlow, ElasticsearchSource}
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.{Done, NotUsed}
+import org.apache.http.HttpHost
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.{
+  IntegerDeserializer,
+  IntegerSerializer,
+  StringDeserializer,
+  StringSerializer
+}
+import org.elasticsearch.client.RestClient
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.KafkaContainer
+import org.testcontainers.elasticsearch.ElasticsearchContainer
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+import scala.collection.immutable
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+object KafkaToElastic extends App {
+
+  final val log = LoggerFactory.getLogger(getClass)
+
+  // Testcontainers: start Elasticsearch in Docker
+  val elasticsearchContainer = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.3")
+  elasticsearchContainer.start()
+  val elasticsearchAddress = elasticsearchContainer.getHttpHostAddress
+
+  // Testcontainers: start Kafka in Docker
+  val kafka = new KafkaContainer()
+  kafka.start()
+  val kafkaBootstrapServers = kafka.getBootstrapServers
+
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  implicit val actorMaterializer: Materializer = ActorMaterializer()
+  implicit val executionContext: ExecutionContext = actorSystem.dispatcher
+
+  val topic = "movies-to-elasticsearch"
+  private val groupId = "docs-group"
+
+  case class Movie(id: Int, title: String)
+
+  implicit val movieFormat: JsonFormat[Movie] = jsonFormat2(Movie)
+
+  implicit val elasticsearchClient: RestClient =
+    RestClient
+      .builder(HttpHost.create(elasticsearchAddress))
+      .build()
+
+  val indexName = "movies"
+
+  private def writeToKafka(movies: immutable.Iterable[Movie]) = {
+    val kafkaProducerSettings = ProducerSettings(actorSystem, new IntegerSerializer, new StringSerializer)
+      .withBootstrapServers(kafkaBootstrapServers)
+
+    val producing: Future[Done] = Source(movies)
+      .map { movie =>
+        log.debug("producing {}", movie)
+        new ProducerRecord(topic, Int.box(movie.id), movie.toJson.compactPrint)
+      }
+      .runWith(Producer.plainSink(kafkaProducerSettings))
+    producing.foreach(_ => log.info("Producing finished"))
+    producing
+  }
+
+  private def readFromKafkaWriteToElasticsearch() = {
+    val kafkaConsumerSettings = ConsumerSettings(actorSystem, new IntegerDeserializer, new StringDeserializer)
+      .withBootstrapServers(kafkaBootstrapServers)
+      .withGroupId(groupId)
+      .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+      .withStopTimeout(5.seconds)
+
+    val control: Consumer.DrainingControl[Done] = Consumer
+      .committableSource(kafkaConsumerSettings, Subscriptions.topics(topic))
+      .startContextPropagation(_.committableOffset)
+      .map(_.record)
+      .map { consumerRecord =>
+        val movie = consumerRecord.value().parseJson.convertTo[Movie]
+        WriteMessage.createUpsertMessage(movie.id.toString, movie)
+      }
+      .via(ElasticsearchFlow.createWithContext(indexName, "_doc"))
+      .map { writeResult =>
+        writeResult.error.foreach { errorJson =>
+          throw new RuntimeException(s"Elasticsearch update failed ${writeResult.errorReason.getOrElse(errorJson)}")
+        }
+        NotUsed
+      }
+      .endContextPropagation
+      .map {
+        case (_, committableOffset) =>
+          committableOffset
+      }
+      .toMat(Committer.sink(CommitterSettings(actorSystem)))(Keep.both)
+      .mapMaterializedValue(Consumer.DrainingControl.apply)
+      .run()
+
+    control
+  }
+
+  private def readFromElasticsearch(): Future[immutable.Seq[Movie]] = {
+    val reading = ElasticsearchSource
+      .typed[Movie](indexName, "_doc", """{"match_all": {}}""")
+      .map(_.source)
+      .runWith(Sink.seq)
+    reading.foreach(_ => log.info("Reading finished"))
+    reading
+  }
+
+  val movies = List(Movie(23, "Psycho"), Movie(423, "Citizen Kane"))
+  val writing: Future[Done] = writeToKafka(movies)
+  Await.result(writing, 10.seconds)
+
+  val control = readFromKafkaWriteToElasticsearch()
+  // Let the read/write stream run a bit
+  Thread.sleep(5.seconds.toMillis)
+  val copyingFinished = control.drainAndShutdown()
+  Await.result(copyingFinished, 10.seconds)
+  val reading = readFromElasticsearch()
+
+  for {
+    read <- reading
+  } {
+    read.foreach(m => println(s"read $m"))
+    kafka.stop()
+    elasticsearchClient.close()
+    elasticsearchContainer.stop()
+    actorSystem.terminate()
+  }
+}

--- a/docs/src/main/paradox/examples/elasticsearch-samples.md
+++ b/docs/src/main/paradox/examples/elasticsearch-samples.md
@@ -26,7 +26,7 @@ Java
 
 - Configure Kafka consumer (1)
 - Data class mapped to Elasticsearch (2)
-- Spray JSON conversion for the data class (3)
+- @scala[Spray JSON]@java[Jackson] conversion for the data class (3)
 - Elasticsearch client setup (4)
 - Kafka consumer with committing support (5)
 - Use `FlowWithContext` to focus on `ConsumerRecord` (6)
@@ -41,6 +41,9 @@ Java
 
 Scala
 : @@snip [snip](/doc-examples/src/main/scala/elastic/KafkaToElastic.scala) { #imports #kafka-setup #es-setup #flow }
+
+Java
+: @@snip [snip](/doc-examples/src/main/java/elastic/KafkaToElasticInJava.java) { #imports #kafka-setup #es-setup #flow }
 
 
 

--- a/docs/src/main/paradox/examples/elasticsearch-samples.md
+++ b/docs/src/main/paradox/examples/elasticsearch-samples.md
@@ -21,6 +21,29 @@ Scala
 Java
 : @@snip [snip](/doc-examples/src/main/java/elastic/FetchUsingSlickAndStreamIntoElasticInJava.java) { #sample }
 
+
+### Example: Read from a Kafka topic and publish to Elasticsearch
+
+- Configure Kafka consumer (1)
+- Data class mapped to Elasticsearch (2)
+- Spray JSON conversion for the data class (3)
+- Elasticsearch client setup (4)
+- Kafka consumer with committing support (5)
+- Use `FlowWithContext` to focus on `ConsumerRecord` (6)
+- Parse message from Kafka to `Movie` and create Elasticsearch write message (7)
+- Use `createWithContext` to use an Elasticsearch flow with context-support (so it passes through the Kafka committ offset) (8)
+- React on write errors (9)
+- Make the context visible again and just keep the committable offset (10)
+- Let the `Committer.sink` aggregate commits to batches and commit to Kafka (11)
+- Combine consumer control and stream completion into `DrainingControl` (12)
+
+
+
+Scala
+: @@snip [snip](/doc-examples/src/main/scala/elastic/KafkaToElastic.scala) { #imports #kafka-setup #es-setup #flow }
+
+
+
 ### Running the example code
 
 This example is contained in a stand-alone runnable main, it can be run

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -108,6 +108,8 @@ object Dependencies {
       "io.netty" % "netty-all" % "4.1.29.Final", // ApacheV2
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.9.8",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8",
+      "org.testcontainers" % "kafka" % "1.11.1",
+      "org.testcontainers" % "elasticsearch" % "1.11.1",
       "org.slf4j" % "log4j-over-slf4j" % "1.7.25",
       "org.slf4j" % "jcl-over-slf4j" % "1.7.25",
       "ch.qos.logback" % "logback-classic" % "1.2.3" // Eclipse Public License 1.0

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -86,6 +86,7 @@ object Dependencies {
 
   val `Doc-examples` = Seq(
     libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
       // https://mina.apache.org/ftpserver-project/downloads.html
       "org.apache.ftpserver" % "ftpserver-core" % "1.1.1", // ApacheV2
       "org.apache.sshd" % "sshd-scp" % "2.1.0", // ApacheV2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -108,8 +108,9 @@ object Dependencies {
       "io.netty" % "netty-all" % "4.1.29.Final", // ApacheV2
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.9.8",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8",
-      "org.testcontainers" % "kafka" % "1.11.1",
-      "org.testcontainers" % "elasticsearch" % "1.11.1",
+      "org.testcontainers" % "kafka" % "1.11.1", // MIT
+      "org.testcontainers" % "elasticsearch" % "1.11.1", // MIT
+      "org.apache.logging.log4j" % "log4j-to-slf4j" % "2.11.2", // ApacheV2
       "org.slf4j" % "log4j-over-slf4j" % "1.7.25",
       "org.slf4j" % "jcl-over-slf4j" % "1.7.25",
       "ch.qos.logback" % "logback-classic" % "1.2.3" // Eclipse Public License 1.0


### PR DESCRIPTION
## Purpose

Add a new self-contained example which reads messages from a Kafka topic and writes these to Elasticsearch.
Make use of the new `withContext` API in Akka Streams.
Use [Testcontainers](https://www.testcontainers.org/) to start Kafka and Elasticsearch.
