### PR TITLE
Try to fix bash script if condition

### DIFF
--- a/scripts/buildChanged.sh
+++ b/scripts/buildChanged.sh
@@ -5,15 +5,15 @@ JDK=$2
 PRE_CMD=$3
 CMD=$4
 
-if [ "$TRAVIS_PULL_REQUEST" ]
+if [ "$TRAVIS_PULL_REQUEST" == "false" ]
 then
-  COMPARE_TO="origin/master"
-else
   # for non-pr (master) builds, comparison for changes is made against the previous commit,
   # which might be:
   # * merge commit, then HEAD^ is the last commit before branching out
   # * squash commit, then HEAD^ is the previous state of master
   COMPARE_TO="HEAD^"
+else
+  COMPARE_TO="origin/master"
 fi
 
 git diff "$COMPARE_TO" --exit-code --quiet "$DIR" build.sbt project/ .travis.yml


### PR DESCRIPTION
After the `buildChanged.sh` improvements (#1650), the master branch build still went of to compare against `origin/master` instead of `HEAD^`. This tries to use more explicit bash syntax in the conditional.