### PR TITLE
xml: flush output after the input is finished

### DIFF
--- a/xml/src/main/scala/akka/stream/alpakka/xml/impl/StreamingXmlWriter.scala
+++ b/xml/src/main/scala/akka/stream/alpakka/xml/impl/StreamingXmlWriter.scala
@@ -97,5 +97,14 @@ import javax.xml.stream.XMLOutputFactory
       }
 
       override def onPull(): Unit = pull(in)
+
+      override def onUpstreamFinish(): Unit = {
+        output.flush()
+        val finalData = byteStringBuilder.result().compact
+        if (finalData.length != 0) {
+          emit(out, finalData)
+        }
+        super.onUpstreamFinish()
+      }
     }
 }

--- a/xml/src/test/scala/docs/scaladsl/XmlWritingSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlWritingSpec.scala
@@ -187,6 +187,24 @@ class XmlWritingSpec extends WordSpec with Matchers with BeforeAndAfterAll with 
       // #writer-usage
     }
 
+    "properly process a string that is not a full document" in {
+      val listEl: List[ParseEvent] = List(
+        StartElement("doc"),
+        StartElement("elem"),
+        Characters("elem1"),
+        EndElement("elem"),
+        StartElement("elem"),
+        Characters("elem2"),
+        EndElement("elem"),
+        EndElement("doc")
+      )
+
+      val doc = "<doc><elem>elem1</elem><elem>elem2</elem></doc>"
+      val resultFuture: Future[String] = Source.fromIterator[ParseEvent](() => listEl.iterator).runWith(writer)
+
+      resultFuture.futureValue(Timeout(20.seconds)) should ===(doc)
+    }
+
   }
 
   override protected def afterAll(): Unit = system.terminate()


### PR DESCRIPTION
This does not appear to be strictly necessary when producing full documents,
but does make a difference when outputting 'snippets'.