### PR TITLE
Revert "Upgrade cassandra driver to 3.7.1"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -66,7 +66,7 @@ object Dependencies {
 
   val Cassandra = Seq(
     libraryDependencies ++= Seq(
-      "com.datastax.cassandra" % "cassandra-driver-core" % "3.7.1" // ApacheV2
+      "com.datastax.cassandra" % "cassandra-driver-core" % "3.5.1" // ApacheV2
     )
   )
 


### PR DESCRIPTION
Reverts akka/alpakka#1640 as we should not update dependency minor versions in a patch release.