### PR TITLE
HBase: version 1.4.9

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,14 +123,14 @@ services:
         python subscriber.py alpakka create testTopic testSubscription
       "
   hbase:
-    image: nerdammer/hbase:1.1.2
+    image: harisekhon/hbase:1.4
     hostname: hbase
     ports:
       - 2181:2181
-      - 60000:60000
-      - 60010:60010
-      - 60020:60020
-      - 60030:60030
+      - 16000:16000
+      - 16010:16010
+      - 16201:16201
+      - 16301:16301
   ibmmq:
     image: ibmcom/mq:9.1.1.0
     environment:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -221,8 +221,8 @@ object Dependencies {
   )
 
   val HBase = {
-    val hbaseVersion = "1.2.6.1"
-    val hadoopVersion = "2.5.2"
+    val hbaseVersion = "1.4.9"
+    val hadoopVersion = "2.7.4"
     Seq(
       libraryDependencies ++= Seq(
           // for some reason version 2.2.3U1 started to get picked which was not accepted by Whitesource)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -225,14 +225,11 @@ object Dependencies {
     val hadoopVersion = "2.7.4"
     Seq(
       libraryDependencies ++= Seq(
-          // for some reason version 2.2.3U1 started to get picked which was not accepted by Whitesource)
-          "com.sun.xml.bind" % "jaxb-impl" % "2.2.3-1", // CDDL + GPLv2
-          // TODO: remove direct dependency ^^ when updating from these very old versions
           "org.apache.hbase" % "hbase-shaded-client" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
           "org.apache.hbase" % "hbase-common" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
           "org.apache.hadoop" % "hadoop-common" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
           "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
-          "org.slf4j" % "log4j-over-slf4j" % log4jOverSlf4jVersion % Test // MIT like: http://www.slf4j.org/license.html
+          "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % Test // MIT like: http://www.slf4j.org/license.html
         )
     )
   }


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

This change is to upgrade Apache HBase to 1.4.9, which is the current stable version.

## Changes

<!-- Bullets for important changes in this PR -->
This PR changed an HBase docker image to run tests using HBase 1.4.
