### PR TITLE
FTP: emit traversed directories from Ftp.ls

### DIFF
--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
@@ -23,7 +23,7 @@ private[ftp] trait CommonFtpOperations {
   type Handler = FTPClient
 
   def listFiles(basePath: String, handler: Handler): immutable.Seq[FtpFile] = {
-    val path = if (!basePath.isEmpty && basePath.head != '/') s"/$basePath" else basePath
+    val path = if (!basePath.isEmpty && basePath.head != '/') s"/$basePath" else if (basePath == "/") "" else basePath
     handler
       .listFiles(path)
       .collect {

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpBrowserGraphStage.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpBrowserGraphStage.scala
@@ -32,6 +32,8 @@ private[ftp] trait FtpBrowserGraphStage[FtpClient, S <: RemoteFileSettings] exte
 
   val branchSelector: FtpFile => Boolean = (f) => true
 
+  val emitTraversedDirectories: Boolean
+
   override def initialAttributes: Attributes =
     super.initialAttributes and Attributes.name(name) and IODispatcher
 
@@ -82,7 +84,7 @@ private[ftp] trait FtpBrowserGraphStage[FtpClient, S <: RemoteFileSettings] exte
       private[this] def fillBuffer(): Unit = buffer match {
         case head +: tail if head.isDirectory && branchSelector(head) =>
           buffer = getFilesFromPath(head.path) ++ tail
-          traversed = traversed :+ head
+          if (emitTraversedDirectories) traversed = traversed :+ head
           fillBuffer()
         case _ => // do nothing
       }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpBrowserGraphStage.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpBrowserGraphStage.scala
@@ -32,7 +32,7 @@ private[ftp] trait FtpBrowserGraphStage[FtpClient, S <: RemoteFileSettings] exte
 
   val branchSelector: FtpFile => Boolean = (f) => true
 
-  val emitTraversedDirectories: Boolean
+  def emitTraversedDirectories: Boolean = false
 
   override def initialAttributes: Attributes =
     super.initialAttributes and Attributes.name(name) and IODispatcher

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
@@ -33,7 +33,8 @@ private[ftp] trait FtpSourceFactory[FtpClient] { self =>
   protected[this] def createBrowserGraph(
       _basePath: String,
       _connectionSettings: S,
-      _branchSelector: FtpFile => Boolean
+      _branchSelector: FtpFile => Boolean,
+      _emitTraversedDirectories: Boolean
   )(implicit _ftpLike: FtpLike[FtpClient, S]): FtpBrowserGraphStage[FtpClient, S] =
     new FtpBrowserGraphStage[FtpClient, S] {
       lazy val name: String = ftpBrowserSourceName
@@ -42,6 +43,7 @@ private[ftp] trait FtpSourceFactory[FtpClient] { self =>
       val ftpClient: () => FtpClient = self.ftpClient
       val ftpLike: FtpLike[FtpClient, S] = _ftpLike
       override val branchSelector: (FtpFile) => Boolean = _branchSelector
+      val emitTraversedDirectories: Boolean = _emitTraversedDirectories
     }
 
   protected[this] def createIOSource(

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
@@ -33,6 +33,13 @@ private[ftp] trait FtpSourceFactory[FtpClient] { self =>
   protected[this] def createBrowserGraph(
       _basePath: String,
       _connectionSettings: S,
+      _branchSelector: FtpFile => Boolean
+  )(implicit _ftpLike: FtpLike[FtpClient, S]): FtpBrowserGraphStage[FtpClient, S] =
+    createBrowserGraph(_basePath, _connectionSettings, _branchSelector, _emitTraversedDirectories = false)
+
+  protected[this] def createBrowserGraph(
+      _basePath: String,
+      _connectionSettings: S,
       _branchSelector: FtpFile => Boolean,
       _emitTraversedDirectories: Boolean
   )(implicit _ftpLike: FtpLike[FtpClient, S]): FtpBrowserGraphStage[FtpClient, S] =
@@ -43,7 +50,7 @@ private[ftp] trait FtpSourceFactory[FtpClient] { self =>
       val ftpClient: () => FtpClient = self.ftpClient
       val ftpLike: FtpLike[FtpClient, S] = _ftpLike
       override val branchSelector: (FtpFile) => Boolean = _branchSelector
-      val emitTraversedDirectories: Boolean = _emitTraversedDirectories
+      override val emitTraversedDirectories: Boolean = _emitTraversedDirectories
     }
 
   protected[this] def createIOSource(

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -95,7 +95,7 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
       basePath: String,
       connectionSettings: S
   ): Source[FtpFile, NotUsed] =
-    ScalaSource.fromGraph(createBrowserGraph(basePath, connectionSettings, f => true)).asJava
+    ScalaSource.fromGraph(createBrowserGraph(basePath, connectionSettings, f => true, false)).asJava
 
   /**
    * Java API: creates a [[akka.stream.javadsl.Source Source]] of [[FtpFile]]s from a base path.
@@ -104,16 +104,17 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
    * @param connectionSettings connection settings
    * @param branchSelector a predicate for pruning the tree. Takes a remote folder and return true
    *                       if you want to enter that remote folder.
-   *                       Default behaviour is full recursiv which is equivalent with calling this function
+   *                       Default behaviour is full recursive which is equivalent with calling this function
    *                       with [[ls(basePath,connectionSettings,f->true)]].
    *
    *                       Calling [[ls(basePath,connectionSettings,f->false)]] will emit only the files and folder in
    *                       non-recursive fashion
+   * @param emitTraversedDirectories whether to include entered directories in the stream
    *
    * @return A [[akka.stream.javadsl.Source Source]] of [[FtpFile]]s
    */
-  def ls(basePath: String, connectionSettings: S, branchSelector: Predicate[FtpFile]): Source[FtpFile, NotUsed] =
-    Source.fromGraph(createBrowserGraph(basePath, connectionSettings, asScalaFromPredicate(branchSelector)))
+  def ls(basePath: String, connectionSettings: S, branchSelector: Predicate[FtpFile], emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed] =
+    Source.fromGraph(createBrowserGraph(basePath, connectionSettings, asScalaFromPredicate(branchSelector), emitTraversedDirectories))
 
   /**
    * Java API: creates a [[akka.stream.javadsl.Source Source]] of [[akka.util.ByteString ByteString]] from some file path.

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -95,7 +95,36 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
       basePath: String,
       connectionSettings: S
   ): Source[FtpFile, NotUsed] =
-    ScalaSource.fromGraph(createBrowserGraph(basePath, connectionSettings, f => true, false)).asJava
+    ScalaSource
+      .fromGraph(
+        createBrowserGraph(basePath, connectionSettings, f => true, _emitTraversedDirectories = false)
+      )
+      .asJava
+
+  /**
+   * Java API: creates a [[akka.stream.javadsl.Source Source]] of [[FtpFile]]s from a base path.
+   *
+   * @param basePath Base path from which traverse the remote file server
+   * @param connectionSettings connection settings
+   * @param branchSelector a predicate for pruning the tree. Takes a remote folder and return true
+   *                       if you want to enter that remote folder.
+   *                       Default behaviour is full recursive which is equivalent with calling this function
+   *                       with [[ls(basePath,connectionSettings,f->true)]].
+   *
+   *                       Calling [[ls(basePath,connectionSettings,f->false)]] will emit only the files and folder in
+   *                       non-recursive fashion
+   *
+   * @return A [[akka.stream.javadsl.Source Source]] of [[FtpFile]]s
+   */
+  def ls(basePath: String, connectionSettings: S, branchSelector: Predicate[FtpFile]): Source[FtpFile, NotUsed] =
+    Source.fromGraph(
+      createBrowserGraph(
+        basePath,
+        connectionSettings,
+        asScalaFromPredicate(branchSelector),
+        _emitTraversedDirectories = false
+      )
+    )
 
   /**
    * Java API: creates a [[akka.stream.javadsl.Source Source]] of [[FtpFile]]s from a base path.
@@ -116,7 +145,7 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
   def ls(basePath: String,
          connectionSettings: S,
          branchSelector: Predicate[FtpFile],
-         emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed] =
+         emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
     Source.fromGraph(
       createBrowserGraph(basePath, connectionSettings, asScalaFromPredicate(branchSelector), emitTraversedDirectories)
     )

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -113,8 +113,13 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
    *
    * @return A [[akka.stream.javadsl.Source Source]] of [[FtpFile]]s
    */
-  def ls(basePath: String, connectionSettings: S, branchSelector: Predicate[FtpFile], emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed] =
-    Source.fromGraph(createBrowserGraph(basePath, connectionSettings, asScalaFromPredicate(branchSelector), emitTraversedDirectories))
+  def ls(basePath: String,
+         connectionSettings: S,
+         branchSelector: Predicate[FtpFile],
+         emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed] =
+    Source.fromGraph(
+      createBrowserGraph(basePath, connectionSettings, asScalaFromPredicate(branchSelector), emitTraversedDirectories)
+    )
 
   /**
    * Java API: creates a [[akka.stream.javadsl.Source Source]] of [[akka.util.ByteString ByteString]] from some file path.

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -88,11 +88,12 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
    *
    *                       Calling [ls(basePath,connectionSettings,f=>false)] will emit only the files and folder in
    *                       non-recursive fashion
+   * @param emitTraversedDirectories whether to include entered directories in the stream
    *
    * @return A [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s
    */
-  def ls(basePath: String, connectionSettings: S, branchSelector: FtpFile => Boolean): Source[FtpFile, NotUsed] =
-    Source.fromGraph(createBrowserGraph(basePath, connectionSettings, branchSelector))
+  def ls(basePath: String, connectionSettings: S, branchSelector: FtpFile => Boolean, emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed] =
+    Source.fromGraph(createBrowserGraph(basePath, connectionSettings, branchSelector, emitTraversedDirectories))
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[akka.util.ByteString ByteString]] from some file path.

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -92,7 +92,10 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
    *
    * @return A [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s
    */
-  def ls(basePath: String, connectionSettings: S, branchSelector: FtpFile => Boolean, emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed] =
+  def ls(basePath: String,
+         connectionSettings: S,
+         branchSelector: FtpFile => Boolean,
+         emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed] =
     Source.fromGraph(createBrowserGraph(basePath, connectionSettings, branchSelector, emitTraversedDirectories))
 
   /**

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -88,6 +88,26 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
    *
    *                       Calling [ls(basePath,connectionSettings,f=>false)] will emit only the files and folder in
    *                       non-recursive fashion
+   *
+   * @return A [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s
+   */
+  def ls(basePath: String, connectionSettings: S, branchSelector: FtpFile => Boolean): Source[FtpFile, NotUsed] =
+    Source.fromGraph(
+      createBrowserGraph(basePath, connectionSettings, branchSelector, _emitTraversedDirectories = false)
+    )
+
+  /**
+   * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s from a base path.
+   *
+   * @param basePath Base path from which traverse the remote file server
+   * @param connectionSettings connection settings
+   * @param branchSelector a function for pruning the tree. Takes a remote folder and return true
+   *                       if you want to enter that remote folder.
+   *                       Default behaviour is fully recursive which is equivalent with calling this function
+   *                       with [ls(basePath,connectionSettings,f=>true)].
+   *
+   *                       Calling [ls(basePath,connectionSettings,f=>false)] will emit only the files and folder in
+   *                       non-recursive fashion
    * @param emitTraversedDirectories whether to include entered directories in the stream
    *
    * @return A [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s
@@ -95,7 +115,7 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
   def ls(basePath: String,
          connectionSettings: S,
          branchSelector: FtpFile => Boolean,
-         emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed] =
+         emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
     Source.fromGraph(createBrowserGraph(basePath, connectionSettings, branchSelector, emitTraversedDirectories))
 
   /**

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/CommonFtpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/CommonFtpStageTest.java
@@ -49,7 +49,7 @@ interface CommonFtpStageTest extends FtpSupport, AkkaSupport {
     // putting test files on the server
     generateFiles(numFiles, pageSize, basePath);
 
-    Source<FtpFile, NotUsed> source = getBrowserSource(basePath).filter(p -> p.isFile());
+    Source<FtpFile, NotUsed> source = getBrowserSource(basePath);
 
     Pair<NotUsed, TestSubscriber.Probe<FtpFile>> pairResult =
         source.toMat(TestSink.probe(system), Keep.both()).run(materializer);

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/CommonFtpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/CommonFtpStageTest.java
@@ -49,7 +49,7 @@ interface CommonFtpStageTest extends FtpSupport, AkkaSupport {
     // putting test files on the server
     generateFiles(numFiles, pageSize, basePath);
 
-    Source<FtpFile, NotUsed> source = getBrowserSource(basePath);
+    Source<FtpFile, NotUsed> source = getBrowserSource(basePath).filter(p -> p.isFile());
 
     Pair<NotUsed, TestSubscriber.Probe<FtpFile>> pairResult =
         source.toMat(TestSink.probe(system), Keep.both()).run(materializer);

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpBaseSupport.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpBaseSupport.java
@@ -58,6 +58,12 @@ public abstract class FtpBaseSupport implements FtpSupport, AkkaSupport {
             rootDir,
             new SimpleFileVisitor<Path>() {
               @Override
+              public FileVisitResult postVisitDirectory(Path dir, IOException exc)
+                  throws IOException {
+                if (dir != rootDir) Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+              }
+              @Override
               public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
                   throws IOException {
                 Files.deleteIfExists(file);

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpBaseSupport.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpBaseSupport.java
@@ -63,6 +63,7 @@ public abstract class FtpBaseSupport implements FtpSupport, AkkaSupport {
                 if (dir != rootDir && !dir.toString().equals(FTP_ROOT_DIR)) Files.delete(dir);
                 return FileVisitResult.CONTINUE;
               }
+
               @Override
               public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
                   throws IOException {

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpBaseSupport.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpBaseSupport.java
@@ -60,7 +60,7 @@ public abstract class FtpBaseSupport implements FtpSupport, AkkaSupport {
               @Override
               public FileVisitResult postVisitDirectory(Path dir, IOException exc)
                   throws IOException {
-                if (dir != rootDir) Files.delete(dir);
+                if (dir != rootDir && !dir.toString().equals(FTP_ROOT_DIR)) Files.delete(dir);
                 return FileVisitResult.CONTINUE;
               }
               @Override

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
@@ -23,7 +23,9 @@ trait BaseFtpSpec extends PlainFtpSupportImpl with BaseSpec {
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =
     Ftp.ls(basePath, settings)
 
-  protected def listFilesWithFilter(basePath: String, branchSelector: FtpFile => Boolean, emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed] =
+  protected def listFilesWithFilter(basePath: String,
+                                    branchSelector: FtpFile => Boolean,
+                                    emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed] =
     Ftp.ls(basePath, settings, branchSelector, emitTraversedDirectories)
 
   protected def retrieveFromPath(path: String): Source[ByteString, Future[IOResult]] =

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
@@ -23,8 +23,8 @@ trait BaseFtpSpec extends PlainFtpSupportImpl with BaseSpec {
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =
     Ftp.ls(basePath, settings)
 
-  protected def listFilesWithFilter(basePath: String, branchSelector: FtpFile => Boolean): Source[FtpFile, NotUsed] =
-    Ftp.ls(basePath, settings, branchSelector)
+  protected def listFilesWithFilter(basePath: String, branchSelector: FtpFile => Boolean, emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed] =
+    Ftp.ls(basePath, settings, branchSelector, emitTraversedDirectories)
 
   protected def retrieveFromPath(path: String): Source[ByteString, Future[IOResult]] =
     Ftp.fromPath(path, settings)

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
@@ -24,8 +24,8 @@ trait BaseFtpsSpec extends FtpsSupportImpl with BaseSpec {
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =
     Ftps.ls(basePath, settings)
 
-  protected def listFilesWithFilter(basePath: String, branchSelector: FtpFile => Boolean): Source[FtpFile, NotUsed] =
-    Ftps.ls(basePath, settings, branchSelector)
+  protected def listFilesWithFilter(basePath: String, branchSelector: FtpFile => Boolean, emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
+    Ftps.ls(basePath, settings, branchSelector, emitTraversedDirectories)
 
   protected def retrieveFromPath(path: String): Source[ByteString, Future[IOResult]] =
     Ftps.fromPath(path, settings)

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
@@ -24,7 +24,9 @@ trait BaseFtpsSpec extends FtpsSupportImpl with BaseSpec {
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =
     Ftps.ls(basePath, settings)
 
-  protected def listFilesWithFilter(basePath: String, branchSelector: FtpFile => Boolean, emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
+  protected def listFilesWithFilter(basePath: String,
+                                    branchSelector: FtpFile => Boolean,
+                                    emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
     Ftps.ls(basePath, settings, branchSelector, emitTraversedDirectories)
 
   protected def retrieveFromPath(path: String): Source[ByteString, Future[IOResult]] =

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
@@ -23,7 +23,9 @@ trait BaseSftpSpec extends SftpSupportImpl with BaseSpec {
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =
     Sftp.ls(basePath, settings)
 
-  protected def listFilesWithFilter(basePath: String, branchSelector: FtpFile => Boolean, emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
+  protected def listFilesWithFilter(basePath: String,
+                                    branchSelector: FtpFile => Boolean,
+                                    emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
     Sftp.ls(basePath, settings, branchSelector, emitTraversedDirectories)
 
   protected def retrieveFromPath(path: String): Source[ByteString, Future[IOResult]] =

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
@@ -23,8 +23,8 @@ trait BaseSftpSpec extends SftpSupportImpl with BaseSpec {
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =
     Sftp.ls(basePath, settings)
 
-  protected def listFilesWithFilter(basePath: String, branchSelector: FtpFile => Boolean): Source[FtpFile, NotUsed] =
-    Sftp.ls(basePath, settings, branchSelector)
+  protected def listFilesWithFilter(basePath: String, branchSelector: FtpFile => Boolean, emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
+    Sftp.ls(basePath, settings, branchSelector, emitTraversedDirectories)
 
   protected def retrieveFromPath(path: String): Source[ByteString, Future[IOResult]] =
     Sftp.fromPath(path, settings)

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
@@ -27,7 +27,7 @@ trait BaseSpec
 
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed]
 
-  protected def listFilesWithFilter(basePath: String, branchSelector: FtpFile => Boolean): Source[FtpFile, NotUsed]
+  protected def listFilesWithFilter(basePath: String, branchSelector: FtpFile => Boolean, emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed]
 
   protected def retrieveFromPath(path: String): Source[ByteString, Future[IOResult]]
 

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
@@ -27,7 +27,9 @@ trait BaseSpec
 
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed]
 
-  protected def listFilesWithFilter(basePath: String, branchSelector: FtpFile => Boolean, emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed]
+  protected def listFilesWithFilter(basePath: String,
+                                    branchSelector: FtpFile => Boolean,
+                                    emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed]
 
   protected def retrieveFromPath(path: String): Source[ByteString, Future[IOResult]]
 

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -127,7 +127,9 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
       val basePath = ""
       generateFiles(1, -1, deepDir)
       val probe =
-        listFilesWithFilter(basePath, _ => true, emitTraversedDirectories = true).toMat(TestSink.probe)(Keep.right).run()
+        listFilesWithFilter(basePath, _ => true, emitTraversedDirectories = true)
+          .toMat(TestSink.probe)(Keep.right)
+          .run()
       probe.request(10).expectNextN(5) // foo, bar, baz, foobar, and sample_1 = 5 files
       probe.expectComplete()
     }


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

This PR is about making `Ftp.ls` emit directories it encounters no matter if they were traversed or not.
The previous behavior being that you only get directories that were not entered, which is unexpected.

## References

References #1657

## Changes

`FtpGraphStageLogic` keeps a record of traversed directories and emit them first on pull.
For instance the path `/foo/bar/sample` will result in the emission of three `FtpFile`, one for `foo`, one for `bar`, and one for `sample`, in that order.

Additionally, the test-related class `FtpBaseSupport` had to be fixed to remove empty directories when cleaning files, and tests have been reviewed to match the new behavior of `listFiles`.


