### PR TITLE
Remove JNR

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -396,8 +396,7 @@ object Dependencies {
 
   val UnixDomainSocket = Seq(
     libraryDependencies ++= Seq(
-      "com.github.jnr" % "jffi" % "1.2.17" classifier "complete", // ApacheV2
-      "com.github.jnr" % "jnr-unixsocket" % "0.22" // BSD/ApacheV2/CPL/MIT as per https://github.com/akka/alpakka/issues/620#issuecomment-348727265
+      "net.java.dev.jna" % "jna" % "5.2.0" // ApacheV2
     )
   )
 

--- a/unix-domain-socket/src/main/java/com/facebook/nailgun/NGUnixDomainSocketLibrary.java
+++ b/unix-domain-socket/src/main/java/com/facebook/nailgun/NGUnixDomainSocketLibrary.java
@@ -50,7 +50,11 @@ public class NGUnixDomainSocketLibrary {
   public static final int F_GETFL = 3;
   public static final int F_SETFL = 4;
 
+  // Added
   public static final int O_NONBLOCK = 0x0004;
+
+  // Added
+  public static final int EINPROGRESS = 115;
 
   // Utility class, do not instantiate.
   private NGUnixDomainSocketLibrary() {}
@@ -158,5 +162,6 @@ public class NGUnixDomainSocketLibrary {
 
   public static native int unlink(String socketFile);
 
+  // Added
   public static native int fcntl(int fd, int cmd, int data) throws LastErrorException;
 }

--- a/unix-domain-socket/src/main/java/com/facebook/nailgun/NGUnixDomainSocketLibrary.java
+++ b/unix-domain-socket/src/main/java/com/facebook/nailgun/NGUnixDomainSocketLibrary.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+/*
+ * This code was extended from:
+ * https://github.com/facebook/nailgun/blob/master/nailgun-server/src/main/java/com/facebook/nailgun/NGUnixDomainSocketLibrary.java
+ */
+
+/*
+  Copyright 2004-2015, Martian Software, Inc.
+  Copyright 2017-Present Facebook, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package com.facebook.nailgun;
+
+import com.sun.jna.LastErrorException;
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
+import com.sun.jna.Structure;
+import com.sun.jna.Union;
+import com.sun.jna.ptr.IntByReference;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+/** Utility class to bridge native Unix domain socket calls to Java using JNA. */
+public class NGUnixDomainSocketLibrary {
+  public static final int PF_LOCAL = 1;
+  public static final int AF_LOCAL = 1;
+  public static final int SOCK_STREAM = 1;
+
+  public static final int SHUT_RD = 0;
+  public static final int SHUT_WR = 1;
+  public static final int SHUT_RDWR = 2;
+
+  public static final int F_GETFL = 3;
+  public static final int F_SETFL = 4;
+
+  public static final int O_NONBLOCK = 0x0004;
+
+  // Utility class, do not instantiate.
+  private NGUnixDomainSocketLibrary() {}
+
+  // BSD platforms write a length byte at the start of struct sockaddr_un.
+  private static final boolean HAS_SUN_LEN =
+      Platform.isMac()
+          || Platform.isFreeBSD()
+          || Platform.isNetBSD()
+          || Platform.isOpenBSD()
+          || Platform.iskFreeBSD();
+
+  /** Bridges {@code struct sockaddr_un} to and from native code. */
+  public static class SockaddrUn extends Structure implements Structure.ByReference {
+    /**
+     * On BSD platforms, the {@code sun_len} and {@code sun_family} values in {@code struct
+     * sockaddr_un}.
+     */
+    public static class SunLenAndFamily extends Structure {
+      public byte sunLen;
+      public byte sunFamily;
+
+      protected List getFieldOrder() {
+        return Arrays.asList(new String[] {"sunLen", "sunFamily"});
+      }
+    }
+
+    /**
+     * On BSD platforms, {@code sunLenAndFamily} will be present. On other platforms, only {@code
+     * sunFamily} will be present.
+     */
+    public static class SunFamily extends Union {
+      public SunLenAndFamily sunLenAndFamily;
+      public short sunFamily;
+    }
+
+    public SunFamily sunFamily = new SunFamily();
+    public byte[] sunPath = new byte[104];
+
+    /** Constructs an empty {@code struct sockaddr_un}. */
+    public SockaddrUn() {
+      if (HAS_SUN_LEN) {
+        sunFamily.sunLenAndFamily = new SunLenAndFamily();
+        sunFamily.setType(SunLenAndFamily.class);
+      } else {
+        sunFamily.setType(Short.TYPE);
+      }
+      allocateMemory();
+    }
+
+    /**
+     * Constructs a {@code struct sockaddr_un} with a path whose bytes are encoded using the default
+     * encoding of the platform.
+     */
+    public SockaddrUn(String path) throws IOException {
+      byte[] pathBytes = path.getBytes();
+      if (pathBytes.length > sunPath.length - 1) {
+        throw new IOException(
+            "Cannot fit name [" + path + "] in maximum unix domain socket length");
+      }
+      System.arraycopy(pathBytes, 0, sunPath, 0, pathBytes.length);
+      sunPath[pathBytes.length] = (byte) 0;
+      if (HAS_SUN_LEN) {
+        int len = fieldOffset("sunPath") + pathBytes.length;
+        sunFamily.sunLenAndFamily = new SunLenAndFamily();
+        sunFamily.sunLenAndFamily.sunLen = (byte) len;
+        sunFamily.sunLenAndFamily.sunFamily = AF_LOCAL;
+        sunFamily.setType(SunLenAndFamily.class);
+      } else {
+        sunFamily.sunFamily = AF_LOCAL;
+        sunFamily.setType(Short.TYPE);
+      }
+      allocateMemory();
+    }
+
+    protected List getFieldOrder() {
+      return Arrays.asList(new String[] {"sunFamily", "sunPath"});
+    }
+  }
+
+  static {
+    Native.register(Platform.C_LIBRARY_NAME);
+  }
+
+  public static native int socket(int domain, int type, int protocol) throws LastErrorException;
+
+  public static native int bind(int fd, SockaddrUn address, int addressLen)
+      throws LastErrorException;
+
+  public static native int listen(int fd, int backlog) throws LastErrorException;
+
+  public static native int connect(int fd, SockaddrUn address, int addressLen)
+      throws LastErrorException;
+
+  public static native int accept(int fd, SockaddrUn address, IntByReference addressLen)
+      throws LastErrorException;
+
+  public static native int read(int fd, ByteBuffer buffer, int count) throws LastErrorException;
+
+  public static native int write(int fd, ByteBuffer buffer, int count) throws LastErrorException;
+
+  public static native int close(int fd) throws LastErrorException;
+
+  public static native int shutdown(int fd, int how) throws LastErrorException;
+
+  public static native int unlink(String socketFile);
+
+  public static native int fcntl(int fd, int cmd, int data) throws LastErrorException;
+}

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/UnixSocketAddress.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/UnixSocketAddress.scala
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.unixdomainsocket
+import java.net.SocketAddress
+import java.nio.file.Path
+
+/**
+ * Represents a path to a file on a file system that a Unix Domain Socket can
+ * bind or connect to.
+ */
+final case class UnixSocketAddress(path: Path) extends SocketAddress

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/UnixDomainSocketImpl.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/UnixDomainSocketImpl.scala
@@ -258,7 +258,7 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
       val (context, connectionFlow) = sendReceiveStructures(sel, receiveBufferSize, sendBufferSize, halfClose)
       try { acceptedChannel.register(sel, SelectionKey.OP_READ, context) } catch { case _: IOException => }
       incomingConnectionQueue.offer(
-        IncomingConnection(localAddress, acceptedChannel.getRemoteAddress, connectionFlow)
+        IncomingConnection(localAddress, UnixSocketAddress(Paths.get("")), connectionFlow)
       )
     }
   }
@@ -272,8 +272,6 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
     cancellable.foreach(_.cancel())
     try {
       connectingChannel.register(sel, SelectionKey.OP_READ, sendReceiveContext)
-      val finishExpected = connectingChannel.finishConnect()
-      require(finishExpected, "Internal error - our call to connection finish wasn't expected.")
       connectionFinished.trySuccess(Done)
     } catch {
       case NonFatal(e) =>

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/nio/UnixServerSocketChannel.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/nio/UnixServerSocketChannel.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.unixdomainsocket
 package impl.nio
 
+import java.nio.channels.SelectionKey
 import java.nio.channels.spi.{AbstractSelectableChannel, SelectorProvider}
 
 import akka.annotation.InternalApi
@@ -23,7 +24,8 @@ private[unixdomainsocket] final class UnixServerSocketChannel(provider: Selector
   override def implConfigureBlocking(block: Boolean): Unit =
     socket.setBlocking(block)
 
-  override def validOps(): Int = ???
+  override def validOps(): Int =
+    SelectionKey.OP_ACCEPT
 
   def acceptNonBlocked(): UnixSocketChannel = {
     val acceptedSocket = socket.accept()

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/nio/UnixServerSocketChannel.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/nio/UnixServerSocketChannel.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.unixdomainsocket
+package impl.nio
+
+import java.nio.channels.spi.{AbstractSelectableChannel, SelectorProvider}
+
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[unixdomainsocket] final class UnixServerSocketChannel(provider: SelectorProvider,
+                                                              private val socket: UnixSocket)
+    extends AbstractSelectableChannel(provider) {
+
+  override def implCloseSelectableChannel(): Unit =
+    socket.close()
+
+  override def implConfigureBlocking(block: Boolean): Unit =
+    socket.setBlocking(block)
+
+  override def validOps(): Int = ???
+
+  def acceptNonBlocked(): UnixSocketChannel = {
+    val acceptedSocket = socket.accept()
+    acceptedSocket.setBlocking(false)
+    new UnixSocketChannel(provider, acceptedSocket)
+  }
+}

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/nio/UnixSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/nio/UnixSocket.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.unixdomainsocket.impl.nio
+
+import java.io.IOException
+import java.nio.ByteBuffer
+
+import akka.annotation.InternalApi
+import akka.stream.alpakka.unixdomainsocket.UnixSocketAddress
+import com.facebook.nailgun.NGUnixDomainSocketLibrary
+import com.sun.jna.LastErrorException
+import com.sun.jna.ptr.IntByReference
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[unixdomainsocket] object UnixSocket {
+  def apply(): UnixSocket =
+    new UnixSocket(
+      tryIo(
+        NGUnixDomainSocketLibrary.socket(NGUnixDomainSocketLibrary.AF_LOCAL, NGUnixDomainSocketLibrary.SOCK_STREAM, 0)
+      )
+    )
+
+  private def tryIo[A](block: => A): A =
+    try {
+      block
+    } catch {
+      case e: LastErrorException => throw new IOException(e)
+    }
+}
+
+/**
+ * INTERNAL API
+ *
+ * The motivation for this class is to maintain a file descriptor
+ * to the native calls. This file descriptor provides complete
+ * access to the state managed by the OS w.r.t. a socket. Both
+ * the socket and server socket channels utilize instances of
+ * this class.
+ */
+@InternalApi
+private[unixdomainsocket] final class UnixSocket(private val fd: Int) {
+
+  import UnixSocket._
+
+  def connect(address: UnixSocketAddress): Unit = {
+    val sockAddr = new NGUnixDomainSocketLibrary.SockaddrUn(address.toString)
+    tryIo(NGUnixDomainSocketLibrary.connect(fd, sockAddr, sockAddr.size))
+  }
+
+  def bind(address: UnixSocketAddress): Unit = {
+    val sockAddr = new NGUnixDomainSocketLibrary.SockaddrUn(address.toString)
+    tryIo(NGUnixDomainSocketLibrary.bind(fd, sockAddr, sockAddr.size))
+  }
+
+  def listen(backlog: Int): Unit =
+    tryIo(NGUnixDomainSocketLibrary.listen(fd, backlog))
+
+  def accept(): UnixSocket = {
+    val sockAddr = new NGUnixDomainSocketLibrary.SockaddrUn
+    val sockAddrSize = new IntByReference(sockAddr.size)
+    new UnixSocket(tryIo(NGUnixDomainSocketLibrary.accept(fd, sockAddr, sockAddrSize)))
+  }
+
+  def read(dst: ByteBuffer): Int =
+    tryIo(NGUnixDomainSocketLibrary.read(fd, dst, dst.remaining()))
+
+  def write(src: ByteBuffer): Int =
+    tryIo(NGUnixDomainSocketLibrary.write(fd, src, src.remaining()))
+
+  def close(): Unit =
+    tryIo(NGUnixDomainSocketLibrary.close(fd))
+
+  def isBlocking: Boolean = {
+    val status = tryIo(NGUnixDomainSocketLibrary.fcntl(fd, NGUnixDomainSocketLibrary.F_GETFL, 0))
+    (status & NGUnixDomainSocketLibrary.O_NONBLOCK) == NGUnixDomainSocketLibrary.O_NONBLOCK
+  }
+
+  def setBlocking(block: Boolean): Unit = {
+    val status = tryIo(NGUnixDomainSocketLibrary.fcntl(fd, NGUnixDomainSocketLibrary.F_GETFL, 0))
+    tryIo(
+      NGUnixDomainSocketLibrary
+        .fcntl(fd, NGUnixDomainSocketLibrary.F_SETFL, status | (if (block) NGUnixDomainSocketLibrary.O_NONBLOCK else 0))
+    )
+  }
+}

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/nio/UnixSocketChannel.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/nio/UnixSocketChannel.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.unixdomainsocket.impl.nio
+
+import java.nio.ByteBuffer
+import java.nio.channels._
+import java.nio.channels.spi.{AbstractSelectableChannel, SelectorProvider}
+
+import akka.annotation.InternalApi
+import akka.stream.alpakka.unixdomainsocket.UnixSocketAddress
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[unixdomainsocket] final class UnixSocketChannel(provider: SelectorProvider, private val socket: UnixSocket)
+    extends AbstractSelectableChannel(provider)
+    with ByteChannel {
+
+  override def implCloseSelectableChannel(): Unit =
+    socket.close()
+
+  override def implConfigureBlocking(block: Boolean): Unit =
+    socket.setBlocking(block)
+
+  override def validOps(): Int = ???
+
+  override def read(dst: ByteBuffer): Int =
+    socket.read(dst)
+
+  override def write(src: ByteBuffer): Int =
+    socket.write(src)
+
+  def finishConnect(): Boolean = ???
+
+  def getRemoteAddress: UnixSocketAddress = ???
+
+  def shutdownInput(): Unit = ???
+
+  def shutdownOutput(): Unit = ???
+}

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/nio/UnixSocketChannel.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/nio/UnixSocketChannel.scala
@@ -9,7 +9,6 @@ import java.nio.channels._
 import java.nio.channels.spi.{AbstractSelectableChannel, SelectorProvider}
 
 import akka.annotation.InternalApi
-import akka.stream.alpakka.unixdomainsocket.UnixSocketAddress
 
 /**
  * INTERNAL API
@@ -25,7 +24,8 @@ private[unixdomainsocket] final class UnixSocketChannel(provider: SelectorProvid
   override def implConfigureBlocking(block: Boolean): Unit =
     socket.setBlocking(block)
 
-  override def validOps(): Int = ???
+  override def validOps(): Int =
+    SelectionKey.OP_READ | SelectionKey.OP_WRITE | SelectionKey.OP_CONNECT
 
   override def read(dst: ByteBuffer): Int =
     socket.read(dst)
@@ -33,11 +33,9 @@ private[unixdomainsocket] final class UnixSocketChannel(provider: SelectorProvid
   override def write(src: ByteBuffer): Int =
     socket.write(src)
 
-  def finishConnect(): Boolean = ???
+  def shutdownInput(): Unit =
+    socket.shutdownInput()
 
-  def getRemoteAddress: UnixSocketAddress = ???
-
-  def shutdownInput(): Unit = ???
-
-  def shutdownOutput(): Unit = ???
+  def shutdownOutput(): Unit =
+    socket.shutdownOutput()
 }

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/nio/UnixSocketSelector.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/nio/UnixSocketSelector.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.unixdomainsocket.impl.nio
+import java.nio.channels.{SelectionKey, Selector}
+import java.nio.channels.spi.{AbstractSelectableChannel, AbstractSelector, SelectorProvider}
+import java.util
+
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ *
+ * This class is the centre of the UDS universe in that it calls on the OS to
+ * receive notifications w.r.t. when IO is signalled on the file descriptors
+ * we manage. This information is accordingly passed on to NIO.
+ */
+@InternalApi
+private[unixdomainsocket] final class UnixSocketSelector(provider: SelectorProvider)
+    extends AbstractSelector(provider) {
+  override def implCloseSelector(): Unit = ???
+  override def register(ch: AbstractSelectableChannel, ops: Int, att: Any): SelectionKey = ???
+  override def keys(): util.Set[SelectionKey] = ???
+  override def selectedKeys(): util.Set[SelectionKey] = ???
+  override def selectNow(): Int = ???
+  override def select(timeout: Long): Int = ???
+  override def select(): Int = ???
+  override def wakeup(): Selector = ???
+}

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/nio/UnixSocketSelectorProvider.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/nio/UnixSocketSelectorProvider.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.unixdomainsocket.impl.nio
+
+import java.net.ProtocolFamily
+import java.nio.channels.spi.SelectorProvider
+import java.nio.channels.{DatagramChannel, Pipe, ServerSocketChannel, SocketChannel}
+
+import akka.annotation.InternalApi
+import akka.stream.alpakka.unixdomainsocket.UnixSocketAddress
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[unixdomainsocket] object UnixSocketSelectorProvider extends UnixSocketSelectorProvider
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[unixdomainsocket] class UnixSocketSelectorProvider extends SelectorProvider {
+  override def openDatagramChannel(): DatagramChannel =
+    throw new NotImplementedError
+
+  override def openDatagramChannel(family: ProtocolFamily): DatagramChannel =
+    throw new NotImplementedError
+
+  override def openPipe(): Pipe =
+    throw new NotImplementedError
+
+  override def openSelector(): UnixSocketSelector =
+    new UnixSocketSelector(this)
+
+  override def openServerSocketChannel(): ServerSocketChannel =
+    throw new NotImplementedError
+
+  override def openSocketChannel(): SocketChannel =
+    throw new NotImplementedError
+
+  def bindAndListenNonBlocked(local: UnixSocketAddress, backlog: Int): UnixServerSocketChannel = {
+    val socket = UnixSocket()
+    socket.setBlocking(false)
+    socket.bind(local)
+    socket.listen(backlog)
+    new UnixServerSocketChannel(this, socket)
+  }
+
+  def connectNonBlocked(remote: UnixSocketAddress): UnixSocketChannel = {
+    val socket = UnixSocket()
+    socket.setBlocking(false)
+    socket.connect(remote)
+    new UnixSocketChannel(this, socket)
+  }
+}

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/javadsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/javadsl/UnixDomainSocket.scala
@@ -2,9 +2,10 @@
  * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.stream.alpakka.unixdomainsocket.javadsl
+package akka.stream.alpakka.unixdomainsocket
+package javadsl
 
-import java.io.File
+import java.nio.file.Path
 import java.util.Optional
 import java.util.concurrent.CompletionStage
 
@@ -16,7 +17,6 @@ import akka.stream.alpakka.unixdomainsocket.scaladsl.{UnixDomainSocket => ScalaU
 import akka.stream.javadsl.{Flow, Source}
 import akka.stream.Materializer
 import akka.util.ByteString
-import jnr.unixsocket.UnixSocketAddress
 
 import scala.concurrent.duration.Duration
 
@@ -113,7 +113,7 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends akka.actor.Ext
    *
    * TODO: Support idleTimeout as per Tcp.
    *
-   * @param file      The file to listen on
+   * @param path      The path to listen on
    * @param backlog   Controls the size of the connection backlog
    * @param halfClose
    *                  Controls whether the connection is kept open even after writing has been completed to the accepted
@@ -125,10 +125,10 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends akka.actor.Ext
    *                  independently whether the client is still attempting to write. This setting is recommended
    *                  for servers, and therefore it is the default setting.
    */
-  def bind(file: File, backlog: Int, halfClose: Boolean): Source[IncomingConnection, CompletionStage[ServerBinding]] =
+  def bind(path: Path, backlog: Int, halfClose: Boolean): Source[IncomingConnection, CompletionStage[ServerBinding]] =
     Source.fromGraph(
       delegate
-        .bind(file, backlog, halfClose)
+        .bind(path, backlog, halfClose)
         .map(new IncomingConnection(_))
         .mapMaterializedValue(_.map(new ServerBinding(_))(ec).toJava)
     )
@@ -141,10 +141,10 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends akka.actor.Ext
    * [[akka.stream.scaladsl.RunnableGraph]] the server is not immediately available. Only after the materialized future
    * completes is the server ready to accept client connections.
    */
-  def bind(file: File): Source[IncomingConnection, CompletionStage[ServerBinding]] =
+  def bind(path: Path): Source[IncomingConnection, CompletionStage[ServerBinding]] =
     Source.fromGraph(
       delegate
-        .bind(file)
+        .bind(path)
         .map(new IncomingConnection(_))
         .mapMaterializedValue(_.map(new ServerBinding(_))(ec).toJava)
     )
@@ -190,10 +190,10 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends akka.actor.Ext
    * to achieve application level chunks you have to introduce explicit framing in your streams,
    * for example using the [[akka.stream.javadsl.Framing]] stages.
    */
-  def outgoingConnection(file: File): Flow[ByteString, ByteString, CompletionStage[OutgoingConnection]] =
+  def outgoingConnection(path: Path): Flow[ByteString, ByteString, CompletionStage[OutgoingConnection]] =
     Flow.fromGraph(
       delegate
-        .outgoingConnection(new UnixSocketAddress(file))
+        .outgoingConnection(UnixSocketAddress(path))
         .mapMaterializedValue(_.map(new OutgoingConnection(_))(ec).toJava)
     )
 

--- a/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
+++ b/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
@@ -16,14 +16,13 @@ import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import akka.japi.Pair;
 
-import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.CompletionStage;
 
 import akka.stream.alpakka.unixdomainsocket.javadsl.UnixDomainSocket.IncomingConnection;
@@ -41,7 +40,7 @@ public class UnixDomainSocketTest {
   }
 
   @BeforeClass
-  public static void setup() throws Exception {
+  public static void setup() {
     final Pair<ActorSystem, Materializer> sysmat = setupMaterializer();
     system = sysmat.first();
     materializer = sysmat.second();
@@ -54,16 +53,15 @@ public class UnixDomainSocketTest {
 
   @Test
   public void aUnixDomainSocketShouldReceiveWhatIsSent() throws Exception {
+    Path dir = Files.createTempDirectory("aUnixDomainSocketShouldReceiveWhatIsSent1");
     // #binding
-    java.io.File file = // ...
+    java.nio.file.Path path = // ...
         // #binding
-        Files.createTempFile("aUnixDomainSocketShouldReceiveWhatIsSent1", ".sock").toFile();
-    Assert.assertTrue(file.delete());
-    file.deleteOnExit();
+        dir.resolve("sock1");
 
     // #binding
     final Source<IncomingConnection, CompletionStage<ServerBinding>> connections =
-        UnixDomainSocket.get(system).bind(file);
+        UnixDomainSocket.get(system).bind(path);
     // #binding
 
     // #outgoingConnection


### PR DESCRIPTION
Use direct JNA calls instead. Uses Nailgun’s JNA declarations for sockets, and provides a NIO wrapper for non-blocking IO.

The motivation for this change is that I’ve had a number of problems with JNR over time. Now there’s a high CPU usage issue we see on a low powered device that we think is internal to JNR, as well as weird behaviour when expecting some signals in the half close state. Rather than again try to fix a foreign code base, I’d rather tackle using Unix sockets directly and possibly gain some performance benefits.

The approach I've taken here is to minimise the layers between NIO and the OS. The OS actually has all the state we require, so we shouldn't duplicate that state in memory (as the JDK itself does with regular sockets).

Warning: API changes. JNR previously leaked out of the API for UnixSocketAddress. I’ve also moved from File to Path as that’s what they are.

TODO: Complete the NIO code.