### PR TITLE
FTP: support partial file download

### DIFF
--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
@@ -63,7 +63,11 @@ private[ftp] trait CommonFtpOperations {
 
   def listFiles(handler: Handler): immutable.Seq[FtpFile] = listFiles("", handler)
 
-  def retrieveFileInputStream(name: String, handler: Handler): Try[InputStream] = Try {
+  def retrieveFileInputStream(name: String, handler: Handler): Try[InputStream] =
+    retrieveFileInputStream(name, handler, 0L)
+
+  def retrieveFileInputStream(name: String, handler: Handler, offset: Long): Try[InputStream] = Try {
+    handler.setRestartOffset(offset)
     val is = handler.retrieveFileStream(name)
     if (is != null) is else throw new IOException(s"$name: No such file or directory")
   }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
@@ -43,9 +43,19 @@ protected[ftp] trait FtpLike[FtpClient, S <: RemoteFileSettings] {
  * INTERNAL API
  */
 @InternalApi
+protected[ftp] trait RetrieveOffset { _: FtpLike[_, _] =>
+
+  def retrieveFileInputStream(name: String, handler: Handler, offset: Long): Try[InputStream]
+
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
 object FtpLike {
   // type class instances
-  implicit val ftpLikeInstance = new FtpLike[FTPClient, FtpSettings] with FtpOperations
-  implicit val ftpsLikeInstance = new FtpLike[FTPSClient, FtpsSettings] with FtpsOperations
-  implicit val sFtpLikeInstance = new FtpLike[SSHClient, SftpSettings] with SftpOperations
+  implicit val ftpLikeInstance = new FtpLike[FTPClient, FtpSettings] with RetrieveOffset with FtpOperations
+  implicit val ftpsLikeInstance = new FtpLike[FTPSClient, FtpsSettings] with RetrieveOffset with FtpsOperations
+  implicit val sFtpLikeInstance = new FtpLike[SSHClient, SftpSettings] with RetrieveOffset with SftpOperations
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
@@ -58,6 +58,14 @@ private[ftp] trait FtpSourceFactory[FtpClient] { self =>
       _connectionSettings: S,
       _chunkSize: Int
   )(implicit _ftpLike: FtpLike[FtpClient, S]): FtpIOSourceStage[FtpClient, S] =
+    createIOSource(_path, _connectionSettings, _chunkSize, 0L)
+
+  protected[this] def createIOSource(
+      _path: String,
+      _connectionSettings: S,
+      _chunkSize: Int,
+      _offset: Long
+  )(implicit _ftpLike: FtpLike[FtpClient, S]): FtpIOSourceStage[FtpClient, S] =
     new FtpIOSourceStage[FtpClient, S] {
       lazy val name: String = ftpIOSourceName
       val path: String = _path
@@ -65,6 +73,7 @@ private[ftp] trait FtpSourceFactory[FtpClient] { self =>
       val ftpClient: () => FtpClient = self.ftpClient
       val ftpLike: FtpLike[FtpClient, S] = _ftpLike
       val chunkSize: Int = _chunkSize
+      override val offset: Long = _offset
     }
 
   protected[this] def createIOSink(

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
@@ -85,9 +85,12 @@ private[ftp] trait SftpOperations { _: FtpLike[SSHClient, SftpSettings] =>
 
   def listFiles(handler: Handler): immutable.Seq[FtpFile] = listFiles(".", handler)
 
-  def retrieveFileInputStream(name: String, handler: Handler): Try[InputStream] = Try {
+  def retrieveFileInputStream(name: String, handler: Handler): Try[InputStream] =
+    retrieveFileInputStream(name, handler, 0L)
+
+  def retrieveFileInputStream(name: String, handler: Handler, offset: Long): Try[InputStream] = Try {
     val remoteFile = handler.open(name, java.util.EnumSet.of(OpenMode.READ))
-    val is = new remoteFile.RemoteFileInputStream() {
+    val is = new remoteFile.RemoteFileInputStream(offset) {
 
       override def close(): Unit =
         try {

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -205,9 +205,29 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
       path: String,
       connectionSettings: S,
       chunkSize: Int = DefaultChunkSize
+  ): Source[ByteString, CompletionStage[IOResult]] =
+    fromPath(path, connectionSettings, chunkSize, 0L)
+
+  /**
+   * Java API: creates a [[akka.stream.javadsl.Source Source]] of [[akka.util.ByteString ByteString]] from some file path.
+   *
+   * @param path the file path
+   * @param connectionSettings connection settings
+   * @param chunkSize the size of transmitted [[akka.util.ByteString ByteString]] chunks
+   * @param offset the offset into the remote file at which to start the file transfer
+   * @return A [[akka.stream.javadsl.Source Source]] of [[akka.util.ByteString ByteString]] that materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[IOResult]]
+   */
+  def fromPath(
+      path: String,
+      connectionSettings: S,
+      chunkSize: Int,
+      offset: Long
   ): Source[ByteString, CompletionStage[IOResult]] = {
     import scala.compat.java8.FutureConverters._
-    ScalaSource.fromGraph(createIOSource(path, connectionSettings, chunkSize)).mapMaterializedValue(_.toJava).asJava
+    ScalaSource
+      .fromGraph(createIOSource(path, connectionSettings, chunkSize, offset))
+      .mapMaterializedValue(_.toJava)
+      .asJava
   }
 
   /**

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -153,7 +153,24 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
       connectionSettings: S,
       chunkSize: Int = DefaultChunkSize
   ): Source[ByteString, Future[IOResult]] =
-    Source.fromGraph(createIOSource(path, connectionSettings, chunkSize))
+    fromPath(path, connectionSettings, chunkSize, 0L)
+
+  /**
+   * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[akka.util.ByteString ByteString]] from some file path.
+   *
+   * @param path the file path
+   * @param connectionSettings connection setting
+   * @param chunkSize the size of transmitted [[akka.util.ByteString ByteString]] chunks
+   * @param offset the offset into the remote file at which to start the file transfer
+   * @return A [[akka.stream.scaladsl.Source Source]] of [[akka.util.ByteString ByteString]] that materializes to a [[scala.concurrent.Future Future]] of [[IOResult]]
+   */
+  def fromPath(
+      path: String,
+      connectionSettings: S,
+      chunkSize: Int,
+      offset: Long
+  ): Source[ByteString, Future[IOResult]] =
+    Source.fromGraph(createIOSource(path, connectionSettings, chunkSize, offset))
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Sink Sink]] of [[akka.util.ByteString ByteString]] to some file path.

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/StrictHostCheckingSftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/StrictHostCheckingSftpSourceTest.java
@@ -15,7 +15,8 @@ import java.net.InetAddress;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
-public class StrictHostCheckingSftpSourceTest extends BaseSftpSupport implements CommonFtpStageTest {
+public class StrictHostCheckingSftpSourceTest extends BaseSftpSupport
+    implements CommonFtpStageTest {
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
@@ -32,6 +32,9 @@ trait BaseFtpSpec extends BaseFtpSupport with BaseSpec {
   protected def retrieveFromPath(path: String, fromRoot: Boolean = false): Source[ByteString, Future[IOResult]] =
     Ftp.fromPath(path, settings)
 
+  protected def retrieveFromPathWithOffset(path: String, offset: Long): Source[ByteString, Future[IOResult]] =
+    Ftp.fromPath(path, settings, 8192, offset)
+
   protected def storeToPath(path: String, append: Boolean): Sink[ByteString, Future[IOResult]] =
     Ftp.toPath(path, settings, append)
 

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
@@ -33,6 +33,9 @@ trait BaseFtpsSpec extends BaseFtpSupport with BaseSpec {
   protected def retrieveFromPath(path: String, fromRoot: Boolean = false): Source[ByteString, Future[IOResult]] =
     Ftps.fromPath(path, settings)
 
+  protected def retrieveFromPathWithOffset(path: String, offset: Long): Source[ByteString, Future[IOResult]] =
+    Ftps.fromPath(path, settings, 8192, offset)
+
   protected def storeToPath(path: String, append: Boolean): Sink[ByteString, Future[IOResult]] =
     Ftps.toPath(path, settings, append)
 

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
@@ -34,6 +34,9 @@ trait BaseSftpSpec extends BaseSftpSupport with BaseSpec {
     Sftp.fromPath(finalPath, settings)
   }
 
+  protected def retrieveFromPathWithOffset(path: String, offset: Long): Source[ByteString, Future[IOResult]] =
+    Sftp.fromPath(ROOT_PATH + path, settings, 8192, offset)
+
   protected def storeToPath(path: String, append: Boolean): Sink[ByteString, Future[IOResult]] =
     Sftp.toPath(ROOT_PATH + path, settings, append)
 

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
@@ -44,6 +44,8 @@ trait BaseSpec
 
   protected def retrieveFromPath(path: String, fromRoot: Boolean = false): Source[ByteString, Future[IOResult]]
 
+  protected def retrieveFromPathWithOffset(path: String, offset: Long): Source[ByteString, Future[IOResult]]
+
   protected def storeToPath(path: String, append: Boolean): Sink[ByteString, Future[IOResult]]
 
   protected def remove(): Sink[FtpFile, Future[IOResult]]


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

This PR makes it possible to download a file partially (from an offset) with `FTP.fromPath`

## References

References #1660 

## Changes

I found it hard to maintain binary compatibility while implementing this. I couldn't add a parameter or a method to the `FtpLike` trait even though it's an internal API and it's protected (is that even related to binary compatibility?), so I added a new trait called `RetrieveOffset` mixed in all the FtpLike instances.

Also `FtpApi` defines a default chunksize parameter to `fromPath` and I couldn't add another parameter to that mehod nor add another method with default parameters, so anyone wanting to define an offset will have to manually specify the chunksize (defaults to 8192).

Eg.: `Ftp.fromPath(path, settings, 8192, offset)`

Two tests were added. 
