### PR TITLE
AWS SQS: Emit all successful batch item entries before failing stream

### DIFF
--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsBatchException.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsBatchException.scala
@@ -6,21 +6,20 @@ package akka.stream.alpakka.sqs
 
 import akka.annotation.InternalApi
 
-final class SqsBatchException @InternalApi private[sqs] (val batchSize: Int, message: String)
-    extends Exception(message) {
+import scala.collection.JavaConverters._
 
-  @InternalApi
-  private[sqs] def this(batchSize: Int, cause: Throwable) {
-    this(batchSize, cause.getMessage)
-    initCause(cause)
-  }
-
-  @InternalApi
-  private[sqs] def this(batchSize: Int, message: String, cause: Throwable) {
-    this(batchSize, message)
-    initCause(cause)
-  }
+final class SqsBatchException[T <: AnyRef] @InternalApi private[sqs] (val errors: List[SqsResultErrorEntry[T]])
+    extends Exception(s"SQS batch operation failed with ${errors.size} errors") {
 
   /** Java API */
-  def getBatchSize: Int = batchSize
+  def getErrors: java.util.List[SqsResultErrorEntry[T]] = errors.asJava
+
+  override def toString: String = s"SqsBatchException(errors=$errors)"
+
+  override def equals(other: Any): Boolean = other match {
+    case that: SqsBatchException[T] => java.util.Objects.equals(this.errors, that.errors)
+    case _ => false
+  }
+
+  override def hashCode(): Int = java.util.Objects.hash(errors)
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsPublishFlow.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsPublishFlow.scala
@@ -7,6 +7,7 @@ package akka.stream.alpakka.sqs.javadsl
 import akka.NotUsed
 import akka.annotation.ApiMayChange
 import akka.stream.alpakka.sqs.{
+  SqsBatchResult,
   SqsPublishBatchSettings,
   SqsPublishGroupedSettings,
   SqsPublishResult,
@@ -61,10 +62,9 @@ object SqsPublishFlow {
       queueUrl: String,
       settings: SqsPublishBatchSettings,
       sqsClient: SqsAsyncClient
-  ): Flow[java.lang.Iterable[SendMessageRequest], java.util.List[SqsPublishResultEntry], NotUsed] =
+  ): Flow[java.lang.Iterable[SendMessageRequest], SqsBatchResult[SqsPublishResultEntry], NotUsed] =
     SFlow[java.lang.Iterable[SendMessageRequest]]
       .map(_.asScala)
       .via(akka.stream.alpakka.sqs.scaladsl.SqsPublishFlow.batch(queueUrl, settings)(sqsClient))
-      .map(_.asJava)
       .asJava
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckFlow.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckFlow.scala
@@ -130,12 +130,18 @@ object SqsAckFlow {
             .successful()
             .asScala
             .map(e => Success(new SqsDeleteResultEntry(idToAction(e.id.toInt), e, responseMetadata)))
+            .toList
           val failed = response
             .failed()
             .asScala
             .map(e => Failure(new SqsBatchException(actions.size, e.message)))
+            .toList
 
-          Stream(successful ++ failed: _*).map(_.get)
+          successful ++ failed
+      }
+      .map {
+        case Success(result) => result
+        case Failure(e) => throw e
       }
 
   private def groupedChangeMessageVisibility(queueUrl: String, settings: SqsAckGroupedSettings)(
@@ -173,11 +179,17 @@ object SqsAckFlow {
             .successful()
             .asScala
             .map(e => Success(new SqsChangeMessageVisibilityResultEntry(idToAction(e.id.toInt), e, responseMetadata)))
+            .toList
           val failed = response
             .failed()
             .asScala
             .map(e => Failure(new SqsBatchException(actions.size, e.message)))
+            .toList
 
-          Stream(successful ++ failed: _*).map(_.get)
+          successful ++ failed
+      }
+      .map {
+        case Success(result) => result
+        case Failure(e) => throw e
       }
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishFlow.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishFlow.scala
@@ -100,7 +100,7 @@ object SqsPublishFlow {
           .toScala
           .map(response => requests -> response)(sameThreadExecutionContext)
       }
-      .map {
+      .mapConcat {
         case (requests, response) =>
           val responseMetadata = response.responseMetadata()
           val idToRequest = requests.zipWithIndex.map(_.swap).toMap
@@ -119,5 +119,8 @@ object SqsPublishFlow {
             }.toList
           List(successful, failed)
       }
-      .mapConcat(_.map(_.map(_.get)))
+      .map(_.map {
+        case Success(result) => result
+        case Failure(e) => throw e
+      })
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishFlow.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishFlow.scala
@@ -14,7 +14,6 @@ import software.amazon.awssdk.services.sqs.model._
 
 import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
-import scala.util.Try
 import scala.util.{Failure, Success}
 
 /**
@@ -116,7 +115,8 @@ object SqsPublishFlow {
             .asScala
             .map { e =>
               Failure(new SqsBatchException(requests.size, e.message()))
-            }.toList
+            }
+            .toList
           List(successful, failed)
       }
       .map(_.map {

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishFlow.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishFlow.scala
@@ -100,7 +100,7 @@ object SqsPublishFlow {
           .toScala
           .map(response => requests -> response)(sameThreadExecutionContext)
       }
-      .mapConcat {
+      .map {
         case (requests, response) =>
           val responseMetadata = response.responseMetadata()
           val idToRequest = requests.zipWithIndex.map(_.swap).toMap
@@ -117,6 +117,7 @@ object SqsPublishFlow {
             .map { e =>
               Failure(new SqsBatchException(requests.size, e.message()))
             }.toList
-          Stream(successful, failed).map(_.map(_.get))
+          List(successful, failed)
       }
+      .mapConcat(_.map(_.map(_.get)))
 }

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/testkit/MessageFactory.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/testkit/MessageFactory.scala
@@ -9,7 +9,7 @@ import akka.stream.alpakka.sqs.SqsAckResultEntry.{
   SqsDeleteResultEntry,
   SqsIgnoreResultEntry
 }
-import akka.stream.alpakka.sqs.{MessageAction, SqsPublishResult, SqsPublishResultEntry, SqsResult}
+import akka.stream.alpakka.sqs._
 import software.amazon.awssdk.services.sqs.model._
 
 /**
@@ -38,6 +38,10 @@ object MessageFactory {
   ): SqsChangeMessageVisibilityResult =
     new SqsChangeMessageVisibilityResult(messageAction, response)
 
+  def createSqsBatchResult[T <: SqsResultEntry](successful: Seq[T],
+                                                failed: Seq[SqsResultErrorEntry[T#Request]] = List.empty): Unit =
+    new SqsBatchResult(successful.toList, failed.toList)
+
   def createSqsDeleteResultEntry(
       messageAction: MessageAction.Delete,
       result: DeleteMessageBatchResultEntry,
@@ -54,4 +58,15 @@ object MessageFactory {
       responseMetadata: SqsResponseMetadata = SqsResult.EmptySqsResponseMetadata
   ): SqsChangeMessageVisibilityResultEntry =
     new SqsChangeMessageVisibilityResultEntry(messageAction, result, responseMetadata)
+
+  def createSqsResultErrorEntry[T <: AnyRef](
+      request: T,
+      result: BatchResultErrorEntry,
+      responseMetadata: SqsResponseMetadata = SqsResult.EmptySqsResponseMetadata
+  ): SqsResultErrorEntry[T] =
+    new SqsResultErrorEntry(request, result, responseMetadata)
+
+  def createSqsBatchException[T <: AnyRef](errors: Seq[SqsResultErrorEntry[T]]): SqsBatchException[T] =
+    new SqsBatchException(errors.toList)
+
 }

--- a/sqs/src/test/java/docs/javadsl/SqsAckTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsAckTest.java
@@ -315,14 +315,16 @@ public class SqsAckTest extends BaseSqsTest {
 
     Source<Message, NotUsed> source = Source.fromIterator(messages::iterator);
     PartialFunction<Throwable, Source<SqsAckResultEntry, NotUsed>> stop =
-            new PFBuilder().match(SqsBatchException.class, ex -> Source.empty(SqsAckResultEntry.class)).build();
+        new PFBuilder()
+            .match(SqsBatchException.class, ex -> Source.empty(SqsAckResultEntry.class))
+            .build();
 
     CompletionStage<List<SqsAckResultEntry>> stage =
-    source
-      .map(m -> MessageAction.delete(m))
-      .via(SqsAckFlow.grouped(queueUrl, SqsAckGroupedSettings.create(), awsClient))
-      .recoverWith(stop)
-      .runWith(Sink.seq(), materializer);
+        source
+            .map(m -> MessageAction.delete(m))
+            .via(SqsAckFlow.grouped(queueUrl, SqsAckGroupedSettings.create(), awsClient))
+            .recoverWith(stop)
+            .runWith(Sink.seq(), materializer);
 
     List<SqsAckResultEntry> results = stage.toCompletableFuture().get(1, TimeUnit.SECONDS);
     assertEquals(9, results.size());

--- a/sqs/src/test/java/docs/javadsl/SqsAckTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsAckTest.java
@@ -315,7 +315,7 @@ public class SqsAckTest extends BaseSqsTest {
 
     Source<Message, NotUsed> source = Source.fromIterator(messages::iterator);
     PartialFunction<Throwable, Source<SqsAckResultEntry, NotUsed>> stop =
-        new PFBuilder()
+        new PFBuilder<Throwable, Source<SqsAckResultEntry, NotUsed>>()
             .match(SqsBatchException.class, ex -> Source.empty(SqsAckResultEntry.class))
             .build();
 

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
@@ -209,7 +209,7 @@ class SqsPublishSinkSpec extends FlatSpec with Matchers with DefaultTestContext 
       .sendNext("notused - 5")
       .sendComplete()
 
-    a[SqsBatchException] should be thrownBy {
+    a[SqsBatchException[_]] should be thrownBy {
       Await.result(future, 1.second)
     }
 

--- a/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
@@ -262,7 +262,8 @@ class SqsAckSpec extends FlatSpec with Matchers with DefaultTestContext {
       .via(SqsAckFlow.grouped("queue", SqsAckGroupedSettings.Defaults))
       .runWith(Sink.ignore)
 
-    future.failed.futureValue shouldBe a[SqsBatchException]
+    // an exception will be thrown in case of successful future
+    future.failed.futureValue
   }
 
   it should "fail if the client invocation failed" in {

--- a/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
@@ -250,12 +250,12 @@ class SqsPublishSpec extends FlatSpec with Matchers with DefaultTestContext {
       Source
         .single(messages)
         .via(SqsPublishFlow.batch(queueUrl))
-        .runWith(Sink.seq)
+        .runWith(Sink.head)
 
-    future.futureValue.flatten.zipWithIndex.foreach {
-      case (result, i) =>
-        result.result.md5OfMessageBody() shouldBe md5HashString(s"Message $i")
-        result.result.sequenceNumber() should not be empty
+    future.futureValue.entries.zipWithIndex.foreach {
+      case (entry, i) =>
+        entry.result.md5OfMessageBody() shouldBe md5HashString(s"Message $i")
+        entry.result.sequenceNumber() should not be empty
     }
 
     receiveMessages(10) should have size 10


### PR DESCRIPTION
## Purpose

Emit successful sqs batch result entry before failing

## References

References #1672

## Changes

- `SqsPublishFlow.batch`
- `SqsAckFlow.batch`

## Background Context

Wrap the result entries into a `Try`.
Collect first all successful results from a batch response and then append the failures.
`mapConcat` emits `Try` of result, unwrapped in a later map stage. 

To be discussed:
```
SqsPublishFlow.batch: Flow[Iterable[SendMessageRequest], List[SqsPublishResult[SendMessageBatchResponse]], NotUsed]
```
This API does not allow to properly tell for a batch which items were successful and witch are failed.

At the moment the old behavior is kept: If only one item fails, the stream fails. For this 'low level API', I would suggest to wrap every `SendMessageBatchResponse` in a `Try`.

