### PR TITLE
Couchbase: reuse `AsyncCluster` via registry

### DIFF
--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/impl/CouchbaseClusterRegistry.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/impl/CouchbaseClusterRegistry.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.couchbase.impl
+
+import java.util.concurrent.atomic.AtomicReference
+
+import akka.actor.ActorSystem
+import akka.annotation.InternalApi
+import akka.event.Logging
+import akka.stream.alpakka.couchbase.CouchbaseSessionSettings
+import akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession
+import com.couchbase.client.java.AsyncCluster
+
+import scala.annotation.tailrec
+import scala.concurrent.{Future, Promise}
+
+/**
+ * Internal API
+ */
+@InternalApi
+final private[couchbase] class CouchbaseClusterRegistry(system: ActorSystem) {
+
+  private val log = Logging(system, classOf[CouchbaseClusterRegistry])
+
+  private val clusters = new AtomicReference(Map.empty[CouchbaseSessionSettings, Future[AsyncCluster]])
+
+  def clusterFor(settings: CouchbaseSessionSettings): Future[AsyncCluster] =
+    clusters.get.get(settings) match {
+      case Some(futureSession) => futureSession
+      case _ => startSession(settings)
+    }
+
+  @tailrec
+  private def startSession(settings: CouchbaseSessionSettings): Future[AsyncCluster] = {
+    val promise = Promise[AsyncCluster]()
+    val oldClusters = clusters.get()
+    val newClusters = oldClusters.updated(settings, promise.future)
+    if (clusters.compareAndSet(oldClusters, newClusters)) {
+      // we won cas, initialize session
+      def nodesAsString = settings.nodes.mkString("\"", "\", \"", "\"")
+      log.info("Starting Couchbase client for nodes [{}]", nodesAsString)
+      promise.completeWith(CouchbaseSession.createClusterClient(settings)(system.dispatcher))
+      val future = promise.future
+      system.registerOnTermination {
+        future.foreach { cluster =>
+          val nodesAsString = settings.nodes.mkString("\"", "\", \"", "\"")
+          log.info("Shutting down Couchbase client for nodes [{}]", nodesAsString)
+          cluster.disconnect()
+        }(system.dispatcher)
+      }
+      future
+    } else {
+      // we lost cas (could be concurrent call for some other settings though), retry
+      startSession(settings)
+    }
+  }
+
+}

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/javadsl/CouchbaseSession.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/javadsl/CouchbaseSession.scala
@@ -40,20 +40,18 @@ object CouchbaseSession {
              executor: Executor): CompletionStage[CouchbaseSession] =
     ScalaDslCouchbaseSession
       .apply(settings, bucketName)(executionContext(executor))
-      .map(new CouchbaseSessionJavaAdapter(_).asInstanceOf[CouchbaseSession])(
+      .map(new CouchbaseSessionJavaAdapter(_): CouchbaseSession)(
         ExecutionContexts.sameThreadExecutionContext
       )
       .toJava
 
   /**
-   * Create a session against the given bucket. The life-cycle of the `client` is the user's responsibility.
+   * Create a given bucket using a pre-existing cluster client, allowing for it to be shared among
+   * multiple `CouchbaseSession`s. The cluster client's life-cycle is the user's responsibility.
    */
-  def create(client: CompletionStage[AsyncCluster],
-             bucketName: String,
-             executor: Executor): CompletionStage[CouchbaseSession] =
-    ScalaDslCouchbaseSession
-      .apply(client.toScala, bucketName)(executionContext(executor))
-      .map(new CouchbaseSessionJavaAdapter(_).asInstanceOf[CouchbaseSession])(
+  def create(client: AsyncCluster, bucketName: String, executor: Executor): CompletionStage[CouchbaseSession] =
+    ScalaDslCouchbaseSession(client, bucketName)(executionContext(executor))
+      .map(new CouchbaseSessionJavaAdapter(_): CouchbaseSession)(
         ExecutionContexts.sameThreadExecutionContext
       )
       .toJava
@@ -236,7 +234,7 @@ abstract class CouchbaseSession {
    * @return a [[java.util.concurrent.CompletionStage]] of `true` if the index was/will be effectively created, `false`
    *      if the index existed and ignoreIfExist` is true. Completion of the `CompletionStage` does not guarantee the index
    *      is online and ready to be used.
-   */
+    **/
   def createIndex(indexName: String, ignoreIfExist: Boolean, fields: AnyRef*): CompletionStage[Boolean]
 
   /**

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/scaladsl/CouchbaseSession.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/scaladsl/CouchbaseSession.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.couchbase.scaladsl
 
-import akka.annotation.DoNotInherit
+import akka.annotation.{DoNotInherit, InternalApi}
 import akka.stream.alpakka.couchbase.impl.{CouchbaseSessionImpl, RxUtilities}
 import akka.stream.alpakka.couchbase.javadsl.{CouchbaseSession => JavaDslCouchbaseSession}
 import akka.stream.alpakka.couchbase.{CouchbaseSessionSettings, CouchbaseWriteSettings}
@@ -32,13 +32,13 @@ object CouchbaseSession {
    */
   def apply(settings: CouchbaseSessionSettings,
             bucketName: String)(implicit ec: ExecutionContext): Future[CouchbaseSession] =
-    openBucket(createClusterClient(settings), disconnectClusterOnClose = true, bucketName)
+    createClusterClient(settings).flatMap(c => openBucket(c, disconnectClusterOnClose = true, bucketName))
 
   /**
-   * Create a session against the given bucket. The life-cycle of the `client` is the user's responsibility.
+   * Create a given bucket using a pre-existing cluster client, allowing for it to be shared among
+   * multiple `CouchbaseSession`s. The cluster client's life-cycle is the user's responsibility.
    */
-  def apply(cluster: Future[AsyncCluster],
-            bucketName: String)(implicit ec: ExecutionContext): Future[CouchbaseSession] =
+  def apply(cluster: AsyncCluster, bucketName: String)(implicit ec: ExecutionContext): Future[CouchbaseSession] =
     openBucket(cluster, disconnectClusterOnClose = false, bucketName)
 
   /**
@@ -49,10 +49,15 @@ object CouchbaseSession {
     new CouchbaseSessionImpl(bucket.async(), None)
 
   /**
+   * INTERNAL API.
+   *
    * Connects to a Couchbase cluster by creating an `AsyncCluster`.
    * The life-cycle of it is the user's responsibility.
    */
-  def createClusterClient(settings: CouchbaseSessionSettings)(implicit ec: ExecutionContext): Future[AsyncCluster] =
+  @InternalApi
+  private[couchbase] def createClusterClient(
+      settings: CouchbaseSessionSettings
+  )(implicit ec: ExecutionContext): Future[AsyncCluster] =
     //wrap CouchbaseAsyncCluster.create up in the Future because it's blocking
     Future(settings.environment match {
       case Some(environment) =>
@@ -61,12 +66,14 @@ object CouchbaseSession {
         CouchbaseAsyncCluster.create(settings.nodes: _*)
     }).map(_.authenticate(settings.username, settings.password))
 
-  private def openBucket(cluster: Future[AsyncCluster], disconnectClusterOnClose: Boolean, bucketName: String)(
+  private def openBucket(cluster: AsyncCluster, disconnectClusterOnClose: Boolean, bucketName: String)(
       implicit ec: ExecutionContext
   ): Future[CouchbaseSession] =
-    cluster
-      .flatMap(c => RxUtilities.singleObservableToFuture(c.openBucket(bucketName), "openBucket").map((c, _)))
-      .map { case (c, bucket) => new CouchbaseSessionImpl(bucket, if (disconnectClusterOnClose) Some(c) else None) }
+    RxUtilities
+      .singleObservableToFuture(cluster.openBucket(bucketName), "openBucket")
+      .map { bucket =>
+        new CouchbaseSessionImpl(bucket, if (disconnectClusterOnClose) Some(cluster) else None)
+      }
 
 }
 

--- a/couchbase/src/test/scala/docs/scaladsl/CouchbaseSourceSpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/CouchbaseSourceSpec.scala
@@ -6,7 +6,7 @@ package docs.scaladsl
 
 import akka.stream.alpakka.couchbase.scaladsl.{CouchbaseSession, CouchbaseSource}
 import akka.stream.alpakka.couchbase.testing.CouchbaseSupport
-import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.scaladsl.Sink
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import com.couchbase.client.java.auth.PasswordAuthenticator
 import com.couchbase.client.java.{Bucket, CouchbaseCluster}

--- a/docs/src/main/paradox/couchbase.md
+++ b/docs/src/main/paradox/couchbase.md
@@ -32,7 +32,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 # Overview
 
-Alpakka Couchbase offers both Akka Streams APIs and a more direct API to access Couchbase:
+Alpakka Couchbase offers both @ref:[Akka Streams APIs](#reading-from-couchbase-in-akka-streams) and a more @ref:[direct API](#using-couchbasesession-directly) to access Couchbase:
 
 * `CouchbaseSession` (@scala[@scaladoc[API](akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession)]@java[@scaladoc[API](akka.stream.alpakka.couchbase.javadsl.CouchbaseSession)]) offers a direct API for one-off operations
 * `CouchbaseSessionRegistry` (@scaladoc[API](akka.stream.alpakka.couchbase.CouchbaseSessionRegistry$)) is an Akka extension to keep track and share `CouchbaseSession`s within an `ActorSystem`
@@ -144,6 +144,20 @@ Java
 
 # Using `CouchbaseSession` directly
 
+## Access via registry
+
+The `CouchbaseSesionRegistry` is an Akka extension to manage the life-cycle of Couchbase sessions. All underlying instances are closed upon actor system termination.
+
+When accessing more than one Couchbase cluster, the `CouchbaseEnvironment` should be shared by setting a single instance for the different `CouchbaseSessionSettings`.
+
+Scala
+: @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/CouchbaseSessionExamplesSpec.scala) { #registry }
+
+Java
+: @@snip [snip](/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #registry }
+
+
+## Manage session life-cycle
 Use `CouchbaseSessionSettings` to get an instance of `CouchbaseSession`. These settings may be specified in `application.conf` and complemented in code. Furthermore a session requires the bucket name and needs an `ExecutionContext` as the creation is asynchronous.
 
 Scala
@@ -153,7 +167,9 @@ Java
 : @@snip [snip](/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #session }
 
 
-Alternatively a `CouchbaseSession` may be created from a Couchbase `Bucket`:
+## Manage bucket life-cycle
+
+For full control a `CouchbaseSession` may be created from a Couchbase `Bucket`:
 
 Scala
 : @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/CouchbaseSessionExamplesSpec.scala) { #fromBucket }

--- a/docs/src/main/paradox/couchbase.md
+++ b/docs/src/main/paradox/couchbase.md
@@ -169,7 +169,7 @@ Java
 
 ## Manage bucket life-cycle
 
-For full control a `CouchbaseSession` may be created from a Couchbase `Bucket`:
+For full control a `CouchbaseSession` may be created from a Couchbase `Bucket`. See @extref:[Scalability and Concurrency](couchbase:managing-connections.html#concurrency) in the Couchbase documentation for details.
 
 Scala
 : @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/CouchbaseSessionExamplesSpec.scala) { #fromBucket }


### PR DESCRIPTION
## Purpose

Cache Couchbase `AsyncCluster` independently of `Buckets` in `CouchbaseSessionRegistry` so that they are shared when more than one bucket is used.

## References

See #1676 

## Changes

* Introduce internal `CouchbaseClusterRegistry` to cache `AsyncCluster` instances per `CouchbaseSessionSettings`
* Add example using the `CouchbaseSessionRegistry` to documentation