### PR TITLE
Align local date in s3 stream signing key to UTC

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.s3.impl
 
-import java.time.{Instant, LocalDate}
+import java.time.{Instant, LocalDate, ZoneOffset}
 
 import akka.actor.ActorSystem
 import akka.annotation.InternalApi
@@ -91,7 +91,7 @@ import akka.util.ByteString
   // def because tokens can expire
   def signingKey(implicit settings: S3Settings) = SigningKey(
     settings.credentialsProvider,
-    CredentialScope(LocalDate.now(), settings.s3RegionProvider.getRegion, "s3")
+    CredentialScope(LocalDate.now(ZoneOffset.UTC), settings.s3RegionProvider.getRegion, "s3")
   )
 
   def download(


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->
Align LocalDate.now() function in S3Stream.scala's signing key with UTC. This is because the credential scope in AWS should be in UTC.

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->

## Changes

<!-- Bullets for important changes in this PR -->

* Align LocalDate.now() to be LocalDate.now(UTC)

## Background Context

<!-- Why did you take this approach? -->
AWS is expecting UTC time zone for credential scope.