### PR TITLE
Add alpakka-csv benchmark and optimize.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,6 +103,11 @@ lazy val couchbase =
 
 lazy val csv = alpakkaProject("csv", "csv", Dependencies.Csv, whitesourceGroup := Whitesource.Group.Supported)
 
+lazy val csvBench = alpakkaProject("csv-bench", "csvBench", publish / skip := true)
+  .dependsOn(csv)
+  .enablePlugins(JmhPlugin)
+  .disablePlugins(BintrayPlugin, MimaPlugin)
+
 lazy val dynamodb = alpakkaProject("dynamodb", "aws.dynamodb", Dependencies.DynamoDB)
 
 lazy val elasticsearch = alpakkaProject(

--- a/csv-bench/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvBench.scala
+++ b/csv-bench/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvBench.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.csv.scaladsl
+
+import java.util.concurrent.TimeUnit
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+/**
+ * Measures the time to parse a 1 MB CSV file, consuming the first field of each row.
+ *
+ * ==Using Oracle Flight Recorder==
+ * To record a Flight Recorder file from a JMH run, run it using the jmh.extras.JFR profiler:
+ * > csv-bench/jmh:run -prof jmh.extras.JFR -t1 -f1 -wi 5 -i 10 .*CsvBench
+ *
+ * This will result in flight recording file which you can open and analyze offline using JMC.
+ * Start with "jmc" from a terminal.
+ *
+ * ==Sample benchmark results==
+ * Your results may differ.
+ * Rerun these on YOUR OWN MACHINE before/after making changes.
+ *
+ * {{{
+ * > csv-bench/jmh:run -t1 -f1 -wi 10 -i 10 .*CsvBench
+ * [info] Benchmark        (bsSize)   Mode  Cnt    Score   Error  Units
+ * [info] CsvBench.parse        32  thrpt   10   78.424 ± 1.351  ops/s
+ * [info] CsvBench.parse      1024  thrpt   10  158.948 ± 3.187  ops/s
+ * [info] CsvBench.parse      8192  thrpt   10  167.617 ± 2.759  ops/s
+ * [info] CsvBench.parse     65536  thrpt   10  170.670 ± 2.462  ops/s
+ * }}}
+ *
+ * @see https://github.com/ktoso/sbt-jmh
+ */
+@Warmup(iterations = 8, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+@Fork(jvmArgsAppend = Array("-Xmx350m", "-XX:+HeapDumpOnOutOfMemoryError"), value = 1)
+@State(Scope.Benchmark)
+class CsvBench {
+
+  implicit val system = ActorSystem()
+  implicit val executionContext = system.dispatcher
+  implicit val mat = ActorMaterializer()
+
+  /**
+   * Size of [[ByteString]] chunks in bytes.
+   *
+   * Total message size remains the same.
+   * This just determines how big the chunks are.
+   *
+   * WSClient returns a Source[ByteString, _] in 8k chunks.
+   */
+  @Param(
+    Array(
+      "32", //   smaller than a field
+      "1024", // ~8x smaller than row
+      "8192", // ~same size as row
+      "65536" // ~8k larger than row
+    )
+  )
+  var bsSize: Int = _
+  var source: Source[ByteString, NotUsed] = _
+
+  @Benchmark
+  def parse(bh: Blackhole): Unit = {
+    val futureDone = {
+      source
+        .via(CsvParsing.lineScanner())
+        .runForeach { fields =>
+          bh.consume(fields.head.utf8String)
+        }
+    }
+    Await.result(futureDone, Duration.Inf)
+  }
+
+  @TearDown
+  def tearDown(): Unit = {
+    mat.shutdown()
+    system.terminate()
+  }
+
+  @Setup
+  def setup(): Unit = {
+
+    /**
+     * 8 fields in a row, each of size 100, with commas and an '\n' is 8008 bytes.
+     */
+    val row = ByteString(('a' to 'h').map(_.toString * 100).mkString("", ",", "\n"))
+
+    val allChunks = Iterator
+      .continually(row)
+      .take(1024 * 1024 / row.length) // approx 1MiB for easy conversion from ops/s
+      .reduce(_ ++ _)
+      /**
+       * Reframe into 8KiB chunks to mimic WSClient, and
+       * so csv boundaries misalign with ByteString chunks as they would in reality.
+       */
+      .grouped(bsSize)
+      /**
+       * Compact is important here.
+       *
+       * alpakka-csv perf suffers a bit over non-compact [[akka.util.ByteString.ByteStrings]].
+       * Its design relies on getting bytes by index from the [[ByteString]].
+       * The indirections add up.
+       *
+       * WSClient will return [[akka.util.ByteString.ByteString1C]] chunks,
+       * so we should do the same.
+       */
+      .map(_.compact)
+      .toIndexedSeq
+
+    source = Source.fromIterator(() => allChunks.iterator)
+  }
+}
+
+/**
+ * For debugging.
+ */
+object CsvBench {
+
+  def main(args: Array[String]): Unit = {
+    val bench = new CsvBench
+    bench.parse(
+      new Blackhole("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.")
+    )
+    bench.tearDown()
+  }
+}

--- a/csv/src/main/mima-filters/1.0.x.backwards.excludes
+++ b/csv/src/main/mima-filters/1.0.x.backwards.excludes
@@ -1,0 +1,2 @@
+# Allow changes to impl
+ProblemFilters.exclude[Problem]("akka.stream.alpakka.csv.impl.*")

--- a/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvParser.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvParser.scala
@@ -9,7 +9,9 @@ import java.nio.charset.UnsupportedCharsetException
 import akka.annotation.InternalApi
 import akka.stream.alpakka.csv.MalformedCsvException
 import akka.stream.alpakka.csv.scaladsl.ByteOrderMark
-import akka.util.{ByteString, ByteStringBuilder}
+import akka.util.{ByteIterator, ByteString, ByteStringBuilder}
+
+import scala.collection.mutable
 
 /**
  * INTERNAL API: Use [[akka.stream.alpakka.csv.scaladsl.CsvParsing]] instead.
@@ -43,34 +45,102 @@ import akka.util.{ByteString, ByteStringBuilder}
 
   import CsvParser._
 
-  private[this] var buffer = ByteString.empty
+  /**
+   * Concatenated input chunks,
+   * appended to by [[offer()]] and dropped from by [[dropReadBuffer()]].
+   *
+   * May include previous chunks that start a field but do not complete it.
+   */
+  private[this] var buffer: ByteString = ByteString.empty
+
+  /**
+   * Flag to run BOM checks against first two bytes of the stream.
+   */
   private[this] var firstData = true
-  private[this] var pos = 0
+
+  /**
+   * Current position within [[buffer]].
+   *
+   * Points to the same byte as [[current.head]].
+   * Used for slicing fields out of [[buffer]] and for debug info.
+   */
+  private[this] var pos: Int = 0
+
+  /**
+   * Number of bytes dropped on the current row.
+   *
+   * Perf:
+   * We need to track this in order to call [[dropReadBuffer()]] after each field instead of each line.
+   * We want to call [[dropReadBuffer()]] ASAP to convert [[buffer]] from a
+   * [[akka.util.ByteString.ByteStrings]] to a [[akka.util.ByteString.ByteString1]]
+   * to exploit the much faster [[ByteString.slice()]] implementation.
+   */
+  private[this] var lineBytesDropped = 0
+
+  /**
+   * Position within the current row.
+   *
+   * Used for enforcing line length limits and as debug info for exceptions.
+   */
+  private[this] def lineLength: Int = lineBytesDropped + pos
+
+  /**
+   * Position within [[buffer]] of the start of the current field.
+   */
   private[this] var fieldStart = 0
   private[this] var currentLineNo = 1L
 
-  def offer(input: ByteString): Unit =
-    buffer ++= input
+  /**
+   * Reset after each row.
+   */
+  private[this] var columns = mutable.ListBuffer[ByteString]()
+  private[this] var state: State = LineStart
+  private[this] var fieldBuilder = new FieldBuilder
+
+  /**
+   * Current iterator being parsed.
+   *
+   * Previous implementation indexed into [[buffer.apply()]] for each byte,
+   * which is slow against [[akka.util.ByteString.ByteStrings]].
+   *
+   * We fully parse each chunk before getting the next, so we only need to track one [[ByteIterator]] at a time.
+   */
+  private[this] var current: ByteIterator = ByteString.empty.iterator
+
+  def offer(next: ByteString): Unit =
+    if (next.nonEmpty) {
+      require(current.isEmpty, "offer(ByteString) may not be called before all buffered input is parsed.")
+      buffer ++= next
+      current = next.iterator
+    }
 
   def poll(requireLineEnd: Boolean): Option[List[ByteString]] =
     if (buffer.nonEmpty) {
-      val preFirstData = firstData
-      val prePos = pos
-      val preFieldStart = fieldStart
       val line = parseLine(requireLineEnd)
       if (line.nonEmpty) {
         currentLineNo += 1
-        dropReadBuffer()
-      } else {
-        firstData = preFirstData
-        pos = prePos
-        fieldStart = preFieldStart
+        if (state == LineEnd) {
+          state = LineStart
+        }
+        resetLine()
+        columns.clear()
       }
       line
     } else None
 
-  private def dropReadBuffer() = {
+  private[this] def advance(n: Int = 1): Unit = {
+    pos += n
+    current.drop(n)
+  }
+
+  private[this] def resetLine(): Unit = {
+    dropReadBuffer()
+    lineBytesDropped = 0
+  }
+
+  private[this] def dropReadBuffer() = {
     buffer = buffer.drop(pos)
+    lineBytesDropped += pos
     pos = 0
     fieldStart = 0
   }
@@ -78,8 +148,11 @@ import akka.util.{ByteString, ByteStringBuilder}
   /** FieldBuilder will just cut the required part out of the incoming ByteBuffer
    * as long as non escaping is used.
    */
-  private final class FieldBuilder(buf: ByteString) {
+  private final class FieldBuilder {
 
+    /**
+     * false if [[builder]] is null.
+     */
     private[this] var useBuilder = false
     private[this] var builder: ByteStringBuilder = _
 
@@ -87,7 +160,7 @@ import akka.util.{ByteString, ByteStringBuilder}
      */
     @inline def init(): Unit =
       if (!useBuilder) {
-        builder = ByteString.newBuilder ++= buf.slice(fieldStart, pos)
+        builder = ByteString.newBuilder ++= buffer.slice(fieldStart, pos)
         useBuilder = true
       }
 
@@ -98,115 +171,115 @@ import akka.util.{ByteString, ByteStringBuilder}
       if (useBuilder) {
         useBuilder = false
         builder.result()
-      } else buf.slice(fieldStart, pos)
+      } else buffer.slice(fieldStart, pos)
 
   }
 
-  protected def parseLine(requireLineEnd: Boolean): Option[List[ByteString]] = {
-    val buf = buffer
-    var columns = Vector[ByteString]()
-    var state: State = LineStart
-    val fieldBuilder = new FieldBuilder(buf)
+  private[this] def noCharEscaped() =
+    throw new MalformedCsvException(currentLineNo,
+                                    lineLength,
+                                    s"wrong escaping at $currentLineNo:$lineLength, no character after escape")
 
-    def noCharEscaped() =
-      throw new MalformedCsvException(currentLineNo,
-                                      pos,
-                                      s"wrong escaping at $currentLineNo:$pos, no character after escape")
-
-    def checkForByteOrderMark(): Unit =
-      if (buf.length >= 2) {
-        if (buf.startsWith(ByteOrderMark.UTF_8)) {
-          pos = 3
-          fieldStart = 3
-        } else {
-          if (buf.startsWith(ByteOrderMark.UTF_16_LE)) {
-            throw new UnsupportedCharsetException("UTF-16 LE and UTF-32 LE")
-          }
-          if (buf.startsWith(ByteOrderMark.UTF_16_BE)) {
-            throw new UnsupportedCharsetException("UTF-16 BE")
-          }
-          if (buf.startsWith(ByteOrderMark.UTF_32_BE)) {
-            throw new UnsupportedCharsetException("UTF-32 BE")
-          }
+  private[this] def checkForByteOrderMark(): Unit =
+    if (buffer.length >= 2) {
+      if (buffer.startsWith(ByteOrderMark.UTF_8)) {
+        advance(4)
+        fieldStart = 3
+      } else {
+        if (buffer.startsWith(ByteOrderMark.UTF_16_LE)) {
+          throw new UnsupportedCharsetException("UTF-16 LE and UTF-32 LE")
+        }
+        if (buffer.startsWith(ByteOrderMark.UTF_16_BE)) {
+          throw new UnsupportedCharsetException("UTF-16 BE")
+        }
+        if (buffer.startsWith(ByteOrderMark.UTF_32_BE)) {
+          throw new UnsupportedCharsetException("UTF-32 BE")
         }
       }
+    }
 
+  protected def parseLine(requireLineEnd: Boolean): Option[List[ByteString]] = {
     if (firstData) {
       checkForByteOrderMark()
       firstData = false
     }
 
-    while (state != LineEnd && pos < buf.length) {
-      if (pos >= maximumLineLength)
+    churn()
+    maybeExtractLine(requireLineEnd)
+  }
+
+  private[this] def churn(): Unit = {
+    while (state != LineEnd && pos < buffer.length) {
+      if (lineLength >= maximumLineLength)
         throw new MalformedCsvException(
           currentLineNo,
-          pos,
+          lineLength,
           s"no line end encountered within $maximumLineLength bytes on line $currentLineNo"
         )
-      val byte = buf(pos)
+      val byte = current.head
       state match {
         case LineStart =>
           byte match {
             case `quoteChar` =>
               state = QuoteStarted
-              pos += 1
+              advance()
               fieldStart = pos
             case `escapeChar` =>
               fieldBuilder.init()
               state = WithinFieldEscaped
-              pos += 1
+              advance()
               fieldStart = pos
             case `delimiter` =>
-              columns :+= ByteString.empty
+              columns += ByteString.empty
               state = AfterDelimiter
-              pos += 1
+              advance()
               fieldStart = pos
             case LF =>
-              columns :+= ByteString.empty
+              columns += ByteString.empty
               state = LineEnd
-              pos += 1
+              advance()
               fieldStart = pos
             case CR =>
-              columns :+= ByteString.empty
+              columns += ByteString.empty
               state = AfterCr
-              pos += 1
+              advance()
               fieldStart = pos
             case b =>
               fieldBuilder.add(b)
               state = WithinField
-              pos += 1
+              advance()
           }
 
         case AfterDelimiter =>
           byte match {
             case `quoteChar` =>
               state = QuoteStarted
-              pos += 1
+              advance()
               fieldStart = pos
             case `escapeChar` =>
               fieldBuilder.init()
               state = WithinFieldEscaped
-              pos += 1
+              advance()
               fieldStart = pos
             case `delimiter` =>
-              columns :+= ByteString.empty
+              columns += ByteString.empty
               state = AfterDelimiter
-              pos += 1
+              advance()
               fieldStart = pos
             case LF =>
-              columns :+= ByteString.empty
+              columns += ByteString.empty
               state = LineEnd
-              pos += 1
+              advance()
               fieldStart = pos
             case CR =>
-              columns :+= ByteString.empty
+              columns += ByteString.empty
               state = AfterCr
-              pos += 1
+              advance()
               fieldStart = pos
             case b =>
               fieldBuilder.add(b)
               state = WithinField
-              pos += 1
+              advance()
           }
 
         case WithinField =>
@@ -214,26 +287,26 @@ import akka.util.{ByteString, ByteStringBuilder}
             case `escapeChar` =>
               fieldBuilder.init()
               state = WithinFieldEscaped
-              pos += 1
+              advance()
             case `delimiter` =>
-              columns :+= fieldBuilder.result(pos)
+              columns += fieldBuilder.result(pos)
               state = AfterDelimiter
-              pos += 1
-              fieldStart = pos
+              advance()
+              dropReadBuffer()
             case LF =>
-              columns :+= fieldBuilder.result(pos)
+              columns += fieldBuilder.result(pos)
               state = LineEnd
-              pos += 1
-              fieldStart = pos
+              advance()
+              dropReadBuffer()
             case CR =>
-              columns :+= fieldBuilder.result(pos)
+              columns += fieldBuilder.result(pos)
               state = AfterCr
-              pos += 1
-              fieldStart = pos
+              advance()
+              dropReadBuffer()
             case b =>
               fieldBuilder.add(b)
               state = WithinField
-              pos += 1
+              advance()
           }
 
         case WithinFieldEscaped =>
@@ -241,13 +314,13 @@ import akka.util.{ByteString, ByteStringBuilder}
             case `escapeChar` | `delimiter` =>
               fieldBuilder.add(byte)
               state = WithinField
-              pos += 1
+              advance()
 
             case b =>
               throw new MalformedCsvException(
                 currentLineNo,
-                pos,
-                s"wrong escaping at $currentLineNo:$pos, only escape or delimiter may be escaped"
+                lineLength,
+                s"wrong escaping at $currentLineNo:$lineLength, only escape or delimiter may be escaped"
               )
           }
 
@@ -256,37 +329,37 @@ import akka.util.{ByteString, ByteStringBuilder}
             case `escapeChar` if escapeChar != quoteChar =>
               fieldBuilder.init()
               state = WithinQuotedFieldEscaped
-              pos += 1
+              advance()
             case `quoteChar` =>
               fieldBuilder.init()
               state = WithinQuotedFieldQuote
-              pos += 1
+              advance()
             case b =>
               fieldBuilder.add(b)
               state = WithinQuotedField
-              pos += 1
+              advance()
           }
 
         case QuoteEnd =>
           byte match {
             case `delimiter` =>
-              columns :+= fieldBuilder.result(pos - 1)
+              columns += fieldBuilder.result(pos - 1)
               state = AfterDelimiter
-              pos += 1
-              fieldStart = pos
+              advance()
+              dropReadBuffer()
             case LF =>
-              columns :+= fieldBuilder.result(pos - 1)
+              columns += fieldBuilder.result(pos - 1)
               state = LineEnd
-              pos += 1
-              fieldStart = pos
+              advance()
+              dropReadBuffer()
             case CR =>
-              columns :+= fieldBuilder.result(pos - 1)
+              columns += fieldBuilder.result(pos - 1)
               state = AfterCr
-              pos += 1
-              fieldStart = pos
+              advance()
+              dropReadBuffer()
             case c =>
               throw new MalformedCsvException(currentLineNo,
-                                              pos,
+                                              lineLength,
                                               s"expected delimiter or end of line at $currentLineNo:$pos")
           }
 
@@ -295,15 +368,15 @@ import akka.util.{ByteString, ByteStringBuilder}
             case `escapeChar` if escapeChar != quoteChar =>
               fieldBuilder.init()
               state = WithinQuotedFieldEscaped
-              pos += 1
+              advance()
             case `quoteChar` =>
               fieldBuilder.init()
               state = WithinQuotedFieldQuote
-              pos += 1
+              advance()
             case b =>
               fieldBuilder.add(b)
               state = WithinQuotedField
-              pos += 1
+              advance()
           }
 
         case WithinQuotedFieldEscaped =>
@@ -311,13 +384,13 @@ import akka.util.{ByteString, ByteStringBuilder}
             case `escapeChar` | `quoteChar` =>
               fieldBuilder.add(byte)
               state = WithinQuotedField
-              pos += 1
+              advance()
 
             case b =>
               throw new MalformedCsvException(
                 currentLineNo,
-                pos,
-                s"wrong escaping at $currentLineNo:$pos, only escape or quote may be escaped within quotes"
+                lineLength,
+                s"wrong escaping at $currentLineNo:$lineLength, only escape or quote may be escaped within quotes"
               )
           }
 
@@ -326,7 +399,7 @@ import akka.util.{ByteString, ByteStringBuilder}
             case `quoteChar` =>
               fieldBuilder.add(byte)
               state = WithinQuotedField
-              pos += 1
+              advance()
 
             case b =>
               state = QuoteEnd
@@ -336,15 +409,17 @@ import akka.util.{ByteString, ByteStringBuilder}
           byte match {
             case CR =>
               state = AfterCr
-              pos += 1
+              advance()
             case LF =>
               state = LineEnd
-              pos += 1
+              advance()
             case _ =>
               state = LineEnd
           }
       }
     }
+  }
+  private[this] def maybeExtractLine(requireLineEnd: Boolean): Option[List[ByteString]] =
     if (requireLineEnd) {
       state match {
         case LineEnd =>
@@ -355,19 +430,19 @@ import akka.util.{ByteString, ByteStringBuilder}
     } else {
       state match {
         case AfterDelimiter =>
-          columns :+= ByteString.empty
+          columns += ByteString.empty
           Some(columns.toList)
         case WithinQuotedField =>
           throw new MalformedCsvException(
             currentLineNo,
-            pos,
-            s"unclosed quote at end of input $currentLineNo:$pos, no matching quote found"
+            lineLength,
+            s"unclosed quote at end of input $currentLineNo:$lineLength, no matching quote found"
           )
         case WithinField =>
-          columns :+= fieldBuilder.result(pos)
+          columns += fieldBuilder.result(pos)
           Some(columns.toList)
         case QuoteEnd | WithinQuotedFieldQuote =>
-          columns :+= fieldBuilder.result(pos - 1)
+          columns += fieldBuilder.result(pos - 1)
           Some(columns.toList)
         case WithinFieldEscaped | WithinQuotedFieldEscaped =>
           noCharEscaped()
@@ -375,6 +450,5 @@ import akka.util.{ByteString, ByteStringBuilder}
           Some(columns.toList)
       }
     }
-  }
 
 }


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->
## Purpose

Improves parsing speed of alpakka-csv from 1.5 MiB/s to 78 MiB/s for the most extreme case.

## References

I searched, but didn't find any other issues or discussions.

## Changes

* New jmh benchmark: `CsvBench`
* `CsvParser` is faster.

## Background Context

While evaluating alpakka-csv as a non-blocking replacement for our currently blocking usage of OpenCSV, I benched it and found that it parses slower than I'd expect, even over benchmarks that play to alpakka-csv's strengths. After poking around, I found some slow spots and optimized them.

#### Before
```
[info] Benchmark       (bsSize)   Mode  Cnt    Score   Error  Units
[info] CsvBench.parse        32  thrpt   10    1.551 ± 0.028  ops/s
[info] CsvBench.parse      1024  thrpt   10   60.279 ± 0.720  ops/s
[info] CsvBench.parse      8192  thrpt   10  117.125 ± 1.138  ops/s
[info] CsvBench.parse     65536  thrpt   10  137.510 ± 3.048  ops/s
```

#### After
```
[info] Benchmark        (bsSize)   Mode  Cnt    Score   Error  Units
[info] CsvBench.parse        32  thrpt   10   78.424 ± 1.351  ops/s
[info] CsvBench.parse      1024  thrpt   10  158.948 ± 3.187  ops/s
[info] CsvBench.parse      8192  thrpt   10  167.617 ± 2.759  ops/s
[info] CsvBench.parse     65536  thrpt   10  170.670 ± 2.462  ops/s
```

### Slow spot 1: Duplicate parsing
On every new input `ByteString`, `parseLine: Option[List[ByteString]]` attempts to parse an entire row. If it doesn't have enough data to complete the row, it rewinds all progress on that row and waits for the next chunk then tries again. This causes duplicate work on every new chunk that continues an existing line. It gets particularly bad when the chunk size is significantly smaller than the row size.

There was already some state in `CsvParser` fields, so I pulled up the method state to class fields as well. It's fully incremental now and doesn't repeat work.

### Slow spot 2: `ByteStrings`/`MultiByteArrayIterator`
Accessing each byte and doing slices is hot inner-loop code and the composites (`ByteStrings`/`MultiByteArrayIterator`) add significant overhead to that.

We can't avoid `ByteStrings.slice(...)` when a field spans multiple chunks, but we can mitigate subsequent slices by calling `dropReadBuffer()` as soon as we complete a field, rather than waiting until we complete the whole line. It should allow `buffer: ByteString` to return to a fast `ByteString1` for all subsequent slices on the row.

Indexing into `ByteStrings.apply(pos)` for each byte is also costly. Even the `MultiByteArrayIterator` produced by `ByteStrings.iterator()` has to do non-free normalization on each `.next(): Byte` call.

An optimization is possible from the observation that `CsvParser` parses each `ByteString` chunk before receiving the next chunk. We can traverse only the single chunk in `parseLine` while keeping the `buffer: ByteStrings` around for slicing which may also need to contain the previous chunk.

Downside is we have to track a bit more state which adds a bit more complexity to the implementation. Upside is at least a 25% improvement across all scenarios, which makes it competitive with OpenCsv.