### PR TITLE
AWS S3: use a single date/time for signing

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/auth/SigningKey.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/auth/SigningKey.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.s3.impl.auth
 
-import java.time.LocalDate
+import java.time.{LocalDate, ZonedDateTime}
 import java.time.format.DateTimeFormatter
 
 import akka.annotation.InternalApi
@@ -22,7 +22,8 @@ import com.amazonaws.auth.{
   def scopeString = s"$formattedDate/$awsRegion/$awsService/aws4_request"
 }
 
-@InternalApi private[impl] final case class SigningKey(credProvider: AWSCredentialsProvider,
+@InternalApi private[impl] final case class SigningKey(requestDate: ZonedDateTime,
+                                                       credProvider: AWSCredentialsProvider,
                                                        scope: CredentialScope,
                                                        algorithm: String = "HmacSHA256") {
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SigningKeySpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SigningKeySpec.scala
@@ -4,7 +4,8 @@
 
 package akka.stream.alpakka.s3.impl.auth
 
-import java.time.LocalDate
+import java.time.{ZoneId, ZonedDateTime}
+
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -15,8 +16,10 @@ class SigningKeySpec extends FlatSpec with Matchers {
     new BasicAWSCredentials("AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
   )
 
-  val scope = CredentialScope(LocalDate.of(2015, 8, 30), "us-east-1", "iam")
-  val signingKey = SigningKey(credentials, scope)
+  val signingKey = {
+    val requestDate = ZonedDateTime.of(2015, 8, 30, 1, 2, 3, 4, ZoneId.of("UTC"))
+    SigningKey(requestDate, credentials, CredentialScope(requestDate.toLocalDate, "us-east-1", "iam"))
+  }
 
   it should "produce a signing key" in {
     val expected: Array[Byte] = Array(196, 175, 177, 204, 87, 113, 216, 113, 118, 58, 57, 62, 68, 183, 3, 87, 27, 85,


### PR DESCRIPTION
## Purpose

During AWS request signing the request timestamp and the date in the signed authorization credential should denote the same date, so they should be constructed from a single timestamp.

## References

This is a follow-up to #1678 

## Changes

* Add `ZonedDateTime` to `SigningKey`
* Dirive date in `CredentialScope` from the request date in `SigningKey`
* unrelated: add missing (but impossible) match case in `processCheckIfExistsResponse`
