### PR TITLE
Sync grpc version to the one that comes from akka-grpc

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -183,7 +183,7 @@ object Dependencies {
   val GooglePubSubGrpc = Seq(
     libraryDependencies ++= Seq(
       "com.google.api.grpc" % "grpc-google-cloud-pubsub-v1" % "0.12.0" % "protobuf", // ApacheV2
-      "io.grpc" % "grpc-auth" % "1.16.1", // ApacheV2
+      "io.grpc" % "grpc-auth" % "1.20.0", // ApacheV2
       "com.google.auth" % "google-auth-library-oauth2-http" % "0.15.0" // BSD 3-clause
     ) ++ Silencer
   )


### PR DESCRIPTION
Otherwise coursier fails to resolve dependencies.