### PR TITLE
SQS/SNS: put aws-spi-akka-http dependency in test scope

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -341,15 +341,15 @@ object Dependencies {
 
   val Sns = Seq(
     libraryDependencies ++= Seq(
-      "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion excludeAll ExclusionRule(
-        organization = "com.typesafe.akka"
-      ), // ApacheV2
       "software.amazon.awssdk" % "sns" % AwsSdk2Version excludeAll (ExclusionRule(
         organization = "software.amazon.awssdk",
         name = "netty-nio-client"
       ), ExclusionRule(organization = "io.netty")), // ApacheV2
       "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion, // ApacheV2
-      "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
+      "org.mockito" % "mockito-core" % mockitoVersion % Test, // MIT
+      "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion % Test excludeAll ExclusionRule(
+        organization = "com.typesafe.akka"
+      ), // ApacheV2
     )
   )
 
@@ -370,16 +370,16 @@ object Dependencies {
 
   val Sqs = Seq(
     libraryDependencies ++= Seq(
-      "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion excludeAll ExclusionRule(
-        organization = "com.typesafe.akka"
-      ), // ApacheV2
       "software.amazon.awssdk" % "sqs" % AwsSdk2Version excludeAll (ExclusionRule(
         organization = "software.amazon.awssdk",
         name = "netty-nio-client"
       ), ExclusionRule(organization = "io.netty")), // ApacheV2
       "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion, // ApacheV2
       "org.mockito" % "mockito-core" % mockitoVersion % Test, // MIT
-      "org.mockito" % "mockito-inline" % mockitoVersion % Test // MIT
+      "org.mockito" % "mockito-inline" % mockitoVersion % Test, // MIT
+      "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion % Test excludeAll ExclusionRule(
+        organization = "com.typesafe.akka"
+      ), // ApacheV2
     )
   )
 

--- a/sns/src/test/scala/akka/stream/alpakka/sns/DefaultTestContext.scala
+++ b/sns/src/test/scala/akka/stream/alpakka/sns/DefaultTestContext.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.sns
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
 import org.mockito.Mockito.reset
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 import software.amazon.awssdk.services.sns.SnsAsyncClient
 

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
@@ -14,7 +14,7 @@ import akka.stream.scaladsl.Keep
 import akka.stream.testkit.scaladsl.TestSource
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar.mock
+import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatest.{FlatSpec, Matchers}
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._

--- a/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
@@ -13,7 +13,7 @@ import akka.stream.alpakka.sqs.scaladsl._
 import akka.stream.scaladsl.{Sink, Source}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{spy, times, verify, when}
-import org.scalatest.mockito.MockitoSugar.mock
+import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatest.{FlatSpec, Matchers}
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._


### PR DESCRIPTION
## Purpose

For some reason the `aws-spi-akka-http` dependency was added on Compile scope, but used only in tests. This gave the impression Alpakka SQS and SNS were built on top of it (https://github.com/akka/alpakka/issues/1665#issuecomment-489404667) which they are not by default. But it is possible to use it as shown in https://github.com/akka/alpakka/blob/v1.0.0/sqs/src/test/java/docs/javadsl/SqsSourceTest.java#L94-L104

## References

Detected while reading up on https://github.com/akka/alpakka/issues/1665
