### PR TITLE
AWS SQS/SNS: more concise docs about the HTTP client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -307,6 +307,7 @@ lazy val docs = project
       "javadoc.akka.http.base_url" -> s"https://doc.akka.io/japi/akka-http/${Dependencies.AkkaHttpVersion}/",
       "javadoc.org.apache.hadoop.base_url" -> s"https://hadoop.apache.org/docs/r${Dependencies.HadoopVersion}/api/",
       "javadoc.com.amazonaws.base_url" -> "https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/",
+      "javadoc.software.amazon.awssdk.base_url" -> "https://sdk.amazonaws.com/java/api/latest/",
       // Eclipse Paho client for MQTT
       "javadoc.org.eclipse.paho.client.mqttv3.base_url" -> "https://www.eclipse.org/paho/files/javadoc/",
       "javadoc.org.bson.codecs.configuration.base_url" -> "https://mongodb.github.io/mongo-java-driver/3.7/javadoc/",

--- a/docs/src/main/paradox/sns.md
+++ b/docs/src/main/paradox/sns.md
@@ -21,7 +21,9 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Setup
 
-Sources provided by this connector need a prepared `AmazonSNSAsyncClient` to publish messages to a topic.
+This connector requires an implicit @javadoc[SnsAsyncClient](software.amazon.awssdk.services.sns.SnsAsyncClient) instance to communicate with AWS SQS.
+
+It is your code's responsibility to call `close` to free any resources held by the client. In this example it will be called when the actor system is terminated.
 
 Scala
 : @@snip [snip](/sns/src/test/scala/akka/stream/alpakka/sns/IntegrationTestContext.scala) { #init-client }
@@ -30,6 +32,8 @@ Java
 : @@snip [snip](/sns/src/test/java/docs/javadsl/SnsPublisherTest.java) { #init-client }
 
 Alpakka SQS and SNS are set up to use @extref:[Akka HTTP](akka-http-docs:) as default HTTP client via the thin adapter library [AWS Akka-Http SPI implementation](https://github.com/matsluni/aws-spi-akka-http). By setting the `httpClient` explicitly (as above) the Akka actor system is reused, if not set explicitly a separate actor system will be created internally.
+
+It is possible to configure the use of Netty instead, which is Amazon's default. Add an appropriate Netty version to the dependencies and configure @javadoc[`NettyNioAsyncHttpClient`](software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient).
 
 We will also need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and an @scaladoc[ActorMaterializer](akka.stream.ActorMaterializer).
 

--- a/docs/src/main/paradox/sns.md
+++ b/docs/src/main/paradox/sns.md
@@ -29,6 +29,8 @@ Scala
 Java
 : @@snip [snip](/sns/src/test/java/docs/javadsl/SnsPublisherTest.java) { #init-client }
 
+Alpakka SQS and SNS are set up to use @extref:[Akka HTTP](akka-http-docs:) as default HTTP client via the thin adapter library [AWS Akka-Http SPI implementation](https://github.com/matsluni/aws-spi-akka-http). By setting the `httpClient` explicitly (as above) the Akka actor system is reused, if not set explicitly a separate actor system will be created internally.
+
 We will also need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and an @scaladoc[ActorMaterializer](akka.stream.ActorMaterializer).
 
 Scala

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -36,7 +36,7 @@ See [Alpakka SQS issues](https://github.com/akka/alpakka/labels/p%3Aaws-sqs)
 
 ## Setup
 
-Prepare an @scaladoc[ActorSystem](akka.actor.ActorSystem) and a @scaladoc[Materializer](akka.stream.Materializer).
+Prepare an @scaladoc[`ActorSystem`](akka.actor.ActorSystem) and a @scaladoc[`Materializer`](akka.stream.Materializer).
 
 Scala
 : @@snip [snip](/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala) { #init-mat }
@@ -45,9 +45,9 @@ Java
 : @@snip [snip](/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/BaseSqsTest.java) { #init-mat }
 
 
-This connector requires an implicit `AmazonSQSAsync` instance to communicate with AWS SQS. 
+This connector requires an implicit @javadoc[`SqsAsyncClient`](software.amazon.awssdk.services.sqs.SqsAsyncClient) instance to communicate with AWS SQS.
 
-It is your code's responsibility to call `shutdown` to free any resources held by the client. In this example it will be called when the actor system is terminated.
+It is your code's responsibility to call `close` to free any resources held by the client. In this example it will be called when the actor system is terminated.
 
 Scala
 : @@snip [snip](/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala) { #init-client }
@@ -59,8 +59,7 @@ Java
 
 Alpakka SQS and SNS are set up to use @extref:[Akka HTTP](akka-http-docs:) as default HTTP client via the thin adapter library [AWS Akka-Http SPI implementation](https://github.com/matsluni/aws-spi-akka-http). By setting the `httpClient` explicitly (as above) the Akka actor system is reused, if not set explicitly a separate actor system will be created internally.
 
-It is possible to configure the use of Netty instead, which is Amazon's default. Please add an appropriate Netty version to the dependencies. `AmazonSQSAsyncClient` uses a fixed thread pool with 50 threads by default. To tune the thread pool used by
-`AmazonSQSAsyncClient` you can supply a custom `ExecutorService` on client creation.
+It is possible to configure the use of Netty instead, which is Amazon's default. Add an appropriate Netty version to the dependencies and configure @javadoc[`NettyNioAsyncHttpClient`](software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient).
 
 Scala
 : @@snip [snip](/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala) { #init-custom-client }

--- a/sns/src/test/java/docs/javadsl/SnsPublisherTest.java
+++ b/sns/src/test/java/docs/javadsl/SnsPublisherTest.java
@@ -15,7 +15,7 @@ import akka.testkit.javadsl.TestKit;
 
 // #init-client
 import java.net.URI;
-
+import com.github.matsluni.akkahttpspi.AkkaHttpClient;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -70,6 +70,7 @@ public class SnsPublisherTest {
                 StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
             .endpointOverride(URI.create(endpoint))
             .region(Region.EU_CENTRAL_1)
+            .httpClient(AkkaHttpClient.builder().withActorSystem(system).build())
             .build();
 
     system.registerOnTermination(() -> awsSnsClient.close());

--- a/sns/src/test/scala/akka/stream/alpakka/sns/IntegrationTestContext.scala
+++ b/sns/src/test/scala/akka/stream/alpakka/sns/IntegrationTestContext.scala
@@ -48,6 +48,7 @@ trait IntegrationTestContext extends BeforeAndAfterAll with ScalaFutures {
     //#init-client
     import java.net.URI
 
+    import com.github.matsluni.akkahttpspi.AkkaHttpClient
     import software.amazon.awssdk.services.sns.SnsAsyncClient
     import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
     import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
@@ -59,6 +60,7 @@ trait IntegrationTestContext extends BeforeAndAfterAll with ScalaFutures {
         .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
         .endpointOverride(URI.create(endEndpoint))
         .region(Region.EU_CENTRAL_1)
+        .httpClient(AkkaHttpClient.builder().withActorSystem(system).build())
         .build()
 
     system.registerOnTermination(awsSnsClient.close())

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
@@ -17,7 +17,7 @@ final class SqsSourceSettings private (
     val attributeNames: immutable.Seq[AttributeName],
     val messageAttributeNames: immutable.Seq[MessageAttributeName],
     val closeOnEmptyReceive: Boolean,
-    val visibilityTimeout: Option[FiniteDuration],
+    val visibilityTimeout: Option[FiniteDuration]
 ) {
   require(maxBatchSize <= maxBufferSize, "maxBatchSize must be lower or equal than maxBufferSize")
   // SQS requirements

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
@@ -17,7 +17,7 @@ final class SqsSourceSettings private (
     val attributeNames: immutable.Seq[AttributeName],
     val messageAttributeNames: immutable.Seq[MessageAttributeName],
     val closeOnEmptyReceive: Boolean,
-    val visibilityTimeout: Option[FiniteDuration]
+    val visibilityTimeout: Option[FiniteDuration],
 ) {
   require(maxBatchSize <= maxBufferSize, "maxBatchSize must be lower or equal than maxBufferSize")
   // SQS requirements

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/BaseSqsTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/BaseSqsTest.java
@@ -9,7 +9,7 @@ import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.testkit.javadsl.TestKit;
 // #init-client
-
+import com.github.matsluni.akkahttpspi.AkkaHttpClient;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -62,6 +62,7 @@ public abstract class BaseSqsTest {
                 StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
             .endpointOverride(URI.create(sqsEndpoint))
             .region(Region.EU_CENTRAL_1)
+            .httpClient(AkkaHttpClient.builder().withActorSystem(system).build())
             .build();
 
     system.registerOnTermination(() -> sqsClient.close());

--- a/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
@@ -91,6 +91,7 @@ public class SqsSourceTest extends BaseSqsTest {
 
     /*
     // #init-custom-client
+    import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
     SdkAsyncHttpClient customClient = NettyNioAsyncHttpClient.builder().maxConcurrency(100).build();
     // #init-custom-client
     */

--- a/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
@@ -14,11 +14,11 @@ import com.github.matsluni.akkahttpspi.AkkaHttpClient;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
-import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 
 import java.net.URI;
 import java.time.Duration;
@@ -29,7 +29,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 
@@ -54,7 +53,7 @@ public class SqsSourceTest extends BaseSqsTest {
                                 .messageBody("alpakka-" + i)
                                 .build()))
                 .collect(Collectors.toList()))
-        .get();
+        .get(2, TimeUnit.SECONDS);
 
     final CompletionStage<List<Message>> cs =
         // #run
@@ -90,6 +89,12 @@ public class SqsSourceTest extends BaseSqsTest {
 
     final String queueUrl = randomQueueUrl();
 
+    /*
+    // #init-custom-client
+    SdkAsyncHttpClient customClient = NettyNioAsyncHttpClient.builder().maxConcurrency(100).build();
+    // #init-custom-client
+    */
+    SdkAsyncHttpClient customClient = AkkaHttpClient.builder().withActorSystem(system).build();
     // #init-custom-client
     final SqsAsyncClient customSqsClient =
         SqsAsyncClient.builder()
@@ -97,8 +102,7 @@ public class SqsSourceTest extends BaseSqsTest {
                 StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
             .endpointOverride(URI.create(sqsEndpoint))
             .region(Region.US_WEST_2)
-            // NettyNioAsyncHttpClient.builder().maxConcurrency(100).build()
-            .httpClient(AkkaHttpClient.builder().build())
+            .httpClient(customClient)
             .build();
 
     system.registerOnTermination(() -> customSqsClient.close());

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
@@ -11,11 +11,13 @@ import akka.stream.alpakka.sqs.SqsSourceSettings
 import akka.stream.{ActorMaterializer, Materializer}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, Matchers, Suite, Tag}
+//#init-client
+import com.github.matsluni.akkahttpspi.AkkaHttpClient
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
-
+//#init-client
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.util.Random
@@ -65,11 +67,13 @@ trait DefaultTestContext extends Matchers with BeforeAndAfterAll with ScalaFutur
 
   def createAsyncClient(sqsEndpoint: String): SqsAsyncClient = {
     //#init-client
+
     implicit val awsSqsClient = SqsAsyncClient
       .builder()
       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
       .endpointOverride(URI.create(sqsEndpoint))
       .region(Region.EU_CENTRAL_1)
+      .httpClient(AkkaHttpClient.builder().withActorSystem(system).build())
       .build()
 
     system.registerOnTermination(awsSqsClient.close())

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -175,6 +175,7 @@ class SqsSourceSpec extends FlatSpec with ScalaFutures with Matchers with Defaul
   "SqsSource" should "stream a single batch from the queue with custom client" taggedAs Integration in new IntegrationFixture {
     /*
     // #init-custom-client
+    import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
     val customClient: SdkAsyncHttpClient = NettyNioAsyncHttpClient.builder().maxConcurrency(100).build()
     // #init-custom-client
      */


### PR DESCRIPTION
## Purpose

Akka HTTP is injected to the AWS client via reflection. This use creates another actor system internally.

## References

I learned this via #1693
See https://github.com/matsluni/aws-spi-akka-http/issues/7

## Changes

* show explicit `AkkaHttpClient` use so that the actor system is reused
* document the use of Netty as another option