### PR TITLE
SQS source: make parallelism configurable

### DIFF
--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -80,7 +80,7 @@ Java
 
 Options:
 
- - `maxBatchSize` - the maximum number of messages to return (see `MaxNumberOfMessages` in AWS docs). Default: 10
+ - `maxBatchSize` - the maximum number of messages to return per request (allowed values 1-10, see `MaxNumberOfMessages` in AWS docs). Default: 10
  - `maxBufferSize` - internal buffer size used by the `Source`. Default: 100 messages
  - `waitTimeSeconds` - the duration for which the call waits for a message to arrive in the queue before
     returning (see `WaitTimeSeconds` in AWS docs). Default: 20 seconds  

--- a/sqs/src/main/mima-filters/1.0.x.backwards.excludes
+++ b/sqs/src/main/mima-filters/1.0.x.backwards.excludes
@@ -1,0 +1,2 @@
+# Allow changes to private constructor
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.sqs.SqsSourceSettings.this")

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
@@ -13,6 +13,7 @@ import scala.concurrent.duration.FiniteDuration
 final class SqsSourceSettings private (
     val waitTimeSeconds: Int,
     val maxBufferSize: Int,
+    val parallelRequests: Int,
     val maxBatchSize: Int,
     val attributeNames: immutable.Seq[AttributeName],
     val messageAttributeNames: immutable.Seq[MessageAttributeName],
@@ -59,6 +60,8 @@ final class SqsSourceSettings private (
    */
   def withMaxBufferSize(maxBufferSize: Int): SqsSourceSettings = copy(maxBufferSize = maxBufferSize)
 
+  def withParallelRequests(value: Int): SqsSourceSettings = copy(parallelRequests = value)
+
   /**
    * The maximum number of messages to return (see MaxNumberOfMessages in AWS docs).
    * Default: 10
@@ -102,6 +105,7 @@ final class SqsSourceSettings private (
   private def copy(
       waitTimeSeconds: Int = waitTimeSeconds,
       maxBufferSize: Int = maxBufferSize,
+      parallelRequests: Int = parallelRequests,
       maxBatchSize: Int = maxBatchSize,
       attributeNames: immutable.Seq[AttributeName] = attributeNames,
       messageAttributeNames: immutable.Seq[MessageAttributeName] = messageAttributeNames,
@@ -110,6 +114,7 @@ final class SqsSourceSettings private (
   ): SqsSourceSettings = new SqsSourceSettings(
     waitTimeSeconds,
     maxBufferSize,
+    parallelRequests,
     maxBatchSize,
     attributeNames,
     messageAttributeNames,
@@ -121,6 +126,7 @@ final class SqsSourceSettings private (
     "SqsSourceSettings(" +
     s"waitTimeSeconds=$waitTimeSeconds, " +
     s"maxBufferSize=$maxBufferSize, " +
+    s"parallelRequests=$parallelRequests, " +
     s"maxBatchSize=$maxBatchSize, " +
     s"attributeNames=${attributeNames.mkString(",")}, " +
     s"messageAttributeNames=${messageAttributeNames.mkString(",")}, " +
@@ -130,13 +136,16 @@ final class SqsSourceSettings private (
 }
 
 object SqsSourceSettings {
-  val Defaults = new SqsSourceSettings(20,
-                                       100,
-                                       10,
-                                       attributeNames = immutable.Seq(),
-                                       messageAttributeNames = immutable.Seq(),
-                                       closeOnEmptyReceive = false,
-                                       visibilityTimeout = None)
+  val Defaults = new SqsSourceSettings(
+    waitTimeSeconds = 20,
+    maxBufferSize = 100,
+    parallelRequests = 1,
+    maxBatchSize = 10,
+    attributeNames = immutable.Seq.empty,
+    messageAttributeNames = immutable.Seq.empty,
+    closeOnEmptyReceive = false,
+    visibilityTimeout = None
+  )
 
   /**
    * Scala API

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
@@ -42,7 +42,7 @@ object SqsSource {
           case Some(t) => requestBuilder.visibilityTimeout(t.toSeconds.toInt).build()
         }
       }
-      .mapAsync(1)(sqsClient.receiveMessage(_).toScala)
+      .mapAsync(settings.parallelRequests)(sqsClient.receiveMessage(_).toScala)
       .map(_.messages().asScala.toList)
       .takeWhile(messages => !settings.closeOnEmptyReceive || messages.nonEmpty)
       .mapConcat(identity)

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
@@ -42,7 +42,7 @@ object SqsSource {
           case Some(t) => requestBuilder.visibilityTimeout(t.toSeconds.toInt).build()
         }
       }
-      .mapAsync(settings.maxBufferSize / settings.maxBatchSize)(sqsClient.receiveMessage(_).toScala)
+      .mapAsync(1)(sqsClient.receiveMessage(_).toScala)
       .map(_.messages().asScala.toList)
       .takeWhile(messages => !settings.closeOnEmptyReceive || messages.nonEmpty)
       .mapConcat(identity)

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/BaseSqsTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/BaseSqsTest.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
 
 import java.net.URI;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 public abstract class BaseSqsTest {
 
@@ -75,7 +76,7 @@ public abstract class BaseSqsTest {
             CreateQueueRequest.builder()
                 .queueName(String.format("queue-%s", new Random().nextInt()))
                 .build())
-        .get()
+        .get(2, TimeUnit.SECONDS)
         .queueUrl();
   }
 }

--- a/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
@@ -72,7 +72,7 @@ public class SqsPublishTest extends BaseSqsTest {
     List<Message> messages =
         sqsClient
             .receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build())
-            .get()
+            .get(2, TimeUnit.SECONDS)
             .messages();
     assertEquals(1, messages.size());
     assertEquals("alpakka", messages.get(0).body());
@@ -97,7 +97,7 @@ public class SqsPublishTest extends BaseSqsTest {
     List<Message> messages =
         sqsClient
             .receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build())
-            .get()
+            .get(2, TimeUnit.SECONDS)
             .messages();
     assertEquals(1, messages.size());
     assertEquals("alpakka", messages.get(0).body());
@@ -121,7 +121,7 @@ public class SqsPublishTest extends BaseSqsTest {
     List<Message> messages =
         sqsClient
             .receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build())
-            .get()
+            .get(2, TimeUnit.SECONDS)
             .messages();
     assertEquals(1, messages.size());
     assertEquals("alpakka", messages.get(0).body());
@@ -146,7 +146,7 @@ public class SqsPublishTest extends BaseSqsTest {
     List<Message> messages =
         sqsClient
             .receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build())
-            .get()
+            .get(2, TimeUnit.SECONDS)
             .messages();
     assertEquals(1, messages.size());
     assertEquals("alpakka-flow", messages.get(0).body());
@@ -171,7 +171,7 @@ public class SqsPublishTest extends BaseSqsTest {
     List<Message> messages =
         sqsClient
             .receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build())
-            .get()
+            .get(2, TimeUnit.SECONDS)
             .messages();
     assertEquals(1, messages.size());
     assertEquals("alpakka-flow", messages.get(0).body());
@@ -199,14 +199,14 @@ public class SqsPublishTest extends BaseSqsTest {
         sqsClient
             .receiveMessage(
                 ReceiveMessageRequest.builder().maxNumberOfMessages(10).queueUrl(queueUrl).build())
-            .get()
+            .get(2, TimeUnit.SECONDS)
             .messages();
 
     List<Message> messagesSecondBatch =
         sqsClient
             .receiveMessage(
                 ReceiveMessageRequest.builder().maxNumberOfMessages(10).queueUrl(queueUrl).build())
-            .get()
+            .get(2, TimeUnit.SECONDS)
             .messages();
 
     assertEquals(20, messagesFirstBatch.size() + messagesSecondBatch.size());
@@ -235,7 +235,7 @@ public class SqsPublishTest extends BaseSqsTest {
         sqsClient
             .receiveMessage(
                 ReceiveMessageRequest.builder().maxNumberOfMessages(10).queueUrl(queueUrl).build())
-            .get()
+            .get(2, TimeUnit.SECONDS)
             .messages();
 
     assertEquals(10, messagesFirstBatch.size());
@@ -266,7 +266,7 @@ public class SqsPublishTest extends BaseSqsTest {
         sqsClient
             .receiveMessage(
                 ReceiveMessageRequest.builder().maxNumberOfMessages(10).queueUrl(queueUrl).build())
-            .get()
+            .get(2, TimeUnit.SECONDS)
             .messages();
 
     assertEquals(10, messagesFirstBatch.size());
@@ -294,7 +294,7 @@ public class SqsPublishTest extends BaseSqsTest {
         sqsClient
             .receiveMessage(
                 ReceiveMessageRequest.builder().maxNumberOfMessages(10).queueUrl(queueUrl).build())
-            .get()
+            .get(2, TimeUnit.SECONDS)
             .messages();
 
     assertEquals(10, messagesFirstBatch.size());
@@ -325,7 +325,7 @@ public class SqsPublishTest extends BaseSqsTest {
         sqsClient
             .receiveMessage(
                 ReceiveMessageRequest.builder().maxNumberOfMessages(10).queueUrl(queueUrl).build())
-            .get()
+            .get(2, TimeUnit.SECONDS)
             .messages();
 
     assertEquals(10, messagesFirstBatch.size());
@@ -348,7 +348,7 @@ public class SqsPublishTest extends BaseSqsTest {
         sqsClient
             .receiveMessage(
                 ReceiveMessageRequest.builder().maxNumberOfMessages(1).queueUrl(queueUrl).build())
-            .get()
+            .get(2, TimeUnit.SECONDS)
             .messages();
 
     assertEquals(1, messages.size());

--- a/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
@@ -54,10 +54,10 @@ public class SqsSourceTest extends BaseSqsTest {
                                 .messageBody("alpakka-" + i)
                                 .build()))
                 .collect(Collectors.toList()))
-        .get();
+        .get(2, TimeUnit.SECONDS);
 
-    final CompletionStage<List<Message>> cs =
-        // #run
+    // #run
+    final CompletionStage<List<Message>> messages =
         SqsSource.create(
                 queueUrl,
                 SqsSourceSettings.create()
@@ -67,7 +67,7 @@ public class SqsSourceTest extends BaseSqsTest {
             .runWith(Sink.seq(), materializer);
     // #run
 
-    assertEquals(100, cs.toCompletableFuture().get(20, TimeUnit.SECONDS).size());
+    assertEquals(100, messages.toCompletableFuture().get(20, TimeUnit.SECONDS).size());
   }
 
   @Test
@@ -106,7 +106,7 @@ public class SqsSourceTest extends BaseSqsTest {
 
     customSqsClient
         .sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody("alpakka").build())
-        .get();
+        .get(2, TimeUnit.SECONDS);
 
     final CompletionStage<String> cs =
         SqsSource.create(

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.sqs.scaladsl
 
 import java.net.URI
+import java.util.concurrent.TimeUnit
 
 import akka.actor.{ActorSystem, Terminated}
 import akka.stream.alpakka.sqs.SqsSourceSettings
@@ -44,7 +45,7 @@ trait DefaultTestContext extends Matchers with BeforeAndAfterAll with ScalaFutur
   def randomQueueUrl(): String =
     sqsClient
       .createQueue(CreateQueueRequest.builder().queueName(s"queue-${Random.nextInt}").build())
-      .get()
+      .get(2, TimeUnit.SECONDS)
       .queueUrl()
 
   val fifoQueueRequest =
@@ -54,7 +55,7 @@ trait DefaultTestContext extends Matchers with BeforeAndAfterAll with ScalaFutur
       .attributesWithStrings(Map("FifoQueue" -> "true", "ContentBasedDeduplication" -> "true").asJava)
       .build()
 
-  def randomFifoQueueUrl(): String = sqsClient.createQueue(fifoQueueRequest).get().queueUrl()
+  def randomFifoQueueUrl(): String = sqsClient.createQueue(fifoQueueRequest).get(2, TimeUnit.SECONDS).queueUrl()
 
   override protected def afterAll(): Unit =
     try {

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.sqs.scaladsl
 
 import java.util.UUID
-import java.util.concurrent.CompletableFuture
+import java.util.concurrent.{CompletableFuture, TimeUnit}
 import java.util.function.Supplier
 
 import akka.Done
@@ -78,7 +78,8 @@ class SqsPublishSinkSpec extends FlatSpec with Matchers with DefaultTestContext 
 
     future.futureValue shouldBe Done
 
-    val result = sqsClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queue2).build()).get()
+    val result =
+      sqsClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queue2).build()).get(2, TimeUnit.SECONDS)
     result.messages().size() shouldBe 1
     result.messages().get(0).body() shouldBe "alpakka"
   }

--- a/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
@@ -4,7 +4,7 @@
 
 package docs.scaladsl
 
-import java.util.concurrent.CompletableFuture
+import java.util.concurrent.{CompletableFuture, TimeUnit}
 import java.util.function.Supplier
 
 import akka.Done
@@ -19,7 +19,6 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
 import scala.concurrent.duration._
-
 import scala.collection.JavaConverters._
 
 class SqsAckSpec extends FlatSpec with Matchers with DefaultTestContext {
@@ -36,7 +35,7 @@ class SqsAckSpec extends FlatSpec with Matchers with DefaultTestContext {
           .messageBody(message)
           .build()
 
-      awsSqsClient.sendMessage(request).get()
+      awsSqsClient.sendMessage(request).get(2, TimeUnit.SECONDS)
     }
 
     def sendMessages(messages: Seq[String]): Unit = {
@@ -56,7 +55,7 @@ class SqsAckSpec extends FlatSpec with Matchers with DefaultTestContext {
           .entries(entries.asJava)
           .build()
 
-      awsSqsClient.sendMessageBatch(batch).get()
+      awsSqsClient.sendMessageBatch(batch).get(2, TimeUnit.SECONDS)
     }
   }
 

--- a/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
@@ -4,6 +4,8 @@
 
 package docs.scaladsl
 
+import java.util.concurrent.TimeUnit
+
 import akka.Done
 import akka.stream.alpakka.sqs._
 import akka.stream.alpakka.sqs.scaladsl._
@@ -23,7 +25,7 @@ class SqsPublishSpec extends FlatSpec with Matchers with DefaultTestContext {
     def receiveMessage(): Message =
       awsSqsClient
         .receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build())
-        .get()
+        .get(2, TimeUnit.SECONDS)
         .messages()
         .asScala
         .head
@@ -39,7 +41,7 @@ class SqsPublishSpec extends FlatSpec with Matchers with DefaultTestContext {
           .maxNumberOfMessages(maxNumberOfMessages)
           .build()
 
-      awsSqsClient.receiveMessage(request).get().messages().asScala.toSeq
+      awsSqsClient.receiveMessage(request).get(2, TimeUnit.SECONDS).messages().asScala.toSeq
     }
   }
 


### PR DESCRIPTION
## Purpose

Make the number of parallel requests issued by `SqsSource` configurable. Use 1 as default. 

## References

References #1605 

## Changes

* Set the parallelism for AWS client fetching via `SqsSourceSettings` (which fetches up to `maxBatchSize` messages)
* cleanup: limit all `CompletionStage.get` calls with a finite duration

## Background Context

As discussed in https://github.com/akka/alpakka/issues/1665#issuecomment-491521609 the higher parallelism could help to fill the buffer when starting up. (See even https://github.com/akka/alpakka/issues/1588#issuecomment-476105607 for the original discussion).

The `buffer` operator in `SqsSource` makes sure more data is fetched eagerly, even if the stream back-pressures, but does not buffer data as long there is down-stream demand ([buffer operator](https://doc.akka.io/docs/akka/current/stream/operators/Source-or-Flow/buffer.html)).

With slow down-stream processing, this may play badly together with the visibility timeout if messages are buffered too long and show up for other consumers as well.