### PR TITLE
Fix: LogRotatorSink does not complete when consuming an empty source

### DIFF
--- a/file/src/main/scala/akka/stream/alpakka/file/scaladsl/LogRotatorSink.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/scaladsl/LogRotatorSink.scala
@@ -124,8 +124,10 @@ final private class LogRotatorSink[C, R](triggerGeneratorCreator: () => ByteStri
           }
         }
 
-        override def onUpstreamFinish(): Unit =
+        override def onUpstreamFinish(): Unit = {
+          promise.trySuccess(Done)
           completeStage()
+        }
 
         override def onUpstreamFailure(ex: Throwable): Unit =
           failThisStage(ex)

--- a/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
@@ -82,6 +82,19 @@ class LogRotatorSinkSpec
   val testByteStrings = TestLines.map(ByteString(_))
 
   "LogRotatorSink" must {
+
+    "complete when consuming an empty source" in assertAllStagesStopped {
+      val triggerCreator: () => ByteString => Option[Path] = () => { element: ByteString =>
+        fail("trigger creator should not be called")
+      }
+
+      val rotatorSink: Sink[ByteString, Future[Done]] =
+        LogRotatorSink(triggerCreator)
+
+      val completion = Source.empty[ByteString].runWith(rotatorSink)
+      completion.futureValue shouldBe Done
+    }
+
     "work for size-based rotation " in assertAllStagesStopped {
       // #size
       import akka.stream.alpakka.file.scaladsl.LogRotatorSink


### PR DESCRIPTION
## Purpose

Fix bug: LogRotatorSink does not terminate when consuming an empty Source

## References

[Related bug report](https://github.com/akka/alpakka/issues/1701)

## Changes

- Complete the stage's promise when`onUpstreamFinish` is called

## Legal info

I signed the CLA