### PR TITLE
CSV: stream may end with delimiter

### DIFF
--- a/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
@@ -238,6 +238,19 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       exception.getMessage should be("unclosed quote at end of input 1:6, no matching quote found")
     }
 
+    "accept delimiter as last input" in {
+      val parser = new CsvParser(delimiter = ',', quoteChar = '"', escapeChar = '\\', maximumLineLength)
+      parser.offer(ByteString("A,B\nA,"))
+      parser.poll(requireLineEnd = false).value.map(_.utf8String) should be(List("A", "B"))
+      parser.poll(requireLineEnd = false).value shouldBe List(ByteString("A"), ByteString.empty)
+    }
+
+    "accept delimiter as last input on first line" in {
+      val parser = new CsvParser(delimiter = ',', quoteChar = '"', escapeChar = '\\', maximumLineLength)
+      parser.offer(ByteString("A,"))
+      parser.poll(requireLineEnd = false).value shouldBe List(ByteString("A"), ByteString.empty)
+    }
+
     "detect line ending correctly if input is split between CR & LF" in {
       val parser = new CsvParser(delimiter = ',', quoteChar = '"', escapeChar = '\\', maximumLineLength)
       parser.offer(ByteString("A,D\r"))

--- a/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
@@ -135,6 +135,20 @@ class CsvParsingSpec extends CsvSpec {
       sink.expectComplete()
     }
 
+    "read all lines without final line end and last column empty" in {
+      val result = Source.single(ByteString(
+        """eins,zwei,drei
+          |uno,""".stripMargin))
+        .via(CsvParsing.lineScanner())
+        .map(_.map(_.utf8String))
+        .runWith(Sink.seq)
+        .futureValue
+
+      result should have size 2
+      result.head should be(List("eins", "zwei", "drei"))
+      result(1) should be(List("uno", ""))
+    }
+
     "parse Apple Numbers exported file" in assertAllStagesStopped {
       val fut =
         FileIO

--- a/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
@@ -136,8 +136,8 @@ class CsvParsingSpec extends CsvSpec {
     }
 
     "read all lines without final line end and last column empty" in {
-      val result = Source.single(ByteString(
-        """eins,zwei,drei
+      val result = Source
+        .single(ByteString("""eins,zwei,drei
           |uno,""".stripMargin))
         .via(CsvParsing.lineScanner())
         .map(_.map(_.utf8String))


### PR DESCRIPTION
## Purpose

The CSV optimisations in #1685 changed the parsing behaviour for streams ending with an empty column, this brings back the expected behaviour.

## References

Optimisation work in #1685 
Reported as bug in #1710 
