### PR TITLE
CSV: accept escape without escapeable byte after

### DIFF
--- a/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvParser.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvParser.scala
@@ -314,12 +314,17 @@ import scala.collection.mutable
               state = WithinField
               advance()
 
-            case b =>
+            case `quoteChar` =>
               throw new MalformedCsvException(
                 currentLineNo,
                 lineLength,
-                s"wrong escaping at $currentLineNo:$lineLength, only escape or delimiter may be escaped"
+                s"wrong escaping at $currentLineNo:$lineLength, quote is escaped as ${quoteChar.toChar}${quoteChar.toChar}"
               )
+
+            case b =>
+              fieldBuilder.add(escapeChar)
+              state = WithinField
+
           }
 
         case QuoteStarted =>
@@ -384,12 +389,16 @@ import scala.collection.mutable
               state = WithinQuotedField
               advance()
 
-            case b =>
+            case `quoteChar` =>
               throw new MalformedCsvException(
                 currentLineNo,
                 lineLength,
-                s"wrong escaping at $currentLineNo:$lineLength, only escape or quote may be escaped within quotes"
+                s"wrong escaping at $currentLineNo:$lineLength, quote is escaped as ${quoteChar.toChar}${quoteChar.toChar}"
               )
+
+            case b =>
+              fieldBuilder.add(escapeChar)
+              state = WithinQuotedField
           }
 
         case WithinQuotedFieldQuote =>

--- a/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvParser.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvParser.scala
@@ -389,13 +389,6 @@ import scala.collection.mutable
               state = WithinQuotedField
               advance()
 
-            case `quoteChar` =>
-              throw new MalformedCsvException(
-                currentLineNo,
-                lineLength,
-                s"wrong escaping at $currentLineNo:$lineLength, quote is escaped as ${quoteChar.toChar}${quoteChar.toChar}"
-              )
-
             case b =>
               fieldBuilder.add(escapeChar)
               state = WithinQuotedField

--- a/csv/src/test/java/docs/javadsl/CsvFormattingTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvFormattingTest.java
@@ -7,8 +7,11 @@ package docs.javadsl;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
+// #import
 import akka.stream.alpakka.csv.javadsl.CsvFormatting;
 import akka.stream.alpakka.csv.javadsl.CsvQuotingStyle;
+
+// #import
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;

--- a/csv/src/test/java/docs/javadsl/CsvToMapTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvToMapTest.java
@@ -7,10 +7,11 @@ package docs.javadsl;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
-// #header-line #column-names
+// #import
 import akka.stream.alpakka.csv.javadsl.CsvParsing;
 import akka.stream.alpakka.csv.javadsl.CsvToMap;
-// #header-line #column-names
+
+// #import
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
@@ -59,7 +60,6 @@ public class CsvToMapTest {
   public void parsedLineShouldBecomeMapKeys() throws Exception {
     CompletionStage<Map<String, ByteString>> completionStage =
         // #header-line
-
         // values as ByteString
         Source.single(ByteString.fromString("eins,zwei,drei\n1,2,3"))
             .via(CsvParsing.lineScanner())
@@ -99,7 +99,6 @@ public class CsvToMapTest {
   public void givenHeadersShouldBecomeMapKeys() throws Exception {
     CompletionStage<Map<String, ByteString>> completionStage =
         // #column-names
-
         // values as ByteString
         Source.single(ByteString.fromString("1,2,3"))
             .via(CsvParsing.lineScanner())

--- a/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
@@ -96,6 +96,10 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       expectInOut("a,\\,,c\n", List("a", ",", "c"))
     }
 
+    "parse escape char into itself if not followed by escape or delimiter" in {
+      expectInOut("a,\\b,\"\\-c\"\n", List("a", "\\b", "\\-c"))
+    }
+
     "fail on escaped quote as quotes are escaped by doubled quote chars" in {
       val in = ByteString("a,\\\",c\n")
       val parser = new CsvParser(',', '"', '\\', maximumLineLength)
@@ -103,7 +107,7 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       val exception = the[MalformedCsvException] thrownBy {
         parser.poll(requireLineEnd = true)
       }
-      exception.getMessage should be("wrong escaping at 1:3, only escape or delimiter may be escaped")
+      exception.getMessage should be("wrong escaping at 1:3, quote is escaped as \"\"")
       exception.getLineNo should be(1)
       exception.getBytePos should be(3)
     }

--- a/csv/src/test/scala/docs/scaladsl/CsvFormattingSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvFormattingSpec.scala
@@ -6,7 +6,6 @@ package docs.scaladsl
 
 import java.nio.charset.StandardCharsets
 
-import akka.stream.alpakka.csv.scaladsl.{ByteOrderMark, CsvFormatting, CsvQuotingStyle}
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.util.ByteString
@@ -16,6 +15,10 @@ import scala.collection.immutable
 class CsvFormattingSpec extends CsvSpec {
 
   def documentation(): Unit = {
+    // #flow-type
+    import akka.stream.alpakka.csv.scaladsl.{CsvFormatting, CsvQuotingStyle}
+
+    // #flow-type
     import CsvFormatting._
     val delimiter = Comma
     val quoteChar = DoubleQuote
@@ -55,7 +58,7 @@ class CsvFormattingSpec extends CsvSpec {
 
     "include Byte Order Mark" in assertAllStagesStopped {
       // #formatting-bom
-      import akka.stream.alpakka.csv.scaladsl.CsvFormatting
+      import akka.stream.alpakka.csv.scaladsl.{ByteOrderMark, CsvFormatting}
 
       // #formatting-bom
       val fut =

--- a/docs/src/main/paradox/data-transformations/csv.md
+++ b/docs/src/main/paradox/data-transformations/csv.md
@@ -83,7 +83,7 @@ Scala
 : @@snip [snip](/csv/src/test/scala/docs/scaladsl/CsvToMapSpec.scala) { #flow-type }
 
 Java
-: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvToMapTest.java) { #flow-type }
+: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvToMapTest.java) { #import #flow-type }
 
 
 This example uses the first line (the header line) in the CSV data as column names:
@@ -92,7 +92,7 @@ Scala
 : @@snip [snip](/csv/src/test/scala/docs/scaladsl/CsvToMapSpec.scala) { #header-line }
 
 Java
-: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvToMapTest.java) { #header-line }
+: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvToMapTest.java) { #import #header-line }
 
 
 This sample will generate the same output as above, but the column names are specified
@@ -102,7 +102,7 @@ Scala
 : @@snip [snip](/csv/src/test/scala/docs/scaladsl/CsvToMapSpec.scala) { #column-names }
 
 Java
-: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvToMapTest.java) { #column-names }
+: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvToMapTest.java) { #import #column-names }
 
 ## CSV formatting
 
@@ -119,7 +119,7 @@ Scala
 : @@snip [snip](/csv/src/test/scala/docs/scaladsl/CsvFormattingSpec.scala) { #flow-type }
 
 Java
-: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvFormattingTest.java) { #flow-type }
+: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvFormattingTest.java) { #import #flow-type }
 
 This example uses the default configuration:
 
@@ -135,4 +135,4 @@ Scala
 : @@snip [snip](/csv/src/test/scala/docs/scaladsl/CsvFormattingSpec.scala) { #formatting }
 
 Java
-: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvFormattingTest.java) { #formatting }
+: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvFormattingTest.java) { #import #formatting }

--- a/docs/src/main/paradox/data-transformations/csv.md
+++ b/docs/src/main/paradox/data-transformations/csv.md
@@ -54,7 +54,7 @@ Scala
 : @@snip [snip](/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala) { #flow-type }
 
 Java
-: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvParsingTest.java) { #flow-type }
+: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvParsingTest.java) { #import #flow-type }
 
 
 In this sample we read a single line of CSV formatted data into a list of column elements:
@@ -63,7 +63,7 @@ Scala
 : @@snip [snip](/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala) { #line-scanner }
 
 Java
-: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvParsingTest.java) { #line-scanner }
+: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvParsingTest.java) { #import #line-scanner }
 
 To convert the `ByteString` columns as `String`, a `map` operation can be added to the Flow:
 
@@ -71,7 +71,7 @@ Scala
 : @@snip [snip](/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala) { #line-scanner-string }
 
 Java
-: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvParsingTest.java) { #line-scanner-string }
+: @@snip [snip](/csv/src/test/java/docs/javadsl/CsvParsingTest.java) { #import #line-scanner-string }
 
 ## CSV conversion into a map
 


### PR DESCRIPTION
## Purpose

Accept an escape byte (eg `\`) in the input which is not followed by an escapeable byte (escape (`\`) or delimiter (`,`)) and add the escape byte itself to the parsed column.
It still fails if escape is followed by quote (eg. `\"`).

## References

#1643 
