### PR TITLE
Update to the latest sbt-site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       name: "Compile all tests (with Scala 2.13)"
     - env: CMD="unidoc"
       name: "Create all API docs"
-    - env: CMD="docs/Paradox/paradox"
+    - env: CMD="docs/paradox"
       name: "Create site with Paradox"
     - env: CMD="mimaReportBinaryIssues"
       name: "Check binary compatibility"

--- a/build.sbt
+++ b/build.sbt
@@ -275,14 +275,14 @@ lazy val docs = project
     publish / skip := true,
     whitesourceIgnore := true,
     makeSite := makeSite.dependsOn(LocalRootProject / ScalaUnidoc / doc).value,
+    previewPath := "docs/alpakka/snapshot/",
     Preprocess / siteSubdirName := s"api/alpakka/${if (isSnapshot.value) "snapshot" else version.value}",
     Preprocess / sourceDirectory := (LocalRootProject / ScalaUnidoc / unidoc / target).value,
     Preprocess / preprocessRules := Seq(
       ("\\.java\\.scala".r, _ => ".java")
     ),
     Paradox / siteSubdirName := s"docs/alpakka/${if (isSnapshot.value) "snapshot" else version.value}",
-    Paradox / sourceDirectory := sourceDirectory.value / "main",
-    Paradox / paradoxProperties ++= Map(
+    paradoxProperties ++= Map(
       "akka.version" -> Dependencies.AkkaVersion,
       "akka-http.version" -> Dependencies.AkkaHttpVersion,
       "couchbase.version" -> Dependencies.CouchbaseVersion,
@@ -322,7 +322,7 @@ lazy val docs = project
         s"$docsHost/api/alpakka/${if (isSnapshot.value) "snapshot" else version.value}/"
       }
     ),
-    Paradox / paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
+    paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
     resolvers += Resolver.jcenterRepo,
     publishRsyncArtifact := makeSite.value -> "www/",
     publishRsyncHost := "akkarepo@gustav.akka.io"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.14")
 // has following PRs merged in:
 // * https://github.com/sbt/sbt-site/pull/141
 // * https://github.com/sbt/sbt-site/pull/139
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.2+24-b76fdbbe")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0-SNAPSHOT")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.6.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,10 +10,7 @@ addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.1.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.14")
-// has following PRs merged in:
-// * https://github.com/sbt/sbt-site/pull/141
-// * https://github.com/sbt/sbt-site/pull/139
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0-SNAPSHOT")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.6.1")


### PR DESCRIPTION
## Purpose

Updates to the latest sbt-site

## References

~This uses not yet released sbt-site feature from https://github.com/sbt/sbt-site/pull/148~

## Changes

`Paradox` configuration scope is not needed anymore when using sbt-site with Paradox.