### PR TITLE
DynamoDb: set port from settings even when tls=true

### DIFF
--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoClientImpl.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoClientImpl.scala
@@ -38,7 +38,7 @@ private[dynamodb] class DynamoClientImpl(
       .withMaxConnections(settings.parallelism)
       .withMaxOpenRequests(settings.maxOpenRequests.getOrElse(settings.parallelism))
     if (settings.tls)
-      Http().cachedHostConnectionPoolHttps[AwsRequestMetadata](settings.host, settings = poolSettings)
+      Http().cachedHostConnectionPoolHttps[AwsRequestMetadata](settings.host, settings.port, settings = poolSettings)
     else
       Http().cachedHostConnectionPool[AwsRequestMetadata](settings.host, settings.port, settings = poolSettings)
   }


### PR DESCRIPTION

## Purpose

Fixes the issue wherein setting tls=true in DynamoSettings overwrites the configured port to 443

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #1662 

## Changes

Passed port to Http().cachedHostConnectionPoolHttps
