### PR TITLE
DynamoDb: set 443 as default port

### DIFF
--- a/dynamodb/src/main/resources/reference.conf
+++ b/dynamodb/src/main/resources/reference.conf
@@ -6,7 +6,7 @@ akka.stream.alpakka.dynamodb {
   host = ""
 
   # The AWS port, https is used as default scheme
-  port = -1
+  port = 443
 
   # Use Transport Level Security (https)
   tls = true


### PR DESCRIPTION
## Purpose

By defaulting to port 443 in `reference.conf` this makes #1722 work backwards-compatible.

## Background Context

As `tls` was enabled by default, with just #1722 the code would try to connect to port `-1`. By making port `443` the default everything should work as previously.
