### PR TITLE
Standardise extref names

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -275,7 +275,7 @@ lazy val docs = project
     publish / skip := true,
     whitesourceIgnore := true,
     makeSite := makeSite.dependsOn(LocalRootProject / ScalaUnidoc / doc).value,
-    previewPath := "docs/alpakka/snapshot/",
+    previewPath := (Paradox / siteSubdirName).value,
     Preprocess / siteSubdirName := s"api/alpakka/${if (isSnapshot.value) "snapshot" else version.value}",
     Preprocess / sourceDirectory := (LocalRootProject / ScalaUnidoc / unidoc / target).value,
     Preprocess / preprocessRules := Seq(
@@ -287,8 +287,12 @@ lazy val docs = project
       "akka-http.version" -> Dependencies.AkkaHttpVersion,
       "couchbase.version" -> Dependencies.CouchbaseVersion,
       "hadoop.version" -> Dependencies.HadoopVersion,
-      "extref.akka-docs.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.AkkaVersion}/%s",
-      "extref.akka-http-docs.base_url" -> s"https://doc.akka.io/docs/akka-http/${Dependencies.AkkaHttpVersion}/%s",
+      "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.AkkaVersion}/%s",
+      "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.AkkaVersion}",
+      "javadoc.akka.base_url" -> s"https://doc.akka.io/japi/akka/${Dependencies.AkkaVersion}/",
+      "extref.akka-http.base_url" -> s"https://doc.akka.io/docs/akka-http/${Dependencies.AkkaHttpVersion}/%s",
+      "scaladoc.akka.http.base_url" -> s"https://doc.akka.io/api/akka-http/${Dependencies.AkkaHttpVersion}/",
+      "javadoc.akka.http.base_url" -> s"https://doc.akka.io/japi/akka-http/${Dependencies.AkkaHttpVersion}/",
       "extref.couchbase.base_url" -> s"https://docs.couchbase.com/java-sdk/${Dependencies.CouchbaseVersionForDocs}/%s",
       "extref.java-api.base_url" -> "https://docs.oracle.com/javase/8/docs/api/index.html?%s.html",
       "extref.geode.base_url" -> s"https://geode.apache.org/docs/guide/${Dependencies.GeodeVersionForDocs}/%s",
@@ -303,22 +307,18 @@ lazy val docs = project
       "javadoc.javax.jms.base_url" -> "https://docs.oracle.com/javaee/7/api/",
       "javadoc.com.couchbase.base_url" -> s"https://docs.couchbase.com/sdk-api/couchbase-java-client-${Dependencies.CouchbaseVersion}/",
       "javadoc.org.apache.kudu.base_url" -> s"https://kudu.apache.org/releases/${Dependencies.KuduVersion}/apidocs/",
-      "javadoc.akka.base_url" -> s"https://doc.akka.io/japi/akka/${Dependencies.AkkaVersion}/",
-      "javadoc.akka.http.base_url" -> s"https://doc.akka.io/japi/akka-http/${Dependencies.AkkaHttpVersion}/",
       "javadoc.org.apache.hadoop.base_url" -> s"https://hadoop.apache.org/docs/r${Dependencies.HadoopVersion}/api/",
       "javadoc.com.amazonaws.base_url" -> "https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/",
       "javadoc.software.amazon.awssdk.base_url" -> "https://sdk.amazonaws.com/java/api/latest/",
       // Eclipse Paho client for MQTT
       "javadoc.org.eclipse.paho.client.mqttv3.base_url" -> "https://www.eclipse.org/paho/files/javadoc/",
       "javadoc.org.bson.codecs.configuration.base_url" -> "https://mongodb.github.io/mongo-java-driver/3.7/javadoc/",
-      "scaladoc.scala.base_url" -> s"https://www.scala-lang.org/api/current/",
-      "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.AkkaVersion}",
-      "scaladoc.akka.http.base_url" -> s"https://doc.akka.io/api/akka-http/${Dependencies.AkkaHttpVersion}/",
+      "scaladoc.scala.base_url" -> s"https://www.scala-lang.org/api/${scalaBinaryVersion.value}.x/",
       "scaladoc.akka.stream.alpakka.base_url" -> {
         val docsHost = sys.env
           .get("CI")
           .map(_ => "https://doc.akka.io")
-          .getOrElse(s"http://localhost:${(previewSite / previewFixedPort).value}")
+          .getOrElse(s"http://localhost:${(previewSite / previewFixedPort).value.getOrElse(4000)}")
         s"$docsHost/api/alpakka/${if (isSnapshot.value) "snapshot" else version.value}/"
       }
     ),

--- a/docs/src/main/paradox/amqp.md
+++ b/docs/src/main/paradox/amqp.md
@@ -46,7 +46,7 @@ Create a sink, that accepts and forwards @scaladoc[ByteString](akka.util.ByteStr
 
 @scala[@scaladoc[AmqpSink](akka.stream.alpakka.amqp.scaladsl.AmqpSink$)]@java[@scaladoc[AmqpSink](akka.stream.alpakka.amqp.javadsl.AmqpSink$)] is a collection of factory methods that facilitates creation of sinks. Here we created a *simple* sink, which means that we are able to pass `ByteString`s to the sink instead of wrapping data into @scaladoc[WriteMessage](akka.stream.alpakka.amqp.WriteMessage)s.
 
-Last step is to @extref[materialize](akka-docs:stream/stream-flows-and-basics.html) and run the sink we have created.
+Last step is to @extref:[materialize](akka:stream/stream-flows-and-basics.html) and run the sink we have created.
 
 Scala
 : @@snip [snip](/amqp/src/test/scala/docs/scaladsl/AmqpDocsSpec.scala) { #create-sink }
@@ -90,7 +90,7 @@ Scala
 Java
 : @@snip [snip](/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java) { #create-exchange-sink }
 
-For the source, we are going to create multiple sources and merge them using @extref[Akka Streams operators](akka-docs:stream/operators/index.html).
+For the source, we are going to create multiple sources and merge them using @extref:[Akka Streams operators](akka:stream/operators/index.html).
 
 Scala
 : @@snip [snip](/amqp/src/test/scala/docs/scaladsl/AmqpDocsSpec.scala) { #create-exchange-source }

--- a/docs/src/main/paradox/cassandra.md
+++ b/docs/src/main/paradox/cassandra.md
@@ -61,7 +61,7 @@ Scala
 Java
 : @@snip [snip](/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java) { #run-source }
 
-Here we used a basic sink to complete the stream by collecting all of the stream elements to a collection. The power of streams comes from building larger data pipelines which leverage backpressure to ensure efficient flow control. Feel free to edit the example code and build @extref[more advanced stream topologies](akka-docs:stream/stream-introduction.html).
+Here we used a basic sink to complete the stream by collecting all of the stream elements to a collection. The power of streams comes from building larger data pipelines which leverage backpressure to ensure efficient flow control. Feel free to edit the example code and build @extref:[more advanced stream topologies](akka:stream/stream-introduction.html).
 
 ## Flow with passthrough
 

--- a/docs/src/main/paradox/data-transformations/compression.md
+++ b/docs/src/main/paradox/data-transformations/compression.md
@@ -6,4 +6,4 @@ elements.
 Use @scaladoc[ScalaDSL Compression](akka.stream.scaladsl.Compression$) or 
 @scaladoc[JavaDSL Compression](akka.stream.javadsl.Compression$) as described in the Akka Stream documentation:
 
-@extref[Akka documentation](akka-docs:stream/stream-cookbook.html#dealing-with-compressed-data-streams)
+@extref:[Akka documentation](akka:stream/stream-cookbook.html#dealing-with-compressed-data-streams)

--- a/docs/src/main/paradox/data-transformations/json.md
+++ b/docs/src/main/paradox/data-transformations/json.md
@@ -8,7 +8,7 @@ ByteString snippets of valid JSON objects.
 See @scaladoc[ScalaDSL JsonFraming](akka.stream.scaladsl.JsonFraming$) or @scaladoc[JavaDSL JsonFraming](akka.stream.javadsl.JsonFraming$)
 
 
-@extref[Akka documentation](akka-docs:stream/stream-io.html#using-framing-in-your-protocol)
+@extref:[Akka documentation](akka:stream/stream-io.html#using-framing-in-your-protocol)
 
 
 

--- a/docs/src/main/paradox/data-transformations/parsing-lines.md
+++ b/docs/src/main/paradox/data-transformations/parsing-lines.md
@@ -4,4 +4,4 @@ Most Alpakka sources stream @scaladoc[ByteString](akka.util.ByteString) elements
 split these at line separators use @scaladoc[ScalaDSL Framing](akka.stream.scaladsl.Framing$) or 
 @scaladoc[JavaDSL Framing](akka.stream.javadsl.Framing$) as described in the Akka Stream documentation.
 
-@extref[Akka documentation](akka-docs:stream/stream-cookbook.html#parsing-lines-from-a-stream-of-bytestrings)
+@extref:[Akka documentation](akka:stream/stream-cookbook.html#parsing-lines-from-a-stream-of-bytestrings)

--- a/docs/src/main/paradox/examples/csv-samples.md
+++ b/docs/src/main/paradox/examples/csv-samples.md
@@ -3,9 +3,9 @@
 ### Example: Fetch CSV from Internet and publish the data as JSON to Kafka
 
 This example uses 
-@extref[Akka HTTP to send the HTTP request](akka-http-docs:client-side/connection-level.html#opening-http-connections) 
+@extref:[Akka HTTP to send the HTTP request](akka-http:client-side/connection-level.html#opening-http-connections) 
 and @scala[Akka HTTPs primary JSON support
-via @extref[Spray JSON](akka-http-docs:common/json-support.html#spray-json-support) to convert the map into a JSON structure.]
+via @extref:[Spray JSON](akka-http:common/json-support.html#spray-json-support) to convert the map into a JSON structure.]
 @java[Jackson JSON generator to convert the map into a JSON-formatted string.] 
 
 - (1) trigger an HTTP request every 30 seconds,

--- a/docs/src/main/paradox/mongodb.md
+++ b/docs/src/main/paradox/mongodb.md
@@ -87,7 +87,7 @@ Java
 
 Here we used a basic sink to complete the stream by collecting all of the stream elements to a collection.
 The power of streams comes from building larger data pipelines which leverage backpressure to ensure efficient flow control.
-Feel free to edit the example code and build @extref[more advanced stream topologies](akka-docs:scala/stream/stream-introduction.html).
+Feel free to edit the example code and build @extref:[more advanced stream topologies](akka:scala/stream/stream-introduction.html).
 
 ## Flow and Sink
 

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -14,8 +14,8 @@ The code in this documentation is compiled against
 
 * Alpakka $project.version$ ([Github](https://github.com/akka/alpakka), [API docs](https://doc.akka.io/api/alpakka/current/akka/stream/alpakka/index.html))
 * Scala $scala.binary.version$ (most modules are available for Scala 2.13, and all are available for Scala 2.11)
-* Akka Streams $akka.version$ (@extref[Docs](akka-docs:stream/index.html), [Github](https://github.com/akka/akka))
-* Akka Http $akka-http.version$ (@extref[Docs Scala](akka-http-docs:scala.html), @extref[Docs Java](akka-http-docs:java.html), [Github](https://github.com/akka/akka-http))
+* Akka Streams $akka.version$ (@extref:[Reference](akka:stream/index.html), [Github](https://github.com/akka/akka))
+* Akka Http $akka-http.version$ (@extref:[Reference](akka-http:), [Github](https://github.com/akka/akka-http))
 
 Release notes are found at @ref:[Release Notes](release-notes/index.md).
 

--- a/docs/src/main/paradox/patterns.md
+++ b/docs/src/main/paradox/patterns.md
@@ -1,7 +1,7 @@
 # Integration Patterns
 
 Many [Enterprise Integration Patterns](http://www.eaipatterns.com/toc.html) can be implemented with Akka Streams 
-(see @extref[Akka Streams documentation](akka-docs:stream/index.html)).
+(see @extref:[Akka Streams documentation](akka:stream/index.html)).
 
 
 # Splitter

--- a/docs/src/main/paradox/sns.md
+++ b/docs/src/main/paradox/sns.md
@@ -31,7 +31,7 @@ Scala
 Java
 : @@snip [snip](/sns/src/test/java/docs/javadsl/SnsPublisherTest.java) { #init-client }
 
-Alpakka SQS and SNS are set up to use @extref:[Akka HTTP](akka-http-docs:) as default HTTP client via the thin adapter library [AWS Akka-Http SPI implementation](https://github.com/matsluni/aws-spi-akka-http). By setting the `httpClient` explicitly (as above) the Akka actor system is reused, if not set explicitly a separate actor system will be created internally.
+Alpakka SQS and SNS are set up to use @extref:[Akka HTTP](akka-http:) as default HTTP client via the thin adapter library [AWS Akka-Http SPI implementation](https://github.com/matsluni/aws-spi-akka-http). By setting the `httpClient` explicitly (as above) the Akka actor system is reused, if not set explicitly a separate actor system will be created internally.
 
 It is possible to configure the use of Netty instead, which is Amazon's default. Add an appropriate Netty version to the dependencies and configure @javadoc[`NettyNioAsyncHttpClient`](software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient).
 

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -49,7 +49,7 @@ Java
 
 ### Underlying HTTP client
 
-Alpakka SQS and SNS are set up to use @extref:[Akka HTTP](akka-http-docs:) as default HTTP client via the thin adapter library [AWS Akka-Http SPI implementation](https://github.com/matsluni/aws-spi-akka-http). By setting the `httpClient` explicitly (as above) the Akka actor system is reused, if not set explicitly a separate actor system will be created internally.
+Alpakka SQS and SNS are set up to use @extref:[Akka HTTP](akka-http:) as default HTTP client via the thin adapter library [AWS Akka-Http SPI implementation](https://github.com/matsluni/aws-spi-akka-http). By setting the `httpClient` explicitly (as above) the Akka actor system is reused, if not set explicitly a separate actor system will be created internally.
 
 It is possible to configure the use of Netty instead, which is Amazon's default. Add an appropriate Netty version to the dependencies and configure @javadoc[`NettyNioAsyncHttpClient`](software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient).
 


### PR DESCRIPTION
## Purpose

* Change extref names `akka-docs` to `akka` and `akka-http-docs` to `akka-http`.
* Fix port in links for `previewSite`
* Sort extref/scaladoc/javadoc links differently
* Point scala Scaladoc to `scalaBinaryVersion`.x
