### PR TITLE
Upgrade to the latest scalafmt 2.0.0-RC7 / sbt-scalafmt 2.0.0

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,8 +1,10 @@
-version = 1.4.0
+version = 2.0.0-RC7
 
 style = defaultWithAlign
 
 align.tokens               = [off]
+align.openParenDefnSite    = true
+align.openParenCallSite    = true
 danglingParentheses        = true
 docstrings                 = JavaDoc
 indentOperator             = spray

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 jobs:
   include:
     - stage: check
-      script: sbt scalafmtCheckAll || { echo "[error] Unformatted code found. Please run 'Test/compile' and commit the reformatted code."; false; }
+      script: sbt scalafmtCheckAll || { echo "[error] Unformatted code found. Please run 'scalafmtAll' and commit the reformatted code."; false; }
       name: "Code style check (fixed with `sbt Test/compile`)"
     - script: sbt scalafmtSbtCheck || { echo "[error] Unformatted sbt code found. Please run 'scalafmtSbt' and commit the reformatted code."; false; }
       name: "Build code style check (fixed with `sbt scalafmtSbt`)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 jobs:
   include:
     - stage: check
-      script: sbt scalafmtCheck || { echo "[error] Unformatted code found. Please run 'Test/compile' and commit the reformatted code."; false; }
+      script: sbt scalafmtCheckAll || { echo "[error] Unformatted code found. Please run 'Test/compile' and commit the reformatted code."; false; }
       name: "Code style check (fixed with `sbt Test/compile`)"
     - script: sbt scalafmtSbtCheck || { echo "[error] Unformatted sbt code found. Please run 'scalafmtSbt' and commit the reformatted code."; false; }
       name: "Build code style check (fixed with `sbt scalafmtSbt`)"

--- a/build.sbt
+++ b/build.sbt
@@ -279,49 +279,49 @@ lazy val docs = project
     Preprocess / siteSubdirName := s"api/alpakka/${if (isSnapshot.value) "snapshot" else version.value}",
     Preprocess / sourceDirectory := (LocalRootProject / ScalaUnidoc / unidoc / target).value,
     Preprocess / preprocessRules := Seq(
-      ("\\.java\\.scala".r, _ => ".java")
-    ),
+        ("\\.java\\.scala".r, _ => ".java")
+      ),
     Paradox / siteSubdirName := s"docs/alpakka/${if (isSnapshot.value) "snapshot" else version.value}",
     paradoxProperties ++= Map(
-      "akka.version" -> Dependencies.AkkaVersion,
-      "akka-http.version" -> Dependencies.AkkaHttpVersion,
-      "couchbase.version" -> Dependencies.CouchbaseVersion,
-      "hadoop.version" -> Dependencies.HadoopVersion,
-      "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.AkkaVersion}/%s",
-      "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.AkkaVersion}",
-      "javadoc.akka.base_url" -> s"https://doc.akka.io/japi/akka/${Dependencies.AkkaVersion}/",
-      "extref.akka-http.base_url" -> s"https://doc.akka.io/docs/akka-http/${Dependencies.AkkaHttpVersion}/%s",
-      "scaladoc.akka.http.base_url" -> s"https://doc.akka.io/api/akka-http/${Dependencies.AkkaHttpVersion}/",
-      "javadoc.akka.http.base_url" -> s"https://doc.akka.io/japi/akka-http/${Dependencies.AkkaHttpVersion}/",
-      "extref.couchbase.base_url" -> s"https://docs.couchbase.com/java-sdk/${Dependencies.CouchbaseVersionForDocs}/%s",
-      "extref.java-api.base_url" -> "https://docs.oracle.com/javase/8/docs/api/index.html?%s.html",
-      "extref.geode.base_url" -> s"https://geode.apache.org/docs/guide/${Dependencies.GeodeVersionForDocs}/%s",
-      "extref.javaee-api.base_url" -> "https://docs.oracle.com/javaee/7/api/index.html?%s.html",
-      "extref.paho-api.base_url" -> "https://www.eclipse.org/paho/files/javadoc/index.html?%s.html",
-      "extref.slick.base_url" -> s"https://slick.lightbend.com/doc/${Dependencies.SlickVersion}/%s",
-      // Solr
-      "extref.solr.base_url" -> s"https://lucene.apache.org/solr/guide/${Dependencies.SolrVersionForDocs}/%s",
-      "javadoc.org.apache.solr.base_url" -> s"https://lucene.apache.org/solr/${Dependencies.SolrVersionForDocs}_0/solr-solrj/",
-      // Java
-      "javadoc.base_url" -> "https://docs.oracle.com/javase/8/docs/api/",
-      "javadoc.javax.jms.base_url" -> "https://docs.oracle.com/javaee/7/api/",
-      "javadoc.com.couchbase.base_url" -> s"https://docs.couchbase.com/sdk-api/couchbase-java-client-${Dependencies.CouchbaseVersion}/",
-      "javadoc.org.apache.kudu.base_url" -> s"https://kudu.apache.org/releases/${Dependencies.KuduVersion}/apidocs/",
-      "javadoc.org.apache.hadoop.base_url" -> s"https://hadoop.apache.org/docs/r${Dependencies.HadoopVersion}/api/",
-      "javadoc.com.amazonaws.base_url" -> "https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/",
-      "javadoc.software.amazon.awssdk.base_url" -> "https://sdk.amazonaws.com/java/api/latest/",
-      // Eclipse Paho client for MQTT
-      "javadoc.org.eclipse.paho.client.mqttv3.base_url" -> "https://www.eclipse.org/paho/files/javadoc/",
-      "javadoc.org.bson.codecs.configuration.base_url" -> "https://mongodb.github.io/mongo-java-driver/3.7/javadoc/",
-      "scaladoc.scala.base_url" -> s"https://www.scala-lang.org/api/${scalaBinaryVersion.value}.x/",
-      "scaladoc.akka.stream.alpakka.base_url" -> {
-        val docsHost = sys.env
-          .get("CI")
-          .map(_ => "https://doc.akka.io")
-          .getOrElse(s"http://localhost:${(previewSite / previewFixedPort).value.getOrElse(4000)}")
-        s"$docsHost/api/alpakka/${if (isSnapshot.value) "snapshot" else version.value}/"
-      }
-    ),
+        "akka.version" -> Dependencies.AkkaVersion,
+        "akka-http.version" -> Dependencies.AkkaHttpVersion,
+        "couchbase.version" -> Dependencies.CouchbaseVersion,
+        "hadoop.version" -> Dependencies.HadoopVersion,
+        "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.AkkaVersion}/%s",
+        "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.AkkaVersion}",
+        "javadoc.akka.base_url" -> s"https://doc.akka.io/japi/akka/${Dependencies.AkkaVersion}/",
+        "extref.akka-http.base_url" -> s"https://doc.akka.io/docs/akka-http/${Dependencies.AkkaHttpVersion}/%s",
+        "scaladoc.akka.http.base_url" -> s"https://doc.akka.io/api/akka-http/${Dependencies.AkkaHttpVersion}/",
+        "javadoc.akka.http.base_url" -> s"https://doc.akka.io/japi/akka-http/${Dependencies.AkkaHttpVersion}/",
+        "extref.couchbase.base_url" -> s"https://docs.couchbase.com/java-sdk/${Dependencies.CouchbaseVersionForDocs}/%s",
+        "extref.java-api.base_url" -> "https://docs.oracle.com/javase/8/docs/api/index.html?%s.html",
+        "extref.geode.base_url" -> s"https://geode.apache.org/docs/guide/${Dependencies.GeodeVersionForDocs}/%s",
+        "extref.javaee-api.base_url" -> "https://docs.oracle.com/javaee/7/api/index.html?%s.html",
+        "extref.paho-api.base_url" -> "https://www.eclipse.org/paho/files/javadoc/index.html?%s.html",
+        "extref.slick.base_url" -> s"https://slick.lightbend.com/doc/${Dependencies.SlickVersion}/%s",
+        // Solr
+        "extref.solr.base_url" -> s"https://lucene.apache.org/solr/guide/${Dependencies.SolrVersionForDocs}/%s",
+        "javadoc.org.apache.solr.base_url" -> s"https://lucene.apache.org/solr/${Dependencies.SolrVersionForDocs}_0/solr-solrj/",
+        // Java
+        "javadoc.base_url" -> "https://docs.oracle.com/javase/8/docs/api/",
+        "javadoc.javax.jms.base_url" -> "https://docs.oracle.com/javaee/7/api/",
+        "javadoc.com.couchbase.base_url" -> s"https://docs.couchbase.com/sdk-api/couchbase-java-client-${Dependencies.CouchbaseVersion}/",
+        "javadoc.org.apache.kudu.base_url" -> s"https://kudu.apache.org/releases/${Dependencies.KuduVersion}/apidocs/",
+        "javadoc.org.apache.hadoop.base_url" -> s"https://hadoop.apache.org/docs/r${Dependencies.HadoopVersion}/api/",
+        "javadoc.com.amazonaws.base_url" -> "https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/",
+        "javadoc.software.amazon.awssdk.base_url" -> "https://sdk.amazonaws.com/java/api/latest/",
+        // Eclipse Paho client for MQTT
+        "javadoc.org.eclipse.paho.client.mqttv3.base_url" -> "https://www.eclipse.org/paho/files/javadoc/",
+        "javadoc.org.bson.codecs.configuration.base_url" -> "https://mongodb.github.io/mongo-java-driver/3.7/javadoc/",
+        "scaladoc.scala.base_url" -> s"https://www.scala-lang.org/api/${scalaBinaryVersion.value}.x/",
+        "scaladoc.akka.stream.alpakka.base_url" -> {
+          val docsHost = sys.env
+            .get("CI")
+            .map(_ => "https://doc.akka.io")
+            .getOrElse(s"http://localhost:${(previewSite / previewFixedPort).value.getOrElse(4000)}")
+          s"$docsHost/api/alpakka/${if (isSnapshot.value) "snapshot" else version.value}/"
+        }
+      ),
     paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
     resolvers += Resolver.jcenterRepo,
     publishRsyncArtifact := makeSite.value -> "www/",
@@ -361,9 +361,9 @@ def alpakkaProject(projectId: String, moduleName: String, additionalSettings: sb
       name := s"akka-stream-alpakka-$projectId",
       AutomaticModuleName.settings(s"akka.stream.alpakka.$moduleName"),
       mimaPreviousArtifacts := Set(
-        organization.value %% name.value % previousStableVersion.value
-          .getOrElse(throw new Error("Unable to determine previous version"))
-      )
+          organization.value %% name.value % previousStableVersion.value
+            .getOrElse(throw new Error("Unable to determine previous version"))
+        )
     )
     .settings(additionalSettings: _*)
 

--- a/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
@@ -105,8 +105,8 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       val parser = new CsvParser(',', '"', '\\', maximumLineLength)
       parser.offer(in)
       val exception = the[MalformedCsvException] thrownBy {
-        parser.poll(requireLineEnd = true)
-      }
+          parser.poll(requireLineEnd = true)
+        }
       exception.getMessage should be("wrong escaping at 1:3, quote is escaped as \"\"")
       exception.getLineNo should be(1)
       exception.getBytePos should be(3)
@@ -117,8 +117,8 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       val parser = new CsvParser(',', '"', '\\', maximumLineLength)
       parser.offer(in)
       val exception = the[MalformedCsvException] thrownBy {
-        parser.poll(requireLineEnd = false)
-      }
+          parser.poll(requireLineEnd = false)
+        }
       exception.getMessage should be("wrong escaping at 1:3, no character after escape")
     }
 
@@ -127,8 +127,8 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       val parser = new CsvParser(',', '"', '\\', maximumLineLength)
       parser.offer(in)
       val exception = the[MalformedCsvException] thrownBy {
-        parser.poll(requireLineEnd = false)
-      }
+          parser.poll(requireLineEnd = false)
+        }
       exception.getMessage should be("wrong escaping at 1:4, no character after escape")
     }
 
@@ -137,8 +137,8 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       val parser = new CsvParser(',', '"', '\\', maximumLineLength)
       parser.offer(in)
       val exception = the[MalformedCsvException] thrownBy {
-        parser.poll(requireLineEnd = false)
-      }
+          parser.poll(requireLineEnd = false)
+        }
       exception.getMessage should be("wrong escaping at 1:4, no character after escape")
     }
 
@@ -237,8 +237,8 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       parser.offer(ByteString("\",B"))
       parser.poll(requireLineEnd = true) should be('empty)
       val exception = the[MalformedCsvException] thrownBy {
-        parser.poll(requireLineEnd = false)
-      }
+          parser.poll(requireLineEnd = false)
+        }
       exception.getMessage should be("unclosed quote at end of input 1:6, no matching quote found")
     }
 
@@ -293,8 +293,8 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       parser.offer(in)
       parser.poll(requireLineEnd = true)
       val exception = the[MalformedCsvException] thrownBy {
-        parser.poll(requireLineEnd = true)
-      }
+          parser.poll(requireLineEnd = true)
+        }
       exception.getMessage should be("no line end encountered within 11 bytes on line 2")
     }
 

--- a/doc-examples/src/main/scala/ftpsamples/RotateLogsToFtp.scala
+++ b/doc-examples/src/main/scala/ftpsamples/RotateLogsToFtp.scala
@@ -38,15 +38,14 @@ object RotateLogsToFtp extends ActorSystemAvailable with App {
   // (2)
   val rotator = () => {
     var last: Char = ' '
-    (bs: ByteString) =>
-      {
-        bs.head.toChar match {
-          case char if char != last =>
-            last = char
-            Some(s"log-$char.z")
-          case _ => None
-        }
+    (bs: ByteString) => {
+      bs.head.toChar match {
+        case char if char != last =>
+          last = char
+          Some(s"log-$char.z")
+        case _ => None
       }
+    }
   }
 
   // (3)

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/AwsClient.scala
@@ -117,10 +117,10 @@ private[dynamodb] trait AwsClient[S <: AwsClientSettings] {
       uri = signableUrl,
       method = original.getHttpMethod,
       headers = List(
-        headers.RawHeader("x-amz-date", amzHeaders.get("X-Amz-Date")),
-        headers.RawHeader("authorization", amzHeaders.get("Authorization")),
-        headers.RawHeader("x-amz-target", amzHeaders.get("X-Amz-Target"))
-      ) ++ tokenHeader,
+          headers.RawHeader("x-amz-date", amzHeaders.get("X-Amz-Date")),
+          headers.RawHeader("authorization", amzHeaders.get("Authorization")),
+          headers.RawHeader("x-amz-target", amzHeaders.get("X-Amz-Target"))
+        ) ++ tokenHeader,
       entity = HttpEntity(defaultContentType, body)
     )
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
@@ -140,9 +140,9 @@ private[elasticsearch] final class ElasticsearchFlowStage[T, C](
       val json = messages
         .map { message =>
           val sharedFields: Seq[(String, JsString)] = Seq(
-            "_index" -> JsString(message.indexName.getOrElse(indexName)),
-            typeNameTuple
-          ) ++ message.customMetadata.map { case (field, value) => field -> JsString(value) }
+              "_index" -> JsString(message.indexName.getOrElse(indexName)),
+              typeNameTuple
+            ) ++ message.customMetadata.map { case (field, value) => field -> JsString(value) }
           val tuple: (String, JsObject) = message.operation match {
             case Index =>
               val fields = Seq(

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSourceStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSourceStage.scala
@@ -111,11 +111,11 @@ private[elasticsearch] final class ElasticsearchSourceLogic[T](indexName: String
         val completeParams = searchParams ++ extraParams.flatten
 
         val searchBody = "{" + completeParams
-          .map {
-            case (name, json) =>
-              "\"" + name + "\":" + json
-          }
-          .mkString(",") + "}"
+            .map {
+              case (name, json) =>
+                "\"" + name + "\":" + json
+            }
+            .mkString(",") + "}"
 
         val endpoint: String = (indexName, typeName) match {
           case (i, Some(t)) => s"/$i/$t/_search"

--- a/file/src/main/scala/akka/stream/alpakka/file/javadsl/LogRotatorSink.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/javadsl/LogRotatorSink.scala
@@ -81,8 +81,7 @@ object LogRotatorSink {
       f: function.Creator[function.Function[ByteString, Optional[C]]]
   ): () => ByteString => Option[C] = () => {
     val fun = f.create()
-    elem =>
-      fun(elem).asScala
+    elem => fun(elem).asScala
   }
 
 }

--- a/file/src/main/scala/akka/stream/alpakka/file/scaladsl/Directory.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/scaladsl/Directory.scala
@@ -34,11 +34,9 @@ object Directory {
     require(Files.isDirectory(directory), s"Path must be a directory, $directory isn't")
     val factory = maxDepth match {
       case None =>
-        () =>
-          Files.walk(directory, fileVisitOptions: _*)
+        () => Files.walk(directory, fileVisitOptions: _*)
       case Some(maxDepth) =>
-        () =>
-          Files.walk(directory, maxDepth, fileVisitOptions: _*)
+        () => Files.walk(directory, maxDepth, fileVisitOptions: _*)
     }
 
     StreamConverters.fromJavaStream(factory)

--- a/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
@@ -62,18 +62,17 @@ class LogRotatorSinkSpec
     val testFunction = () => {
       val max = 2002
       var size: Long = max
-      (element: ByteString) =>
-        {
-          if (size + element.size > max) {
-            val path = Files.createTempFile(fs.getPath("/"), "test", ".log")
-            files :+= path
-            size = element.size
-            Option(path)
-          } else {
-            size += element.size
-            Option.empty[Path]
-          }
+      (element: ByteString) => {
+        if (size + element.size > max) {
+          val path = Files.createTempFile(fs.getPath("/"), "test", ".log")
+          files :+= path
+          size = element.size
+          Option(path)
+        } else {
+          size += element.size
+          Option.empty[Path]
         }
+      }
     }
     val listFiles = () => files
     (testFunction, listFiles)
@@ -84,8 +83,8 @@ class LogRotatorSinkSpec
   "LogRotatorSink" must {
 
     "complete when consuming an empty source" in assertAllStagesStopped {
-      val triggerCreator: () => ByteString => Option[Path] = () => { element: ByteString =>
-        fail("trigger creator should not be called")
+      val triggerCreator: () => ByteString => Option[Path] = () => {
+        element: ByteString => fail("trigger creator should not be called")
       }
 
       val rotatorSink: Sink[ByteString, Future[Done]] =
@@ -131,16 +130,15 @@ class LogRotatorSinkSpec
 
       val timeBasedTriggerCreator: () => ByteString => Option[Path] = () => {
         var currentFilename: Option[String] = None
-        (_: ByteString) =>
-          {
-            val newName = LocalDateTime.now().format(formatter)
-            if (currentFilename.contains(newName)) {
-              None
-            } else {
-              currentFilename = Some(newName)
-              Some(destinationDir.resolve(newName))
-            }
+        (_: ByteString) => {
+          val newName = LocalDateTime.now().format(formatter)
+          if (currentFilename.contains(newName)) {
+            None
+          } else {
+            currentFilename = Some(newName)
+            Some(destinationDir.resolve(newName))
           }
+        }
       }
 
       val timeBasedSink: Sink[ByteString, Future[Done]] =
@@ -173,17 +171,16 @@ class LogRotatorSinkSpec
       var files = Seq.empty[Path]
       val triggerFunctionCreator = () => {
         var fileName: String = null
-        (element: ByteString) =>
-          {
-            if (fileName == null) {
-              val path = Files.createTempFile(fs.getPath("/"), "test", ".log")
-              files :+= path
-              fileName = path.toString
-              Some(path)
-            } else {
-              None
-            }
+        (element: ByteString) => {
+          if (fileName == null) {
+            val path = Files.createTempFile(fs.getPath("/"), "test", ".log")
+            files :+= path
+            fileName = path.toString
+            Some(path)
+          } else {
+            None
           }
+        }
       }
       val completion = Source(testByteStrings).runWith(LogRotatorSink(triggerFunctionCreator))
       Await.result(completion, 3.seconds)
@@ -260,8 +257,8 @@ class LogRotatorSinkSpec
 
     "function fail on path creation" in assertAllStagesStopped {
       val ex = new Exception("my-exception")
-      val triggerFunctionCreator = () => { (x: ByteString) =>
-        {
+      val triggerFunctionCreator = () => {
+        (x: ByteString) => {
           throw ex
         }
       }
@@ -273,8 +270,8 @@ class LogRotatorSinkSpec
 
     "downstream fail on file write" in assertAllStagesStopped {
       val path = Files.createTempFile(fs.getPath("/"), "test", ".log")
-      val triggerFunctionCreator = () => { (x: ByteString) =>
-        {
+      val triggerFunctionCreator = () => {
+        (x: ByteString) => {
           Option(path)
         }
       }

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/PubSubSettings.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/PubSubSettings.scala
@@ -73,7 +73,7 @@ object PubSubSettings {
       config.getString("rootCa") match {
         case fileName if fileName != "none" => pubSubConfig.withRootCa(fileName)
         case _ => pubSubConfig
-    }
+      }
     val setCallCredentials = (pubSubConfig: PubSubSettings) =>
       config.getString("callCredentials") match {
         case "google-application-default" =>
@@ -81,7 +81,7 @@ object PubSubSettings {
             .map(pubSubConfig.withCallCredentials)
             .getOrElse(pubSubConfig)
         case _ => pubSubConfig
-    }
+      }
 
     Seq(setRootCa, setCallCredentials).foldLeft(pubSubConfig) {
       case (config, f) => f(config)

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmFlows.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmFlows.scala
@@ -29,7 +29,7 @@ private[fcm] object FcmFlows {
             in =>
               session.getToken().flatMap { token =>
                 sender.send(conf.projectId, token, http, FcmSend(conf.isTest, in._1)).zip(Future.successful(in._2))
-            }
+              }
           )
       }
       .mapMaterializedValue(_ => NotUsed)
@@ -46,7 +46,7 @@ private[fcm] object FcmFlows {
             in =>
               session.getToken().flatMap { token =>
                 sender.send(conf.projectId, token, http, FcmSend(conf.isTest, in))
-            }
+              }
           )
       }
       .mapMaterializedValue(_ => NotUsed)

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
@@ -53,11 +53,11 @@ class JmsAckConnectorsSpec extends JmsSpec {
           )
 
         val msgsIn = 1 to 100 map { n =>
-          JmsTextMessage(n.toString)
-            .withProperty("Number", n)
-            .withProperty("IsOdd", n % 2 == 1)
-            .withProperty("IsEven", n % 2 == 0)
-        }
+            JmsTextMessage(n.toString)
+              .withProperty("Number", n)
+              .withProperty("IsOdd", n % 2 == 1)
+              .withProperty("IsEven", n % 2 == 0)
+          }
 
         Source(msgsIn).runWith(jmsSink)
 
@@ -92,11 +92,11 @@ class JmsAckConnectorsSpec extends JmsSpec {
         )
 
         val msgsIn = 1 to 100 map { n =>
-          JmsTextMessage(n.toString)
-            .withProperty("Number", n)
-            .withProperty("IsOdd", n % 2 == 1)
-            .withProperty("IsEven", n % 2 == 0)
-        }
+            JmsTextMessage(n.toString)
+              .withProperty("Number", n)
+              .withProperty("IsOdd", n % 2 == 1)
+              .withProperty("IsEven", n % 2 == 0)
+          }
         Source(msgsIn).runWith(jmsSink)
 
         val jmsSource = JmsConsumer.ackSource(

--- a/jms/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
@@ -54,11 +54,11 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
         )
 
         val msgsIn = 1 to 100 map { n =>
-          JmsTextMessage(n.toString)
-            .withProperty("Number", n)
-            .withProperty("IsOdd", n % 2 == 1)
-            .withProperty("IsEven", n % 2 == 0)
-        }
+            JmsTextMessage(n.toString)
+              .withProperty("Number", n)
+              .withProperty("IsOdd", n % 2 == 1)
+              .withProperty("IsEven", n % 2 == 0)
+          }
 
         Source(msgsIn).runWith(jmsSink)
 
@@ -97,11 +97,11 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
         )
 
         val msgsIn = 1 to 100 map { n =>
-          JmsTextMessage(n.toString)
-            .withProperty("Number", n)
-            .withProperty("IsOdd", n % 2 == 1)
-            .withProperty("IsEven", n % 2 == 0)
-        }
+            JmsTextMessage(n.toString)
+              .withProperty("Number", n)
+              .withProperty("IsOdd", n % 2 == 1)
+              .withProperty("IsEven", n % 2 == 0)
+          }
         Source(msgsIn).runWith(jmsSink)
 
         val jmsSource = JmsConsumer.ackSource(

--- a/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
@@ -575,7 +575,7 @@ class JmsConnectorsSpec extends JmsSpec {
             Future {
               Thread.sleep(100)
               JmsTextMessage(n.toString)
-          }
+            }
         )
         .runWith(jmsSink)
 

--- a/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
@@ -53,11 +53,11 @@ class JmsTxConnectorsSpec extends JmsSpec {
         )
 
         val msgsIn = 1 to 100 map { n =>
-          JmsTextMessage(n.toString)
-            .withProperty("Number", n)
-            .withProperty("IsOdd", n % 2 == 1)
-            .withProperty("IsEven", n % 2 == 0)
-        }
+            JmsTextMessage(n.toString)
+              .withProperty("Number", n)
+              .withProperty("IsOdd", n % 2 == 1)
+              .withProperty("IsEven", n % 2 == 0)
+          }
 
         Source(msgsIn).runWith(jmsSink)
 
@@ -95,8 +95,8 @@ class JmsTxConnectorsSpec extends JmsSpec {
           JmsProducerSettings(producerConfig, connectionFactory).withQueue("numbers")
         )
         val msgsIn = 1 to 100 map { n =>
-          JmsTextMessage(n.toString).withProperty("Number", n)
-        }
+            JmsTextMessage(n.toString).withProperty("Number", n)
+          }
 
         Source(msgsIn).runWith(jmsSink)
 
@@ -132,11 +132,11 @@ class JmsTxConnectorsSpec extends JmsSpec {
         )
 
         val msgsIn = 1 to 100 map { n =>
-          JmsTextMessage(n.toString)
-            .withProperty("Number", n)
-            .withProperty("IsOdd", n % 2 == 1)
-            .withProperty("IsEven", n % 2 == 0)
-        }
+            JmsTextMessage(n.toString)
+              .withProperty("Number", n)
+              .withProperty("IsOdd", n % 2 == 1)
+              .withProperty("IsEven", n % 2 == 0)
+          }
         Source(msgsIn).runWith(jmsSink)
 
         val jmsSource = JmsConsumer.txSource(

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -457,7 +457,7 @@ import scala.util.{Failure, Success}
                 data.copy(
                   activeConsumers = data.activeConsumers + (topicName -> consumer),
                   pendingRemotePublications =
-                  data.pendingRemotePublications.take(i) ++ data.pendingRemotePublications.drop(i + 1)
+                    data.pendingRemotePublications.take(i) ++ data.pendingRemotePublications.drop(i + 1)
                 )
               )
             } else {
@@ -512,7 +512,7 @@ import scala.util.{Failure, Success}
                 data.copy(
                   activeProducers = data.activeProducers + (topicName -> producer),
                   pendingLocalPublications =
-                  data.pendingLocalPublications.take(i) ++ data.pendingLocalPublications.drop(i + 1)
+                    data.pendingLocalPublications.take(i) ++ data.pendingLocalPublications.drop(i + 1)
                 )
               )
             } else {

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -157,7 +157,7 @@ import scala.util.{Failure, Success}
           listening(
             data.copy(
               clientConnections = data.clientConnections
-                .filterNot { case (_, (clientId, _)) => clientId == connect.clientId } + newConnection
+                  .filterNot { case (_, (clientId, _)) => clientId == connect.clientId } + newConnection
             )
           )
         case (_, ConnAckReceivedLocally(connectionId, connAck, remote)) =>
@@ -548,7 +548,7 @@ import scala.util.{Failure, Success}
                 data.copy(
                   activeConsumers = data.activeConsumers + (topicName -> consumer),
                   pendingRemotePublications =
-                  data.pendingRemotePublications.take(i) ++ data.pendingRemotePublications.drop(i + 1)
+                    data.pendingRemotePublications.take(i) ++ data.pendingRemotePublications.drop(i + 1)
                 )
               )
             } else {
@@ -603,7 +603,7 @@ import scala.util.{Failure, Success}
                 data.copy(
                   activeProducers = data.activeProducers + (topicName -> producer),
                   pendingLocalPublications =
-                  data.pendingLocalPublications.take(i) ++ data.pendingLocalPublications.drop(i + 1)
+                    data.pendingLocalPublications.take(i) ++ data.pendingLocalPublications.drop(i + 1)
                 )
               )
             } else {

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/model.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/model.scala
@@ -975,9 +975,9 @@ object MqttCodec {
           }
         val topicFilters = decodeTopicFilters(l - (packetLen - v.len), Vector.empty)
         val topicFiltersValid = topicFilters.nonEmpty && topicFilters.foldLeft(true) {
-          case (true, (Right(_), tff)) if tff.underlying < ControlPacketFlags.QoSReserved.underlying => true
-          case _ => false
-        }
+            case (true, (Right(_), tff)) if tff.underlying < ControlPacketFlags.QoSReserved.underlying => true
+            case _ => false
+          }
         if (topicFiltersValid) {
           Right(Subscribe(packetId, topicFilters.flatMap {
             case (Right(tfs), tff) => List(tfs -> tff)
@@ -1006,9 +1006,9 @@ object MqttCodec {
           }
         val returnCodes = decodeReturnCodes(l - (packetLen - v.len), Vector.empty)
         val returnCodesValid = returnCodes.nonEmpty && returnCodes.foldLeft(true) {
-          case (true, rc) if rc.underlying < ControlPacketFlags.QoSReserved.underlying => true
-          case _ => false
-        }
+            case (true, rc) if rc.underlying < ControlPacketFlags.QoSReserved.underlying => true
+            case _ => false
+          }
         if (returnCodesValid) {
           Right(SubAck(packetId, returnCodes))
         } else {
@@ -1037,9 +1037,9 @@ object MqttCodec {
           }
         val topicFilters = decodeTopicFilters(l - (packetLen - v.len), Vector.empty)
         val topicFiltersValid = topicFilters.nonEmpty && topicFilters.foldLeft(true) {
-          case (true, Right(_)) => true
-          case _ => false
-        }
+            case (true, Right(_)) => true
+            case _ => false
+          }
         if (topicFiltersValid) {
           Right(Unsubscribe(packetId, topicFilters.flatMap {
             case Right(tfs) => List(tfs)

--- a/mqtt/src/main/scala/akka/stream/alpakka/mqtt/impl/MqttFlowStage.scala
+++ b/mqtt/src/main/scala/akka/stream/alpakka/mqtt/impl/MqttFlowStage.scala
@@ -135,7 +135,7 @@ private[mqtt] final class MqttFlowStage(connectionSettings: MqttConnectionSettin
               args.promise.complete(SuccessfullyDone)
             } catch {
               case e: Throwable => args.promise.failure(e)
-          }
+            }
         )
 
       mqttClient.setCallback(new MqttCallbackExtended {

--- a/mqtt/src/test/scala/docs/scaladsl/MqttSourceSpec.scala
+++ b/mqtt/src/test/scala/docs/scaladsl/MqttSourceSpec.scala
@@ -197,7 +197,7 @@ class MqttSourceSpec
             Seq(
               MqttMessage(topic1, ByteString(s"ohi_$i")),
               MqttMessage(topic2, ByteString(s"ohi_$i"))
-          )
+            )
         )
 
       //#create-source

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -25,65 +25,65 @@ object Common extends AutoPlugin {
                             "https://gitter.im/akka/dev",
                             url("https://github.com/akka/alpakka/graphs/contributors")),
     licenses := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
-    description := "Alpakka is a Reactive Enterprise Integration library for Java and Scala, based on Reactive Streams and Akka.",
+    description := "Alpakka is a Reactive Enterprise Integration library for Java and Scala, based on Reactive Streams and Akka."
   )
 
   override lazy val projectSettings = Dependencies.Common ++ Seq(
-    projectInfoVersion := (if (isSnapshot.value) "snapshot" else version.value),
-    whitesourceGroup := Whitesource.Group.Community,
-    crossVersion := CrossVersion.binary,
-    crossScalaVersions := Dependencies.ScalaVersions,
-    scalaVersion := Dependencies.Scala212,
-    scalacOptions ++= Seq(
-      "-encoding",
-      "UTF-8",
-      "-feature",
-      "-unchecked",
-      "-deprecation",
-      //"-Xfatal-warnings",
-      "-Xlint",
-      "-Ywarn-dead-code",
-      "-Xfuture",
-      "-target:jvm-1.8"
-    ),
-    scalacOptions ++= (scalaVersion.value match {
-      case Dependencies.Scala213 => Seq.empty[String]
-      case _ => Seq("-Yno-adapted-args")
-    }),
-    Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
-      "-doc-title",
-      "Alpakka",
-      "-doc-version",
-      version.value,
-      "-sourcepath",
-      (baseDirectory in ThisBuild).value.toString,
-      "-doc-source-url", {
-        val branch = if (isSnapshot.value) "master" else s"v${version.value}"
-        s"https://github.com/akka/alpakka/tree/${branch}€{FILE_PATH}.scala#L1"
-      },
-      "-skip-packages",
-      "akka.pattern:" + // for some reason Scaladoc creates this
-      "org.mongodb.scala:" + // this one is a mystery as well
-      // excluding generated grpc classes, except the model ones (com.google.pubsub)
-      "com.google.api:com.google.cloud:com.google.iam:com.google.logging:" +
-      "com.google.longrunning:com.google.protobuf:com.google.rpc:com.google.type"
-    ),
-    javacOptions in compile ++= Seq(
-      "-Xlint:unchecked"
-    ),
-    autoAPIMappings := true,
-    apiURL := Some(url(s"https://doc.akka.io/api/alpakka/${version.value}/akka/stream/alpakka/index.html")),
-    // show full stack traces and test case durations
-    testOptions in Test += Tests.Argument("-oDF"),
-    // -a Show stack traces and exception class name for AssertionErrors.
-    // -v Log "test run started" / "test started" / "test run finished" events on log level "info" instead of "debug".
-    // -q Suppress stdout for successful tests.
-    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "-q"),
-    // By default scalatest futures time out in 150 ms, dilate that to 600ms.
-    // This should not impact the total test time as we don't expect to hit this
-    // timeout.
-    testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-F", "4"),
-    scalafmtOnCompile := true,
-    headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>"))
-  )
+      projectInfoVersion := (if (isSnapshot.value) "snapshot" else version.value),
+      whitesourceGroup := Whitesource.Group.Community,
+      crossVersion := CrossVersion.binary,
+      crossScalaVersions := Dependencies.ScalaVersions,
+      scalaVersion := Dependencies.Scala212,
+      scalacOptions ++= Seq(
+          "-encoding",
+          "UTF-8",
+          "-feature",
+          "-unchecked",
+          "-deprecation",
+          //"-Xfatal-warnings",
+          "-Xlint",
+          "-Ywarn-dead-code",
+          "-Xfuture",
+          "-target:jvm-1.8"
+        ),
+      scalacOptions ++= (scalaVersion.value match {
+          case Dependencies.Scala213 => Seq.empty[String]
+          case _ => Seq("-Yno-adapted-args")
+        }),
+      Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
+          "-doc-title",
+          "Alpakka",
+          "-doc-version",
+          version.value,
+          "-sourcepath",
+          (baseDirectory in ThisBuild).value.toString,
+          "-doc-source-url", {
+            val branch = if (isSnapshot.value) "master" else s"v${version.value}"
+            s"https://github.com/akka/alpakka/tree/${branch}€{FILE_PATH}.scala#L1"
+          },
+          "-skip-packages",
+          "akka.pattern:" + // for some reason Scaladoc creates this
+          "org.mongodb.scala:" + // this one is a mystery as well
+          // excluding generated grpc classes, except the model ones (com.google.pubsub)
+          "com.google.api:com.google.cloud:com.google.iam:com.google.logging:" +
+          "com.google.longrunning:com.google.protobuf:com.google.rpc:com.google.type"
+        ),
+      javacOptions in compile ++= Seq(
+          "-Xlint:unchecked"
+        ),
+      autoAPIMappings := true,
+      apiURL := Some(url(s"https://doc.akka.io/api/alpakka/${version.value}/akka/stream/alpakka/index.html")),
+      // show full stack traces and test case durations
+      testOptions in Test += Tests.Argument("-oDF"),
+      // -a Show stack traces and exception class name for AssertionErrors.
+      // -v Log "test run started" / "test started" / "test run finished" events on log level "info" instead of "debug".
+      // -q Suppress stdout for successful tests.
+      testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "-q"),
+      // By default scalatest futures time out in 150 ms, dilate that to 600ms.
+      // This should not impact the total test time as we don't expect to hit this
+      // timeout.
+      testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-F", "4"),
+      scalafmtOnCompile := true,
+      headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>"))
+    )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,48 +36,48 @@ object Dependencies {
   val Common = Seq(
     // These libraries are added to all modules via the `Common` AutoPlugin
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-      "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-      "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion % Test,
-      "ch.qos.logback" % "logback-classic" % "1.2.3" % Test, // Eclipse Public License 1.0
-      "org.scalatest" %% "scalatest" % "3.0.7" % Test, // ApacheV2
-      "com.novocode" % "junit-interface" % "0.11" % Test, // BSD-style
-      "junit" % "junit" % "4.12" % Test // Eclipse Public License 1.0
-    )
+        "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
+        "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion % Test,
+        "ch.qos.logback" % "logback-classic" % "1.2.3" % Test, // Eclipse Public License 1.0
+        "org.scalatest" %% "scalatest" % "3.0.7" % Test, // ApacheV2
+        "com.novocode" % "junit-interface" % "0.11" % Test, // BSD-style
+        "junit" % "junit" % "4.12" % Test // Eclipse Public License 1.0
+      )
   )
 
   val Amqp = Seq(
     libraryDependencies ++= Seq(
-      "com.rabbitmq" % "amqp-client" % "5.3.0" // APLv2
-    )
+        "com.rabbitmq" % "amqp-client" % "5.3.0" // APLv2
+      )
   )
 
   val AwsLambda = Seq(
     libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "lambda" % AwsSdk2Version, // ApacheV2
-      "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
-    )
+        "software.amazon.awssdk" % "lambda" % AwsSdk2Version, // ApacheV2
+        "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
+      )
   )
 
   val AzureStorageQueue = Seq(
     libraryDependencies ++= Seq(
-      "com.microsoft.azure" % "azure-storage" % "8.0.0" // ApacheV2
-    )
+        "com.microsoft.azure" % "azure-storage" % "8.0.0" // ApacheV2
+      )
   )
 
   val Cassandra = Seq(
     libraryDependencies ++= Seq(
-      "com.datastax.cassandra" % "cassandra-driver-core" % "3.5.1" // ApacheV2
-    )
+        "com.datastax.cassandra" % "cassandra-driver-core" % "3.5.1" // ApacheV2
+      )
   )
 
   val Couchbase = Seq(
     libraryDependencies ++= Seq(
-      "com.couchbase.client" % "java-client" % CouchbaseVersion, // ApacheV2
-      "io.reactivex" % "rxjava-reactive-streams" % "1.2.1", //ApacheV2
-      "com.typesafe.play" %% "play-json" % "2.7.1" % Test, // MIT like: http://www.slf4j.org/license.html
-      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion % Test // Apache V2
-    )
+        "com.couchbase.client" % "java-client" % CouchbaseVersion, // ApacheV2
+        "io.reactivex" % "rxjava-reactive-streams" % "1.2.1", //ApacheV2
+        "com.typesafe.play" %% "play-json" % "2.7.1" % Test, // MIT like: http://www.slf4j.org/license.html
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion % Test // Apache V2
+      )
   )
 
   val Csv = Seq(
@@ -86,76 +86,76 @@ object Dependencies {
 
   val `Doc-examples` = Seq(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-      // https://mina.apache.org/ftpserver-project/downloads.html
-      "org.apache.ftpserver" % "ftpserver-core" % "1.1.1", // ApacheV2
-      "org.apache.sshd" % "sshd-scp" % "2.1.0", // ApacheV2
-      "org.apache.sshd" % "sshd-sftp" % "2.1.0", // ApacheV2
-      "com.google.jimfs" % "jimfs" % "1.1", // ApacheV2
-      "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-      "com.typesafe.akka" %% "akka-http-xml" % AkkaHttpVersion,
-      "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-      // https://github.com/akka/alpakka-kafka/releases
-      "com.typesafe.akka" %% "akka-stream-kafka" % "1.0.3",
-      // https://github.com/embeddedkafka/embedded-kafka/releases
-      "io.github.embeddedkafka" %% "embedded-kafka" % "2.1.1", // MIT
-      // https://github.com/javaee/javax.jms
-      "javax.jms" % "jms" % "1.1", // CDDL Version 1.1
-      // http://activemq.apache.org/download.html
-      "org.apache.activemq" % "activemq-all" % "5.15.4" exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2
-      "com.h2database" % "h2" % "1.4.197", // Eclipse Public License 1.0
-      "org.elasticsearch.client" % "elasticsearch-rest-client" % "6.3.1", // ApacheV2
-      "org.codelibs" % "elasticsearch-cluster-runner" % "6.3.1.0", // ApacheV2
-      "io.netty" % "netty-all" % "4.1.29.Final", // ApacheV2
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.9.8",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8",
-      "org.testcontainers" % "kafka" % "1.11.1", // MIT
-      "org.testcontainers" % "elasticsearch" % "1.11.1", // MIT
-      "org.apache.logging.log4j" % "log4j-to-slf4j" % "2.11.2", // ApacheV2
-      "org.slf4j" % "log4j-over-slf4j" % "1.7.25",
-      "org.slf4j" % "jcl-over-slf4j" % "1.7.25",
-      "ch.qos.logback" % "logback-classic" % "1.2.3" // Eclipse Public License 1.0
-    )
+        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+        // https://mina.apache.org/ftpserver-project/downloads.html
+        "org.apache.ftpserver" % "ftpserver-core" % "1.1.1", // ApacheV2
+        "org.apache.sshd" % "sshd-scp" % "2.1.0", // ApacheV2
+        "org.apache.sshd" % "sshd-sftp" % "2.1.0", // ApacheV2
+        "com.google.jimfs" % "jimfs" % "1.1", // ApacheV2
+        "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-http-xml" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+        // https://github.com/akka/alpakka-kafka/releases
+        "com.typesafe.akka" %% "akka-stream-kafka" % "1.0.3",
+        // https://github.com/embeddedkafka/embedded-kafka/releases
+        "io.github.embeddedkafka" %% "embedded-kafka" % "2.1.1", // MIT
+        // https://github.com/javaee/javax.jms
+        "javax.jms" % "jms" % "1.1", // CDDL Version 1.1
+        // http://activemq.apache.org/download.html
+        "org.apache.activemq" % "activemq-all" % "5.15.4" exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2
+        "com.h2database" % "h2" % "1.4.197", // Eclipse Public License 1.0
+        "org.elasticsearch.client" % "elasticsearch-rest-client" % "6.3.1", // ApacheV2
+        "org.codelibs" % "elasticsearch-cluster-runner" % "6.3.1.0", // ApacheV2
+        "io.netty" % "netty-all" % "4.1.29.Final", // ApacheV2
+        "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.9.8",
+        "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8",
+        "org.testcontainers" % "kafka" % "1.11.1", // MIT
+        "org.testcontainers" % "elasticsearch" % "1.11.1", // MIT
+        "org.apache.logging.log4j" % "log4j-to-slf4j" % "2.11.2", // ApacheV2
+        "org.slf4j" % "log4j-over-slf4j" % "1.7.25",
+        "org.slf4j" % "jcl-over-slf4j" % "1.7.25",
+        "ch.qos.logback" % "logback-classic" % "1.2.3" // Eclipse Public License 1.0
+      )
   )
 
   val DynamoDB = Seq(
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk-dynamodb" % AwsSdkVersion, // ApacheV2
-      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion
-    )
+        "com.amazonaws" % "aws-java-sdk-dynamodb" % AwsSdkVersion, // ApacheV2
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion
+      )
   )
 
   val Elasticsearch = Seq(
     libraryDependencies ++= Seq(
-      "org.elasticsearch.client" % "elasticsearch-rest-client" % "6.3.1", // ApacheV2
-      "io.spray" %% "spray-json" % "1.3.5", // ApacheV2
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.8", // ApacheV2
-      "org.codelibs" % "elasticsearch-cluster-runner" % "6.3.1.0" % Test, // ApacheV2
-      "org.slf4j" % "jcl-over-slf4j" % "1.7.25" % Test,
-    )
+        "org.elasticsearch.client" % "elasticsearch-rest-client" % "6.3.1", // ApacheV2
+        "io.spray" %% "spray-json" % "1.3.5", // ApacheV2
+        "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.8", // ApacheV2
+        "org.codelibs" % "elasticsearch-cluster-runner" % "6.3.1.0" % Test, // ApacheV2
+        "org.slf4j" % "jcl-over-slf4j" % "1.7.25" % Test
+      )
   )
 
   val File = Seq(
     libraryDependencies ++= Seq(
-      "com.google.jimfs" % "jimfs" % "1.1" % Test // ApacheV2
-    )
+        "com.google.jimfs" % "jimfs" % "1.1" % Test // ApacheV2
+      )
   )
 
   val AvroParquet = Seq(
     libraryDependencies ++= Seq(
-      "org.apache.parquet" % "parquet-avro" % "1.10.0", //Apache2
-      "org.apache.hadoop" % "hadoop-client" % "3.1.0" % Test exclude ("log4j", "log4j"), //Apache2
-      "org.apache.hadoop" % "hadoop-common" % "2.2.0" % Test exclude ("log4j", "log4j"), //Apache2
-      "org.specs2" %% "specs2-core" % "4.4.1" % Test, //MIT like: https://github.com/etorreborre/specs2/blob/master/LICENSE.txt
-      "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % Test // MIT like: http://www.slf4j.org/license.html
-    )
+        "org.apache.parquet" % "parquet-avro" % "1.10.0", //Apache2
+        "org.apache.hadoop" % "hadoop-client" % "3.1.0" % Test exclude ("log4j", "log4j"), //Apache2
+        "org.apache.hadoop" % "hadoop-common" % "2.2.0" % Test exclude ("log4j", "log4j"), //Apache2
+        "org.specs2" %% "specs2-core" % "4.4.1" % Test, //MIT like: https://github.com/etorreborre/specs2/blob/master/LICENSE.txt
+        "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % Test // MIT like: http://www.slf4j.org/license.html
+      )
   )
 
   val Ftp = Seq(
     libraryDependencies ++= Seq(
-      "commons-net" % "commons-net" % "3.6", // ApacheV2
-      "com.hierynomus" % "sshj" % "0.26.0" // ApacheV2
-    )
+        "commons-net" % "commons-net" % "3.6", // ApacheV2
+        "com.hierynomus" % "sshj" % "0.26.0" // ApacheV2
+      )
   )
 
   val GeodeVersion = "1.8.0"
@@ -176,31 +176,31 @@ object Dependencies {
 
   val GooglePubSub = Seq(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-      "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-      "com.pauldijou" %% "jwt-core" % "2.1.0", // ApacheV2
-      "org.mockito" % "mockito-core" % mockitoVersion % Test, // MIT
-      "com.github.tomakehurst" % "wiremock" % "2.18.0" % Test // ApacheV2
-    )
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+        "com.pauldijou" %% "jwt-core" % "2.1.0", // ApacheV2
+        "org.mockito" % "mockito-core" % mockitoVersion % Test, // MIT
+        "com.github.tomakehurst" % "wiremock" % "2.18.0" % Test // ApacheV2
+      )
   )
 
   val GooglePubSubGrpc = Seq(
     libraryDependencies ++= Seq(
-      "com.google.api.grpc" % "grpc-google-cloud-pubsub-v1" % "0.12.0" % "protobuf", // ApacheV2
-      "io.grpc" % "grpc-auth" % "1.20.0", // ApacheV2
-      "com.google.auth" % "google-auth-library-oauth2-http" % "0.15.0" // BSD 3-clause
-    ) ++ Silencer
+        "com.google.api.grpc" % "grpc-google-cloud-pubsub-v1" % "0.12.0" % "protobuf", // ApacheV2
+        "io.grpc" % "grpc-auth" % "1.20.0", // ApacheV2
+        "com.google.auth" % "google-auth-library-oauth2-http" % "0.15.0" // BSD 3-clause
+      ) ++ Silencer
   )
 
   val GooglePubSubGrpcAlpnAgent = "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.7"
 
   val GoogleFcm = Seq(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-      "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-      "com.pauldijou" %% "jwt-core" % "2.1.0", // ApacheV2
-      "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
-    )
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+        "com.pauldijou" %% "jwt-core" % "2.1.0", // ApacheV2
+        "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
+      )
   )
 
   val HBase = {
@@ -208,115 +208,115 @@ object Dependencies {
     val hadoopVersion = "2.5.2"
     Seq(
       libraryDependencies ++= Seq(
-        // for some reason version 2.2.3U1 started to get picked which was not accepted by Whitesource)
-        "com.sun.xml.bind" % "jaxb-impl" % "2.2.3-1", // CDDL + GPLv2
-        // TODO: remove direct dependency ^^ when updating from these very old versions
-        "org.apache.hbase" % "hbase-shaded-client" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
-        "org.apache.hbase" % "hbase-common" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
-        "org.apache.hadoop" % "hadoop-common" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
-        "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
-        "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % Test // MIT like: http://www.slf4j.org/license.html
-      )
+          // for some reason version 2.2.3U1 started to get picked which was not accepted by Whitesource)
+          "com.sun.xml.bind" % "jaxb-impl" % "2.2.3-1", // CDDL + GPLv2
+          // TODO: remove direct dependency ^^ when updating from these very old versions
+          "org.apache.hbase" % "hbase-shaded-client" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
+          "org.apache.hbase" % "hbase-common" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
+          "org.apache.hadoop" % "hadoop-common" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
+          "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
+          "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % Test // MIT like: http://www.slf4j.org/license.html
+        )
     )
   }
 
   val HadoopVersion = "3.1.1"
   val Hdfs = Seq(
     libraryDependencies ++= Seq(
-      "org.apache.hadoop" % "hadoop-client" % HadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2
-      "org.typelevel" %% "cats-core" % "1.6.0", // MIT,
-      "org.apache.hadoop" % "hadoop-hdfs" % HadoopVersion % Test classifier "tests" exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2
-      "org.apache.hadoop" % "hadoop-common" % HadoopVersion % Test classifier "tests" exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2
-      "org.apache.hadoop" % "hadoop-minicluster" % HadoopVersion % Test exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2
-      "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % Test // MIT like: http://www.slf4j.org/license.html
-    )
+        "org.apache.hadoop" % "hadoop-client" % HadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2
+        "org.typelevel" %% "cats-core" % "1.6.0", // MIT,
+        "org.apache.hadoop" % "hadoop-hdfs" % HadoopVersion % Test classifier "tests" exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2
+        "org.apache.hadoop" % "hadoop-common" % HadoopVersion % Test classifier "tests" exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2
+        "org.apache.hadoop" % "hadoop-minicluster" % HadoopVersion % Test exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2
+        "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % Test // MIT like: http://www.slf4j.org/license.html
+      )
   )
 
   val IronMq = Seq(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-      "de.heikoseeberger" %% "akka-http-circe" % "1.21.0" // ApacheV2
-    )
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+        "de.heikoseeberger" %% "akka-http-circe" % "1.21.0" // ApacheV2
+      )
   )
 
   val Jms = Seq(
     libraryDependencies ++= Seq(
-      "javax.jms" % "jms" % "1.1" % Provided, // CDDL + GPLv2
-      "com.ibm.mq" % "com.ibm.mq.allclient" % "9.1.1.0" % Test, // IBM International Program License Agreement https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/maven/licenses/L-APIG-AZYF2E/LI_en.html
-      "org.apache.activemq" % "activemq-broker" % "5.15.4" % Test, // ApacheV2
-      "org.apache.activemq" % "activemq-client" % "5.15.4" % Test, // ApacheV2
-      "io.github.sullis" %% "jms-testkit" % "0.2.1" % Test, // ApacheV2
-      "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
-    ),
+        "javax.jms" % "jms" % "1.1" % Provided, // CDDL + GPLv2
+        "com.ibm.mq" % "com.ibm.mq.allclient" % "9.1.1.0" % Test, // IBM International Program License Agreement https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/maven/licenses/L-APIG-AZYF2E/LI_en.html
+        "org.apache.activemq" % "activemq-broker" % "5.15.4" % Test, // ApacheV2
+        "org.apache.activemq" % "activemq-client" % "5.15.4" % Test, // ApacheV2
+        "io.github.sullis" %% "jms-testkit" % "0.2.1" % Test, // ApacheV2
+        "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
+      ),
     // Having JBoss as a first resolver is a workaround for https://github.com/coursier/coursier/issues/200
     externalResolvers := ("jboss" at "http://repository.jboss.org/nexus/content/groups/public") +: externalResolvers.value
   )
 
   val JsonStreaming = Seq(
     libraryDependencies ++= Seq(
-      "com.github.jsurfer" % "jsurfer" % "1.4.3", // MIT,
-      "com.github.jsurfer" % "jsurfer-jackson" % "1.4.3" // MIT
-    )
+        "com.github.jsurfer" % "jsurfer" % "1.4.3", // MIT,
+        "com.github.jsurfer" % "jsurfer-jackson" % "1.4.3" // MIT
+      )
   )
 
   val Kinesis = Seq(
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk-kinesis" % AwsSdkVersion, // ApacheV2
-      "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
-    )
+        "com.amazonaws" % "aws-java-sdk-kinesis" % AwsSdkVersion, // ApacheV2
+        "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
+      )
   )
 
   val KuduVersion = "1.7.1"
   val Kudu = Seq(
     libraryDependencies ++= Seq(
-      "org.apache.kudu" % "kudu-client-tools" % KuduVersion, // ApacheV2
-      "org.apache.kudu" % "kudu-client" % KuduVersion % Test // ApacheV2
-    )
+        "org.apache.kudu" % "kudu-client-tools" % KuduVersion, // ApacheV2
+        "org.apache.kudu" % "kudu-client" % KuduVersion % Test // ApacheV2
+      )
   )
 
   val MongoDb = Seq(
     libraryDependencies ++= Seq(
-      "org.mongodb" % "mongodb-driver-reactivestreams" % "1.11.0", // ApacheV2
-      "org.mongodb.scala" %% "mongo-scala-bson" % "2.4.2" % "test" // ApacheV2
-    )
+        "org.mongodb" % "mongodb-driver-reactivestreams" % "1.11.0", // ApacheV2
+        "org.mongodb.scala" %% "mongo-scala-bson" % "2.4.2" % "test" // ApacheV2
+      )
   )
 
   val Mqtt = Seq(
     libraryDependencies ++= Seq(
-      "org.eclipse.paho" % "org.eclipse.paho.client.mqttv3" % "1.2.0" // Eclipse Public License 1.0
-    )
+        "org.eclipse.paho" % "org.eclipse.paho.client.mqttv3" % "1.2.0" // Eclipse Public License 1.0
+      )
   )
 
   val MqttStreaming = Seq(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-actor-typed" % AkkaVersion, // ApacheV2
-      "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % "test", // ApacheV2
-      "com.typesafe.akka" %% "akka-stream-typed" % AkkaVersion // ApacheV2
-    )
+        "com.typesafe.akka" %% "akka-actor-typed" % AkkaVersion, // ApacheV2
+        "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % "test", // ApacheV2
+        "com.typesafe.akka" %% "akka-stream-typed" % AkkaVersion // ApacheV2
+      )
   )
 
   val OrientDB = Seq(
     libraryDependencies ++= Seq(
-      "com.orientechnologies" % "orientdb-graphdb" % "3.0.13", // ApacheV2
-      "com.orientechnologies" % "orientdb-object" % "3.0.13" // ApacheV2
-    )
+        "com.orientechnologies" % "orientdb-graphdb" % "3.0.13", // ApacheV2
+        "com.orientechnologies" % "orientdb-object" % "3.0.13" // ApacheV2
+      )
   )
 
   val Reference = Seq(
     // connector specific library dependencies and resolver settings
     libraryDependencies ++= Seq(
-      )
+        )
   )
 
   val S3 = Seq(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-      "com.typesafe.akka" %% "akka-http-xml" % AkkaHttpVersion,
-      "com.amazonaws" % "aws-java-sdk-core" % AwsSdkVersion, // ApacheV2
-      // in-memory filesystem for file related tests
-      "com.google.jimfs" % "jimfs" % "1.1" % Test, // ApacheV2
-      "com.github.tomakehurst" % "wiremock" % "2.18.0" % Test // ApacheV2
-    )
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-xml" % AkkaHttpVersion,
+        "com.amazonaws" % "aws-java-sdk-core" % AwsSdkVersion, // ApacheV2
+        // in-memory filesystem for file related tests
+        "com.google.jimfs" % "jimfs" % "1.1" % Test, // ApacheV2
+        "com.github.tomakehurst" % "wiremock" % "2.18.0" % Test // ApacheV2
+      )
   )
 
   val SpringWeb = {
@@ -324,37 +324,37 @@ object Dependencies {
     val SpringBootVersion = "2.1.2.RELEASE"
     Seq(
       libraryDependencies ++= Seq(
-        "org.springframework" % "spring-core" % SpringVersion,
-        "org.springframework" % "spring-context" % SpringVersion,
-        "org.springframework.boot" % "spring-boot-autoconfigure" % SpringBootVersion, // TODO should this be provided?
-        "org.springframework.boot" % "spring-boot-configuration-processor" % SpringBootVersion % Optional,
-        // for examples
-        "org.springframework.boot" % "spring-boot-starter-web" % SpringBootVersion % Test
-      )
+          "org.springframework" % "spring-core" % SpringVersion,
+          "org.springframework" % "spring-context" % SpringVersion,
+          "org.springframework.boot" % "spring-boot-autoconfigure" % SpringBootVersion, // TODO should this be provided?
+          "org.springframework.boot" % "spring-boot-configuration-processor" % SpringBootVersion % Optional,
+          // for examples
+          "org.springframework.boot" % "spring-boot-starter-web" % SpringBootVersion % Test
+        )
     )
   }
 
   val SlickVersion = "3.3.0"
   val Slick = Seq(
     libraryDependencies ++= Seq(
-      "com.typesafe.slick" %% "slick" % SlickVersion, // BSD 2-clause "Simplified" License
-      "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion, // BSD 2-clause "Simplified" License
-      "com.h2database" % "h2" % "1.4.197" % Test // Eclipse Public License 1.0
-    )
+        "com.typesafe.slick" %% "slick" % SlickVersion, // BSD 2-clause "Simplified" License
+        "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion, // BSD 2-clause "Simplified" License
+        "com.h2database" % "h2" % "1.4.197" % Test // Eclipse Public License 1.0
+      )
   )
 
   val Sns = Seq(
     libraryDependencies ++= Seq(
-      "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion excludeAll ExclusionRule(
-        organization = "com.typesafe.akka"
-      ), // ApacheV2
-      "software.amazon.awssdk" % "sns" % AwsSdk2Version excludeAll (ExclusionRule(
-        organization = "software.amazon.awssdk",
-        name = "netty-nio-client"
-      ), ExclusionRule(organization = "io.netty")), // ApacheV2
-      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion, // ApacheV2
-      "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
-    )
+        "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion excludeAll ExclusionRule(
+          organization = "com.typesafe.akka"
+        ), // ApacheV2
+        "software.amazon.awssdk" % "sns" % AwsSdk2Version excludeAll (ExclusionRule(
+          organization = "software.amazon.awssdk",
+          name = "netty-nio-client"
+        ), ExclusionRule(organization = "io.netty")), // ApacheV2
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion, // ApacheV2
+        "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
+      )
   )
 
   val SolrjVersion = "7.4.0"
@@ -364,47 +364,47 @@ object Dependencies {
     val slf4jVersion = "1.7.25"
     Seq(
       libraryDependencies ++= Seq(
-        "org.apache.solr" % "solr-solrj" % SolrjVersion, // ApacheV2
-        "org.apache.solr" % "solr-test-framework" % SolrjVersion % Test exclude ("org.apache.logging.log4j", "log4j-slf4j-impl"), // ApacheV2
-        "org.slf4j" % "log4j-over-slf4j" % slf4jVersion % Test // MIT like: http://www.slf4j.org/license.html
-      ),
+          "org.apache.solr" % "solr-solrj" % SolrjVersion, // ApacheV2
+          "org.apache.solr" % "solr-test-framework" % SolrjVersion % Test exclude ("org.apache.logging.log4j", "log4j-slf4j-impl"), // ApacheV2
+          "org.slf4j" % "log4j-over-slf4j" % slf4jVersion % Test // MIT like: http://www.slf4j.org/license.html
+        ),
       resolvers += ("restlet" at "https://maven.restlet.com")
     )
   }
 
   val Sqs = Seq(
     libraryDependencies ++= Seq(
-      "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion excludeAll ExclusionRule(
-        organization = "com.typesafe.akka"
-      ), // ApacheV2
-      "software.amazon.awssdk" % "sqs" % AwsSdk2Version excludeAll (ExclusionRule(
-        organization = "software.amazon.awssdk",
-        name = "netty-nio-client"
-      ), ExclusionRule(organization = "io.netty")), // ApacheV2
-      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion, // ApacheV2
-      "org.mockito" % "mockito-core" % mockitoVersion % Test, // MIT
-      "org.mockito" % "mockito-inline" % mockitoVersion % Test // MIT
-    )
+        "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion excludeAll ExclusionRule(
+          organization = "com.typesafe.akka"
+        ), // ApacheV2
+        "software.amazon.awssdk" % "sqs" % AwsSdk2Version excludeAll (ExclusionRule(
+          organization = "software.amazon.awssdk",
+          name = "netty-nio-client"
+        ), ExclusionRule(organization = "io.netty")), // ApacheV2
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion, // ApacheV2
+        "org.mockito" % "mockito-core" % mockitoVersion % Test, // MIT
+        "org.mockito" % "mockito-inline" % mockitoVersion % Test // MIT
+      )
   )
 
   val Sse = Seq(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-      "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test
-    )
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test
+      )
   )
 
   val UnixDomainSocket = Seq(
     libraryDependencies ++= Seq(
-      "com.github.jnr" % "jffi" % "1.2.17" classifier "complete", // ApacheV2
-      "com.github.jnr" % "jnr-unixsocket" % "0.22" // BSD/ApacheV2/CPL/MIT as per https://github.com/akka/alpakka/issues/620#issuecomment-348727265
-    )
+        "com.github.jnr" % "jffi" % "1.2.17" classifier "complete", // ApacheV2
+        "com.github.jnr" % "jnr-unixsocket" % "0.22" // BSD/ApacheV2/CPL/MIT as per https://github.com/akka/alpakka/issues/620#issuecomment-348727265
+      )
   )
 
   val Xml = Seq(
     libraryDependencies ++= Seq(
-      "com.fasterxml" % "aalto-xml" % "1.1.0" // ApacheV2
-    )
+        "com.fasterxml" % "aalto-xml" % "1.1.0" // ApacheV2
+      )
   )
 
 }

--- a/project/TestChanged.scala
+++ b/project/TestChanged.scala
@@ -35,10 +35,10 @@ object TestChanged extends AutoPlugin {
 
   override lazy val projectSettings = Seq(
     testChanged := Def.taskDyn {
-      val skip = Def.setting { task(()) }
-      if (shouldBuild(name.value, changedDirectories.value)) test in Test
-      else skip
-    }.value
+        val skip = Def.setting { task(()) }
+        if (shouldBuild(name.value, changedDirectories.value)) test in Test
+        else skip
+      }.value
   )
 
   implicit class RegexHelper(val sc: StringContext) extends AnyVal {

--- a/project/Whitesource.scala
+++ b/project/Whitesource.scala
@@ -41,7 +41,7 @@ object Whitesource extends AutoPlugin {
       )
     },
     whitesourceForceCheckAllDependencies := true,
-    whitesourceFailOnError := true,
+    whitesourceFailOnError := true
   )
 
   private def describe(base: File) = Process(Seq("git", "describe", "--all"), base).!!

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.0-RC5")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.3.0")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.1")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "1.1.2")

--- a/s3/src/main/scala/akka/stream/alpakka/s3/S3Headers.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/S3Headers.scala
@@ -60,12 +60,12 @@ final class S3Headers private (val cannedAcl: Option[CannedAcl] = None,
                                val serverSideEncryption: Option[ServerSideEncryption] = None) {
 
   @InternalApi private[s3] val headers: Seq[HttpHeader] =
-  cannedAcl.toIndexedSeq.map(_.header) ++
-  metaHeaders.toIndexedSeq.flatMap(_.headers) ++
-  storageClass.toIndexedSeq.map(_.header) ++
-  customHeaders.map { header =>
-    RawHeader(header._1, header._2)
-  }
+    cannedAcl.toIndexedSeq.map(_.header) ++
+    metaHeaders.toIndexedSeq.flatMap(_.headers) ++
+    storageClass.toIndexedSeq.map(_.header) ++
+    customHeaders.map { header =>
+      RawHeader(header._1, header._2)
+    }
 
   @InternalApi private[s3] def headersFor(request: S3Request) =
     headers ++ serverSideEncryption.toIndexedSeq.flatMap(_.headersFor(request))

--- a/s3/src/main/scala/akka/stream/alpakka/s3/headers/ServerSideEncryption.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/headers/ServerSideEncryption.scala
@@ -65,8 +65,8 @@ final class KMS private[headers] (val keyId: String, val context: Option[String]
 
   @InternalApi private[s3] override def headers: immutable.Seq[HttpHeader] = {
     val baseHeaders = RawHeader("x-amz-server-side-encryption", "aws:kms") ::
-    RawHeader("x-amz-server-side-encryption-aws-kms-key-id", keyId) ::
-    Nil
+      RawHeader("x-amz-server-side-encryption-aws-kms-key-id", keyId) ::
+      Nil
 
     val headers = baseHeaders ++ context.map(ctx => RawHeader("x-amz-server-side-encryption-context", ctx)).toSeq
     headers
@@ -128,16 +128,16 @@ final class CustomerKeys private[headers] (val key: String, val md5: Option[Stri
       headers
     case CopyPart =>
       val copyHeaders =
-      RawHeader("x-amz-copy-source-server-side-encryption-customer-algorithm", "AES256") ::
-      RawHeader("x-amz-copy-source-server-side-encryption-customer-key", key) ::
-      RawHeader(
-        "x-amz-copy-source-server-side-encryption-customer-key-MD5",
-        md5.getOrElse({
-          val decodedKey = Base64.decode(key)
-          val md5 = Md5Utils.md5AsBase64(decodedKey)
-          md5
-        })
-      ) :: Nil
+        RawHeader("x-amz-copy-source-server-side-encryption-customer-algorithm", "AES256") ::
+        RawHeader("x-amz-copy-source-server-side-encryption-customer-key", key) ::
+        RawHeader(
+          "x-amz-copy-source-server-side-encryption-customer-key-MD5",
+          md5.getOrElse({
+            val decodedKey = Base64.decode(key)
+            val md5 = Md5Utils.md5AsBase64(decodedKey)
+            md5
+          })
+        ) :: Nil
       headers ++: copyHeaders
     case _ => Nil
   }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/DiskBuffer.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/DiskBuffer.scala
@@ -79,7 +79,9 @@ import akka.annotation.InternalApi
 
       override def postStop(): Unit =
         // close stream even if we didn't emit
-        try { pathOut.close() } catch { case x: Throwable => () }
+        try {
+          pathOut.close()
+        } catch { case x: Throwable => () }
 
       private def emit(): Unit = {
         pathOut.close()

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -359,7 +359,7 @@ import akka.util.ByteString
                 case StatusCodes.Forbidden => AccessDenied
                 case StatusCodes.OK => AccessGranted
                 case other => throw new IllegalArgumentException(s"received status $other")
-            }
+              }
           )
       case HttpResponse(_, _, entity, _) =>
         Unmarshal(entity).to[String].map { err =>

--- a/simple-codecs/src/test/scala/docs/scaladsl/RecordIOFramingSpec.scala
+++ b/simple-codecs/src/test/scala/docs/scaladsl/RecordIOFramingSpec.scala
@@ -71,8 +71,8 @@ class RecordIOFramingSpec(_system: ActorSystem)
 
     // When
     val result = Source.single(ByteString(recordIOInput)) via
-    RecordIOFraming.scanner() runWith
-    stringSeqSink
+      RecordIOFraming.scanner() runWith
+      stringSeqSink
 
     // Then
     result.futureValue shouldBe Seq(FirstRecordData, SecondRecordData)
@@ -91,8 +91,8 @@ class RecordIOFramingSpec(_system: ActorSystem)
 
     // When
     val result = Source(chunkedInput) via
-    RecordIOFraming.scanner() runWith
-    stringSeqSink
+      RecordIOFraming.scanner() runWith
+      stringSeqSink
 
     // Then
     result.futureValue shouldBe Seq(FirstRecordData, SecondRecordData)
@@ -101,9 +101,9 @@ class RecordIOFramingSpec(_system: ActorSystem)
   it should "handle an empty stream" in {
     // When
     val result =
-    Source.empty via
-    RecordIOFraming.scanner() runWith
-    stringSeqSink
+      Source.empty via
+      RecordIOFraming.scanner() runWith
+      stringSeqSink
 
     // Then
     result.futureValue shouldBe Seq.empty
@@ -115,8 +115,8 @@ class RecordIOFramingSpec(_system: ActorSystem)
 
     // When
     val result = Source(input) via
-    RecordIOFraming.scanner() runWith
-    stringSeqSink
+      RecordIOFraming.scanner() runWith
+      stringSeqSink
 
     // Then
     result.futureValue shouldBe Seq.empty
@@ -128,8 +128,8 @@ class RecordIOFramingSpec(_system: ActorSystem)
 
     // When
     val result = Source.single(ByteString(recordIOInput)) via
-    RecordIOFraming.scanner(1024) runWith
-    stringSeqSink
+      RecordIOFraming.scanner(1024) runWith
+      stringSeqSink
 
     // Then
     result.failed.futureValue shouldBe a[NumberFormatException]
@@ -141,8 +141,8 @@ class RecordIOFramingSpec(_system: ActorSystem)
 
     // When
     val result = infinitePrefixSource via
-    RecordIOFraming.scanner(1024) runWith
-    stringSeqSink
+      RecordIOFraming.scanner(1024) runWith
+      stringSeqSink
 
     // Then
     result.failed.futureValue shouldBe a[FramingException]
@@ -154,8 +154,8 @@ class RecordIOFramingSpec(_system: ActorSystem)
 
     // When
     val result = Source.single(ByteString(recordIOInput)) via
-    RecordIOFraming.scanner() runWith
-    stringSeqSink
+      RecordIOFraming.scanner() runWith
+      stringSeqSink
 
     // Then
     result.failed.futureValue shouldBe a[FramingException]
@@ -167,8 +167,8 @@ class RecordIOFramingSpec(_system: ActorSystem)
 
     // When
     val result = Source.single(ByteString(recordIOInput)) via
-    RecordIOFraming.scanner(FirstRecordData.length - 1) runWith
-    stringSeqSink
+      RecordIOFraming.scanner(FirstRecordData.length - 1) runWith
+      stringSeqSink
 
     // Then
     result.failed.futureValue shouldBe a[FramingException]
@@ -180,8 +180,8 @@ class RecordIOFramingSpec(_system: ActorSystem)
 
     // When
     val result = Source.single(ByteString(recordIOInput)) via
-    RecordIOFraming.scanner() runWith
-    stringSeqSink
+      RecordIOFraming.scanner() runWith
+      stringSeqSink
 
     // Then
     result.failed.futureValue shouldBe a[FramingException]

--- a/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
@@ -237,9 +237,9 @@ class SqsPublishSpec extends FlatSpec with Matchers with DefaultTestContext {
     // override val queueUrl = "https://sqs.us-east-1.amazonaws.com/$AWS_ACCOUNT_ID/$queue_name.fifo"
     // override implicit val awsSqsClient: SqsAsyncClient = SqsAsyncClient.builder().build()
 
-    val messages = for (i <- 0 until 10)
-      yield
-        SendMessageRequest
+    val messages =
+      for (i <- 0 until 10)
+        yield SendMessageRequest
           .builder()
           .messageBody(s"Message $i")
           .messageGroupId("group-id")

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -210,9 +210,9 @@ class SqsSourceSpec extends FlatSpec with ScalaFutures with Matchers with Defaul
   }
 
   it should "stream multiple batches from the queue" taggedAs Integration in new IntegrationFixture {
-    val input = for (i <- 1 to 100)
-      yield
-        SendMessageRequest
+    val input =
+      for (i <- 1 to 100)
+        yield SendMessageRequest
           .builder()
           .queueUrl(queueUrl)
           .messageBody(s"alpakka-$i")

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/UnixDomainSocketImpl.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/impl/UnixDomainSocketImpl.scala
@@ -245,12 +245,16 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
   )(sel: Selector, key: SelectionKey)(implicit mat: ActorMaterializer, ec: ExecutionContext): Unit = {
 
     val acceptingChannel = key.channel().asInstanceOf[UnixServerSocketChannel]
-    val acceptedChannel = try { acceptingChannel.accept() } catch { case _: IOException => null }
+    val acceptedChannel = try {
+      acceptingChannel.accept()
+    } catch { case _: IOException => null }
 
     if (acceptedChannel != null) {
       acceptedChannel.configureBlocking(false)
       val (context, connectionFlow) = sendReceiveStructures(sel, receiveBufferSize, sendBufferSize, halfClose)
-      try { acceptedChannel.register(sel, SelectionKey.OP_READ, context) } catch { case _: IOException => }
+      try {
+        acceptedChannel.register(sel, SelectionKey.OP_READ, context)
+      } catch { case _: IOException => }
       incomingConnectionQueue.offer(
         IncomingConnection(localAddress, acceptingChannel.getRemoteSocketAddress, connectionFlow)
       )


### PR DESCRIPTION
## Purpose

Upgrades to the latest scalafmt sbt plugin and formatter itself.

## References

sbt plugin contains performance fixes: https://github.com/scalameta/sbt-scalafmt/releases/tag/v2.0.0

## Background Context

To make the rebase For PRs that are already open easier, this PR has the formatting commit separate from the configuration change.