### PR TITLE
S3: Move FailedUpload exception to the user facing API

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -61,10 +61,6 @@ import akka.util.ByteString
     extends UploadPartResponse
 
 /** Internal Api */
-@InternalApi private[impl] final case class FailedUpload(reasons: Seq[Throwable])
-    extends Exception(reasons.map(_.getMessage).mkString(", "))
-
-/** Internal Api */
 @InternalApi private[impl] final case class CompleteMultipartUploadResult(location: Uri,
                                                                           bucket: String,
                                                                           key: String,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
@@ -114,6 +114,25 @@ object MultipartUploadResult {
 }
 
 /**
+ * Thrown when multipart upload or multipart copy fails because of a server failure.
+ */
+final class FailedUpload private (
+    val reasons: Seq[Throwable]
+) extends Exception(reasons.map(_.getMessage).mkString(", ")) {
+
+  /** Java API */
+  def getReasons: java.util.List[Throwable] = reasons.asJava
+}
+
+object FailedUpload {
+
+  def apply(reasons: Seq[Throwable]) = new FailedUpload(reasons)
+
+  /** Java API */
+  def create(reasons: Seq[Throwable]) = FailedUpload(reasons)
+}
+
+/**
  * @param bucketName The name of the bucket in which this object is stored
  * @param key The key under which this object is stored
  * @param eTag Hex encoded MD5 hash of this object's contents, as computed by Amazon S3

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -39,6 +39,33 @@ abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockSer
       )
     )
 
+  def mockFailureAfterInitiate(): Unit = {
+    mock
+      .register(
+        post(urlEqualTo(s"/$bucketKey?uploads")).willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("x-amz-id-2", "Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==")
+            .withHeader("x-amz-request-id", "656c76696e6727732072657175657374")
+            .withBody(s"""<?xml version="1.0" encoding="UTF-8"?>
+                 |<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                 |  <Bucket>$bucket</Bucket>
+                 |  <Key>$bucketKey</Key>
+                 |  <UploadId>$uploadId</UploadId>
+                 |</InitiateMultipartUploadResult>""".stripMargin)
+        )
+      )
+
+    mock.register(
+      put(urlEqualTo(s"/$bucketKey?partNumber=1&uploadId=$uploadId"))
+        .withRequestBody(matching(body))
+        .willReturn(
+          aResponse()
+            .withStatus(500)
+        )
+    )
+  }
+
   def mockSSEInvalidRequest(): Unit =
     mock.register(
       any(anyUrl()).willReturn(


### PR DESCRIPTION
## Purpose

Moves FailedUpload exception to the user facing API

## References

Fixes #1706

## Changes

* makes the `FailedUpload` exception public
* adds a test that mocks a failure after the initial request succeeds
