### PR TITLE
AWS S3: Fix plus char usage in s3 key

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -219,8 +219,13 @@ import scala.concurrent.{ExecutionContext, Future}
   private def rawRequestUri(uri: Uri): String = {
     val rawUri = uri.toString
     val rawPath = uri.path.toString()
-    val fixedPath = rawPath.replaceAll("\\+", "%2B")
 
-    rawUri.replaceFirst(rawPath, fixedPath)
+    if (rawPath.contains("+")) {
+      val fixedPath = rawPath.replaceAll("\\+", "%2B")
+
+      rawUri.replace(rawPath, fixedPath)
+    } else {
+      rawUri
+    }
   }
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -153,12 +153,11 @@ import scala.concurrent.{ExecutionContext, Future}
       implicit conf: S3Settings
   ): HttpRequest = {
     val s3RequestUri = uriFn(requestUri(s3Location.bucket, Some(s3Location.key)))
-    val rawUri = s3RequestUri.toString.replaceAll("\\+", "%2B")
 
     HttpRequest(method)
       .withHeaders(
         Host(requestAuthority(s3Location.bucket, conf.s3RegionProvider.getRegion)),
-        `Raw-Request-URI`(rawUri)
+        `Raw-Request-URI`(rawRequestUri(s3RequestUri))
       )
       .withUri(s3RequestUri)
   }
@@ -215,5 +214,13 @@ import scala.concurrent.{ExecutionContext, Future}
       case None =>
         uri.withScheme("https")
     }
+  }
+
+  private def rawRequestUri(uri: Uri): String = {
+    val rawUri = uri.toString
+    val rawPath = uri.path.toString()
+    val fixedPath = rawPath.replaceAll("\\+", "%2B")
+
+    rawUri.replaceFirst(rawPath, fixedPath)
   }
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -11,7 +11,7 @@ import akka.annotation.InternalApi
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport._
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.Uri.{Authority, Query}
-import akka.http.scaladsl.model.headers.{Host, RawHeader, `Raw-Request-URI`}
+import akka.http.scaladsl.model.headers.{`Raw-Request-URI`, Host, RawHeader}
 import akka.http.scaladsl.model.{ContentTypes, RequestEntity, _}
 import akka.stream.alpakka.s3.{ApiVersion, S3Settings}
 import akka.stream.scaladsl.Source
@@ -153,7 +153,7 @@ import scala.concurrent.{ExecutionContext, Future}
       implicit conf: S3Settings
   ): HttpRequest = {
     val s3RequestUri = uriFn(requestUri(s3Location.bucket, Some(s3Location.key)))
-    val rawUri = s3RequestUri.toString.replaceAll("+", "%2B")
+    val rawUri = s3RequestUri.toString.replaceAll("\\+", "%2B")
 
     HttpRequest(method)
       .withHeaders(

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/auth/Signer.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/auth/Signer.scala
@@ -10,7 +10,7 @@ import java.time.ZonedDateTime
 
 import akka.NotUsed
 import akka.annotation.InternalApi
-import akka.http.scaladsl.model.headers.{RawHeader, `Raw-Request-URI`}
+import akka.http.scaladsl.model.headers.{`Raw-Request-URI`, RawHeader}
 import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
 import akka.stream.scaladsl.Source
 

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/auth/Signer.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/auth/Signer.scala
@@ -10,7 +10,7 @@ import java.time.ZonedDateTime
 
 import akka.NotUsed
 import akka.annotation.InternalApi
-import akka.http.scaladsl.model.headers.{`Raw-Request-URI`, RawHeader}
+import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
 import akka.stream.scaladsl.Source
 
@@ -25,9 +25,7 @@ import akka.stream.scaladsl.Source
         val headersToAdd = Vector(RawHeader("x-amz-date", key.requestDate.format(dateFormatter)),
                                   RawHeader("x-amz-content-sha256", hb)) ++ sessionHeader(key)
         val reqWithHeaders = request.withHeaders(request.headers ++ headersToAdd)
-        val cr = CanonicalRequest.from(
-          reqWithHeaders.withHeaders(reqWithHeaders.headers.filterNot(_.isInstanceOf[`Raw-Request-URI`]))
-        )
+        val cr = CanonicalRequest.from(reqWithHeaders)
         val authHeader = authorizationHeader("AWS4-HMAC-SHA256", key, key.requestDate, cr)
         reqWithHeaders.withHeaders(reqWithHeaders.headers :+ authHeader)
       }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/auth/Signer.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/auth/Signer.scala
@@ -10,7 +10,7 @@ import java.time.ZonedDateTime
 
 import akka.NotUsed
 import akka.annotation.InternalApi
-import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.headers.{RawHeader, `Raw-Request-URI`}
 import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
 import akka.stream.scaladsl.Source
 
@@ -25,7 +25,9 @@ import akka.stream.scaladsl.Source
         val headersToAdd = Vector(RawHeader("x-amz-date", key.requestDate.format(dateFormatter)),
                                   RawHeader("x-amz-content-sha256", hb)) ++ sessionHeader(key)
         val reqWithHeaders = request.withHeaders(request.headers ++ headersToAdd)
-        val cr = CanonicalRequest.from(reqWithHeaders)
+        val cr = CanonicalRequest.from(
+          reqWithHeaders.withHeaders(reqWithHeaders.headers.filterNot(_.isInstanceOf[`Raw-Request-URI`]))
+        )
         val authHeader = authorizationHeader("AWS4-HMAC-SHA256", key, key.requestDate, cr)
         reqWithHeaders.withHeaders(reqWithHeaders.headers :+ authHeader)
       }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -9,7 +9,7 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri.Query
-import akka.http.scaladsl.model.headers.{ByteRange, RawHeader, `Raw-Request-URI`}
+import akka.http.scaladsl.model.headers.{`Raw-Request-URI`, ByteRange, RawHeader}
 import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.s3.headers.{CannedAcl, ServerSideEncryption, StorageClass}

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -9,7 +9,7 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri.Query
-import akka.http.scaladsl.model.headers.{ByteRange, RawHeader}
+import akka.http.scaladsl.model.headers.{ByteRange, RawHeader, `Raw-Request-URI`}
 import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.s3.headers.{CannedAcl, ServerSideEncryption, StorageClass}
@@ -175,6 +175,16 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
     req.uri.authority.host.toString shouldEqual "bucket.s3.amazonaws.com"
     req.uri.path.toString shouldEqual "/test%20folder/test%20file.txt"
     req.uri.rawQueryString shouldBe empty
+  }
+
+  it should "support download requests with keys containing plus" in {
+    implicit val settings = getSettings()
+
+    val location = S3Location("bucket", "test folder/1 + 2 = 3")
+    val req = HttpRequests.getDownloadRequest(location)
+    req.uri.authority.host.toString shouldEqual "bucket.s3.amazonaws.com"
+    req.uri.path.toString shouldEqual "/test%20folder/1%20+%202%20=%203"
+    req.headers should contain(`Raw-Request-URI`("https://bucket.s3.amazonaws.com/test%20folder/1%20%2B%202%20=%203"))
   }
 
   it should "support download requests with keys containing spaces with path-style access in other regions" in {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/CanonicalRequestSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/CanonicalRequestSpec.scala
@@ -156,4 +156,27 @@ class CanonicalRequestSpec extends FlatSpec with Matchers {
       }
     }
   }
+
+  it should "correctly build a canonicalString when synthetic headers are present" in {
+    val req = HttpRequest(
+      HttpMethods.GET,
+      Uri("https://s3-eu-central-1.amazonaws.com/my.test.bucket/file+name.txt")
+    ).withHeaders(
+      RawHeader("x-amz-content-sha256", "testhash"),
+      `Content-Type`(ContentTypes.`application/json`),
+      `Raw-Request-URI`("/my.test.bucket/file%2Bname.txt"),
+      `Remote-Address`(RemoteAddress.Unknown)
+    )
+    val canonical = CanonicalRequest.from(req)
+    canonical.canonicalString should equal(
+      """GET
+        |/my.test.bucket/file%2Bname.txt
+        |
+        |content-type:application/json
+        |x-amz-content-sha256:testhash
+        |
+        |content-type;x-amz-content-sha256
+        |testhash""".stripMargin
+    )
+  }
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SignerSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SignerSpec.scala
@@ -8,7 +8,7 @@ import java.time.{LocalDateTime, ZoneOffset, ZonedDateTime}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpMethods, HttpRequest}
-import akka.http.scaladsl.model.headers.{Host, RawHeader}
+import akka.http.scaladsl.model.headers.{Host, RawHeader, `Raw-Request-URI`}
 import akka.stream.scaladsl.Sink
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.TestKit
@@ -21,7 +21,10 @@ import com.amazonaws.auth.{
 }
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.OptionValues._
 import org.scalatest.time.{Millis, Seconds, Span}
+
+import scala.compat.java8.OptionConverters._
 
 class SignerSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLike with Matchers with ScalaFutures {
   def this() = this(ActorSystem("SignerSpec"))
@@ -133,6 +136,26 @@ class SignerSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLik
 
     whenReady(srFuture) { signedRequest =>
       signedRequest.getHeader("x-amz-security-token").get.value should equal(initialCredentials.getSessionToken)
+    }
+  }
+
+  it should "correctly sign request with Raw-Request-URI header" in {
+    val req = HttpRequest(HttpMethods.GET)
+      .withUri("https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08")
+      .withHeaders(
+        Host("iam.amazonaws.com"),
+        RawHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8"),
+        `Raw-Request-URI`("/1 + 2=3")
+      )
+
+    val date = LocalDateTime.of(2015, 8, 30, 12, 36, 0).atZone(ZoneOffset.UTC)
+    val srFuture = Signer.signedRequest(req, signingKey(date)).runWith(Sink.head)
+
+    whenReady(srFuture) { signedRequest =>
+      signedRequest.getHeader("Authorization").asScala.value shouldEqual RawHeader(
+        "Authorization",
+        "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=dd479fa8a80364edf2119ec24bebde66712ee9c9cb2b0d92eb3ab9ccdc0c3947"
+      )
     }
   }
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SignerSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SignerSpec.scala
@@ -8,7 +8,7 @@ import java.time.{LocalDateTime, ZoneOffset, ZonedDateTime}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpMethods, HttpRequest}
-import akka.http.scaladsl.model.headers.{Host, RawHeader, `Raw-Request-URI`}
+import akka.http.scaladsl.model.headers.{`Raw-Request-URI`, Host, RawHeader}
 import akka.stream.scaladsl.Sink
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.TestKit

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -240,12 +240,18 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
     S3.deleteObject(defaultRegionBucket, objectKey).runWith(Sink.head).futureValue shouldEqual akka.Done
   }
 
-  it should "upload, download and delete with spaces in the key in non us-east-1 zone" in uploadDownloadAndDeteleInOtherRegionCase("test folder/test file.txt")
+  it should "upload, download and delete with spaces in the key in non us-east-1 zone" in uploadDownloadAndDeteleInOtherRegionCase(
+    "test folder/test file.txt"
+  )
 
   // we want ASCII and other UTF-8 characters!
-  it should "upload, download and delete with special characters in the key in non us-east-1 zone" in uploadDownloadAndDeteleInOtherRegionCase("føldęrü/1234()[]><!? .TXT")
+  it should "upload, download and delete with special characters in the key in non us-east-1 zone" in uploadDownloadAndDeteleInOtherRegionCase(
+    "føldęrü/1234()[]><!? .TXT"
+  )
 
-  it should "upload, download and delete with `+` character in the key in non us-east-1 zone" in uploadDownloadAndDeteleInOtherRegionCase("1 + 2 = 3")
+  it should "upload, download and delete with `+` character in the key in non us-east-1 zone" in uploadDownloadAndDeteleInOtherRegionCase(
+    "1 + 2 = 3"
+  )
 
   it should "upload, copy, download the copy, and delete" in {
     val sourceKey = "original/file.txt"


### PR DESCRIPTION
## Purpose

Fixes issue with using `+` char in a S3 object key

## References

https://github.com/akka/alpakka/issues/838 S3 Connector - Using `+` (plus) symbol causes mismatched request signature

## Changes

- HttpRequests adds a synthetic akka http header `Raw-Request-URI` to the built request. The header contains stringified uri of a request with all `+` characters replaced with the url-encoded representation `%2B`.
- Signer now ignores a synthetic akka http header `Raw-Request-URI`.