### PR TITLE
Couchbase: Akka Discovery support

### DIFF
--- a/couchbase/src/main/java/akka/stream/alpakka/couchbase/javadsl/DiscoverySupport.java
+++ b/couchbase/src/main/java/akka/stream/alpakka/couchbase/javadsl/DiscoverySupport.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.couchbase.javadsl;
+
+import akka.actor.ActorSystem;
+import akka.stream.alpakka.couchbase.CouchbaseSessionSettings;
+import com.typesafe.config.Config;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Utility to delegate Couchbase node address lookup to [[https://doc.akka.io/docs/akka/current/discovery/index.html Akka Discovery]].
+ */
+public final class DiscoverySupport {
+
+  private static final akka.stream.alpakka.couchbase.scaladsl.DiscoverySupport SUPPORT =
+      akka.stream.alpakka.couchbase.scaladsl.DiscoverySupport.INSTANCE();
+
+  /**
+   * Expects a `service` section in the given Config and reads the given service name's address to
+   * be used as Couchbase `nodes`.
+   */
+  public static final java.util.function.Function<
+          CouchbaseSessionSettings, CompletionStage<CouchbaseSessionSettings>>
+      getNodes(Config config, ActorSystem system) {
+    return SUPPORT.getNodes(config, system);
+  }
+
+  /**
+   * Expects a `service` section in the given Config and reads the given service name's address to
+   * be used as Couchbase `nodes`.
+   */
+  public static final java.util.function.Function<
+          CouchbaseSessionSettings, CompletionStage<CouchbaseSessionSettings>>
+      getNodes(ActorSystem system) {
+    return SUPPORT.getNodes(
+        system.settings().config().getConfig(CouchbaseSessionSettings.configPath()), system);
+  }
+
+  private DiscoverySupport() {}
+}

--- a/couchbase/src/main/java/akka/stream/alpakka/couchbase/javadsl/DiscoverySupport.java
+++ b/couchbase/src/main/java/akka/stream/alpakka/couchbase/javadsl/DiscoverySupport.java
@@ -11,7 +11,8 @@ import com.typesafe.config.Config;
 import java.util.concurrent.CompletionStage;
 
 /**
- * Utility to delegate Couchbase node address lookup to [[https://doc.akka.io/docs/akka/current/discovery/index.html Akka Discovery]].
+ * Utility to delegate Couchbase node address lookup to
+ * [[https://doc.akka.io/docs/akka/current/discovery/index.html Akka Discovery]].
  */
 public final class DiscoverySupport {
 

--- a/couchbase/src/main/mima-filters/1.0.2.backwards.excludes
+++ b/couchbase/src/main/mima-filters/1.0.2.backwards.excludes
@@ -1,0 +1,3 @@
+# PR #1745
+# new argument to private constructor
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.couchbase.CouchbaseSessionSettings.this")

--- a/couchbase/src/main/mima-filters/1.0.2.backwards.excludes
+++ b/couchbase/src/main/mima-filters/1.0.2.backwards.excludes
@@ -1,3 +1,3 @@
-# PR #1745
+# PR #1746
 # new argument to private constructor
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.couchbase.CouchbaseSessionSettings.this")

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/CouchbaseSessionRegistry.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/CouchbaseSessionRegistry.scala
@@ -55,8 +55,8 @@ final class CouchbaseSessionRegistry(system: ExtendedActorSystem) extends Extens
    * if you need a more fine grained life cycle control, create the CouchbaseSession manually instead.
    */
   def sessionFor(settings: CouchbaseSessionSettings, bucketName: String): Future[CouchbaseSession] =
-    settings.enriched.flatMap { sett =>
-      val key = SessionKey(sett, bucketName)
+    settings.enriched.flatMap { enrichedSettings =>
+      val key = SessionKey(enrichedSettings, bucketName)
       sessions.get.get(key) match {
         case Some(futureSession) => futureSession
         case _ => startSession(key)

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/CouchbaseSessionRegistry.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/CouchbaseSessionRegistry.scala
@@ -54,13 +54,14 @@ final class CouchbaseSessionRegistry(system: ExtendedActorSystem) extends Extens
    * Note that the session must not be stopped manually, it is shut down when the actor system is shutdown,
    * if you need a more fine grained life cycle control, create the CouchbaseSession manually instead.
    */
-  def sessionFor(settings: CouchbaseSessionSettings, bucketName: String): Future[CouchbaseSession] = {
-    val key = SessionKey(settings, bucketName)
-    sessions.get.get(key) match {
-      case Some(futureSession) => futureSession
-      case _ => startSession(key)
-    }
-  }
+  def sessionFor(settings: CouchbaseSessionSettings, bucketName: String): Future[CouchbaseSession] =
+    settings.enriched.flatMap { sett =>
+      val key = SessionKey(sett, bucketName)
+      sessions.get.get(key) match {
+        case Some(futureSession) => futureSession
+        case _ => startSession(key)
+      }
+    }(system.dispatcher)
 
   /**
    * Java API: Get an existing session or start a new one with the given settings and bucket name,

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/DiscoverySupport.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/DiscoverySupport.scala
@@ -13,6 +13,9 @@ import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
+/**
+ * Utility to delegate Couchbase node address lookup to [[https://doc.akka.io/docs/akka/current/discovery/index.html Akka Discovery]].
+ */
 sealed class DiscoverySupport {
 
   /**
@@ -62,6 +65,9 @@ sealed class DiscoverySupport {
     nodes(system.settings.config.getConfig(CouchbaseSessionSettings.configPath))(system)
 }
 
+/**
+ * Utility to delegate Couchbase node address lookup to [[https://doc.akka.io/docs/akka/current/discovery/index.html Akka Discovery]].
+ */
 object DiscoverySupport extends DiscoverySupport {
   val INSTANCE: DiscoverySupport = this
 }

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/DiscoverySupport.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/DiscoverySupport.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.couchbase
+
+import akka.actor.ActorSystem
+import akka.discovery.Discovery
+import akka.util.JavaDurationConverters._
+import com.typesafe.config.Config
+
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+sealed class DiscoverySupport {
+
+  /**
+   * Use Akka Discovery to read the addresses for `serviceName` within `lookupTimeout`.
+   */
+  def readNodes(
+      serviceName: String,
+      lookupTimeout: FiniteDuration
+  )(implicit system: ActorSystem): Future[immutable.Seq[String]] = {
+    import system.dispatcher
+    val discovery = Discovery(system).discovery
+    discovery.lookup(serviceName, lookupTimeout).map { resolved =>
+      resolved.addresses.map(_.host)
+    }
+  }
+
+  /**
+   * Expect a `service` section in Config and use Akka Discovery to read the addresses for `name` within `lookup-timeout`.
+   */
+  def readNodes(config: Config)(implicit system: ActorSystem): Future[immutable.Seq[String]] =
+    if (config.hasPath("service")) {
+      val serviceName = config.getString("service.name")
+      val lookupTimeout = config.getDuration("service.lookup-timeout").asScala
+      readNodes(serviceName, lookupTimeout)
+    } else throw new IllegalArgumentException(s"config $config does not contain `service` section")
+
+  /**
+   * Expects a `service` section in the given Config and reads the given service name's address
+   * to be used as Couchbase `nodes`.
+   */
+  def nodes(
+      config: Config
+  )(implicit system: ActorSystem): CouchbaseSessionSettings => Future[CouchbaseSessionSettings] = {
+    import system.dispatcher
+    settings =>
+      readNodes(config)
+        .map { nodes =>
+          settings.withNodes(nodes)
+        }
+  }
+
+  /**
+   * Expects a `service` section in `alpakka.couchbase.session` and reads the given service name's address
+   * to be used as Couchbase `nodes`.
+   */
+  def nodes()(implicit system: ActorSystem): CouchbaseSessionSettings => Future[CouchbaseSessionSettings] =
+    nodes(system.settings.config.getConfig(CouchbaseSessionSettings.configPath))(system)
+}
+
+object DiscoverySupport extends DiscoverySupport {
+  val INSTANCE: DiscoverySupport = this
+}

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/model.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/model.scala
@@ -114,7 +114,7 @@ object CouchbaseSessionSettings {
     val username = config.getString("username")
     val password = config.getString("password")
     val nodes = config.getStringList("nodes").asScala.toList
-    new CouchbaseSessionSettings(username, password, nodes, None, EnrichAsync)
+    new CouchbaseSessionSettings(username, password, nodes, environment = None, enrichAsync = Future.successful)
   }
 
   /**
@@ -129,7 +129,7 @@ object CouchbaseSessionSettings {
    * Scala API:
    */
   def apply(username: String, password: String): CouchbaseSessionSettings =
-    new CouchbaseSessionSettings(username, password, Nil, None, EnrichAsync)
+    new CouchbaseSessionSettings(username, password, Nil, environment = None, enrichAsync = Future.successful)
 
   /**
    * Java API:
@@ -151,9 +151,6 @@ object CouchbaseSessionSettings {
    */
   def create(system: ActorSystem): CouchbaseSessionSettings =
     apply(system.settings.config.getConfig(configPath))
-
-  private val EnrichAsync: CouchbaseSessionSettings => Future[CouchbaseSessionSettings] = s => Future.successful(s)
-
 }
 
 final class CouchbaseSessionSettings private (

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/model.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/model.scala
@@ -189,7 +189,7 @@ final class CouchbaseSessionSettings private (
   /** Java API:
    * Allows to provide an asynchronous method to update the settings.
    */
-  def withEnrichCompletionStage(
+  def withEnrichAsyncCs(
       value: java.util.function.Function[CouchbaseSessionSettings, CompletionStage[CouchbaseSessionSettings]]
   ): CouchbaseSessionSettings =
     copy(enrichAsync = (s: CouchbaseSessionSettings) => value.apply(s).toScala)

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/model.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/model.scala
@@ -190,7 +190,7 @@ final class CouchbaseSessionSettings private (
    * Allows to provide an asynchronous method to update the settings.
    */
   def withEnrichCompletionStage(
-      value: CouchbaseSessionSettings => CompletionStage[CouchbaseSessionSettings]
+      value: java.util.function.Function[CouchbaseSessionSettings, CompletionStage[CouchbaseSessionSettings]]
   ): CouchbaseSessionSettings =
     copy(enrichAsync = (s: CouchbaseSessionSettings) => value.apply(s).toScala)
 

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/scaladsl/DiscoverySupport.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/scaladsl/DiscoverySupport.scala
@@ -86,6 +86,7 @@ sealed class DiscoverySupport private {
  * Utility to delegate Couchbase node address lookup to [[https://doc.akka.io/docs/akka/current/discovery/index.html Akka Discovery]].
  */
 object DiscoverySupport extends DiscoverySupport {
+
   /** Internal API */
-  @InternalApi private[couchbase] val INSTANCE: DiscoverySupport = this
+  @InternalApi val INSTANCE: DiscoverySupport = this
 }

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/scaladsl/DiscoverySupport.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/scaladsl/DiscoverySupport.scala
@@ -2,26 +2,32 @@
  * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.stream.alpakka.couchbase
+package akka.stream.alpakka.couchbase.scaladsl
+
+import java.util.concurrent.CompletionStage
 
 import akka.actor.ActorSystem
+import akka.annotation.InternalApi
 import akka.discovery.Discovery
+import akka.stream.alpakka.couchbase.CouchbaseSessionSettings
 import akka.util.JavaDurationConverters._
 import com.typesafe.config.Config
 
 import scala.collection.immutable
+import scala.compat.java8.FunctionConverters._
+import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
 /**
  * Utility to delegate Couchbase node address lookup to [[https://doc.akka.io/docs/akka/current/discovery/index.html Akka Discovery]].
  */
-sealed class DiscoverySupport {
+sealed class DiscoverySupport private {
 
   /**
    * Use Akka Discovery to read the addresses for `serviceName` within `lookupTimeout`.
    */
-  def readNodes(
+  private def readNodes(
       serviceName: String,
       lookupTimeout: FiniteDuration
   )(implicit system: ActorSystem): Future[immutable.Seq[String]] = {
@@ -35,7 +41,7 @@ sealed class DiscoverySupport {
   /**
    * Expect a `service` section in Config and use Akka Discovery to read the addresses for `name` within `lookup-timeout`.
    */
-  def readNodes(config: Config)(implicit system: ActorSystem): Future[immutable.Seq[String]] =
+  private def readNodes(config: Config)(implicit system: ActorSystem): Future[immutable.Seq[String]] =
     if (config.hasPath("service")) {
       val serviceName = config.getString("service.name")
       val lookupTimeout = config.getDuration("service.lookup-timeout").asScala
@@ -58,16 +64,28 @@ sealed class DiscoverySupport {
   }
 
   /**
+   * Internal API: Java wrapper.
+   */
+  @InternalApi
+  private[couchbase] def getNodes(
+      config: Config,
+      system: ActorSystem
+  ): java.util.function.Function[CouchbaseSessionSettings, CompletionStage[CouchbaseSessionSettings]] =
+    nodes(config)(system).andThen(_.toJava).asJava
+
+  /**
    * Expects a `service` section in `alpakka.couchbase.session` and reads the given service name's address
    * to be used as Couchbase `nodes`.
    */
   def nodes()(implicit system: ActorSystem): CouchbaseSessionSettings => Future[CouchbaseSessionSettings] =
     nodes(system.settings.config.getConfig(CouchbaseSessionSettings.configPath))(system)
+
 }
 
 /**
  * Utility to delegate Couchbase node address lookup to [[https://doc.akka.io/docs/akka/current/discovery/index.html Akka Discovery]].
  */
 object DiscoverySupport extends DiscoverySupport {
-  val INSTANCE: DiscoverySupport = this
+  /** Internal API */
+  @InternalApi private[couchbase] val INSTANCE: DiscoverySupport = this
 }

--- a/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
+++ b/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
@@ -53,7 +53,7 @@ public class DiscoveryTest {
 
     CouchbaseSessionSettings sessionSettings =
         CouchbaseSessionSettings.create(actorSystem)
-            .withEnrichCompletionStage(DiscoverySupport.getNodes(actorSystem));
+            .withEnrichAsyncCs(DiscoverySupport.getNodes(actorSystem));
     CompletionStage<CouchbaseSession> session = registry.getSessionFor(sessionSettings, bucketName);
     // #registry
     try {

--- a/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
+++ b/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.javadsl;
+
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+// #registry
+import akka.stream.alpakka.couchbase.CouchbaseSessionRegistry;
+import akka.stream.alpakka.couchbase.CouchbaseSessionSettings;
+import akka.stream.alpakka.couchbase.DiscoverySupport;
+// #registry
+import akka.stream.alpakka.couchbase.javadsl.CouchbaseSession;
+import akka.testkit.javadsl.TestKit;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class DiscoveryTest {
+
+  private static ActorSystem actorSystem;
+  private static Materializer materializer;
+  private static final String bucketName = "akka";
+
+  @BeforeClass
+  public static void beforeAll() {
+    Config config = ConfigFactory.parseResources("discovery.conf");
+    actorSystem = ActorSystem.create("DiscoveryTest", config);
+    materializer = ActorMaterializer.create(actorSystem);
+  }
+
+  @AfterClass
+  public static void afterAll() {
+    TestKit.shutdownActorSystem(actorSystem);
+  }
+
+  @Test
+  public void configDiscovery() throws Exception {
+    // #registry
+
+    CouchbaseSessionRegistry registry = CouchbaseSessionRegistry.get(actorSystem);
+
+    CouchbaseSessionSettings sessionSettings =
+        CouchbaseSessionSettings.create(actorSystem)
+            .withEnrichAsync(DiscoverySupport.INSTANCE().nodes(actorSystem));
+    CompletionStage<CouchbaseSession> session = registry.getSessionFor(sessionSettings, bucketName);
+    // #registry
+    try {
+      CouchbaseSession couchbaseSession = session.toCompletableFuture().get(5, TimeUnit.SECONDS);
+    } catch (java.util.concurrent.ExecutionException e) {
+      assertThat(
+          e.getCause(),
+          is(instanceOf(com.couchbase.client.core.config.ConfigurationException.class)));
+    }
+  }
+}

--- a/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
+++ b/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
@@ -10,9 +10,9 @@ import akka.stream.Materializer;
 // #registry
 import akka.stream.alpakka.couchbase.CouchbaseSessionRegistry;
 import akka.stream.alpakka.couchbase.CouchbaseSessionSettings;
-import akka.stream.alpakka.couchbase.DiscoverySupport;
-// #registry
+import akka.stream.alpakka.couchbase.javadsl.DiscoverySupport;
 import akka.stream.alpakka.couchbase.javadsl.CouchbaseSession;
+// #registry
 import akka.testkit.javadsl.TestKit;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -53,7 +53,7 @@ public class DiscoveryTest {
 
     CouchbaseSessionSettings sessionSettings =
         CouchbaseSessionSettings.create(actorSystem)
-            .withEnrichAsync(DiscoverySupport.INSTANCE().nodes(actorSystem));
+            .withEnrichCompletionStage(DiscoverySupport.getNodes(actorSystem));
     CompletionStage<CouchbaseSession> session = registry.getSessionFor(sessionSettings, bucketName);
     // #registry
     try {

--- a/couchbase/src/test/resources/application.conf
+++ b/couchbase/src/test/resources/application.conf
@@ -4,6 +4,7 @@ akka {
   loglevel = "DEBUG"
 }
 
+// #settings
 alpakka.couchbase {
   session {
     nodes = ["localhost"]
@@ -11,3 +12,4 @@ alpakka.couchbase {
     password = "password"
   }
 }
+// #settings

--- a/couchbase/src/test/resources/discovery.conf
+++ b/couchbase/src/test/resources/discovery.conf
@@ -1,0 +1,27 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  loglevel = "DEBUG"
+}
+
+// #discovery-settings
+alpakka.couchbase {
+  session {
+    service {
+      name = couchbase-service
+      lookup-timeout = 1 s
+    }
+    username = "anotherUser"
+    password = "differentPassword"
+  }
+}
+
+akka.discovery.method = config
+akka.discovery.config.services = {
+  couchbase-service = {
+    endpoints = [
+      { host = "akka.io" }
+    ]
+  }
+}
+// #discovery-settings

--- a/couchbase/src/test/scala/akka/stream/alpakka/couchbase/testing/CouchbaseSupport.scala
+++ b/couchbase/src/test/scala/akka/stream/alpakka/couchbase/testing/CouchbaseSupport.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.couchbase.testing
 
 import akka.Done
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.alpakka.couchbase.scaladsl._
 import akka.stream.alpakka.couchbase.{CouchbaseSessionSettings, CouchbaseWriteSettings}
 import akka.stream.scaladsl.{Sink, Source}
@@ -32,7 +32,7 @@ trait CouchbaseSupport {
 
   //#init-actor-system
   implicit val actorSystem: ActorSystem = ActorSystem()
-  implicit val mat: ActorMaterializer = ActorMaterializer()
+  implicit val mat: Materializer = ActorMaterializer()
   //#init-actor-system
 
   val sampleData = TestObject("First", "First")

--- a/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.scaladsl
+
+import akka.actor.ActorSystem
+import akka.stream.{ActorMaterializer, Materializer}
+import com.couchbase.client.java.document.JsonDocument
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+
+class DiscoverySpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+
+  implicit val actorSystem: ActorSystem = ActorSystem(
+    "with-discovery",
+    ConfigFactory.parseString("""
+      akka {
+        loggers = ["akka.event.slf4j.Slf4jLogger"]
+        logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+        loglevel = "DEBUG"
+      }
+
+      // #discovery-settings
+      alpakka.couchbase {
+        session {
+          service {
+            name = couchbase-service
+            lookup-timeout = 1 s
+          }
+          username = "anotherUser"
+          password = "differentPassword"
+        }
+      }
+
+      akka.discovery.method = config
+      akka.discovery.config.services = {
+        couchbase-service = {
+          endpoints = [
+            { host = "akka.io" }
+          ]
+        }
+      }
+      // #discovery-settings
+     """)
+  )
+  implicit val mat: Materializer = ActorMaterializer()
+
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(10.seconds, 250.millis)
+
+  val bucketName = "akka"
+
+  override def afterAll(): Unit =
+    actorSystem.terminate()
+
+  "a Couchbasesession" should {
+    "be managed by the registry" in {
+      // #registry
+      import akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession
+      import akka.stream.alpakka.couchbase.{CouchbaseSessionRegistry, CouchbaseSessionSettings, DiscoverySupport}
+
+      val registry = CouchbaseSessionRegistry(actorSystem)
+
+      val sessionSettings = CouchbaseSessionSettings(actorSystem)
+        .withEnrichAsync(DiscoverySupport.nodes())
+      val sessionFuture: Future[CouchbaseSession] = registry.sessionFor(sessionSettings, bucketName)
+      // #registry
+      sessionFuture.failed.futureValue shouldBe a[com.couchbase.client.core.config.ConfigurationException]
+    }
+
+    "be created from settings" in {
+      // #create
+      import akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession
+      import akka.stream.alpakka.couchbase.{CouchbaseSessionSettings, DiscoverySupport}
+
+      implicit val ec: ExecutionContext = actorSystem.dispatcher
+      val sessionSettings = CouchbaseSessionSettings(actorSystem)
+        .withEnrichAsync(DiscoverySupport.nodes())
+      val sessionFuture: Future[CouchbaseSession] = CouchbaseSession(sessionSettings, bucketName)
+      actorSystem.registerOnTermination(sessionFuture.flatMap(_.close()))
+
+      val documentFuture = sessionFuture.flatMap { session =>
+        val id = "myId"
+        val documentFuture: Future[Option[JsonDocument]] = session.get(id)
+        documentFuture.flatMap {
+          case Some(jsonDocument) =>
+            Future.successful(jsonDocument)
+          case None =>
+            Future.failed(new RuntimeException(s"document $id wasn't found"))
+        }
+      }
+      // #create
+      documentFuture.failed.futureValue shouldBe a[RuntimeException]
+    }
+
+  }
+}

--- a/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala
@@ -7,7 +7,7 @@ package docs.scaladsl
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
 import com.couchbase.client.java.document.JsonDocument
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 
@@ -16,38 +16,9 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class DiscoverySpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
 
-  implicit val actorSystem: ActorSystem = ActorSystem(
-    "with-discovery",
-    ConfigFactory.parseString("""
-      akka {
-        loggers = ["akka.event.slf4j.Slf4jLogger"]
-        logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
-        loglevel = "DEBUG"
-      }
+  val config: Config = ConfigFactory.parseResources("discovery.conf")
 
-      // #discovery-settings
-      alpakka.couchbase {
-        session {
-          service {
-            name = couchbase-service
-            lookup-timeout = 1 s
-          }
-          username = "anotherUser"
-          password = "differentPassword"
-        }
-      }
-
-      akka.discovery.method = config
-      akka.discovery.config.services = {
-        couchbase-service = {
-          endpoints = [
-            { host = "akka.io" }
-          ]
-        }
-      }
-      // #discovery-settings
-     """)
-  )
+  implicit val actorSystem: ActorSystem = ActorSystem("DiscoverySpec", config)
   implicit val mat: Materializer = ActorMaterializer()
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(10.seconds, 250.millis)

--- a/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala
@@ -31,8 +31,8 @@ class DiscoverySpec extends WordSpec with Matchers with BeforeAndAfterAll with S
   "a Couchbasesession" should {
     "be managed by the registry" in {
       // #registry
-      import akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession
-      import akka.stream.alpakka.couchbase.{CouchbaseSessionRegistry, CouchbaseSessionSettings, DiscoverySupport}
+      import akka.stream.alpakka.couchbase.scaladsl.{CouchbaseSession, DiscoverySupport}
+      import akka.stream.alpakka.couchbase.{CouchbaseSessionRegistry, CouchbaseSessionSettings}
 
       val registry = CouchbaseSessionRegistry(actorSystem)
 
@@ -45,8 +45,8 @@ class DiscoverySpec extends WordSpec with Matchers with BeforeAndAfterAll with S
 
     "be created from settings" in {
       // #create
-      import akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession
-      import akka.stream.alpakka.couchbase.{CouchbaseSessionSettings, DiscoverySupport}
+      import akka.stream.alpakka.couchbase.scaladsl.{CouchbaseSession, DiscoverySupport}
+      import akka.stream.alpakka.couchbase.CouchbaseSessionSettings
 
       implicit val ec: ExecutionContext = actorSystem.dispatcher
       val sessionSettings = CouchbaseSessionSettings(actorSystem)

--- a/docs/src/main/paradox/couchbase.md
+++ b/docs/src/main/paradox/couchbase.md
@@ -49,7 +49,7 @@ Settings
 
 ## Using Akka Discovery
 
-To delegate the configuration of Couchbase nodes to any of [Akka Discovery's lookup mechanisms](https://doc.akka.io/docs/akka/current/discovery/index.html), specify a service name and lookup timeout in the Couchbase section, and pass in @scaladoc[DiscoverySupport](akka.stream.alpakka.couchbase.DiscoverySupport$) nodes lookup to `enrichAsync` and configure Akka Discovery accordingly.
+To delegate the configuration of Couchbase nodes to any of [Akka Discovery's lookup mechanisms](https://doc.akka.io/docs/akka/current/discovery/index.html), specify a service name and lookup timeout in the Couchbase section, and pass in @scala[@scaladoc[DiscoverySupport](akka.stream.alpakka.couchbase.scaladsl.DiscoverySupport$)]@java[@scaladoc[DiscoverySupport](akka.stream.alpakka.couchbase.javadsl.DiscoverySupport)] nodes lookup to `enrichAsync` and configure Akka Discovery accordingly.
 
 **The Akka Discovery dependency has to be added explicitly**.
 

--- a/docs/src/main/paradox/couchbase.md
+++ b/docs/src/main/paradox/couchbase.md
@@ -38,7 +38,30 @@ Alpakka Couchbase offers both @ref:[Akka Streams APIs](#reading-from-couchbase-i
 * `CouchbaseSessionRegistry` (@scaladoc[API](akka.stream.alpakka.couchbase.CouchbaseSessionRegistry$)) is an Akka extension to keep track and share `CouchbaseSession`s within an `ActorSystem`
 * `CouchbaseSource` (@scala[@scaladoc[API](akka.stream.alpakka.couchbase.scaladsl.CouchbaseSource$)]@java[@scaladoc[API](akka.stream.alpakka.couchbase.javadsl.CouchbaseSource$)]), `CouchbaseFlow` (@scala[@scaladoc[API](akka.stream.alpakka.couchbase.scaladsl.CouchbaseFlow$)]@java[@scaladoc[API](akka.stream.alpakka.couchbase.javadsl.CouchbaseFlow$)]), and `CouchbaseSink` (@scala[@scaladoc[API](akka.stream.alpakka.couchbase.scaladsl.CouchbaseSink$)]@java[@scaladoc[API](akka.stream.alpakka.couchbase.javadsl.CouchbaseSink$)]) offer factory methods to create Akka Stream operators
 
+## Configuration
+
 All operations use the `CouchbaseSession` internally. A session is configured with `CouchbaseSessionSettings` (@scaladoc[API](akka.stream.alpakka.couchbase.CouchbaseSessionSettings$)) and a Couchbase bucket name. The Akka Stream factory methods create and access the corresponding session instance behind the scenes.
+
+By default the `CouchbaseSessionSettings` are read from the `alpakka.couchbase.session` section from the configuration eg. in your `application.conf`.
+
+Settings
+: @@snip [snip](/couchbase/src/test/resources/application.conf) { #settings }
+
+## Using Akka Discovery
+
+To defer the configuration of Couchbase nodes to any of [Akka Discovery's lookup mechanisms](https://doc.akka.io/docs/akka/current/discovery/index.html), specify a service name and lookup timeout in the Couchbase section and configure Akka Discovery accordingly.
+
+The Akka Discovery dependency has to be added explicitly.
+
+Discovery settings (Config discovery)
+: @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala) { #discovery-settings }
+
+
+To enable Akka Discovery on the `CouchbaseSessionSettings`, use `DiscoverySupport.nodes()` as enrichment function.
+
+Scala
+: @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala) { #registry }
+
 
 # Reading from Couchbase in Akka Streams
 

--- a/docs/src/main/paradox/couchbase.md
+++ b/docs/src/main/paradox/couchbase.md
@@ -49,9 +49,9 @@ Settings
 
 ## Using Akka Discovery
 
-To defer the configuration of Couchbase nodes to any of [Akka Discovery's lookup mechanisms](https://doc.akka.io/docs/akka/current/discovery/index.html), specify a service name and lookup timeout in the Couchbase section and configure Akka Discovery accordingly.
+To delegate the configuration of Couchbase nodes to any of [Akka Discovery's lookup mechanisms](https://doc.akka.io/docs/akka/current/discovery/index.html), specify a service name and lookup timeout in the Couchbase section, and pass in @scaladoc[DiscoverySupport](akka.stream.alpakka.couchbase.DiscoverySupport$) nodes lookup to `enrichAsync` and configure Akka Discovery accordingly.
 
-The Akka Discovery dependency has to be added explicitly.
+**The Akka Discovery dependency has to be added explicitly**.
 
 Discovery settings (Config discovery)
 : @@snip [snip](/couchbase/src/test/resources/discovery.conf) { #discovery-settings }

--- a/docs/src/main/paradox/couchbase.md
+++ b/docs/src/main/paradox/couchbase.md
@@ -54,13 +54,16 @@ To defer the configuration of Couchbase nodes to any of [Akka Discovery's lookup
 The Akka Discovery dependency has to be added explicitly.
 
 Discovery settings (Config discovery)
-: @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala) { #discovery-settings }
+: @@snip [snip](/couchbase/src/test/resources/discovery.conf) { #discovery-settings }
 
 
 To enable Akka Discovery on the `CouchbaseSessionSettings`, use `DiscoverySupport.nodes()` as enrichment function.
 
 Scala
 : @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala) { #registry }
+
+Java
+: @@snip [snip](/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java) { #registry }
 
 
 # Reading from Couchbase in Akka Streams

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,7 +83,8 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "com.couchbase.client" % "java-client" % CouchbaseVersion, // ApacheV2
         "io.reactivex" % "rxjava-reactive-streams" % "1.2.1", //ApacheV2
-        "com.typesafe.play" %% "play-json" % "2.7.4" % Test, // MIT like: http://www.slf4j.org/license.html
+        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion % Provided, // Apache V2
+        "com.typesafe.play" %% "play-json" % "2.7.4" % Test, // Apache V2
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion % Test // Apache V2
       )
   )


### PR DESCRIPTION
## Purpose

Add support for use of Akka Discovery to configure Couchbase nodes.

## Changes

* Add `enrichAsync` to `CouchbaseSessionSettings`
* Apply `enrichAsync` before using settings
* Test case with `DiscoverySupport` usage
* Documentation