### PR TITLE
S3: Empty exception issue #1589

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/S3Exception.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/S3Exception.scala
@@ -4,6 +4,8 @@
 
 package akka.stream.alpakka.s3
 
+import akka.http.scaladsl.model.StatusCode
+
 import scala.util.Try
 import scala.xml.{Elem, XML}
 
@@ -23,5 +25,14 @@ class S3Exception(val code: String, val message: String, val requestId: String, 
       )
     )
 
-  override def toString = s"${super.toString} (Code: $code, RequestID: $requestId, HostID: $hostId)"
+  def this(response: String, code: StatusCode) =
+    this(
+      Try(XML.loadString(response)).getOrElse(
+        <Error><Code>{code}</Code><Message>{response}</Message><RequestID>-</RequestID><HostID>-</HostID></Error>
+      )
+    )
+
+  override def toString: String =
+    s"${super.toString} (Code: $code, RequestID: $requestId, HostID: $hostId)"
+
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -180,10 +180,10 @@ import akka.util.ByteString
             }
           case HttpResponse(NotFound, _, entity, _) =>
             Source.fromFuture(entity.discardBytes().future().map(_ => None))
-          case HttpResponse(_, _, entity, _) =>
+          case HttpResponse(code, _, entity, _) =>
             Source.fromFuture {
               Unmarshal(entity).to[String].map { err =>
-                throw new S3Exception(err)
+                throw new S3Exception(err, code)
               }
             }
         }
@@ -197,10 +197,10 @@ import akka.util.ByteString
         request(s3Location, HttpMethods.DELETE, versionId = versionId).flatMapConcat {
           case HttpResponse(NoContent, _, entity, _) =>
             Source.fromFuture(entity.discardBytes().future().map(_ => Done))
-          case HttpResponse(_, _, entity, _) =>
+          case HttpResponse(code, _, entity, _) =>
             Source.fromFuture {
               Unmarshal(entity).to[String].map { err =>
-                throw new S3Exception(err)
+                throw new S3Exception(err, code)
               }
             }
         }
@@ -240,10 +240,10 @@ import akka.util.ByteString
                   ObjectMetadata(h :+ `Content-Length`(entity.contentLengthOption.getOrElse(0)))
                 }
               }
-            case HttpResponse(_, _, entity, _) =>
+            case HttpResponse(code, _, entity, _) =>
               Source.fromFuture {
                 Unmarshal(entity).to[String].map { err =>
-                  throw new S3Exception(err)
+                  throw new S3Exception(err, code)
                 }
               }
           }
@@ -331,9 +331,9 @@ import akka.util.ByteString
     response match {
       case HttpResponse(status, _, entity, _) if status.isSuccess() =>
         entity.discardBytes().future()
-      case HttpResponse(_, _, entity, _) =>
+      case HttpResponse(code, _, entity, _) =>
         Unmarshal(entity).to[String].map { err =>
-          throw new S3Exception(err)
+          throw new S3Exception(err, code)
         }
     }
   }
@@ -357,9 +357,9 @@ import akka.util.ByteString
                 case other => throw new IllegalArgumentException(s"received status $other")
               }
           )
-      case HttpResponse(_, _, entity, _) =>
+      case HttpResponse(code, _, entity, _) =>
         Unmarshal(entity).to[String].map { err =>
-          throw new S3Exception(err)
+          throw new S3Exception(err, code)
         }
     }
   }
@@ -391,10 +391,10 @@ import akka.util.ByteString
         signAndRequest(req).flatMapConcat {
           case HttpResponse(status, _, entity, _) if status.isSuccess() =>
             Source.fromFuture(Unmarshal(entity).to[MultipartUpload])
-          case HttpResponse(_, _, entity, _) =>
+          case HttpResponse(code, _, entity, _) =>
             Source.fromFuture {
               Unmarshal(entity).to[String].map { err =>
-                throw new S3Exception(err)
+                throw new S3Exception(err, code)
               }
             }
         }
@@ -685,9 +685,9 @@ import akka.util.ByteString
     resp match {
       case HttpResponse(status, headers, entity, _) if status.isSuccess() && !status.isRedirection() =>
         Future.successful((entity, headers))
-      case HttpResponse(_, _, entity, _) =>
+      case HttpResponse(code, _, entity, _) =>
         Unmarshal(entity).to[String].map { err =>
-          throw new S3Exception(err)
+          throw new S3Exception(err, code)
         }
     }
   }
@@ -761,7 +761,7 @@ import akka.util.ByteString
               case statusCode: StatusCode =>
                 Unmarshal(entity).to[String].map { err =>
                   val response = Option(err).getOrElse(s"Failed to upload part into S3, status code was: $statusCode")
-                  throw new S3Exception(response)
+                  throw new S3Exception(response, statusCode)
                 }
             }
 


### PR DESCRIPTION
## Purpose
Right now, when alpakka receives an empty message it throws S3Exception but doesn't include any clue for the user on how to fix it. As all communication with S3 is just standard Http alpakka has the response code but ignores it before calling S3Exception's constructor.

Purpose of this PR is to include more information in exception message
## References

References #1589

## Changes
Added a response code to exception's constructor to later be displayed for the user.
