### PR TITLE
Elasticsearch: use proper FlowWithContext

### DIFF
--- a/elasticsearch/src/main/mima-filters/1.0.2.backwards.excludes
+++ b/elasticsearch/src/main/mima-filters/1.0.2.backwards.excludes
@@ -1,0 +1,3 @@
+# PR #1766 use proper FlowWithContext
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.alpakka.elasticsearch.javadsl.ElasticsearchFlow.createWithContext")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.alpakka.elasticsearch.scaladsl.ElasticsearchFlow.createWithContext")


### PR DESCRIPTION
## Purpose

Replace the raw tuple-based "with context" implementation with the new types from Akka 2.5.23.

## References

See #1713