### PR TITLE
Nitpick: lower-case connector

### DIFF
--- a/docs/src/main/paradox/awslambda.md
+++ b/docs/src/main/paradox/awslambda.md
@@ -1,6 +1,6 @@
 # AWS Lambda
 
-The AWS Lambda Connector provides Akka Flow for AWS Lambda integration.
+The AWS Lambda connector provides Akka Flow for AWS Lambda integration.
 
 For more information about AWS Lambda please visit the [AWS lambda documentation](https://aws.amazon.com/documentation/lambda/).
 

--- a/docs/src/main/paradox/other-docs/webinars-presentations-articles.md
+++ b/docs/src/main/paradox/other-docs/webinars-presentations-articles.md
@@ -32,7 +32,7 @@ blog by Sidharth Khattri, May 2018
 
 [Alpakka (Akka Streams) vs Apache Camel: who wins?](http://www.thedevpiece.com/alpakka-akka-streams-vs-apache-camel-who-wins/) Blog by Gabriel Francisco, May 2018 
 
-[Alpakka – a new world of Connectors for Reactive Enterprise Integration](https://www.youtube.com/watch?v=EcNZ2mJZmCk)
+[Alpakka – a new world of connectors for Reactive Enterprise Integration](https://www.youtube.com/watch?v=EcNZ2mJZmCk)
 presentation by Jan Pustelnik, Actyx, ReactSphere Kraków, April 2018
 
 [Revitalizing Enterprise Integration with Reactive Streams](https://info.lightbend.com/webinar-revitalizing-enterprise-integration-with-reactive-streams-recording.html)
@@ -49,7 +49,7 @@ Presentation by Colin Breck, Tesla, February 2018
 [Build Real-Time Streaming ETL Pipelines with Akka Streams, Alpakka and Apache Kafka](https://www.lightbend.com/blog/build-real-time-streaming-etl-pipelines-with-akka-streams-alpakka-and-apache-kafka)
 Webinar by Konrad Malawski, Lightbend, October 2017
 
-[Alpakka File CSV and ElasticSearch Connectors](https://abhsrivastava.github.io/2017/10/02/Alpkka-File-CSV-Elastic/)
+[Alpakka File CSV and ElasticSearch connectors](https://abhsrivastava.github.io/2017/10/02/Alpkka-File-CSV-Elastic/)
 blog by Abhishek Srivastava, October 2017
 
 [Stream Avro Records into Kafka using Avro4s and Akka Streams Kafka](https://abhsrivastava.github.io/2017/10/02/Stream-Avro-Records-into-Kafka/)

--- a/docs/src/main/paradox/release-notes/1.0-M2.md
+++ b/docs/src/main/paradox/release-notes/1.0-M2.md
@@ -14,12 +14,12 @@ Everything done in this release is [in the milestone](https://github.com/akka/al
 
 ## Highlights in this release
 
-* new Akka Stream native @ref:[MQTT Streaming Connector](../mqtt-streaming.md) thanks to [@huntc](https://github.com/huntc), the existing Eclipse Paho-based connector will stay around for a while but might be discontinued in the future
-* new @ref:[Couchbase Connector](../couchbase.md) which even is the base for the new [Akka Persistence Couchbase](https://doc.akka.io/docs/akka-persistence-couchbase/current/), thanks to [@dannylesnik](https://github.com/dannylesnik) 
-* refactoring of the @ref:[S3 Connector](../s3.md). See below for more details
-* refactoring of the @ref:[JMS Connector](../jms/index.md).
+* new Akka Stream native @ref:[MQTT Streaming connector](../mqtt-streaming.md) thanks to [@huntc](https://github.com/huntc), the existing Eclipse Paho-based connector will stay around for a while but might be discontinued in the future
+* new @ref:[Couchbase connector](../couchbase.md) which even is the base for the new [Akka Persistence Couchbase](https://doc.akka.io/docs/akka-persistence-couchbase/current/), thanks to [@dannylesnik](https://github.com/dannylesnik) 
+* refactoring of the @ref:[S3 connector](../s3.md). See below for more details
+* refactoring of the @ref:[JMS connector](../jms/index.md).
   Also support for retries and connection status thanks to [@andreas-schroeder](https://github.com/andreas-schroeder)
-* refactoring of the @ref:[Google Cloud Pub/Sub Connector](../google-cloud-pub-sub.md) thanks to [@tg44](https://github.com/tg44)
+* refactoring of the @ref:[Google Cloud Pub/Sub connector](../google-cloud-pub-sub.md) thanks to [@tg44](https://github.com/tg44)
 
 
 ## Changes per module


### PR DESCRIPTION
It has been pointed out that we used to have an inconsistent spelling of "connector". This changes the last remainders.