### PR TITLE
FTP: enable Scala 2.13 and 2.12.9 compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ jobs:
     - env: CMD="++2.11.12 Test/compile"
       name: "Compile all code with Scala 2.11"
       if: type != cron
-    - env: CMD="++2.12.7 Test/compile"
-      name: "Compile all code with Scala 2.12 and fatal warnings enabled. Run locally with: env CI=true sbt ++2.12.7 Test/compile"
+    - env: CMD="++2.12.9 Test/compile"
+      name: "Compile all code with Scala 2.12 and fatal warnings enabled. Run locally with: env CI=true sbt ++2.12.9 Test/compile"
     - env: CMD="++2.13.0 Test/compile"
       name: "Compile all code with Scala 2.13"
     - env: CMD="unidoc"
@@ -144,8 +144,8 @@ jobs:
     - stage: publish
       env: CMD="++2.11.12 publish"
       name: "Publish artifacts for Scala 2.11.12"
-    - env: CMD="++2.12.7 publish"
-      name: "Publish artifacts for Scala 2.12.7"
+    - env: CMD="++2.12.9 publish"
+      name: "Publish artifacts for Scala 2.12.9"
     - env: CMD="++2.13.0 publish"
       name: "Publish artifacts for Scala 2.13.0"
     - script: openssl aes-256-cbc -K $encrypted_bbf1dc4f2a07_key -iv $encrypted_bbf1dc4f2a07_iv -in .travis/travis_alpakka_rsa.enc -out .travis/id_rsa -d && eval "$(ssh-agent -s)" && chmod 600 .travis/id_rsa && ssh-add .travis/id_rsa && sbt -jvm-opts .jvmopts-travis docs/publishRsync

--- a/build.sbt
+++ b/build.sbt
@@ -127,8 +127,7 @@ lazy val ftp = alpakkaProject(
   parallelExecution in Test := false,
   fork in Test := true,
   // To avoid potential blocking in machines with low entropy (default is `/dev/random`)
-  javaOptions in Test += "-Djava.security.egd=file:/dev/./urandom",
-  crossScalaVersions -= Dependencies.Scala213 // https://github.com/akka/alpakka/issues/1532
+  javaOptions in Test += "-Djava.security.egd=file:/dev/./urandom"
 )
 
 lazy val geode =

--- a/ftp/src/main/mima-filters/1.1.x.backwards.excludes
+++ b/ftp/src/main/mima-filters/1.1.x.backwards.excludes
@@ -1,2 +1,8 @@
 # Allow changes to impl
 ProblemFilters.exclude[Problem]("akka.stream.alpakka.ftp.impl.*")
+
+
+ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.stream.alpakka.ftp.javadsl.FtpApi.*")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.ftp.javadsl.FtpApi.ftpLike")
+ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.stream.alpakka.ftp.scaladsl.FtpApi.*")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.ftp.scaladsl.FtpApi.ftpLike")

--- a/ftp/src/main/mima-filters/1.1.x.backwards.excludes
+++ b/ftp/src/main/mima-filters/1.1.x.backwards.excludes
@@ -1,7 +1,4 @@
-# Allow changes to impl
-ProblemFilters.exclude[Problem]("akka.stream.alpakka.ftp.impl.*")
-
-
+# Restructure to enable compilation with Scala 2.12.8+ PR #1779
 ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.stream.alpakka.ftp.javadsl.FtpApi.*")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.ftp.javadsl.FtpApi.ftpLike")
 ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.stream.alpakka.ftp.scaladsl.FtpApi.*")

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
@@ -48,17 +48,17 @@ private[ftp] trait CommonFtpOperations {
 
   private def getPosixFilePermissions(file: FTPFile) =
     Map(
-      PosixFilePermission.OWNER_READ → file.hasPermission(FTPFile.USER_ACCESS, FTPFile.READ_PERMISSION),
-      PosixFilePermission.OWNER_WRITE → file.hasPermission(FTPFile.USER_ACCESS, FTPFile.WRITE_PERMISSION),
-      PosixFilePermission.OWNER_EXECUTE → file.hasPermission(FTPFile.USER_ACCESS, FTPFile.EXECUTE_PERMISSION),
-      PosixFilePermission.GROUP_READ → file.hasPermission(FTPFile.GROUP_ACCESS, FTPFile.READ_PERMISSION),
-      PosixFilePermission.GROUP_WRITE → file.hasPermission(FTPFile.GROUP_ACCESS, FTPFile.WRITE_PERMISSION),
-      PosixFilePermission.GROUP_EXECUTE → file.hasPermission(FTPFile.GROUP_ACCESS, FTPFile.EXECUTE_PERMISSION),
-      PosixFilePermission.OTHERS_READ → file.hasPermission(FTPFile.WORLD_ACCESS, FTPFile.READ_PERMISSION),
-      PosixFilePermission.OTHERS_WRITE → file.hasPermission(FTPFile.WORLD_ACCESS, FTPFile.WRITE_PERMISSION),
-      PosixFilePermission.OTHERS_EXECUTE → file.hasPermission(FTPFile.WORLD_ACCESS, FTPFile.EXECUTE_PERMISSION)
+      PosixFilePermission.OWNER_READ -> file.hasPermission(FTPFile.USER_ACCESS, FTPFile.READ_PERMISSION),
+      PosixFilePermission.OWNER_WRITE -> file.hasPermission(FTPFile.USER_ACCESS, FTPFile.WRITE_PERMISSION),
+      PosixFilePermission.OWNER_EXECUTE -> file.hasPermission(FTPFile.USER_ACCESS, FTPFile.EXECUTE_PERMISSION),
+      PosixFilePermission.GROUP_READ -> file.hasPermission(FTPFile.GROUP_ACCESS, FTPFile.READ_PERMISSION),
+      PosixFilePermission.GROUP_WRITE -> file.hasPermission(FTPFile.GROUP_ACCESS, FTPFile.WRITE_PERMISSION),
+      PosixFilePermission.GROUP_EXECUTE -> file.hasPermission(FTPFile.GROUP_ACCESS, FTPFile.EXECUTE_PERMISSION),
+      PosixFilePermission.OTHERS_READ -> file.hasPermission(FTPFile.WORLD_ACCESS, FTPFile.READ_PERMISSION),
+      PosixFilePermission.OTHERS_WRITE -> file.hasPermission(FTPFile.WORLD_ACCESS, FTPFile.WRITE_PERMISSION),
+      PosixFilePermission.OTHERS_EXECUTE -> file.hasPermission(FTPFile.WORLD_ACCESS, FTPFile.EXECUTE_PERMISSION)
     ).collect {
-      case (perm, true) ⇒ perm
+      case (perm, true) => perm
     }.toSet
 
   def listFiles(handler: Handler): immutable.Seq[FtpFile] = listFiles("", handler)

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpIOGraphStage.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpIOGraphStage.scala
@@ -178,7 +178,7 @@ private[ftp] trait FtpIOSinkStage[FtpClient, S <: RemoteFileSettings]
               write(grab(in))
               pull(in)
             } catch {
-              case NonFatal(e) ⇒
+              case NonFatal(e) =>
                 failed = true
                 matFailure(e)
                 failStage(e)

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
@@ -16,9 +16,7 @@ import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
  * INTERNAL API
  */
 @InternalApi
-private[ftp] trait FtpSourceFactory[FtpClient] { self =>
-
-  type S <: RemoteFileSettings
+private[ftp] trait FtpSourceFactory[FtpClient, S <: RemoteFileSettings] { self =>
 
   protected[this] final val DefaultChunkSize = 8192
 
@@ -140,7 +138,7 @@ private[ftp] trait FtpSourceFactory[FtpClient] { self =>
  * INTERNAL API
  */
 @InternalApi
-private[ftp] trait FtpSource extends FtpSourceFactory[FTPClient] {
+private[ftp] trait FtpSource extends FtpSourceFactory[FTPClient, FtpSettings] {
   protected final val FtpBrowserSourceName = "FtpBrowserSource"
   protected final val FtpIOSourceName = "FtpIOSource"
   protected final val FtpDirectorySource = "FtpDirectorySource"
@@ -157,7 +155,7 @@ private[ftp] trait FtpSource extends FtpSourceFactory[FTPClient] {
  * INTERNAL API
  */
 @InternalApi
-private[ftp] trait FtpsSource extends FtpSourceFactory[FTPSClient] {
+private[ftp] trait FtpsSource extends FtpSourceFactory[FTPSClient, FtpsSettings] {
   protected final val FtpsBrowserSourceName = "FtpsBrowserSource"
   protected final val FtpsIOSourceName = "FtpsIOSource"
   protected final val FtpsDirectorySource = "FtpsDirectorySource"
@@ -174,7 +172,7 @@ private[ftp] trait FtpsSource extends FtpSourceFactory[FTPSClient] {
  * INTERNAL API
  */
 @InternalApi
-private[ftp] trait SftpSource extends FtpSourceFactory[SSHClient] {
+private[ftp] trait SftpSource extends FtpSourceFactory[SSHClient, SftpSettings] {
   protected final val sFtpBrowserSourceName = "sFtpBrowserSource"
   protected final val sFtpIOSourceName = "sFtpIOSource"
   protected final val sFtpDirectorySource = "sFtpDirectorySource"
@@ -195,8 +193,8 @@ private[ftp] trait SftpSource extends FtpSourceFactory[SSHClient] {
 private[ftp] trait FtpDefaultSettings {
   protected def defaultSettings(
       hostname: String,
-      username: Option[String],
-      password: Option[String]
+      username: Option[String] = None,
+      password: Option[String] = None
   ): FtpSettings =
     FtpSettings(
       InetAddress.getByName(hostname)
@@ -215,8 +213,8 @@ private[ftp] trait FtpDefaultSettings {
 private[ftp] trait FtpsDefaultSettings {
   protected def defaultSettings(
       hostname: String,
-      username: Option[String],
-      password: Option[String]
+      username: Option[String] = None,
+      password: Option[String] = None
   ): FtpsSettings =
     FtpsSettings(
       InetAddress.getByName(hostname)
@@ -235,8 +233,8 @@ private[ftp] trait FtpsDefaultSettings {
 private[ftp] trait SftpDefaultSettings {
   protected def defaultSettings(
       hostname: String,
-      username: Option[String],
-      password: Option[String]
+      username: Option[String] = None,
+      password: Option[String] = None
   ): SftpSettings =
     SftpSettings(
       InetAddress.getByName(hostname)

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -294,7 +294,7 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
     import scala.compat.java8.FutureConverters._
     ScalaSink
       .fromGraph(createMoveSink(destinationPath.asScala, connectionSettings))
-      .mapMaterializedValue(_.toJava)
+      .mapMaterializedValue[CompletionStage[IOResult]](_.toJava)
       .asJava
   }
 

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -4,14 +4,15 @@
 
 package akka.stream.alpakka.ftp.javadsl
 
-import java.util.concurrent.CompletionStage
-import java.util.function._
-
-import akka.stream.alpakka.ftp.impl.{FtpLike, FtpSourceFactory, _}
-import akka.stream.alpakka.ftp.{FtpFile, RemoteFileSettings}
-import akka.stream.javadsl.{Sink, Source}
-import akka.stream.scaladsl.{Sink => ScalaSink, Source => ScalaSource}
-import akka.stream.{IOResult, Materializer}
+import akka.NotUsed
+import akka.stream.alpakka.ftp.impl._
+import akka.stream.alpakka.ftp.{FtpFile, FtpSettings, FtpsSettings, RemoteFileSettings, SftpSettings}
+import akka.stream.alpakka.ftp.impl.{FtpLike, FtpSourceFactory}
+import akka.stream.IOResult
+import akka.stream.javadsl.Source
+import akka.stream.javadsl.Sink
+import akka.stream.scaladsl.{Source => ScalaSource}
+import akka.stream.scaladsl.{Sink => ScalaSink}
 import akka.util.ByteString
 import akka.{Done, NotUsed}
 import net.schmizz.sshj.SSHClient
@@ -19,12 +20,7 @@ import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
 
 import scala.compat.java8.FunctionConverters._
 
-sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
-
-  /**
-   * The refined [[RemoteFileSettings]] type.
-   */
-  type S <: RemoteFileSettings
+sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[FtpClient, S] =>
 
   /**
    * Java API: creates a [[akka.stream.javadsl.Source Source]] of [[FtpFile]]s from the remote user `root` directory.
@@ -311,9 +307,10 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
 
   protected[this] implicit def ftpLike: FtpLike[FtpClient, S]
 }
-class SftpApi extends FtpApi[SSHClient] with SftpSourceParams
-object Ftp extends FtpApi[FTPClient] with FtpSourceParams
-object Ftps extends FtpApi[FTPSClient] with FtpsSourceParams
+object Ftp extends FtpApi[FTPClient, FtpSettings] with FtpSourceParams
+object Ftps extends FtpApi[FTPSClient, FtpsSettings] with FtpsSourceParams
+
+class SftpApi extends FtpApi[SSHClient, SftpSettings] with SftpSourceParams
 object Sftp extends SftpApi {
 
   /**

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -7,6 +7,7 @@ package akka.stream.alpakka.ftp.javadsl
 import java.util.concurrent.CompletionStage
 import java.util.function._
 
+import akka.annotation.DoNotInherit
 import akka.stream.alpakka.ftp._
 import akka.stream.alpakka.ftp.impl._
 import akka.stream.javadsl.{Sink, Source}
@@ -18,6 +19,7 @@ import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
 
 import scala.compat.java8.FunctionConverters._
 
+@DoNotInherit
 sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[FtpClient, S] =>
 
   /**
@@ -255,6 +257,11 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
    * @return A [[akka.stream.javadsl.Sink Sink]] of [[FtpFile]] that materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[IOResult]]
    */
   def remove(connectionSettings: S): Sink[FtpFile, CompletionStage[IOResult]]
+
+  protected[javadsl] def func[T, R](f: T => R): akka.japi.function.Function[T, R] =
+    new akka.japi.function.Function[T, R] {
+      override def apply(param: T): R = f(param)
+    }
 }
 
 object Ftp extends FtpApi[FTPClient, FtpSettings] with FtpSourceParams {
@@ -313,18 +320,18 @@ object Ftp extends FtpApi[FTPClient, FtpSettings] with FtpSourceParams {
     import scala.compat.java8.FutureConverters._
     Source
       .fromGraph(createIOSource(path, connectionSettings, chunkSize, offset))
-      .mapMaterializedValue(_.toJava)
+      .mapMaterializedValue(func(_.toJava))
   }
 
   def mkdir(basePath: String, name: String, connectionSettings: S): Source[Done, NotUsed] =
-    Source.fromGraph(createMkdirGraph(basePath, name, connectionSettings)).map(_ => Done)
+    Source.fromGraph(createMkdirGraph(basePath, name, connectionSettings)).map(func(_ => Done))
 
   def mkdirAsync(basePath: String, name: String, connectionSettings: S, mat: Materializer): CompletionStage[Done] =
     mkdir(basePath, name, connectionSettings).runWith(Sink.head(), mat)
 
   def toPath(path: String, connectionSettings: S, append: Boolean): Sink[ByteString, CompletionStage[IOResult]] = {
     import scala.compat.java8.FutureConverters._
-    Sink.fromGraph(createIOSink(path, connectionSettings, append)).mapMaterializedValue(_.toJava)
+    Sink.fromGraph(createIOSink(path, connectionSettings, append)).mapMaterializedValue(func(_.toJava))
   }
 
   def toPath(path: String, connectionSettings: S): Sink[ByteString, CompletionStage[IOResult]] =
@@ -336,12 +343,12 @@ object Ftp extends FtpApi[FTPClient, FtpSettings] with FtpSourceParams {
     import scala.compat.java8.FutureConverters._
     Sink
       .fromGraph(createMoveSink(destinationPath.asScala, connectionSettings))
-      .mapMaterializedValue[CompletionStage[IOResult]](_.toJava)
+      .mapMaterializedValue[CompletionStage[IOResult]](func(_.toJava))
   }
 
   def remove(connectionSettings: S): Sink[FtpFile, CompletionStage[IOResult]] = {
     import scala.compat.java8.FutureConverters._
-    Sink.fromGraph(createRemoveSink(connectionSettings)).mapMaterializedValue(_.toJava)
+    Sink.fromGraph(createRemoveSink(connectionSettings)).mapMaterializedValue(func(_.toJava))
   }
 
 }
@@ -401,18 +408,18 @@ object Ftps extends FtpApi[FTPSClient, FtpsSettings] with FtpsSourceParams {
     import scala.compat.java8.FutureConverters._
     Source
       .fromGraph(createIOSource(path, connectionSettings, chunkSize, offset))
-      .mapMaterializedValue(_.toJava)
+      .mapMaterializedValue(func(_.toJava))
   }
 
   def mkdir(basePath: String, name: String, connectionSettings: S): Source[Done, NotUsed] =
-    Source.fromGraph(createMkdirGraph(basePath, name, connectionSettings)).map(_ => Done)
+    Source.fromGraph(createMkdirGraph(basePath, name, connectionSettings)).map(func(_ => Done))
 
   def mkdirAsync(basePath: String, name: String, connectionSettings: S, mat: Materializer): CompletionStage[Done] =
     mkdir(basePath, name, connectionSettings).runWith(Sink.head(), mat)
 
   def toPath(path: String, connectionSettings: S, append: Boolean): Sink[ByteString, CompletionStage[IOResult]] = {
     import scala.compat.java8.FutureConverters._
-    Sink.fromGraph(createIOSink(path, connectionSettings, append)).mapMaterializedValue(_.toJava)
+    Sink.fromGraph(createIOSink(path, connectionSettings, append)).mapMaterializedValue(func(_.toJava))
   }
 
   def toPath(path: String, connectionSettings: S): Sink[ByteString, CompletionStage[IOResult]] =
@@ -424,12 +431,12 @@ object Ftps extends FtpApi[FTPSClient, FtpsSettings] with FtpsSourceParams {
     import scala.compat.java8.FutureConverters._
     Sink
       .fromGraph(createMoveSink(destinationPath.asScala, connectionSettings))
-      .mapMaterializedValue[CompletionStage[IOResult]](_.toJava)
+      .mapMaterializedValue(func(_.toJava))
   }
 
   def remove(connectionSettings: S): Sink[FtpFile, CompletionStage[IOResult]] = {
     import scala.compat.java8.FutureConverters._
-    Sink.fromGraph(createRemoveSink(connectionSettings)).mapMaterializedValue(_.toJava)
+    Sink.fromGraph(createRemoveSink(connectionSettings)).mapMaterializedValue(func(_.toJava))
   }
 
 }
@@ -490,18 +497,18 @@ class SftpApi extends FtpApi[SSHClient, SftpSettings] with SftpSourceParams {
     import scala.compat.java8.FutureConverters._
     Source
       .fromGraph(createIOSource(path, connectionSettings, chunkSize, offset))
-      .mapMaterializedValue(_.toJava)
+      .mapMaterializedValue(func(_.toJava))
   }
 
   def mkdir(basePath: String, name: String, connectionSettings: S): Source[Done, NotUsed] =
-    Source.fromGraph(createMkdirGraph(basePath, name, connectionSettings)).map(_ => Done)
+    Source.fromGraph(createMkdirGraph(basePath, name, connectionSettings)).map(func(_ => Done))
 
   def mkdirAsync(basePath: String, name: String, connectionSettings: S, mat: Materializer): CompletionStage[Done] =
     mkdir(basePath, name, connectionSettings).runWith(Sink.head(), mat)
 
   def toPath(path: String, connectionSettings: S, append: Boolean): Sink[ByteString, CompletionStage[IOResult]] = {
     import scala.compat.java8.FutureConverters._
-    Sink.fromGraph(createIOSink(path, connectionSettings, append)).mapMaterializedValue(_.toJava)
+    Sink.fromGraph(createIOSink(path, connectionSettings, append)).mapMaterializedValue(func(_.toJava))
   }
 
   def toPath(path: String, connectionSettings: S): Sink[ByteString, CompletionStage[IOResult]] =
@@ -513,12 +520,12 @@ class SftpApi extends FtpApi[SSHClient, SftpSettings] with SftpSourceParams {
     import scala.compat.java8.FutureConverters._
     Sink
       .fromGraph(createMoveSink(destinationPath.asScala, connectionSettings))
-      .mapMaterializedValue[CompletionStage[IOResult]](_.toJava)
+      .mapMaterializedValue(func(_.toJava))
   }
 
   def remove(connectionSettings: S): Sink[FtpFile, CompletionStage[IOResult]] = {
     import scala.compat.java8.FutureConverters._
-    Sink.fromGraph(createRemoveSink(connectionSettings)).mapMaterializedValue(_.toJava)
+    Sink.fromGraph(createRemoveSink(connectionSettings)).mapMaterializedValue(func(_.toJava))
   }
 
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.ftp
 import java.net.InetAddress
 import java.nio.file.attribute.PosixFilePermission
 
-import akka.annotation.InternalApi
+import akka.annotation.{DoNotInherit, InternalApi}
 import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
 
 /**
@@ -35,6 +35,7 @@ final case class FtpFile(
 /**
  * Common remote file settings.
  */
+@DoNotInherit
 sealed abstract class RemoteFileSettings {
   def host: InetAddress
   def port: Int
@@ -44,6 +45,7 @@ sealed abstract class RemoteFileSettings {
 /**
  * Common settings for FTP and FTPs.
  */
+@DoNotInherit
 sealed abstract class FtpFileSettings extends RemoteFileSettings {
   def binary: Boolean // BINARY or ASCII (default)
   def passiveMode: Boolean

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -4,6 +4,7 @@
 
 package akka.stream.alpakka.ftp.scaladsl
 
+import akka.annotation.DoNotInherit
 import akka.stream.alpakka.ftp.impl.{FtpSourceFactory, FtpSourceParams, FtpsSourceParams, SftpSourceParams}
 import akka.stream.alpakka.ftp._
 import akka.stream.scaladsl.{Sink, Source}
@@ -15,6 +16,7 @@ import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
 
 import scala.concurrent.Future
 
+@DoNotInherit
 sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[FtpClient, S] =>
 
   /**

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.ftp.scaladsl
 import akka.{Done, NotUsed}
 import akka.stream.{IOResult, Materializer}
 import akka.stream.alpakka.ftp.impl._
-import akka.stream.alpakka.ftp.{FtpFile, RemoteFileSettings}
+import akka.stream.alpakka.ftp.{FtpFile, FtpSettings, FtpsSettings, RemoteFileSettings, SftpSettings}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import net.schmizz.sshj.SSHClient
@@ -15,12 +15,7 @@ import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
 
 import scala.concurrent.Future
 
-sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
-
-  /**
-   * The refined [[RemoteFileSettings]] type.
-   */
-  type S <: RemoteFileSettings
+sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[FtpClient, S] =>
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s from the remote user `root` directory.
@@ -229,10 +224,10 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
   protected[this] implicit def ftpLike: FtpLike[FtpClient, S]
 }
 
-class SftpApi extends FtpApi[SSHClient] with SftpSourceParams
-object Ftp extends FtpApi[FTPClient] with FtpSourceParams
-object Ftps extends FtpApi[FTPSClient] with FtpsSourceParams
+object Ftp extends FtpApi[FTPClient, FtpSettings] with FtpSourceParams
+object Ftps extends FtpApi[FTPSClient, FtpsSettings] with FtpsSourceParams
 
+class SftpApi extends FtpApi[SSHClient, SftpSettings] with SftpSourceParams
 object Sftp extends SftpApi {
 
   /**

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -4,16 +4,12 @@
 
 package akka.stream.alpakka.ftp.scaladsl
 
-import akka.NotUsed
-import akka.stream.IOResult
 import akka.stream.alpakka.ftp.impl.{FtpSourceFactory, FtpSourceParams, FtpsSourceParams, SftpSourceParams}
 import akka.stream.alpakka.ftp._
-import akka.{Done, NotUsed}
-import akka.stream.{IOResult, Materializer}
-import akka.stream.alpakka.ftp.impl._
-import akka.stream.alpakka.ftp.{FtpFile, FtpSettings, FtpsSettings, RemoteFileSettings, SftpSettings}
 import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.{IOResult, Materializer}
 import akka.util.ByteString
+import akka.{Done, NotUsed}
 import net.schmizz.sshj.SSHClient
 import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
 
@@ -109,24 +105,22 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
          emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed]
 
   /**
-   *  Scala API for creating a directory in a given path
+   * Scala API for creating a directory in a given path
    * @param basePath path to start with
    * @param name name of a directory to create
    * @param connectionSettings connection settings
    * @return [[akka.stream.scaladsl.Source Source]] of [[akka.Done]]
    */
-  def mkdir(basePath: String, name: String, connectionSettings: S): Source[Done, NotUsed] =
-    Source.fromGraph(createMkdirGraph(basePath, name, connectionSettings)).map(_ => Done)
+  def mkdir(basePath: String, name: String, connectionSettings: S): Source[Done, NotUsed]
 
   /**
-   *  Scala API for creating a directory in a given path
+   * Scala API for creating a directory in a given path
    * @param basePath path to start with
    * @param name name of a directory to create
    * @param connectionSettings connection settings
    * @return [[scala.concurrent.Future Future]] of [[akka.Done]] indicating a materialized, asynchronous request
    */
-  def mkdirAsync(basePath: String, name: String, connectionSettings: S)(implicit mat: Materializer): Future[Done] =
-    mkdir(basePath, name, connectionSettings).runWith(Sink.head)
+  def mkdirAsync(basePath: String, name: String, connectionSettings: S)(implicit mat: Materializer): Future[Done]
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[akka.util.ByteString ByteString]] from some file path.
@@ -223,7 +217,7 @@ object Ftp extends FtpApi[FTPClient, FtpSettings] with FtpSourceParams {
     ls(basePath, defaultSettings(host, Some(username), Some(password)))
 
   def ls(basePath: String, connectionSettings: S): Source[FtpFile, NotUsed] =
-    ls(basePath, connectionSettings, f => true)
+    ls(basePath, connectionSettings, _ => true)
 
   def ls(basePath: String, connectionSettings: S, branchSelector: FtpFile => Boolean): Source[FtpFile, NotUsed] =
     Source.fromGraph(
@@ -251,6 +245,12 @@ object Ftp extends FtpApi[FTPClient, FtpSettings] with FtpSourceParams {
                chunkSize: Int,
                offset: Long): Source[ByteString, Future[IOResult]] =
     Source.fromGraph(createIOSource(path, connectionSettings, chunkSize, offset))
+
+  def mkdir(basePath: String, name: String, connectionSettings: S): Source[Done, NotUsed] =
+    Source.fromGraph(createMkdirGraph(basePath, name, connectionSettings)).map(_ => Done)
+
+  def mkdirAsync(basePath: String, name: String, connectionSettings: S)(implicit mat: Materializer): Future[Done] =
+    mkdir(basePath, name, connectionSettings).runWith(Sink.head)
 
   def toPath(path: String, connectionSettings: S, append: Boolean = false): Sink[ByteString, Future[IOResult]] =
     Sink.fromGraph(createIOSink(path, connectionSettings, append))
@@ -275,7 +275,7 @@ object Ftps extends FtpApi[FTPSClient, FtpsSettings] with FtpsSourceParams {
     ls(basePath, defaultSettings(host, Some(username), Some(password)))
 
   def ls(basePath: String, connectionSettings: S): Source[FtpFile, NotUsed] =
-    ls(basePath, connectionSettings, f => true)
+    ls(basePath, connectionSettings, _ => true)
 
   def ls(basePath: String, connectionSettings: S, branchSelector: FtpFile => Boolean): Source[FtpFile, NotUsed] =
     Source.fromGraph(
@@ -303,6 +303,12 @@ object Ftps extends FtpApi[FTPSClient, FtpsSettings] with FtpsSourceParams {
                chunkSize: Int,
                offset: Long): Source[ByteString, Future[IOResult]] =
     Source.fromGraph(createIOSource(path, connectionSettings, chunkSize, offset))
+
+  def mkdir(basePath: String, name: String, connectionSettings: S): Source[Done, NotUsed] =
+    Source.fromGraph(createMkdirGraph(basePath, name, connectionSettings)).map(_ => Done)
+
+  def mkdirAsync(basePath: String, name: String, connectionSettings: S)(implicit mat: Materializer): Future[Done] =
+    mkdir(basePath, name, connectionSettings).runWith(Sink.head)
 
   def toPath(path: String, connectionSettings: S, append: Boolean = false): Sink[ByteString, Future[IOResult]] =
     Sink.fromGraph(createIOSink(path, connectionSettings, append))
@@ -326,7 +332,7 @@ class SftpApi extends FtpApi[SSHClient, SftpSettings] with SftpSourceParams {
     ls(basePath, defaultSettings(host, Some(username), Some(password)))
 
   def ls(basePath: String, connectionSettings: S): Source[FtpFile, NotUsed] =
-    ls(basePath, connectionSettings, f => true)
+    ls(basePath, connectionSettings, _ => true)
 
   def ls(basePath: String, connectionSettings: S, branchSelector: FtpFile => Boolean): Source[FtpFile, NotUsed] =
     Source.fromGraph(
@@ -355,6 +361,12 @@ class SftpApi extends FtpApi[SSHClient, SftpSettings] with SftpSourceParams {
                offset: Long): Source[ByteString, Future[IOResult]] =
     Source.fromGraph(createIOSource(path, connectionSettings, chunkSize, offset))
 
+  def mkdir(basePath: String, name: String, connectionSettings: S): Source[Done, NotUsed] =
+    Source.fromGraph(createMkdirGraph(basePath, name, connectionSettings)).map(_ => Done)
+
+  def mkdirAsync(basePath: String, name: String, connectionSettings: S)(implicit mat: Materializer): Future[Done] =
+    mkdir(basePath, name, connectionSettings).runWith(Sink.head)
+
   def toPath(path: String, connectionSettings: S, append: Boolean = false): Sink[ByteString, Future[IOResult]] =
     Sink.fromGraph(createIOSink(path, connectionSettings, append))
 
@@ -375,6 +387,6 @@ object Sftp extends SftpApi {
    */
   def apply(customSshClient: SSHClient): SftpApi =
     new SftpApi {
-      override val sshClient = customSshClient
+      override val sshClient: SSHClient = customSshClient
     }
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -4,6 +4,10 @@
 
 package akka.stream.alpakka.ftp.scaladsl
 
+import akka.NotUsed
+import akka.stream.IOResult
+import akka.stream.alpakka.ftp.impl.{FtpSourceFactory, FtpSourceParams, FtpsSourceParams, SftpSourceParams}
+import akka.stream.alpakka.ftp._
 import akka.{Done, NotUsed}
 import akka.stream.{IOResult, Materializer}
 import akka.stream.alpakka.ftp.impl._
@@ -24,8 +28,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
    * @param host FTP, FTPs or SFTP host
    * @return A [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s
    */
-  def ls(host: String): Source[FtpFile, NotUsed] =
-    ls(host, basePath = "")
+  def ls(host: String): Source[FtpFile, NotUsed]
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s from a base path.
@@ -35,8 +38,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
    * @param basePath Base path from which traverse the remote file server
    * @return A [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s
    */
-  def ls(host: String, basePath: String): Source[FtpFile, NotUsed] =
-    ls(basePath, defaultSettings(host))
+  def ls(host: String, basePath: String): Source[FtpFile, NotUsed]
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s from the remote user `root` directory.
@@ -46,8 +48,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
    * @param password password
    * @return A [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s
    */
-  def ls(host: String, username: String, password: String): Source[FtpFile, NotUsed] =
-    ls("", defaultSettings(host, Some(username), Some(password)))
+  def ls(host: String, username: String, password: String): Source[FtpFile, NotUsed]
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s from a base path.
@@ -58,8 +59,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
    * @param basePath Base path from which traverse the remote file server
    * @return A [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s
    */
-  def ls(host: String, username: String, password: String, basePath: String): Source[FtpFile, NotUsed] =
-    ls(basePath, defaultSettings(host, Some(username), Some(password)))
+  def ls(host: String, username: String, password: String, basePath: String): Source[FtpFile, NotUsed]
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s from a base path.
@@ -68,8 +68,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
    * @param connectionSettings connection settings
    * @return A [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s
    */
-  def ls(basePath: String, connectionSettings: S): Source[FtpFile, NotUsed] =
-    ls(basePath, connectionSettings, f => true)
+  def ls(basePath: String, connectionSettings: S): Source[FtpFile, NotUsed]
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s from a base path.
@@ -86,10 +85,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
    *
    * @return A [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s
    */
-  def ls(basePath: String, connectionSettings: S, branchSelector: FtpFile => Boolean): Source[FtpFile, NotUsed] =
-    Source.fromGraph(
-      createBrowserGraph(basePath, connectionSettings, branchSelector, _emitTraversedDirectories = false)
-    )
+  def ls(basePath: String, connectionSettings: S, branchSelector: FtpFile => Boolean): Source[FtpFile, NotUsed]
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s from a base path.
@@ -110,8 +106,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
   def ls(basePath: String,
          connectionSettings: S,
          branchSelector: FtpFile => Boolean,
-         emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
-    Source.fromGraph(createBrowserGraph(basePath, connectionSettings, branchSelector, emitTraversedDirectories))
+         emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed]
 
   /**
    *  Scala API for creating a directory in a given path
@@ -140,8 +135,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
    * @param path the file path
    * @return A [[akka.stream.scaladsl.Source Source]] of [[akka.util.ByteString ByteString]] that materializes to a [[scala.concurrent.Future Future]] of [[IOResult]]
    */
-  def fromPath(host: String, path: String): Source[ByteString, Future[IOResult]] =
-    fromPath(path, defaultSettings(host))
+  def fromPath(host: String, path: String): Source[ByteString, Future[IOResult]]
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[akka.util.ByteString ByteString]] from some file path.
@@ -152,8 +146,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
    * @param path the file path
    * @return A [[akka.stream.scaladsl.Source Source]] of [[akka.util.ByteString ByteString]] that materializes to a [[scala.concurrent.Future Future]] of [[IOResult]]
    */
-  def fromPath(host: String, username: String, password: String, path: String): Source[ByteString, Future[IOResult]] =
-    fromPath(path, defaultSettings(host, Some(username), Some(password)))
+  def fromPath(host: String, username: String, password: String, path: String): Source[ByteString, Future[IOResult]]
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[akka.util.ByteString ByteString]] from some file path.
@@ -167,8 +160,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
       path: String,
       connectionSettings: S,
       chunkSize: Int = DefaultChunkSize
-  ): Source[ByteString, Future[IOResult]] =
-    fromPath(path, connectionSettings, chunkSize, 0L)
+  ): Source[ByteString, Future[IOResult]]
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[akka.util.ByteString ByteString]] from some file path.
@@ -184,8 +176,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
       connectionSettings: S,
       chunkSize: Int,
       offset: Long
-  ): Source[ByteString, Future[IOResult]] =
-    Source.fromGraph(createIOSource(path, connectionSettings, chunkSize, offset))
+  ): Source[ByteString, Future[IOResult]]
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Sink Sink]] of [[akka.util.ByteString ByteString]] to some file path.
@@ -199,8 +190,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
       path: String,
       connectionSettings: S,
       append: Boolean = false
-  ): Sink[ByteString, Future[IOResult]] =
-    Sink.fromGraph(createIOSink(path, connectionSettings, append))
+  ): Sink[ByteString, Future[IOResult]]
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Sink Sink]] of a [[FtpFile]] that moves a file to some file path.
@@ -209,8 +199,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
    * @param connectionSettings connection settings
    * @return A [[akka.stream.scaladsl.Sink Sink]] of [[FtpFile]] that materializes to a [[scala.concurrent.Future Future]] of [[IOResult]]
    */
-  def move(destinationPath: FtpFile => String, connectionSettings: S): Sink[FtpFile, Future[IOResult]] =
-    Sink.fromGraph(createMoveSink(destinationPath, connectionSettings))
+  def move(destinationPath: FtpFile => String, connectionSettings: S): Sink[FtpFile, Future[IOResult]]
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Sink Sink]] of a [[FtpFile]] that removes a file.
@@ -218,16 +207,164 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
    * @param connectionSettings connection settings
    * @return A [[akka.stream.scaladsl.Sink Sink]] of [[FtpFile]] that materializes to a [[scala.concurrent.Future Future]] of [[IOResult]]
    */
+  def remove(connectionSettings: S): Sink[FtpFile, Future[IOResult]]
+}
+
+object Ftp extends FtpApi[FTPClient, FtpSettings] with FtpSourceParams {
+
+  def ls(host: String): Source[FtpFile, NotUsed] = ls(host, basePath = "")
+
+  def ls(host: String, basePath: String): Source[FtpFile, NotUsed] = ls(basePath, defaultSettings(host))
+
+  def ls(host: String, username: String, password: String): Source[FtpFile, NotUsed] =
+    ls("", defaultSettings(host, Some(username), Some(password)))
+
+  def ls(host: String, username: String, password: String, basePath: String): Source[FtpFile, NotUsed] =
+    ls(basePath, defaultSettings(host, Some(username), Some(password)))
+
+  def ls(basePath: String, connectionSettings: S): Source[FtpFile, NotUsed] =
+    ls(basePath, connectionSettings, f => true)
+
+  def ls(basePath: String, connectionSettings: S, branchSelector: FtpFile => Boolean): Source[FtpFile, NotUsed] =
+    Source.fromGraph(
+      createBrowserGraph(basePath, connectionSettings, branchSelector, _emitTraversedDirectories = false)
+    )
+
+  def ls(basePath: String,
+         connectionSettings: S,
+         branchSelector: FtpFile => Boolean,
+         emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
+    Source.fromGraph(createBrowserGraph(basePath, connectionSettings, branchSelector, emitTraversedDirectories))
+
+  def fromPath(host: String, path: String): Source[ByteString, Future[IOResult]] = fromPath(path, defaultSettings(host))
+
+  def fromPath(host: String, username: String, password: String, path: String): Source[ByteString, Future[IOResult]] =
+    fromPath(path, defaultSettings(host, Some(username), Some(password)))
+
+  def fromPath(path: String,
+               connectionSettings: S,
+               chunkSize: Int = DefaultChunkSize): Source[ByteString, Future[IOResult]] =
+    fromPath(path, connectionSettings, chunkSize, 0L)
+
+  def fromPath(path: String,
+               connectionSettings: S,
+               chunkSize: Int,
+               offset: Long): Source[ByteString, Future[IOResult]] =
+    Source.fromGraph(createIOSource(path, connectionSettings, chunkSize, offset))
+
+  def toPath(path: String, connectionSettings: S, append: Boolean = false): Sink[ByteString, Future[IOResult]] =
+    Sink.fromGraph(createIOSink(path, connectionSettings, append))
+
+  def move(destinationPath: FtpFile => String, connectionSettings: S): Sink[FtpFile, Future[IOResult]] =
+    Sink.fromGraph(createMoveSink(destinationPath, connectionSettings))
+
   def remove(connectionSettings: S): Sink[FtpFile, Future[IOResult]] =
     Sink.fromGraph(createRemoveSink(connectionSettings))
 
-  protected[this] implicit def ftpLike: FtpLike[FtpClient, S]
 }
 
-object Ftp extends FtpApi[FTPClient, FtpSettings] with FtpSourceParams
-object Ftps extends FtpApi[FTPSClient, FtpsSettings] with FtpsSourceParams
+object Ftps extends FtpApi[FTPSClient, FtpsSettings] with FtpsSourceParams {
+  def ls(host: String): Source[FtpFile, NotUsed] = ls(host, basePath = "")
 
-class SftpApi extends FtpApi[SSHClient, SftpSettings] with SftpSourceParams
+  def ls(host: String, basePath: String): Source[FtpFile, NotUsed] = ls(basePath, defaultSettings(host))
+
+  def ls(host: String, username: String, password: String): Source[FtpFile, NotUsed] =
+    ls("", defaultSettings(host, Some(username), Some(password)))
+
+  def ls(host: String, username: String, password: String, basePath: String): Source[FtpFile, NotUsed] =
+    ls(basePath, defaultSettings(host, Some(username), Some(password)))
+
+  def ls(basePath: String, connectionSettings: S): Source[FtpFile, NotUsed] =
+    ls(basePath, connectionSettings, f => true)
+
+  def ls(basePath: String, connectionSettings: S, branchSelector: FtpFile => Boolean): Source[FtpFile, NotUsed] =
+    Source.fromGraph(
+      createBrowserGraph(basePath, connectionSettings, branchSelector, _emitTraversedDirectories = false)
+    )
+
+  def ls(basePath: String,
+         connectionSettings: S,
+         branchSelector: FtpFile => Boolean,
+         emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
+    Source.fromGraph(createBrowserGraph(basePath, connectionSettings, branchSelector, emitTraversedDirectories))
+
+  def fromPath(host: String, path: String): Source[ByteString, Future[IOResult]] = fromPath(path, defaultSettings(host))
+
+  def fromPath(host: String, username: String, password: String, path: String): Source[ByteString, Future[IOResult]] =
+    fromPath(path, defaultSettings(host, Some(username), Some(password)))
+
+  def fromPath(path: String,
+               connectionSettings: S,
+               chunkSize: Int = DefaultChunkSize): Source[ByteString, Future[IOResult]] =
+    fromPath(path, connectionSettings, chunkSize, 0L)
+
+  def fromPath(path: String,
+               connectionSettings: S,
+               chunkSize: Int,
+               offset: Long): Source[ByteString, Future[IOResult]] =
+    Source.fromGraph(createIOSource(path, connectionSettings, chunkSize, offset))
+
+  def toPath(path: String, connectionSettings: S, append: Boolean = false): Sink[ByteString, Future[IOResult]] =
+    Sink.fromGraph(createIOSink(path, connectionSettings, append))
+
+  def move(destinationPath: FtpFile => String, connectionSettings: S): Sink[FtpFile, Future[IOResult]] =
+    Sink.fromGraph(createMoveSink(destinationPath, connectionSettings))
+
+  def remove(connectionSettings: S): Sink[FtpFile, Future[IOResult]] =
+    Sink.fromGraph(createRemoveSink(connectionSettings))
+}
+
+class SftpApi extends FtpApi[SSHClient, SftpSettings] with SftpSourceParams {
+  def ls(host: String): Source[FtpFile, NotUsed] = ls(host, basePath = "")
+
+  def ls(host: String, basePath: String): Source[FtpFile, NotUsed] = ls(basePath, defaultSettings(host))
+
+  def ls(host: String, username: String, password: String): Source[FtpFile, NotUsed] =
+    ls("", defaultSettings(host, Some(username), Some(password)))
+
+  def ls(host: String, username: String, password: String, basePath: String): Source[FtpFile, NotUsed] =
+    ls(basePath, defaultSettings(host, Some(username), Some(password)))
+
+  def ls(basePath: String, connectionSettings: S): Source[FtpFile, NotUsed] =
+    ls(basePath, connectionSettings, f => true)
+
+  def ls(basePath: String, connectionSettings: S, branchSelector: FtpFile => Boolean): Source[FtpFile, NotUsed] =
+    Source.fromGraph(
+      createBrowserGraph(basePath, connectionSettings, branchSelector, _emitTraversedDirectories = false)
+    )
+
+  def ls(basePath: String,
+         connectionSettings: S,
+         branchSelector: FtpFile => Boolean,
+         emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
+    Source.fromGraph(createBrowserGraph(basePath, connectionSettings, branchSelector, emitTraversedDirectories))
+
+  def fromPath(host: String, path: String): Source[ByteString, Future[IOResult]] = fromPath(path, defaultSettings(host))
+
+  def fromPath(host: String, username: String, password: String, path: String): Source[ByteString, Future[IOResult]] =
+    fromPath(path, defaultSettings(host, Some(username), Some(password)))
+
+  def fromPath(path: String,
+               connectionSettings: S,
+               chunkSize: Int = DefaultChunkSize): Source[ByteString, Future[IOResult]] =
+    fromPath(path, connectionSettings, chunkSize, 0L)
+
+  def fromPath(path: String,
+               connectionSettings: S,
+               chunkSize: Int,
+               offset: Long): Source[ByteString, Future[IOResult]] =
+    Source.fromGraph(createIOSource(path, connectionSettings, chunkSize, offset))
+
+  def toPath(path: String, connectionSettings: S, append: Boolean = false): Sink[ByteString, Future[IOResult]] =
+    Sink.fromGraph(createIOSink(path, connectionSettings, append))
+
+  def move(destinationPath: FtpFile => String, connectionSettings: S): Sink[FtpFile, Future[IOResult]] =
+    Sink.fromGraph(createMoveSink(destinationPath, connectionSettings))
+
+  def remove(connectionSettings: S): Sink[FtpFile, Future[IOResult]] =
+    Sink.fromGraph(createRemoveSink(connectionSettings))
+
+}
 object Sftp extends SftpApi {
 
   /**

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -143,7 +143,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
 
       files should have size 1
       inside(files.head) {
-        case FtpFile(actualFileName, actualPath, isDirectory, size, lastModified, perms) ⇒
+        case FtpFile(actualFileName, actualPath, isDirectory, size, lastModified, perms) =>
           actualFileName shouldBe fileName
           // actualPath shouldBe s"/$basePath$fileName"
           isDirectory shouldBe false
@@ -227,7 +227,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
     "no file is already present at the target location" should {
       "create a new file from the provided stream of bytes regardless of the append mode" in assertAllStagesStopped {
         val fileName = "sample_io_" + Instant.now().getNano
-        List(true, false).foreach { mode ⇒
+        List(true, false).foreach { mode =>
           val result =
             Source.single(ByteString(getDefaultContent)).runWith(storeToPath(s"/$fileName", mode)).futureValue
 
@@ -290,7 +290,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
 
       val result = Source[Byte](fileContents.toList)
         .grouped(8192)
-        .map(s ⇒ ByteString.apply(s.toArray))
+        .map(s => ByteString.apply(s.toArray))
         .runWith(storeToPath(s"/$fileName", append = false))
         .futureValue
 
@@ -306,7 +306,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
 
     "fail and report the exception in the result status if upstream fails" in assertAllStagesStopped {
       val fileName = "sample_io_upstream_" + Instant.now().getNano
-      val brokenSource = Source(10.to(0, -1)).map(x ⇒ ByteString(10 / x))
+      val brokenSource = Source(10.to(0, -1)).map(x => ByteString(10 / x))
 
       val result = brokenSource.runWith(storeToPath(s"/$fileName", append = false)).futureValue
 

--- a/mqtt/src/main/scala/akka/stream/alpakka/mqtt/settings.scala
+++ b/mqtt/src/main/scala/akka/stream/alpakka/mqtt/settings.scala
@@ -286,9 +286,26 @@ final class MqttConnectionSettings private (val broker: String,
     )
 
   override def toString =
-    s"""MqttConnectionSettings(broker=$broker,clientId=$clientId,persistence=$persistence,auth(username)=${auth.map(
-      _._1
-    )},socketFactory=$socketFactory,cleanSession=$cleanSession,will=$will,automaticReconnect=$automaticReconnect,keepAliveInterval=$keepAliveInterval,connectionTimeout=$connectionTimeout,disconnectQuiesceTimeout=$disconnectQuiesceTimeout,disconnectTimeout=$disconnectTimeout,maxInFlight=$maxInFlight,mqttVersion=$mqttVersion,serverUris=$serverUris,sslHostnameVerifier=$sslHostnameVerifier,sslProperties=$sslProperties,offlinePersistenceSettings=$offlinePersistenceSettings)"""
+    "MqttConnectionSettings(" +
+    s"broker=$broker," +
+    s"clientId=$clientId," +
+    s"persistence=$persistence," +
+    s"auth(username)=${auth.map(_._1)}," +
+    s"socketFactory=$socketFactory," +
+    s"cleanSession=$cleanSession," +
+    s"will=$will," +
+    s"automaticReconnect=$automaticReconnect," +
+    s"keepAliveInterval=$keepAliveInterval," +
+    s"connectionTimeout=$connectionTimeout," +
+    s"disconnectQuiesceTimeout=$disconnectQuiesceTimeout," +
+    s"disconnectTimeout=$disconnectTimeout," +
+    s"maxInFlight=$maxInFlight," +
+    s"mqttVersion=$mqttVersion," +
+    s"serverUris=$serverUris," +
+    s"sslHostnameVerifier=$sslHostnameVerifier," +
+    s"sslProperties=$sslProperties," +
+    s"offlinePersistenceSettings=$offlinePersistenceSettings" +
+    ")"
 }
 
 /**

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val Nightly = sys.env.get("TRAVIS_EVENT_TYPE").contains("cron")
 
   val Scala211 = "2.11.12"
-  val Scala212 = "2.12.7"
+  val Scala212 = "2.12.9"
   val Scala213 = "2.13.0"
   val ScalaVersions = Seq(Scala212, Scala211, Scala213).filterNot(_ == Scala211 && Nightly)
 


### PR DESCRIPTION
## Purpose

Allow publishing Alpakka FTP for Scala 2.13, and using Scala 2.12.9 for compilation.

## References

Issue #1532 

## Background Context

Using Scala 2.12.8 hits https://github.com/scala/bug/issues/11305
Scala 2.13.0 does not compile the Java tests successfully which looks like the same problem of missing type signatures.

## Changes

Due to the changed handling of static forwarders in Scala 2.12.8+ the pattern used to implement the different FTP styles doesn't compile anymore. 

* Make `FtpApi` just an interface
* Move type member to type parameter in `FtpApi`
* Repeat implementations of the operations in every FTP style