### PR TITLE
Fix link in CSV release notes

### DIFF
--- a/docs/src/main/paradox/release-notes/1.0.x/csv.md
+++ b/docs/src/main/paradox/release-notes/1.0.x/csv.md
@@ -3,7 +3,7 @@
 ## 1.0.2
 
 * CSV: accept escape without escapeable byte after [#1717](https://github.com/akka/alpakka/pull/1717)
-* CSV: stream may end with delimiter [#1711](§https://github.com/akka/alpakka/pull/1711)
+* CSV: stream may end with delimiter [#1711](https://github.com/akka/alpakka/pull/1711)
 
 [*closed in 1.0.2*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.0.2+label%3Ap%3Acsv)
 


### PR DESCRIPTION
Remove extra char breaking the link address.