### PR TITLE
Fix ScalaFmt resolution on master

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
+resolvers += Resolver.sonatypeRepo("snapshots")
+
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.1+2-8845e734-SNAPSHOT")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.1")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "1.1.2")


### PR DESCRIPTION
The latest sbt-scalafmt 2.0.1 plugin is not able to resolve
the scalafmt-2.0.0-RC8 correctly and thus broke the alpakka master
build.

Use the snapshot repository for scalafmt where the latest build on
sbt-scalafmt works as expected.

<!--
# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [n/a] Have you updated the documentation?
* [n/a] Have you added tests for any changed functionality?
-->
## Purpose

Restore the correct functionality of scalafmt on master.

## References

See the latest broken build on https://travis-ci.com/akka/alpakka/jobs/211465051 where the scalafmt resolution was failing:
```
[error] failed to resolve Scalafmt version '2.0.0-RC8': /home/travis/build/akka/alpakka/.scalafmt.conf
```

## Changes

The latest version of sbt-scalafmt on master resolves the problem.


