### PR TITLE
Issue 1786 - 'messageId' and 'publishTime' should not be published

### DIFF
--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/model.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/model.scala
@@ -80,11 +80,12 @@ object PubSubConfig {
 /**
  *
  * @param data the base64 encoded data
- * @param messageId the message id
+ * @param messageId the message id given by server. It must not be populated when publishing.
  * @param attributes optional extra attributes for this message.
  * @param publishTime the time the message was published. It must not be populated when publishing.
  */
 final case class PubSubMessage(data: String,
+                               //Should be Option[String]. '""' is used as default when creating messages for publishing.
                                messageId: String,
                                attributes: Option[immutable.Map[String, String]] = None,
                                publishTime: Option[Instant] = None) {
@@ -99,9 +100,18 @@ final case class PubSubMessage(data: String,
 
 object PubSubMessage {
 
+  def apply(data: String): PubSubMessage = PubSubMessage(data, "")
+
+  def apply(data: String, attributes: immutable.Map[String, String]): PubSubMessage =
+    PubSubMessage(data, "", Some(attributes), None)
+
   /**
    * Java API: create [[PubSubMessage]]
    */
+  def create(data: String) =
+    PubSubMessage(data)
+
+  @deprecated("Setting messageId when creating message for publishing is futile.", "1.0.3")
   def create(data: String, messageId: String) =
     PubSubMessage(data, messageId)
 }

--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/model.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/model.scala
@@ -111,7 +111,7 @@ object PubSubMessage {
   def create(data: String) =
     PubSubMessage(data)
 
-  @deprecated("Setting messageId when creating message for publishing is futile.", "1.0.3")
+  @deprecated("Setting messageId when creating message for publishing is futile.", "1.1.0")
   def create(data: String, messageId: String) =
     PubSubMessage(data, messageId)
 }

--- a/google-cloud-pub-sub/src/test/java/docs/javadsl/ExampleUsageJava.java
+++ b/google-cloud-pub-sub/src/test/java/docs/javadsl/ExampleUsageJava.java
@@ -55,8 +55,7 @@ public class ExampleUsageJava {
 
     // #publish-single
     PubSubMessage publishMessage =
-        PubSubMessage.create(
-            "1", new String(Base64.getEncoder().encode("Hello Google!".getBytes())));
+        PubSubMessage.create(new String(Base64.getEncoder().encode("Hello Google!".getBytes())));
     PublishRequest publishRequest = PublishRequest.of(Lists.newArrayList(publishMessage));
 
     Source<PublishRequest, NotUsed> source = Source.single(publishRequest);

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
@@ -47,7 +47,7 @@ class GooglePubSubSpec extends FlatSpec with MockitoSugar with ScalaFutures with
       config = config
     )
 
-    val request = PublishRequest(Seq(PubSubMessage(messageId = "1", data = base64String("Hello Google!"))))
+    val request = PublishRequest(Seq(PubSubMessage(data = base64String("Hello Google!"))))
 
     val source = Source(List(request))
 
@@ -87,7 +87,7 @@ class GooglePubSubSpec extends FlatSpec with MockitoSugar with ScalaFutures with
       config = config
     )
 
-    val request = PublishRequest(Seq(PubSubMessage(messageId = "2", data = base64String("Hello Google!"))))
+    val request = PublishRequest(Seq(PubSubMessage(data = base64String("Hello Google!"))))
 
     val source = Source(List(request))
     val result = source.via(flow).runWith(Sink.seq)

--- a/google-cloud-pub-sub/src/test/scala/docs/scaladsl/ExampleUsage.scala
+++ b/google-cloud-pub-sub/src/test/scala/docs/scaladsl/ExampleUsage.scala
@@ -47,7 +47,7 @@ class ExampleUsage {
 
   //#publish-single
   val publishMessage =
-    PubSubMessage(messageId = "1", data = new String(Base64.getEncoder.encode("Hello Google!".getBytes)))
+    PubSubMessage(new String(Base64.getEncoder.encode("Hello Google!".getBytes)))
   val publishRequest = PublishRequest(Seq(publishMessage))
 
   val source: Source[PublishRequest, NotUsed] = Source.single(publishRequest)


### PR DESCRIPTION
Nor should be 'messageId' be required when creating PubSubMessage for publishing.

<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->
## Purpose
Improve Scala and Java API - don't require redundant parameter
Improve compliance with Google Cloud PubSub HTTP API - don't send fields that shouldn't be sent.

## References

References #1786

## Changes

* Added Scala and Java api that doesn't require 'messageId'
* Do not encode 'messageId' and 'publishTime' when sending JSON body

## Background Context
I wanted to create separate case class for publishing PubSub message but I went in a direction to not break code.

If for 1.1 we can break source and binary compatibility, I'd like to contribute other change.
