### PR TITLE
Nightly with Akka 2.6

### DIFF
--- a/mqtt/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -112,12 +112,9 @@ public class MqttFlowTest {
     // #create-flow-ack
 
     // #run-flow-ack
-    final Pair<Pair<NotUsed, CompletionStage<Done>>,
-            CompletionStage<List<MqttMessageWithAck>>>
+    final Pair<Pair<NotUsed, CompletionStage<Done>>, CompletionStage<List<MqttMessageWithAck>>>
         materialized =
-            source.viaMat(mqttFlow, Keep.both())
-                    .toMat(Sink.seq(), Keep.both())
-                    .run(materializer);
+            source.viaMat(mqttFlow, Keep.both()).toMat(Sink.seq(), Keep.both()).run(materializer);
 
     // #run-flow-ack
 
@@ -131,10 +128,9 @@ public class MqttFlowTest {
   class MqttMessageWithAckFake extends MqttMessageWithAckImpl {
     Boolean acked;
 
-    MqttMessageWithAckFake(){
+    MqttMessageWithAckFake() {
       acked = false;
     }
-
 
     @Override
     public CompletionStage<Done> messageArrivedComplete() {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,15 +3,14 @@ import Keys._
 
 object Dependencies {
 
+  val Nightly = sys.env.get("TRAVIS_EVENT_TYPE").contains("cron")
+
   val Scala211 = "2.11.12"
   val Scala212 = "2.12.7"
   val Scala213 = "2.13.0"
-  val ScalaVersions = Seq(Scala212, Scala211, Scala213)
+  val ScalaVersions = Seq(Scala212, Scala211, Scala213).filterNot(_ == Scala211 && Nightly)
 
-  val AkkaVersion = sys.env.get("AKKA_SERIES") match {
-    case Some("2.4") => sys.error("Akka 2.4 is not supported anymore")
-    case _ => "2.5.23"
-  }
+  val AkkaVersion = if (Nightly) "2.6.0-M3" else "2.5.23"
 
   val InfluxDBJavaVersion = "2.15"
 


### PR DESCRIPTION
## Purpose

When in nightly, build with Akka 2.6.

## Changes

When in nightly:
* switches Akka to the latest mileston
* drops 2.11 cross Scala version
