### PR TITLE
Google Cloud Storage: don't publish for Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -176,7 +176,10 @@ lazy val googleCloudPubSubGrpc = alpakkaProject(
 ).enablePlugins(AkkaGrpcPlugin, JavaAgent)
 
 lazy val googleCloudStorage =
-  alpakkaProject("google-cloud-storage", "google.cloud.storage", Dependencies.GoogleStorage).disablePlugins(MimaPlugin)
+  alpakkaProject("google-cloud-storage",
+                 "google.cloud.storage",
+                 Dependencies.GoogleStorage,
+                 crossScalaVersions -= Dependencies.Scala211).disablePlugins(MimaPlugin)
 
 lazy val googleFcm = alpakkaProject(
   "google-fcm",


### PR DESCRIPTION
## Purpose

Switch off Scala 2.11 compilation for Google Cloud Storage.

## Background Context

New connectors should not support outdated Scala versions.