### PR TITLE
Canonical URL fix

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -17,7 +17,7 @@ object Common extends AutoPlugin {
     organization := "com.lightbend.akka",
     organizationName := "Lightbend Inc.",
     organizationHomepage := Some(url("https://www.lightbend.com/")),
-    homepage := Some(url("https://doc.akka.io/docs/alpakka/current/")),
+    homepage := Some(url("https://doc.akka.io/docs/alpakka/current")),
     apiURL := Some(url(s"https://doc.akka.io/api/alpakka/${version.value}")),
     scmInfo := Some(ScmInfo(url("https://github.com/akka/alpakka"), "git@github.com:akka/alpakka.git")),
     developers += Developer("contributors",


### PR DESCRIPTION
## Purpose

Remove doubled slash in canonical URLs in Paradox generated docs.

## Background Context

The `homepage` URL gets promoted to Paradox to be used as the base for canonical URLs. The Akka Paradox template introduces an extra slash which makes the URLs included two slashes and Google doesn't seem to like that.
