### PR TITLE
sync google modules jwt-core version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,6 @@ lazy val alpakka = project
       (ScalaUnidoc / unidoc / fullClasspath).value
         .filterNot(_.data.getAbsolutePath.contains("protobuf-java-2.5.0.jar"))
         .filterNot(_.data.getAbsolutePath.contains("guava-27.1-android.jar"))
-        .filterNot(_.data.getAbsolutePath.contains("jwt-core_2.12-3.0.1.jar"))
     },
     ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(`doc-examples`),
     crossScalaVersions := List() // workaround for https://github.com/sbt/sbt/issues/3465
@@ -155,8 +154,7 @@ lazy val googleCloudPubSub = alpakkaProject(
   fork in Test := true,
   envVars in Test := Map("PUBSUB_EMULATOR_HOST" -> "localhost:8538"),
   // For mockito https://github.com/akka/alpakka/issues/390
-  parallelExecution in Test := false,
-  crossScalaVersions -= Dependencies.Scala213 // requires upgrade of jwt-core to 3.0.1
+  parallelExecution in Test := false
 )
 
 lazy val googleCloudPubSubGrpc = alpakkaProject(
@@ -183,8 +181,7 @@ lazy val googleFcm = alpakkaProject(
   "google-fcm",
   "google.firebase.fcm",
   Dependencies.GoogleFcm,
-  fork in Test := true,
-  crossScalaVersions -= Dependencies.Scala213 // requires upgrade of jwt-core to 3.0.1
+  fork in Test := true
 )
 
 lazy val hbase = alpakkaProject("hbase", "hbase", Dependencies.HBase, fork in Test := true)

--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/impl/GoogleTokenApi.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/impl/GoogleTokenApi.scala
@@ -13,17 +13,21 @@ import akka.annotation.InternalApi
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import spray.json.{DefaultJsonProtocol, RootJsonFormat}
 import pdi.jwt.{Jwt, JwtAlgorithm, JwtClaim, JwtTime}
+import java.time.Clock
 
 import scala.concurrent.Future
 
 @InternalApi
 private[googlecloud] class GoogleTokenApi(http: => HttpExt) {
+
+  implicit val clock = Clock.systemUTC()
+
   protected val encodingAlgorithm: JwtAlgorithm.RS256.type = JwtAlgorithm.RS256
 
   private val googleTokenUrl = "https://www.googleapis.com/oauth2/v4/token"
   private val scope = "https://www.googleapis.com/auth/pubsub"
 
-  def now: Long = JwtTime.nowSeconds
+  def now: Long = JwtTime.nowSeconds(Clock.systemUTC())
 
   private def generateJwt(clientEmail: String, privateKey: String): String = {
     val claim = JwtClaim(content = s"""{"scope":"$scope","aud":"$googleTokenUrl"}""", issuer = Option(clientEmail))

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/GoogleTokenApiSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/GoogleTokenApiSpec.scala
@@ -41,23 +41,35 @@ class GoogleTokenApiSpec
 
   implicit val materializer = ActorMaterializer()
 
-  //http://travistidwell.com/jsencrypt/demo/
+  // openssl genrsa -out mykey.pem 1024
+  // openssl pkcs8 -topk8 -nocrypt -in mykey.pem -out myrsakey_pcks8
+  // openssl rsa -in mykey.pem -pubout > mykey.pub
   val privateKey =
-    """-----BEGIN RSA PRIVATE KEY-----
-      |MIIBOgIBAAJBAJHPYfmEpShPxAGP12oyPg0CiL1zmd2V84K5dgzhR9TFpkAp2kl2
-      |9BTc8jbAY0dQW4Zux+hyKxd6uANBKHOWacUCAwEAAQJAQVyXbMS7TGDFWnXieKZh
-      |Dm/uYA6sEJqheB4u/wMVshjcQdHbi6Rr0kv7dCLbJz2v9bVmFu5i8aFnJy1MJOpA
-      |2QIhAPyEAaVfDqJGjVfryZDCaxrsREmdKDlmIppFy78/d8DHAiEAk9JyTHcapckD
-      |uSyaE6EaqKKfyRwSfUGO1VJXmPjPDRMCIF9N900SDnTiye/4FxBiwIfdynw6K3dW
-      |fBLb6uVYr/r7AiBUu/p26IMm6y4uNGnxvJSqe+X6AxR6Jl043OWHs4AEbwIhANuz
-      |Ay3MKOeoVbx0L+ruVRY5fkW+oLHbMGtQ9dZq7Dp9
-      |-----END RSA PRIVATE KEY-----""".stripMargin
+    """-----BEGIN PRIVATE KEY-----
+    |MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAMwkmdwrWp+LLlsf
+    |bVE+neFjZtUNuaD4/tpQ2UIh2u+qU6sr4bG8PPuqSdrt5b0/0vfMZA11mQWmKpg5
+    |PK98kEkhbSvC08fG0TtpR9+vflghOuuvcw6kCniwNbHlOXnE8DwtKQp1DbTUPzMD
+    |hhsIjJaUtv19Xk7gh4MqYgANTm6lAgMBAAECgYEAwBXIeHSKxwiNS8ycbg//Oq7v
+    |eZV6j077bq0YYLO+cDjSlYOq0DSRJTSsXcXvoE1H00aM9mUq4TfjaGyi/3SzxYsr
+    |rSzu/qpYC58MJsnprIjlLgFZmZGe5MOSoul/u6JsBTJGkYPV0xGrtXJY103aSYzC
+    |xthpY0BHy9eO9I/pNlkCQQD/64g4INAiBdM4R5iONQvh8LLvqbb8Bw4vVwVFFnAr
+    |YHcomxtT9TunMad6KPgbOCd/fTttDADrv54htBrFGXeXAkEAzDTtisPKXPByJnUd
+    |jKO2oOg0Fs9IjGeWbnkrsN9j0134ldARE+WbT5S8G5EFo+bQi4ffU3+Y/4ly6Amm
+    |OAAzIwJBANV2GAD5HaHDShK/ZTf4dxjWM+pDnSVKnUJPS039EUKdC8cK2RiGjGNA
+    |v3jdg1Tw2cE1K8QhJwN8qOFj4JBWVbECQQCwcntej9bnf4vi1wd1YnCHkJyRqQIS
+    |7974DhNGfYAQPv5w1JwtCRSuKuJvH1w0R1ijd//scjCNfQKgpNXPRbzpAkAQ8MFA
+    |MLpOLGqezUQthJWmVtnXEXaAlb3yFSRTZQVEselObiIc6EvYzNXv780IDT4pyKjg
+    |8DS9i5jJDIVWr7mA
+    |-----END PRIVATE KEY-----
+  """.stripMargin
 
-  val publicKey =
-    """-----BEGIN PUBLIC KEY-----
-        |MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAJHPYfmEpShPxAGP12oyPg0CiL1zmd2V
-        |84K5dgzhR9TFpkAp2kl29BTc8jbAY0dQW4Zux+hyKxd6uANBKHOWacUCAwEAAQ==
-        |-----END PUBLIC KEY-----""".stripMargin
+  val publicKey = """-----BEGIN PUBLIC KEY-----
+    |MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDMJJncK1qfiy5bH21RPp3hY2bV
+    |Dbmg+P7aUNlCIdrvqlOrK+GxvDz7qkna7eW9P9L3zGQNdZkFpiqYOTyvfJBJIW0r
+    |wtPHxtE7aUffr35YITrrr3MOpAp4sDWx5Tl5xPA8LSkKdQ201D8zA4YbCIyWlLb9
+    |fV5O4IeDKmIADU5upQIDAQAB
+    |-----END PUBLIC KEY-----
+  """.stripMargin
 
   "GoogleTokenApi" should {
 
@@ -92,9 +104,10 @@ class GoogleTokenApiSpec
       val jwt = data.replace("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=", "")
       val decoded = Jwt.decode(jwt, publicKey, Seq(JwtAlgorithm.RS256))
       decoded.isSuccess shouldBe true
-      decoded.get should include(""""aud":"https://www.googleapis.com/oauth2/v4/token"""")
-      decoded.get should include(""""scope":"https://www.googleapis.com/auth/pubsub"""")
-      decoded.get should include(""""iss":"email"""")
+      val claimsJson = decoded.get.toJson
+      claimsJson should include(""""aud":"https://www.googleapis.com/oauth2/v4/token"""")
+      claimsJson should include(""""scope":"https://www.googleapis.com/auth/pubsub"""")
+      claimsJson should include(""""iss":"email"""")
 
     }
 

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GoogleTokenApiSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GoogleTokenApiSpec.scala
@@ -107,7 +107,7 @@ class GoogleTokenApiSpec extends WordSpecLike with Matchers with ScalaFutures wi
       val claimsJson = decoded.get.toJson
       claimsJson should include(""""aud":"https://www.googleapis.com/oauth2/v4/token"""")
       claimsJson should include(""""scope":"https://www.googleapis.com/auth/devstorage.read_write"""")
-      claimsJson should include("email")
+      claimsJson should include(""""iss":"email"""")
 
     }
 

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleTokenApi.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleTokenApi.scala
@@ -11,6 +11,7 @@ import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
 import akka.stream.alpakka.google.firebase.fcm.impl.GoogleTokenApi.{AccessTokenExpiry, OAuthResponse}
 import pdi.jwt.{Jwt, JwtAlgorithm, JwtClaim, JwtTime}
+import java.time.Clock
 
 import scala.concurrent.Future
 
@@ -21,12 +22,14 @@ import scala.concurrent.Future
 private[fcm] class GoogleTokenApi(http: => HttpExt) {
   import FcmJsonSupport._
 
+  implicit val clock = Clock.systemUTC()
+
   protected val encodingAlgorithm: JwtAlgorithm.RS256.type = JwtAlgorithm.RS256
 
   private val googleTokenUrl = "https://www.googleapis.com/oauth2/v4/token"
   private val scope = "https://www.googleapis.com/auth/firebase.messaging"
 
-  def now: Long = JwtTime.nowSeconds
+  def now: Long = JwtTime.nowSeconds(Clock.systemUTC())
 
   private def generateJwt(clientEmail: String, privateKey: String): String = {
     val claim = JwtClaim(content = s"""{"scope":"$scope","aud":"$googleTokenUrl"}""", issuer = Option(clientEmail))

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleTokenApiSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleTokenApiSpec.scala
@@ -41,23 +41,35 @@ class GoogleTokenApiSpec
 
   implicit val materializer: Materializer = ActorMaterializer()
 
-  //http://travistidwell.com/jsencrypt/demo/
+  // openssl genrsa -out mykey.pem 1024
+  // openssl pkcs8 -topk8 -nocrypt -in mykey.pem -out myrsakey_pcks8
+  // openssl rsa -in mykey.pem -pubout > mykey.pub
   val privateKey =
-    """-----BEGIN RSA PRIVATE KEY-----
-      |MIIBOgIBAAJBAJHPYfmEpShPxAGP12oyPg0CiL1zmd2V84K5dgzhR9TFpkAp2kl2
-      |9BTc8jbAY0dQW4Zux+hyKxd6uANBKHOWacUCAwEAAQJAQVyXbMS7TGDFWnXieKZh
-      |Dm/uYA6sEJqheB4u/wMVshjcQdHbi6Rr0kv7dCLbJz2v9bVmFu5i8aFnJy1MJOpA
-      |2QIhAPyEAaVfDqJGjVfryZDCaxrsREmdKDlmIppFy78/d8DHAiEAk9JyTHcapckD
-      |uSyaE6EaqKKfyRwSfUGO1VJXmPjPDRMCIF9N900SDnTiye/4FxBiwIfdynw6K3dW
-      |fBLb6uVYr/r7AiBUu/p26IMm6y4uNGnxvJSqe+X6AxR6Jl043OWHs4AEbwIhANuz
-      |Ay3MKOeoVbx0L+ruVRY5fkW+oLHbMGtQ9dZq7Dp9
-      |-----END RSA PRIVATE KEY-----""".stripMargin
+    """-----BEGIN PRIVATE KEY-----
+    |MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAMwkmdwrWp+LLlsf
+    |bVE+neFjZtUNuaD4/tpQ2UIh2u+qU6sr4bG8PPuqSdrt5b0/0vfMZA11mQWmKpg5
+    |PK98kEkhbSvC08fG0TtpR9+vflghOuuvcw6kCniwNbHlOXnE8DwtKQp1DbTUPzMD
+    |hhsIjJaUtv19Xk7gh4MqYgANTm6lAgMBAAECgYEAwBXIeHSKxwiNS8ycbg//Oq7v
+    |eZV6j077bq0YYLO+cDjSlYOq0DSRJTSsXcXvoE1H00aM9mUq4TfjaGyi/3SzxYsr
+    |rSzu/qpYC58MJsnprIjlLgFZmZGe5MOSoul/u6JsBTJGkYPV0xGrtXJY103aSYzC
+    |xthpY0BHy9eO9I/pNlkCQQD/64g4INAiBdM4R5iONQvh8LLvqbb8Bw4vVwVFFnAr
+    |YHcomxtT9TunMad6KPgbOCd/fTttDADrv54htBrFGXeXAkEAzDTtisPKXPByJnUd
+    |jKO2oOg0Fs9IjGeWbnkrsN9j0134ldARE+WbT5S8G5EFo+bQi4ffU3+Y/4ly6Amm
+    |OAAzIwJBANV2GAD5HaHDShK/ZTf4dxjWM+pDnSVKnUJPS039EUKdC8cK2RiGjGNA
+    |v3jdg1Tw2cE1K8QhJwN8qOFj4JBWVbECQQCwcntej9bnf4vi1wd1YnCHkJyRqQIS
+    |7974DhNGfYAQPv5w1JwtCRSuKuJvH1w0R1ijd//scjCNfQKgpNXPRbzpAkAQ8MFA
+    |MLpOLGqezUQthJWmVtnXEXaAlb3yFSRTZQVEselObiIc6EvYzNXv780IDT4pyKjg
+    |8DS9i5jJDIVWr7mA
+    |-----END PRIVATE KEY-----
+  """.stripMargin
 
-  val publicKey =
-    """-----BEGIN PUBLIC KEY-----
-        |MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAJHPYfmEpShPxAGP12oyPg0CiL1zmd2V
-        |84K5dgzhR9TFpkAp2kl29BTc8jbAY0dQW4Zux+hyKxd6uANBKHOWacUCAwEAAQ==
-        |-----END PUBLIC KEY-----""".stripMargin
+  val publicKey = """-----BEGIN PUBLIC KEY-----
+    |MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDMJJncK1qfiy5bH21RPp3hY2bV
+    |Dbmg+P7aUNlCIdrvqlOrK+GxvDz7qkna7eW9P9L3zGQNdZkFpiqYOTyvfJBJIW0r
+    |wtPHxtE7aUffr35YITrrr3MOpAp4sDWx5Tl5xPA8LSkKdQ201D8zA4YbCIyWlLb9
+    |fV5O4IeDKmIADU5upQIDAQAB
+    |-----END PUBLIC KEY-----
+  """.stripMargin
 
   "GoogleTokenApi" should {
 
@@ -92,9 +104,10 @@ class GoogleTokenApiSpec
       val jwt = data.replace("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=", "")
       val decoded = Jwt.decode(jwt, publicKey, Seq(JwtAlgorithm.RS256))
       decoded.isSuccess shouldBe true
-      decoded.get should include(""""aud":"https://www.googleapis.com/oauth2/v4/token"""")
-      decoded.get should include(""""scope":"https://www.googleapis.com/auth/firebase.messaging"""")
-      decoded.get should include(""""iss":"email"""")
+      val claimsJson = decoded.get.toJson
+      claimsJson should include(""""aud":"https://www.googleapis.com/oauth2/v4/token"""")
+      claimsJson should include(""""scope":"https://www.googleapis.com/auth/firebase.messaging"""")
+      claimsJson should include(""""iss":"email"""")
 
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -175,7 +175,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "com.pauldijou" %% "jwt-core" % "2.1.0", // ApacheV2
+        "com.pauldijou" %% "jwt-core" % JwtCoreVersion, // ApacheV2
         "org.mockito" % "mockito-core" % mockitoVersion % Test, // MIT
         "com.github.tomakehurst" % "wiremock" % "2.24.0" % Test // ApacheV2
       )
@@ -195,7 +195,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "com.pauldijou" %% "jwt-core" % "2.1.0", // ApacheV2
+        "com.pauldijou" %% "jwt-core" % JwtCoreVersion, // ApacheV2
         "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
       )
   )


### PR DESCRIPTION
fixes #1811 and enable scala 2.13 cross build for all google modules
fixes #1762
fixes #1763

As jwt-core 2 and 3 are not compatible this is a breaking change

to continue the cleanup see #773