### PR TITLE
FTP: Mkdir

### DIFF
--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -115,6 +115,20 @@ This sink will consume @scaladoc[FtpFile](akka.stream.alpakka.ftp.FtpFile) eleme
 
 Typical use-case for this would be listing files from a ftp location, do some processing and move the files when done. An example of this use case can be found below.
 
+## Creating directory
+
+In order to create a directory the user has to specify a parent directory (also known as base path) and directory's name.
+
+Alpakka provides a materialized API `mkdirAsync` (based on @scala[Future]@java[Completion Stage]) and unmaterialized API `mkdir` (using Sources) to let the user choose when the action will be executed.
+
+Scala
+: @@snip [snip](/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala) { #mkdir-source }
+
+Java
+: @@snip [snip](/ftp/src/test/java/docs/javadsl/FtpMkdirExample.java){ #mkdir-source }
+
+Please note that to include a subdirectory in result of `ls` the `emitTraversedDirectories` has to be set to `true`.
+
 ### Example: downloading files from an FTP location and move the original files  
 
 Scala

--- a/ftp/src/main/mima-filters/1.1.x.backwards.excludes
+++ b/ftp/src/main/mima-filters/1.1.x.backwards.excludes
@@ -1,0 +1,2 @@
+# Allow changes to impl
+ProblemFilters.exclude[Problem]("akka.stream.alpakka.ftp.impl.*")

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
@@ -85,4 +85,22 @@ private[ftp] trait CommonFtpOperations {
 
   def completePendingCommand(handler: Handler): Boolean =
     handler.completePendingCommand()
+
+  def mkdir(path: String, name: String, handler: Handler): Unit = {
+    val updatedPath = CommonFtpOperations.concatPath(path, name)
+    handler.makeDirectory(updatedPath)
+
+    if (handler.getReplyCode != 257) {
+      throw new IOException(handler.getReplyString)
+    }
+  }
+}
+
+private[ftp] object CommonFtpOperations {
+  def concatPath(path: String, name: String): String =
+    if (path.endsWith("/")) {
+      path ++ name
+    } else {
+      s"$path/$name"
+    }
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpBrowserGraphStage.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpBrowserGraphStage.scala
@@ -6,36 +6,20 @@ package akka.stream.alpakka.ftp
 package impl
 
 import akka.annotation.InternalApi
-import akka.stream.stage.{GraphStage, OutHandler}
-import akka.stream.{Attributes, Outlet, SourceShape}
-import akka.stream.impl.Stages.DefaultAttributes.IODispatcher
+import akka.stream.{Attributes, Outlet}
+import akka.stream.stage.OutHandler
 
 /**
  * INTERNAL API
  */
 @InternalApi
-private[ftp] trait FtpBrowserGraphStage[FtpClient, S <: RemoteFileSettings] extends GraphStage[SourceShape[FtpFile]] {
-
-  def name: String
-
-  def basePath: String
-
-  def connectionSettings: S
-
-  def ftpClient: () => FtpClient
-
+private[ftp] trait FtpBrowserGraphStage[FtpClient, S <: RemoteFileSettings]
+    extends FtpGraphStage[FtpClient, S, FtpFile] {
   val ftpLike: FtpLike[FtpClient, S]
-
-  val shape: SourceShape[FtpFile] = SourceShape(Outlet[FtpFile](s"$name.out"))
-
-  val out = shape.outlets.head.asInstanceOf[Outlet[FtpFile]]
 
   val branchSelector: FtpFile => Boolean = (f) => true
 
   def emitTraversedDirectories: Boolean = false
-
-  override def initialAttributes: Attributes =
-    super.initialAttributes and Attributes.name(name) and IODispatcher
 
   def createLogic(inheritedAttributes: Attributes) = {
     val logic = new FtpGraphStageLogic[FtpFile, FtpClient, S](shape, ftpLike, connectionSettings, ftpClient) {

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpDirectoryOperationsGraphStage.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpDirectoryOperationsGraphStage.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.ftp.impl
+
+import akka.annotation.InternalApi
+import akka.stream.alpakka.ftp.RemoteFileSettings
+import akka.stream.stage.{GraphStageLogic, OutHandler}
+import akka.stream.{Attributes, Outlet}
+
+@InternalApi
+private[ftp] trait FtpDirectoryOperationsGraphStage[FtpClient, S <: RemoteFileSettings]
+    extends FtpGraphStage[FtpClient, S, Unit] {
+  val ftpLike: FtpLike[FtpClient, S]
+  val directoryName: String
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new FtpGraphStageLogic(shape, ftpLike, connectionSettings, ftpClient) {
+      setHandler(
+        out,
+        new OutHandler {
+          override def onPull(): Unit = {
+            push(out, ftpLike.mkdir(basePath, directoryName, handler.get))
+            complete(out)
+          }
+        }
+      )
+
+      override protected def doPreStart(): Unit = ()
+
+      override protected def matSuccess(): Boolean = true
+
+      override protected def matFailure(t: Throwable): Boolean = true
+    }
+}

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpGraphStage.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpGraphStage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.ftp.impl
+
+import akka.stream.alpakka.ftp.RemoteFileSettings
+import akka.stream.impl.Stages.DefaultAttributes.IODispatcher
+import akka.stream.stage.GraphStage
+import akka.stream.{Attributes, Outlet, SourceShape}
+
+trait FtpGraphStage[FtpClient, S <: RemoteFileSettings, T] extends GraphStage[SourceShape[T]] {
+  def name: String
+
+  def basePath: String
+
+  def connectionSettings: S
+
+  def ftpClient: () => FtpClient
+
+  val shape: SourceShape[T] = SourceShape(Outlet[T](s"$name.out"))
+
+  val out: Outlet[T] = shape.outlets.head.asInstanceOf[Outlet[T]]
+
+  override def initialAttributes: Attributes =
+    super.initialAttributes and Attributes.name(name) and IODispatcher
+}

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
@@ -37,6 +37,8 @@ protected[ftp] trait FtpLike[FtpClient, S <: RemoteFileSettings] {
   def move(fromPath: String, destinationPath: String, handler: Handler): Unit
 
   def remove(path: String, handler: Handler): Unit
+
+  def mkdir(path: String, name: String, handler: Handler): Unit
 }
 
 /**

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpSourceFactory.scala
@@ -26,6 +26,8 @@ private[ftp] trait FtpSourceFactory[FtpClient] { self =>
 
   protected[this] def ftpBrowserSourceName: String
 
+  protected[this] def ftpDirectorySourceName: String = "GenericDirectorySource"
+
   protected[this] def ftpIOSourceName: String
 
   protected[this] def ftpIOSinkName: String
@@ -51,6 +53,23 @@ private[ftp] trait FtpSourceFactory[FtpClient] { self =>
       val ftpLike: FtpLike[FtpClient, S] = _ftpLike
       override val branchSelector: (FtpFile) => Boolean = _branchSelector
       override val emitTraversedDirectories: Boolean = _emitTraversedDirectories
+    }
+
+  protected[this] def createMkdirGraph(baseDirectoryPath: String, dirName: String, currentConnectionSettings: S)(
+      implicit _ftpLike: FtpLike[FtpClient, S]
+  ): FtpDirectoryOperationsGraphStage[FtpClient, S] =
+    new FtpDirectoryOperationsGraphStage[FtpClient, S] {
+      override val ftpLike: FtpLike[FtpClient, S] = _ftpLike
+
+      override def name: String = ftpDirectorySourceName
+
+      override def basePath: String = baseDirectoryPath
+
+      override def connectionSettings: S = currentConnectionSettings
+
+      override def ftpClient: () => FtpClient = self.ftpClient
+
+      override val directoryName: String = dirName
     }
 
   protected[this] def createIOSource(
@@ -124,11 +143,14 @@ private[ftp] trait FtpSourceFactory[FtpClient] { self =>
 private[ftp] trait FtpSource extends FtpSourceFactory[FTPClient] {
   protected final val FtpBrowserSourceName = "FtpBrowserSource"
   protected final val FtpIOSourceName = "FtpIOSource"
+  protected final val FtpDirectorySource = "FtpDirectorySource"
   protected final val FtpIOSinkName = "FtpIOSink"
+
   protected val ftpClient: () => FTPClient = () => new FTPClient
   protected val ftpBrowserSourceName: String = FtpBrowserSourceName
   protected val ftpIOSourceName: String = FtpIOSourceName
   protected val ftpIOSinkName: String = FtpIOSinkName
+  override protected val ftpDirectorySourceName: String = FtpDirectorySource
 }
 
 /**
@@ -138,11 +160,14 @@ private[ftp] trait FtpSource extends FtpSourceFactory[FTPClient] {
 private[ftp] trait FtpsSource extends FtpSourceFactory[FTPSClient] {
   protected final val FtpsBrowserSourceName = "FtpsBrowserSource"
   protected final val FtpsIOSourceName = "FtpsIOSource"
+  protected final val FtpsDirectorySource = "FtpsDirectorySource"
   protected final val FtpsIOSinkName = "FtpsIOSink"
+
   protected val ftpClient: () => FTPSClient = () => new FTPSClient
   protected val ftpBrowserSourceName: String = FtpsBrowserSourceName
   protected val ftpIOSourceName: String = FtpsIOSourceName
   protected val ftpIOSinkName: String = FtpsIOSinkName
+  override protected val ftpDirectorySourceName: String = FtpsDirectorySource
 }
 
 /**
@@ -152,12 +177,15 @@ private[ftp] trait FtpsSource extends FtpSourceFactory[FTPSClient] {
 private[ftp] trait SftpSource extends FtpSourceFactory[SSHClient] {
   protected final val sFtpBrowserSourceName = "sFtpBrowserSource"
   protected final val sFtpIOSourceName = "sFtpIOSource"
+  protected final val sFtpDirectorySource = "sFtpDirectorySource"
   protected final val sFtpIOSinkName = "sFtpIOSink"
+
   def sshClient(): SSHClient = new SSHClient()
   protected val ftpClient: () => SSHClient = () => sshClient()
   protected val ftpBrowserSourceName: String = sFtpBrowserSourceName
   protected val ftpIOSourceName: String = sFtpIOSourceName
   protected val ftpIOSinkName: String = sFtpIOSinkName
+  override protected val ftpDirectorySourceName: String = sFtpDirectorySource
 }
 
 /**

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
@@ -52,7 +52,7 @@ private[ftp] trait SftpOperations { _: FtpLike[SSHClient, SftpSettings] =>
   }
 
   def listFiles(basePath: String, handler: Handler): immutable.Seq[FtpFile] = {
-    val path = if (!basePath.isEmpty && basePath.head != '/') s"/$basePath" else basePath
+    val path = if (basePath.nonEmpty && basePath.head != '/') s"/$basePath" else basePath
     val entries = handler.ls(path).asScala
     entries.map { file =>
       FtpFile(
@@ -64,6 +64,11 @@ private[ftp] trait SftpOperations { _: FtpLike[SSHClient, SftpSettings] =>
         getPosixFilePermissions(file)
       )
     }.toVector
+  }
+
+  def mkdir(path: String, name: String, handler: Handler): Unit = {
+    val updatedPath = CommonFtpOperations.concatPath(path, name)
+    handler.mkdirs(updatedPath)
   }
 
   private def getPosixFilePermissions(file: RemoteResourceInfo) = {

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -4,9 +4,9 @@
 
 package akka.stream.alpakka.ftp.scaladsl
 
-import akka.NotUsed
-import akka.stream.IOResult
-import akka.stream.alpakka.ftp.impl.{FtpLike, FtpSourceFactory, FtpSourceParams, FtpsSourceParams, SftpSourceParams}
+import akka.{Done, NotUsed}
+import akka.stream.{IOResult, Materializer}
+import akka.stream.alpakka.ftp.impl._
 import akka.stream.alpakka.ftp.{FtpFile, RemoteFileSettings}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
@@ -117,6 +117,26 @@ sealed trait FtpApi[FtpClient] { _: FtpSourceFactory[FtpClient] =>
          branchSelector: FtpFile => Boolean,
          emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
     Source.fromGraph(createBrowserGraph(basePath, connectionSettings, branchSelector, emitTraversedDirectories))
+
+  /**
+   *  Scala API for creating a directory in a given path
+   * @param basePath path to start with
+   * @param name name of a directory to create
+   * @param connectionSettings connection settings
+   * @return [[akka.stream.scaladsl.Source Source]] of [[akka.Done]]
+   */
+  def mkdir(basePath: String, name: String, connectionSettings: S): Source[Done, NotUsed] =
+    Source.fromGraph(createMkdirGraph(basePath, name, connectionSettings)).map(_ => Done)
+
+  /**
+   *  Scala API for creating a directory in a given path
+   * @param basePath path to start with
+   * @param name name of a directory to create
+   * @param connectionSettings connection settings
+   * @return [[scala.concurrent.Future Future]] of [[akka.Done]] indicating a materialized, asynchronous request
+   */
+  def mkdirAsync(basePath: String, name: String, connectionSettings: S)(implicit mat: Materializer): Future[Done] =
+    mkdir(basePath, name, connectionSettings).runWith(Sink.head)
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[akka.util.ByteString ByteString]] from some file path.

--- a/ftp/src/test/java/docs/javadsl/FtpMkdirExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpMkdirExample.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.javadsl;
+
+// #mkdir-source
+import akka.Done;
+import akka.NotUsed;
+import akka.stream.alpakka.ftp.FtpSettings;
+import akka.stream.alpakka.ftp.javadsl.Ftp;
+import akka.stream.javadsl.Source;
+
+public class FtpMkdirExample {
+  public Source<Done, NotUsed> mkdir(
+      String parentPath, String directoryName, FtpSettings settings) {
+    return Ftp.mkdir(parentPath, directoryName, settings);
+  }
+}
+
+// #mkdir-source

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
@@ -4,11 +4,12 @@
 
 package akka.stream.alpakka.ftp
 
-import akka.NotUsed
+import akka.{Done, NotUsed}
 import akka.stream.IOResult
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.alpakka.ftp.scaladsl.Ftp
 import akka.util.ByteString
+
 import scala.concurrent.Future
 import java.net.InetAddress
 
@@ -43,4 +44,7 @@ trait BaseFtpSpec extends BaseFtpSupport with BaseSpec {
 
   protected def move(destinationPath: FtpFile => String): Sink[FtpFile, Future[IOResult]] =
     Ftp.move(destinationPath, settings)
+
+  protected def mkdir(basePath: String, name: String): Source[Done, NotUsed] =
+    Ftp.mkdir(basePath, name, settings)
 }

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.ftp
 import java.net.InetAddress
 
-import akka.NotUsed
+import akka.{Done, NotUsed}
 import akka.stream.IOResult
 import akka.stream.alpakka.ftp.scaladsl.Ftps
 import akka.stream.scaladsl.{Sink, Source}
@@ -44,4 +44,7 @@ trait BaseFtpsSpec extends BaseFtpSupport with BaseSpec {
 
   protected def move(destinationPath: FtpFile => String): Sink[FtpFile, Future[IOResult]] =
     Ftps.move(destinationPath, settings)
+
+  protected def mkdir(basePath: String, name: String): Source[Done, NotUsed] =
+    Ftps.mkdir(basePath, name, settings)
 }

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.ftp
 import java.net.InetAddress
 
-import akka.NotUsed
+import akka.{Done, NotUsed}
 import akka.stream.IOResult
 import akka.stream.alpakka.ftp.scaladsl.Sftp
 import akka.stream.scaladsl.{Sink, Source}
@@ -45,4 +45,7 @@ trait BaseSftpSpec extends BaseSftpSupport with BaseSpec {
 
   protected def move(destinationPath: FtpFile => String): Sink[FtpFile, Future[IOResult]] =
     Sftp.move(file => ROOT_PATH + destinationPath(file), settings)
+
+  protected def mkdir(basePath: String, name: String): Source[Done, NotUsed] =
+    Sftp.mkdir(ROOT_PATH + basePath, name, settings)
 }

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.ftp
 
-import akka.NotUsed
+import akka.{Done, NotUsed}
 import akka.stream.IOResult
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
@@ -51,6 +51,8 @@ trait BaseSpec
   protected def remove(): Sink[FtpFile, Future[IOResult]]
 
   protected def move(destinationPath: FtpFile => String): Sink[FtpFile, Future[IOResult]]
+
+  protected def mkdir(basePath: String, name: String): Source[Done, NotUsed]
 
   /** For a few tests `assertAllStagesStopped` failed on Travis, this hook allows to inject a bit more patience
    * for the check.

--- a/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala
+++ b/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala
@@ -70,6 +70,20 @@ object scalaExamples {
     //#moving
   }
 
+  object mkdir {
+    //#mkdir-source
+
+    import akka.NotUsed
+    import akka.stream.scaladsl.Source
+    import akka.stream.alpakka.ftp.scaladsl.Ftp
+    import akka.Done
+
+    def mkdir(basePath: String, directoryName: String, settings: FtpSettings): Source[Done, NotUsed] =
+      Ftp.mkdir(basePath, directoryName, settings)
+
+    //#mkdir-source
+  }
+
   object processAndMove {
     //#processAndMove
     import java.nio.file.Files


### PR DESCRIPTION
## Purpose

PR introduces an ability to create a directory

## Changes

- Some refactoring to the way that specific GraphStage-s are created. Common methods (not related specifically to the Graph were moved higher)
- Introduced another Graph Stage, that is responsible for directory operation. For now, it is only creating action but this can be expanded to deleting using a sealed trait and matching type in Graph Stage's method `onPull`.

## Background Context

For now alpakka lacks asych API to create a bucket and it is necessary for our application to have one. I've done something similar that is in S3 module, where create bucket has 2 versions: one materialized (future / completion stage) and other not materialized (source). Since both api-s doesn't return anything after successfully creating bucket or directory, I've used the same signature. 

## Feedback
I'd like to ask you for some suggestions on testing this API. Right now all I do is check whether the action didn't throw exception while executing. Is it the right way?
