### PR TITLE
Docs: fix links to 1.0.x release notes

### DIFF
--- a/docs/src/main/paradox/release-notes/1.1.x/amqp.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/amqp.md
@@ -6,4 +6,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Aamqp)
 
-For earlier changes see [1.0.x versions](../1.0.x/amqp.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/amqp.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/avroparquet.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/avroparquet.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.2+label%3Ap%3Aavroparquet)
 
-For earlier changes see [1.0.x versions](../1.0.x/avroparquet.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/avroparquet.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/awslambda.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/awslambda.md
@@ -6,4 +6,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Aaws-lambda)
 
-For earlier changes see [1.0.x versions](../1.0.x/awslambda.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/awslambda.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/azure-storage-queue.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/azure-storage-queue.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Aazure-storage-queue)
 
-For earlier changes see [1.0.x versions](../1.0.x/azure-storage-queue.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/azure-storage-queue.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/cassandra.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/cassandra.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.2*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Acassandra)
 
-For earlier changes see [1.0.x versions](../1.0.x/cassandra.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/cassandra.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/couchbase.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/couchbase.md
@@ -7,4 +7,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Acouchbase)
 
-For earlier changes see [1.0.x versions](../1.0.x/couchbase.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/couchbase.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/csv.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/csv.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Acsv)
 
-For earlier changes see [1.0.x versions](../1.0.x/csv.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/csv.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/dynamodb.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/dynamodb.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Adynamodb)
 
-For earlier changes see [1.0.x versions](../1.0.x/dynamodb.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/dynamodb.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/elasticsearch.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/elasticsearch.md
@@ -6,4 +6,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Aelasticsearch)
 
-For earlier changes see [1.0.x versions](../1.0.x/elasticsearch.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/elasticsearch.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/file.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/file.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Afile)
 
-For earlier changes see [1.0.x versions](../1.0.x/file.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/file.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/ftp.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/ftp.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Aftp)
 
-For earlier changes see [1.0.x versions](../1.0.x/ftp.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/ftp.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/geode.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/geode.md
@@ -6,4 +6,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Ageode)
 
-For earlier changes see [1.0.x versions](../1.0.x/geode.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/geode.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/google-cloud-pub-sub-grpc.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/google-cloud-pub-sub-grpc.md
@@ -6,4 +6,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Agoogle-cloud-pub-sub-grpc)
 
-For earlier changes see [1.0.x versions](../1.0.x/google-cloud-pub-sub-grpc.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/google-cloud-pub-sub-grpc.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/google-cloud-pub-sub.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/google-cloud-pub-sub.md
@@ -7,4 +7,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Agoogle-cloud-pub-sub)
 
-For earlier changes see [1.0.x versions](../1.0.x/google-cloud-pub-sub.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/google-cloud-pub-sub.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/google-fcm.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/google-fcm.md
@@ -6,4 +6,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Agoogle-fcm)
 
-For earlier changes see [1.0.x versions](../1.0.x/google-fcm.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/google-fcm.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/hbase.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/hbase.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Ahbase)
 
-For earlier changes see [1.0.x versions](../1.0.x/hbase.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/hbase.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/hdfs.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/hdfs.md
@@ -6,4 +6,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Ahdfs)
 
-For earlier changes see [1.0.x versions](../1.0.x/hdfs.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/hdfs.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/ironmq.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/ironmq.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Aironmq)
 
-For earlier changes see [1.0.x versions](../1.0.x/ironmq.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/ironmq.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/jms.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/jms.md
@@ -7,4 +7,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Ajms)
 
-For earlier changes see [1.0.x versions](../1.0.x/jms.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/jms.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/json-streaming.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/json-streaming.md
@@ -6,4 +6,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Ajson-streaming)
 
-For earlier changes see [1.0.x versions](../1.0.x/json-streaming.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/json-streaming.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/kinesis.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/kinesis.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Akinesis)
 
-For earlier changes see [1.0.x versions](../1.0.x/kinesis.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/kinesis.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/kudu.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/kudu.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Akudu)
 
-For earlier changes see [1.0.x versions](../1.0.x/kudu.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/kudu.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/mongodb.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/mongodb.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Amongodb)
 
-For earlier changes see [1.0.x versions](../1.0.x/mongodb.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/mongodb.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/mqtt-streaming.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/mqtt-streaming.md
@@ -6,4 +6,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Amqtt-streaming)
 
-For earlier changes see [1.0.x versions](../1.0.x/mqtt-streaming.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/mqtt-streaming.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/mqtt.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/mqtt.md
@@ -6,4 +6,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Amqtt)
 
-For earlier changes see [1.0.x versions](../1.0.x/mqtt.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/mqtt.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/orientdb.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/orientdb.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Aorientdb)
 
-For earlier changes see [1.0.x versions](../1.0.x/orientdb.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/orientdb.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/s3.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/s3.md
@@ -7,4 +7,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Aaws-s3)
 
-For earlier changes see [1.0.x versions](../1.0.x/s3.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/s3.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/simple-codecs.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/simple-codecs.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Arecordio)
 
-For earlier changes see [1.0.x versions](../1.0.x/simple-codecs.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/simple-codecs.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/slick.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/slick.md
@@ -6,4 +6,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Aslick)
 
-For earlier changes see [1.0.x versions](../1.0.x/slick.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/slick.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/sns.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/sns.md
@@ -7,4 +7,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.0.2+label%3Ap%3Aaws-sns)
 
-For earlier changes see [1.0.x versions](../1.0.x/sns.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/sns.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/solr.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/solr.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Asolr)
 
-For earlier changes see [1.0.x versions](../1.0.x/solr.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/solr.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/spring-web.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/spring-web.md
@@ -6,5 +6,5 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Aspring-web)
 
-For earlier changes see [1.0.x versions](../1.0.x/spring-web.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/spring-web.md)
 

--- a/docs/src/main/paradox/release-notes/1.1.x/sqs.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/sqs.md
@@ -8,4 +8,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Aaws-sqs)
 
-For earlier changes see [1.0.x versions](../1.0.x/sqs.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/sqs.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/sse.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/sse.md
@@ -7,4 +7,4 @@
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Asse)
 
-For earlier changes see [1.0.x versions](../1.0.x/sse.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/sse.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/udp.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/udp.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Audp)
 
-For earlier changes see [1.0.x versions](../1.0.x/udp.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/udp.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/unix-domain-socket.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/unix-domain-socket.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Aunix-domain-socket)
 
-For earlier changes see [1.0.x versions](../1.0.x/unix-domain-socket.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/unix-domain-socket.md)

--- a/docs/src/main/paradox/release-notes/1.1.x/xml.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/xml.md
@@ -6,4 +6,4 @@ No changes.
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Axml)
 
-For earlier changes see [1.0.x versions](../1.0.x/xml.md)
+For earlier changes see @ref:[1.0.x versions](../1.0.x/xml.md)


### PR DESCRIPTION
## Purpose

Use the `@ref` directive for links to the 1.0.x release notes.