### PR TITLE
Allow opt-out of using the ack-timeout.

### DIFF
--- a/jms/src/main/resources/reference.conf
+++ b/jms/src/main/resources/reference.conf
@@ -47,9 +47,9 @@ alpakka.jms {
     # See eg. javax.jms.Session.AUTO_ACKNOWLEDGE
     # Allowed values: "off", "auto", "client", "duplicates-ok", "session", integer value
     acknowledge-mode = off
-    # Timeout for acknowledge.
+    # Timeout for acknowledge, use null for no acknowledge timeout
     # (Used by TX consumers.)
-    ack-timeout = 1 second
+    ack-timeout = null
   }
   #consumer
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
@@ -8,6 +8,8 @@ import akka.actor.ActorSystem
 import akka.util.JavaDurationConverters._
 import com.typesafe.config.{Config, ConfigValueType}
 
+import scala.concurrent.duration.Duration
+
 /**
  * Settings for [[akka.stream.alpakka.jms.scaladsl.JmsConsumer]] and [[akka.stream.alpakka.jms.javadsl.JmsConsumer]].
  */
@@ -134,7 +136,7 @@ object JmsConsumerSettings {
     val selector = getStringOption("selector")
     val acknowledgeMode =
       getOption("acknowledge-mode", c => AcknowledgeMode.from(c.getString("acknowledge-mode")))
-    val ackTimeout = c.getDuration("ack-timeout").asScala
+    val ackTimeout = if (c.hasPath("ack-timeout")) c.getDuration("ack-timeout").asScala else Duration.Inf
     new JmsConsumerSettings(
       connectionFactory,
       connectionRetrySettings,

--- a/jms/src/test/scala/docs/scaladsl/JmsSettingsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsSettingsSpec.scala
@@ -79,7 +79,7 @@ class JmsSettingsSpec extends JmsSpec with OptionValues {
         .withConnectionRetrySettings(retrySettings)
         .withSessionCount(1)
         .withBufferSize(100)
-        .withAckTimeout(1.second)
+        .withAckTimeout(Duration.Inf)
       //#consumer-settings
 
       val retrySettings2 = ConnectionRetrySettings(system)


### PR DESCRIPTION
The ack-timeout introduced in alpakka 1.0.0 is set to 1 second by default for TX Consumers.

This means that if no different timeout is configured and handling the message takes more than one second, then rollback is automatically called. Which surprised me (as I did not know of this default configuration)

In this PR I have disabled the ack-timeout by default. I could understand that this might lead to some discussion. And I would be happy to implement a better solution or different timeout.

One of the problems (which maybe could be addressed separately) is that calling `commit()` on `TxEnvelope` does NOT throw an exception if the session was already rolled back due to the ack-timeout. This seems to be because the `commitFuture` of the `TxEnvelope` is not completed.