### PR TITLE
HDFS: fix target file overwrite

### DIFF
--- a/hdfs/src/main/mima-filters/1.1.x.backwards.excludes
+++ b/hdfs/src/main/mima-filters/1.1.x.backwards.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[Problem]("akka.stream.alpakka.hdfs.impl.*")

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/DataWriter.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/DataWriter.scala
@@ -15,30 +15,30 @@ import org.apache.hadoop.fs.{FSDataOutputStream, FileSystem, Path}
  */
 @InternalApi
 private[writer] final case class DataWriter(
-    fs: FileSystem,
-    pathGenerator: FilePathGenerator,
+    override val fs: FileSystem,
+    override val pathGenerator: FilePathGenerator,
     maybeTargetPath: Option[Path],
-    overwrite: Boolean
+    override val overwrite: Boolean
 ) extends HdfsWriter[FSDataOutputStream, ByteString] {
 
-  protected lazy val target: Path =
+  override protected lazy val target: Path =
     getOrCreatePath(maybeTargetPath, createTargetPath(pathGenerator, 0))
 
-  def sync(): Unit = output.hsync()
+  override def sync(): Unit = output.hsync()
 
-  def write(input: ByteString, separator: Option[Array[Byte]]): Long = {
+  override def write(input: ByteString, separator: Option[Array[Byte]]): Long = {
     val bytes = input.toArray
     output.write(bytes)
     separator.foreach(output.write)
     output.size()
   }
 
-  def rotate(rotationCount: Long): DataWriter = {
+  override def rotate(rotationCount: Long): DataWriter = {
     output.close()
     copy(maybeTargetPath = Some(createTargetPath(pathGenerator, rotationCount)))
   }
 
-  def create(fs: FileSystem, file: Path): FSDataOutputStream = fs.create(file, overwrite)
+  override def create(fs: FileSystem, file: Path): FSDataOutputStream = fs.create(file, overwrite)
 
 }
 

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/HdfsWriter.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/HdfsWriter.scala
@@ -22,6 +22,8 @@ private[hdfs] trait HdfsWriter[W, I] {
   def moveToTarget(): Boolean = {
     if (!fs.exists(target.getParent))
       fs.mkdirs(target.getParent)
+    // mimics FileContext#rename(temp, target, Options.Rename.Overwrite) semantics
+    if (overwrite) fs.delete(target, false)
     fs.rename(temp, target)
   }
 
@@ -36,6 +38,8 @@ private[hdfs] trait HdfsWriter[W, I] {
   protected def target: Path
 
   protected def fs: FileSystem
+
+  protected def overwrite: Boolean
 
   protected def pathGenerator: FilePathGenerator
 

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/SequenceWriter.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/SequenceWriter.scala
@@ -17,29 +17,29 @@ import org.apache.hadoop.io.{SequenceFile, Writable}
  */
 @InternalApi
 private[writer] final case class SequenceWriter[K <: Writable, V <: Writable](
-    fs: FileSystem,
+    override val fs: FileSystem,
     writerOptions: Seq[Writer.Option],
-    pathGenerator: FilePathGenerator,
-    overwrite: Boolean,
+    override val pathGenerator: FilePathGenerator,
+    override val overwrite: Boolean,
     maybeTargetPath: Option[Path]
 ) extends HdfsWriter[SequenceFile.Writer, (K, V)] {
 
-  protected lazy val target: Path =
+  override protected lazy val target: Path =
     getOrCreatePath(maybeTargetPath, createTargetPath(pathGenerator, 0))
 
-  def sync(): Unit = output.hsync()
+  override def sync(): Unit = output.hsync()
 
-  def write(input: (K, V), separator: Option[Array[Byte]]): Long = {
+  override def write(input: (K, V), separator: Option[Array[Byte]]): Long = {
     output.append(input._1, input._2)
     output.getLength
   }
 
-  def rotate(rotationCount: Long): SequenceWriter[K, V] = {
+  override def rotate(rotationCount: Long): SequenceWriter[K, V] = {
     output.close()
     copy(maybeTargetPath = Some(createTargetPath(pathGenerator, rotationCount)))
   }
 
-  protected def create(fs: FileSystem, file: Path): SequenceFile.Writer = {
+  override protected def create(fs: FileSystem, file: Path): SequenceFile.Writer = {
     val ops = SequenceFile.Writer.file(file) +: writerOptions
     SequenceFile.createWriter(fs.getConf, ops: _*)
   }

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/SequenceWriter.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/SequenceWriter.scala
@@ -20,6 +20,7 @@ private[writer] final case class SequenceWriter[K <: Writable, V <: Writable](
     fs: FileSystem,
     writerOptions: Seq[Writer.Option],
     pathGenerator: FilePathGenerator,
+    overwrite: Boolean,
     maybeTargetPath: Option[Path]
 ) extends HdfsWriter[SequenceFile.Writer, (K, V)] {
 
@@ -54,9 +55,10 @@ private[hdfs] object SequenceWriter {
       fs: FileSystem,
       classK: Class[K],
       classV: Class[V],
-      pathGenerator: FilePathGenerator
+      pathGenerator: FilePathGenerator,
+      overwrite: Boolean
   ): SequenceWriter[K, V] =
-    new SequenceWriter[K, V](fs, options(classK, classV), pathGenerator, None)
+    new SequenceWriter[K, V](fs, options(classK, classV), pathGenerator, overwrite, None)
 
   def apply[K <: Writable, V <: Writable](
       fs: FileSystem,
@@ -64,9 +66,14 @@ private[hdfs] object SequenceWriter {
       compressionCodec: CompressionCodec,
       classK: Class[K],
       classV: Class[V],
-      pathGenerator: FilePathGenerator
+      pathGenerator: FilePathGenerator,
+      overwrite: Boolean
   ): SequenceWriter[K, V] =
-    new SequenceWriter[K, V](fs, options(compressionType, compressionCodec, classK, classV), pathGenerator, None)
+    new SequenceWriter[K, V](fs,
+                             options(compressionType, compressionCodec, classK, classV),
+                             pathGenerator,
+                             overwrite,
+                             None)
 
   private def options[K <: Writable, V <: Writable](
       classK: Class[K],

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/scaladsl/HdfsFlow.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/scaladsl/HdfsFlow.scala
@@ -195,7 +195,7 @@ object HdfsFlow {
           syncStrategy,
           rotationStrategy,
           settings,
-          SequenceWriter(fs, classK, classV, settings.pathGenerator)
+          SequenceWriter(fs, classK, classV, settings.pathGenerator, settings.overwrite)
         )
       )
 
@@ -228,7 +228,13 @@ object HdfsFlow {
           syncStrategy,
           rotationStrategy,
           settings,
-          SequenceWriter(fs, compressionType, compressionCodec, classK, classV, settings.pathGenerator)
+          SequenceWriter(fs,
+                         compressionType,
+                         compressionCodec,
+                         classK,
+                         classV,
+                         settings.pathGenerator,
+                         settings.overwrite)
         )
       )
 }


### PR DESCRIPTION
Fixes https://github.com/akka/alpakka/issues/1761

## Purpose

Overwrite HDFS target file when the `overwrite` setting is set to true.

## Changes

* propagated overwrite information to HdfsWriter base trait
* deleted existing file if overwrite is enabled in HdfsWriter#moveToTarget function

## Background Context

This is the most simple fix I could come up with but there are still some issues with the code imho:
* First the result of the `moveToTarget` operation is ignored at https://github.com/akka/alpakka/blob/master/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/HdfsFlowStage.scala#L144 . This results in silent errors which lead to the original issue. What would be the best approach to handle errors here?
* Secondly, `org.apache.hadoop.fs.FileSystem` does not provide a `rename` function that can take an overwrite flag or option. This is why I had to break the atomicity of the `rename` operation with a `delete`. `org.apache.hadoop.fs.FileContext` does provide such a `rename` method https://hadoop.apache.org/docs/r3.1.1/api/org/apache/hadoop/fs/FileContext.html#rename-org.apache.hadoop.fs.Path-org.apache.hadoop.fs.Path-org.apache.hadoop.fs.Options.Rename...- but using it would require to use `FileContext` instead of `FileSystem` all the way around, and ultimately, break the public API.
