### PR TITLE
Update to Akka 2.6.0-M5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val Scala213 = "2.13.0"
   val ScalaVersions = Seq(Scala212, Scala211, Scala213).filterNot(_ == Scala211 && Nightly)
 
-  val AkkaVersion = if (Nightly) "2.6.0-M4" else "2.5.23"
+  val AkkaVersion = if (Nightly) "2.6.0-M5" else "2.5.23"
 
   val InfluxDBJavaVersion = "2.15"
 


### PR DESCRIPTION
## Purpose

Updates to the latest Akka milestone 2.6.0-RC5 for the nightly runs.