### PR TITLE
[elasticsearch] Prepend the index name to the url in _bulk operations when necessary

### DIFF
--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -121,9 +121,12 @@ Java
 | bufferSize          | 10      | Flow and Sink batch messages to bulk requests when back-pressure applies.                             |
 | versionType         | None    | If set, `ElasticsearchSink` uses the chosen versionType to index documents. See [Version types](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types) for accepted settings. |
 | retryLogic | No retries | See below |
+| allowExplicitIndex | True | When set to False, the index name will be included in the URL instead of on each document | See below |
 
 
 A bulk request might fail partially for some reason. To retry failed writes to Elasticsearch, a `RetryLogic` can be specified. The provided implementation is `RetryAtFixedRate`.
+
+When using the `_bulk` API, Elasticsearch will reject requests that have an explicit index in the request body if explicit index names are not allowed. See [URL-based access control](https://www.elastic.co/guide/en/elasticsearch/reference/current/url-access-control.html)
 
 @@@ warning
 If using retries, you will receive messages **out of order downstream** in cases when Elasticsearch returns an error on some of the documents in a bulk request.

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchWriteSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchWriteSettings.scala
@@ -54,7 +54,7 @@ final class ElasticsearchWriteSettings private (val bufferSize: Int,
 
   def withVersionType(value: String): ElasticsearchWriteSettings = copy(versionType = Option(value))
 
-  def withMultiAllowExplicitIndex(value: Boolean): ElasticsearchWriteSettings = copy(allowExplicitIndex = value)
+  def withAllowExplicitIndex(value: Boolean): ElasticsearchWriteSettings = copy(allowExplicitIndex = value)
 
   private def copy(bufferSize: Int = bufferSize,
                    retryLogic: RetryLogic = retryLogic,

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchWriteSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchWriteSettings.scala
@@ -44,7 +44,8 @@ object RetryAtFixedRate {
  */
 final class ElasticsearchWriteSettings private (val bufferSize: Int,
                                                 val retryLogic: RetryLogic,
-                                                val versionType: Option[String]) {
+                                                val versionType: Option[String],
+                                                val multiAllowExplicitIndex: Boolean) {
 
   def withBufferSize(value: Int): ElasticsearchWriteSettings = copy(bufferSize = value)
 
@@ -53,18 +54,24 @@ final class ElasticsearchWriteSettings private (val bufferSize: Int,
 
   def withVersionType(value: String): ElasticsearchWriteSettings = copy(versionType = Option(value))
 
+  def withMultiAllowExplicitIndex(value: Boolean): ElasticsearchWriteSettings = copy(multiAllowExplicitIndex = value)
+
   private def copy(bufferSize: Int = bufferSize,
                    retryLogic: RetryLogic = retryLogic,
-                   versionType: Option[String] = versionType): ElasticsearchWriteSettings =
-    new ElasticsearchWriteSettings(bufferSize = bufferSize, retryLogic = retryLogic, versionType = versionType)
+                   versionType: Option[String] = versionType,
+                   multiAllowExplicitIndex: Boolean = multiAllowExplicitIndex): ElasticsearchWriteSettings =
+    new ElasticsearchWriteSettings(bufferSize = bufferSize,
+                                   retryLogic = retryLogic,
+                                   versionType = versionType,
+                                   multiAllowExplicitIndex = multiAllowExplicitIndex)
 
   override def toString =
-    s"ElasticsearchUpdateSettings(bufferSize=$bufferSize,retryLogic=$retryLogic,versionType=$versionType)"
+    s"ElasticsearchUpdateSettings(bufferSize=$bufferSize,retryLogic=$retryLogic,versionType=$versionType,multiAllowExplicitIndex=$multiAllowExplicitIndex)"
 
 }
 
 object ElasticsearchWriteSettings {
-  val Default = new ElasticsearchWriteSettings(bufferSize = 10, retryLogic = RetryNever, versionType = None)
+  val Default = new ElasticsearchWriteSettings(bufferSize = 10, retryLogic = RetryNever, versionType = None, multiAllowExplicitIndex = False)
 
   /** Scala API */
   def apply(): ElasticsearchWriteSettings = Default

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchWriteSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchWriteSettings.scala
@@ -45,7 +45,7 @@ object RetryAtFixedRate {
 final class ElasticsearchWriteSettings private (val bufferSize: Int,
                                                 val retryLogic: RetryLogic,
                                                 val versionType: Option[String],
-                                                val multiAllowExplicitIndex: Boolean) {
+                                                val allowExplicitIndex: Boolean) {
 
   def withBufferSize(value: Int): ElasticsearchWriteSettings = copy(bufferSize = value)
 
@@ -54,24 +54,24 @@ final class ElasticsearchWriteSettings private (val bufferSize: Int,
 
   def withVersionType(value: String): ElasticsearchWriteSettings = copy(versionType = Option(value))
 
-  def withMultiAllowExplicitIndex(value: Boolean): ElasticsearchWriteSettings = copy(multiAllowExplicitIndex = value)
+  def withMultiAllowExplicitIndex(value: Boolean): ElasticsearchWriteSettings = copy(allowExplicitIndex = value)
 
   private def copy(bufferSize: Int = bufferSize,
                    retryLogic: RetryLogic = retryLogic,
                    versionType: Option[String] = versionType,
-                   multiAllowExplicitIndex: Boolean = multiAllowExplicitIndex): ElasticsearchWriteSettings =
+                   allowExplicitIndex: Boolean = allowExplicitIndex): ElasticsearchWriteSettings =
     new ElasticsearchWriteSettings(bufferSize = bufferSize,
                                    retryLogic = retryLogic,
                                    versionType = versionType,
-                                   multiAllowExplicitIndex = multiAllowExplicitIndex)
+                                   allowExplicitIndex = allowExplicitIndex)
 
   override def toString =
-    s"ElasticsearchUpdateSettings(bufferSize=$bufferSize,retryLogic=$retryLogic,versionType=$versionType,multiAllowExplicitIndex=$multiAllowExplicitIndex)"
+    s"ElasticsearchUpdateSettings(bufferSize=$bufferSize,retryLogic=$retryLogic,versionType=$versionType,allowExplicitIndex=$allowExplicitIndex)"
 
 }
 
 object ElasticsearchWriteSettings {
-  val Default = new ElasticsearchWriteSettings(bufferSize = 10, retryLogic = RetryNever, versionType = None, multiAllowExplicitIndex = True)
+  val Default = new ElasticsearchWriteSettings(bufferSize = 10, retryLogic = RetryNever, versionType = None, allowExplicitIndex = True)
 
   /** Scala API */
   def apply(): ElasticsearchWriteSettings = Default

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchWriteSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchWriteSettings.scala
@@ -74,7 +74,7 @@ object ElasticsearchWriteSettings {
   val Default = new ElasticsearchWriteSettings(bufferSize = 10,
                                                retryLogic = RetryNever,
                                                versionType = None,
-                                               allowExplicitIndex = True)
+                                               allowExplicitIndex = true)
 
   /** Scala API */
   def apply(): ElasticsearchWriteSettings = Default

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchWriteSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchWriteSettings.scala
@@ -71,7 +71,10 @@ final class ElasticsearchWriteSettings private (val bufferSize: Int,
 }
 
 object ElasticsearchWriteSettings {
-  val Default = new ElasticsearchWriteSettings(bufferSize = 10, retryLogic = RetryNever, versionType = None, allowExplicitIndex = True)
+  val Default = new ElasticsearchWriteSettings(bufferSize = 10,
+                                               retryLogic = RetryNever,
+                                               versionType = None,
+                                               allowExplicitIndex = True)
 
   /** Scala API */
   def apply(): ElasticsearchWriteSettings = Default

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
@@ -40,6 +40,8 @@ private[elasticsearch] final class ElasticsearchFlowStage[T, C](
 
   private val sharedFieldsFn = if (settings.multiAllowExplicitIndex) sharedFields else sharedFieldsNoIndex
 
+  private val endpoint = if (settings.multiAllowExplicitIndex) "/_bulk" else s"/$indexName/_bulk"
+
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new StageLogic()
 
   private class StageLogic extends TimerGraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
@@ -206,7 +208,7 @@ private[elasticsearch] final class ElasticsearchFlowStage[T, C](
 
       client.performRequestAsync(
         "POST",
-        "/_bulk",
+        endpoint,
         java.util.Collections.emptyMap[String, String](),
         new StringEntity(json, StandardCharsets.UTF_8),
         new ResponseListener() {

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
@@ -122,6 +122,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll wi
         .withBufferSize(10)
         .withVersionType("internal")
         .withRetryLogic(RetryAtFixedRate(maxRetries = 5, retryInterval = 1.second))
+        .withAllowExplicitIndex(true)
     //#sink-settings
   }
 
@@ -137,6 +138,20 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll wi
       }
       .runWith(Sink.seq)
 
+  "Sink Settings" should {
+    "copy explicit index name permission" in {
+      val sinkSettings =
+        ElasticsearchWriteSettings()
+          .withBufferSize(10)
+          .withVersionType("internal")
+          .withRetryLogic(RetryAtFixedRate(maxRetries = 5, retryInterval = 1.second))
+
+      val restrictiveCopy = sinkSettings.withAllowExplicitIndex(false)
+
+      restrictiveCopy.allowExplicitIndex shouldEqual false
+    }
+
+  }
   "Source Settings" should {
     "convert scrollDuration value to correct scroll string value (Days)" in {
       val sourceSettings = ElasticsearchSourceSettings()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -102,7 +102,7 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-http-xml" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
         // https://github.com/akka/alpakka-kafka/releases
-        "com.typesafe.akka" %% "akka-stream-kafka" % "1.0.4",
+        "com.typesafe.akka" %% "akka-stream-kafka" % "1.0.5",
         // https://github.com/javaee/javax.jms
         "javax.jms" % "jms" % "1.1", // CDDL Version 1.1
         // http://activemq.apache.org/download.html


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ x] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose
Enables the use of the Elasticsearch Sink in non-default environments where url-based access control is performed.
<!-- What does this PR do? -->

## References


<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #1843 

## Changes

<!-- Bullets for important changes in this PR -->
* Adding two fields to `ElasticsearchFlowStage [T,C]`: The actual endpoint to which the `_bulk` request will be performed and a method that includes (or not ) the index name on each document. The Stage contains all necessary information at construct-time.
 
## Background Context

Current implementation of the Elastic search Sink will fail (requests rejected) if the cluster configuration does not hold the default setting for the `rest.action.multi.allow_explicit_index` property, which is common when url-based access control is performed (multi-tenancy)

These changes enabled the elasticsearch sink to work in these conditions, while preserving the current behaviour by default.

