### PR TITLE
 JMS transactions: fail stream or log on ack timeouts 

### DIFF
--- a/jms/src/main/mima-filters/1.1.1.backwards.excludes
+++ b/jms/src/main/mima-filters/1.1.1.backwards.excludes
@@ -1,0 +1,3 @@
+# PR #1857
+# new field in settings
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.jms.JmsConsumerSettings.this")

--- a/jms/src/main/resources/reference.conf
+++ b/jms/src/main/resources/reference.conf
@@ -52,7 +52,7 @@ alpakka.jms {
     ack-timeout = 1 second
     # For use with transactions, if true the stream fails if Alpakka rolls back the transaction
     # when `ack-timeout` is hit.
-    fail-on-ack-timeout = false
+    fail-stream-on-ack-timeout = false
   }
   #consumer
 

--- a/jms/src/main/resources/reference.conf
+++ b/jms/src/main/resources/reference.conf
@@ -50,6 +50,9 @@ alpakka.jms {
     # Timeout for acknowledge.
     # (Used by TX consumers.)
     ack-timeout = 1 second
+    # For use with transactions, if true the stream fails if Alpakka rolls back the transaction
+    # when `ack-timeout` is hit.
+    fail-on-ack-timeout = false
   }
   #consumer
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
@@ -21,7 +21,7 @@ final class JmsConsumerSettings private (
     val selector: Option[String],
     val acknowledgeMode: Option[AcknowledgeMode],
     val ackTimeout: scala.concurrent.duration.Duration,
-    val failOnAckTimeout: Boolean
+    val failStreamOnAckTimeout: Boolean
 ) extends akka.stream.alpakka.jms.JmsSettings {
 
   /** Factory to use for creating JMS connections. */
@@ -76,8 +76,8 @@ final class JmsConsumerSettings private (
   /**
    * For use with transactions, if true the stream fails if Alpakka rolls back the transaction when `ackTimeout` is hit.
    */
-  def withFailOnAckTimeout(value: Boolean): JmsConsumerSettings =
-    if (failOnAckTimeout == value) this else copy(failOnAckTimeout = value)
+  def withFailStreamOnAckTimeout(value: Boolean): JmsConsumerSettings =
+    if (failStreamOnAckTimeout == value) this else copy(failStreamOnAckTimeout = value)
 
   private def copy(
       connectionFactory: javax.jms.ConnectionFactory = connectionFactory,
@@ -89,7 +89,7 @@ final class JmsConsumerSettings private (
       selector: Option[String] = selector,
       acknowledgeMode: Option[AcknowledgeMode] = acknowledgeMode,
       ackTimeout: scala.concurrent.duration.Duration = ackTimeout,
-      failOnAckTimeout: Boolean = failOnAckTimeout
+      failStreamOnAckTimeout: Boolean = failStreamOnAckTimeout
   ): JmsConsumerSettings = new JmsConsumerSettings(
     connectionFactory = connectionFactory,
     connectionRetrySettings = connectionRetrySettings,
@@ -100,7 +100,7 @@ final class JmsConsumerSettings private (
     selector = selector,
     acknowledgeMode = acknowledgeMode,
     ackTimeout = ackTimeout,
-    failOnAckTimeout = failOnAckTimeout
+    failStreamOnAckTimeout = failStreamOnAckTimeout
   )
 
   override def toString =
@@ -114,8 +114,8 @@ final class JmsConsumerSettings private (
     s"selector=$selector," +
     s"acknowledgeMode=${acknowledgeMode.map(m => AcknowledgeMode.asString(m))}," +
     s"ackTimeout=${ackTimeout.toCoarsest}," +
-    s"failOnAckTimeout=$failOnAckTimeout"
-  ")"
+    s"failStreamOnAckTimeout=$failStreamOnAckTimeout" +
+    ")"
 }
 
 object JmsConsumerSettings {
@@ -145,7 +145,7 @@ object JmsConsumerSettings {
     val acknowledgeMode =
       getOption("acknowledge-mode", c => AcknowledgeMode.from(c.getString("acknowledge-mode")))
     val ackTimeout = c.getDuration("ack-timeout").asScala
-    val failOnAckTimeout = c.getBoolean("fail-on-ack-timeout")
+    val failStreamOnAckTimeout = c.getBoolean("fail-stream-on-ack-timeout")
     new JmsConsumerSettings(
       connectionFactory,
       connectionRetrySettings,
@@ -156,7 +156,7 @@ object JmsConsumerSettings {
       selector,
       acknowledgeMode,
       ackTimeout,
-      failOnAckTimeout
+      failStreamOnAckTimeout
     )
   }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsExceptions.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsExceptions.scala
@@ -6,6 +6,7 @@ package akka.stream.alpakka.jms
 import javax.jms
 
 import scala.concurrent.TimeoutException
+import scala.concurrent.duration.Duration
 import scala.util.control.NoStackTrace
 
 /**
@@ -56,3 +57,6 @@ final case class StopMessageListenerException() extends Exception("Stopping Mess
 case object JmsNotConnected extends Exception("JmsConnector is not connected") with NoStackTrace
 
 case class JmsConnectTimedOut(message: String) extends TimeoutException(message)
+
+final class JmsTxAckTimeout(ackTimeout: Duration)
+    extends TimeoutException(s"The TxEnvelope didn't get committed or rolled back within ack-timeout ($ackTimeout)")

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsTxSourceStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsTxSourceStage.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.jms.impl
 
 import akka.annotation.InternalApi
-import akka.stream.alpakka.jms.{AcknowledgeMode, Destination, JmsConsumerSettings, TxEnvelope}
+import akka.stream.alpakka.jms.{AcknowledgeMode, Destination, JmsConsumerSettings, JmsTxAckTimeout, TxEnvelope}
 import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue}
 import akka.stream.{Attributes, Outlet, SourceShape}
 import javax.jms
@@ -50,10 +50,23 @@ private[jms] final class JmsTxSourceStage(settings: JmsConsumerSettings, destina
                     try {
                       val envelope = TxEnvelope(message, session)
                       handleMessage.invoke(envelope)
-                      val action = Await.result(envelope.commitFuture, settings.ackTimeout)
-                      action()
+                      try {
+                        // JMS spec defines that commit/rollback must be done on the same thread.
+                        // While some JMS implementations work without this constraint, IBM MQ is
+                        // very strict about the spec and throws exceptions when called from a different thread.
+                        val action = Await.result(envelope.commitFuture, settings.ackTimeout)
+                        action()
+                      } catch {
+                        case _: TimeoutException =>
+                          val exception = new JmsTxAckTimeout(settings.ackTimeout)
+                          session.session.rollback()
+                          if (settings.failOnAckTimeout) {
+                            handleError.invoke(exception)
+                          } else {
+                            log.warning(exception.getMessage)
+                          }
+                      }
                     } catch {
-                      case _: TimeoutException => session.session.rollback()
                       case e: IllegalArgumentException => handleError.invoke(e) // Invalid envelope. Fail the stage.
                       case e: jms.JMSException => handleError.invoke(e)
                     }
@@ -63,7 +76,7 @@ private[jms] final class JmsTxSourceStage(settings: JmsConsumerSettings, destina
 
           case _ =>
             throw new IllegalArgumentException(
-              "Session must be of type JMSAckSession, it is a " +
+              "Session must be of type JmsAckSession, it is a " +
               jmsSession.getClass.getName
             )
         }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsTxSourceStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsTxSourceStage.scala
@@ -60,7 +60,7 @@ private[jms] final class JmsTxSourceStage(settings: JmsConsumerSettings, destina
                         case _: TimeoutException =>
                           val exception = new JmsTxAckTimeout(settings.ackTimeout)
                           session.session.rollback()
-                          if (settings.failOnAckTimeout) {
+                          if (settings.failStreamOnAckTimeout) {
                             handleError.invoke(exception)
                           } else {
                             log.warning(exception.getMessage)

--- a/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
@@ -572,7 +572,7 @@ class JmsTxConnectorsSpec extends JmsSpec {
         resultList.toSet should contain theSameElementsAs numsIn.map(_.toString)
     }
 
-    "fail the stream when ack-timeout causes a rollback (and fail-on-ack-timeout is true)" in {
+    "fail the stream when ack-timeout causes a rollback (and fail-stream-on-ack-timeout is true)" in {
       withConnectionFactory() { connectionFactory =>
         val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer.sink(
           JmsProducerSettings(producerConfig, connectionFactory).withQueue("numbers")
@@ -591,7 +591,7 @@ class JmsTxConnectorsSpec extends JmsSpec {
             .withSessionCount(5)
             .withQueue("numbers")
             .withAckTimeout(10.millis)
-            .withFailOnAckTimeout(true)
+            .withFailStreamOnAckTimeout(true)
         )
 
         val r = new java.util.Random

--- a/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
@@ -519,7 +519,7 @@ class JmsTxConnectorsSpec extends JmsSpec {
             Sink.foreach { env =>
               val text = env.message.asInstanceOf[TextMessage].getText
               if (r.nextInt(3) <= 1) {
-                // Artifially timing out this message
+                // Artificially timing out this message
                 Thread.sleep(20)
               }
               resultQueue.add(text)
@@ -570,6 +570,53 @@ class JmsTxConnectorsSpec extends JmsSpec {
 
         // messages might get delivered more than once, use set to ignore duplicates
         resultList.toSet should contain theSameElementsAs numsIn.map(_.toString)
+    }
+
+    "fail the stream when ack-timeout causes a rollback (and fail-on-ack-timeout is true)" in {
+      withConnectionFactory() { connectionFactory =>
+        val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer.sink(
+          JmsProducerSettings(producerConfig, connectionFactory).withQueue("numbers")
+        )
+
+        val publishKillSwitch = Source
+          .unfold(1)(n => Some(n + 1 -> n))
+          .throttle(15, 1.second, 2, ThrottleMode.shaping) // Higher than consumption rate.
+          .viaMat(KillSwitches.single)(Keep.right)
+          .alsoTo(Flow[Int].map(n => JmsTextMessage(n.toString).withProperty("Number", n)).to(jmsSink))
+          .toMat(Sink.ignore)(Keep.left)
+          .run()
+
+        val jmsSource: Source[TxEnvelope, JmsConsumerControl] = JmsConsumer.txSource(
+          JmsConsumerSettings(consumerConfig, connectionFactory)
+            .withSessionCount(5)
+            .withQueue("numbers")
+            .withAckTimeout(10.millis)
+            .withFailOnAckTimeout(true)
+        )
+
+        val r = new java.util.Random
+
+        val (killSwitch, streamDone) = jmsSource
+          .throttle(10, 1.second, 2, ThrottleMode.shaping)
+          .toMat(
+            Sink.foreach { env =>
+              if (r.nextInt(3) <= 1) {
+                // Artificially timing out this message
+                Thread.sleep(20)
+              }
+              env.commit()
+            }
+          )(Keep.both)
+          .run()
+
+        // Need to wait for the stream to have started and running for sometime.
+        Thread.sleep(3000)
+
+        killSwitch.shutdown()
+
+        streamDone.failed.futureValue shouldBe a[JmsTxAckTimeout]
+        publishKillSwitch.shutdown()
+      }
     }
   }
 }


### PR DESCRIPTION
## Purpose

Let the user notice when a transaction gets rolled back because `ack-timeout` was hit.

## References

Implements #1855 
See #1831 

## Changes

* Log warning or fail the stream when the commit future isn't completed within `ack-timeout`
* Introduce setting `fail-stream-on-ack-timeout` to let the user opt-in to let the stream fail

## Background Context

It might seem natural to fail the promise in `TxEnvelope` so that `commit` and `rollback` would fail with "Promise already completed" when an ACK timeout occurred. This behaviour could be desirable but is not backwards compatible for scenarios that handle duplicated messages today. cc @andreas-schroeder 
