### PR TITLE
CSV: accept quotes ending mid-column

### DIFF
--- a/csv/src/test/resources/correctness.csv
+++ b/csv/src/test/resources/correctness.csv
@@ -5,3 +5,5 @@ Year,Make,Model,Description,Price
 air, moon roof, loaded",4799.00
 1999,Chevy,"Venture ""Extended Edition, Very Large""",,5000.00
 ,,"Venture ""Extended Edition""","",4900.00
+1995,VW,Golf "GTE",,5000.00
+1996,VW,"Golf" GTE,,5000.00

--- a/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
@@ -72,6 +72,18 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       expectInOut("a,\"\",c\n", List("a", "", "c"))
     }
 
+    "accept mid-column quotes" in {
+      expectInOut("11,22\"z\",13\n", List("11", "22\"z\"", "13"))
+    }
+
+    "accept quote ending mid-column" in {
+      expectInOut("11,\"z\"22,13\n", List("11", "z22", "13"))
+    }
+
+    "accept quote ending mid-column (with new line)" in {
+      expectInOut("11,\"z\n\"22,13\n", List("11", "z\n22", "13"))
+    }
+
     "parse double quote chars within quotes into one quote" in {
       expectInOut("a,\"\"\"\",c\n", List("a", "\"", "c"))
     }

--- a/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
@@ -228,6 +228,24 @@ class CsvParsingSpec extends CsvSpec {
           "Price" -> "4900.00"
         )
       )
+      res(5) should contain allElementsOf (
+        Map(
+          "Year" -> "1995",
+          "Make" -> "VW",
+          "Model" -> "Golf \"GTE\"",
+          "Description" -> "",
+          "Price" -> "5000.00"
+        )
+      )
+      res(6) should contain allElementsOf (
+        Map(
+          "Year" -> "1996",
+          "Make" -> "VW",
+          "Model" -> "Golf GTE",
+          "Description" -> "",
+          "Price" -> "5000.00"
+        )
+      )
     }
   }
 }


### PR DESCRIPTION
##  Purpose

Allow quotes to end mid-column (those quotes disappear in output).

## References

Reported in #1835 

## Background Context

The Alpakka CSV parser was strict on the second quote of a quoted column to end it. Instead, it now reads on as if the field wasn't quoted in the first place.