### PR TITLE
Mima: don't check reference connector, as it is not published

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -231,8 +231,7 @@ lazy val mqttStreaming = alpakkaProject("mqtt-streaming",
                                         "mqttStreaming",
                                         Dependencies.MqttStreaming,
                                         crossScalaVersions -= Dependencies.Scala211)
-lazy val mqttStreamingBench = internalProject("mqtt-streaming-bench",
-                                             crossScalaVersions -= Dependencies.Scala211)
+lazy val mqttStreamingBench = internalProject("mqtt-streaming-bench", crossScalaVersions -= Dependencies.Scala211)
   .enablePlugins(JmhPlugin)
   .dependsOn(mqtt, mqttStreaming)
 
@@ -242,8 +241,7 @@ lazy val orientdb = alpakkaProject("orientdb",
                                    fork in Test := true,
                                    parallelExecution in Test := false)
 
-lazy val reference = alpakkaProject("reference", "reference", Dependencies.Reference, publish / skip := true)
-  .disablePlugins(BintrayPlugin)
+lazy val reference = internalProject("reference", Dependencies.Reference)
 
 lazy val s3 = alpakkaProject("s3", "aws.s3", Dependencies.S3)
 
@@ -370,7 +368,6 @@ lazy val `doc-examples` = project
 
 def alpakkaProject(projectId: String, moduleName: String, additionalSettings: sbt.Def.SettingsDefinition*): Project = {
   import com.typesafe.tools.mima.core.{Problem, ProblemFilters}
-  import sbt.Keys.publish
   Project(id = projectId, base = file(projectId))
     .enablePlugins(AutomateHeaderPlugin)
     .disablePlugins(SitePlugin)
@@ -384,7 +381,7 @@ def alpakkaProject(projectId: String, moduleName: String, additionalSettings: sb
       mimaBinaryIssueFilters += ProblemFilters.exclude[Problem]("*.impl.*")
     )
     .settings(additionalSettings: _*)
-  }
+}
 
 def internalProject(projectId: String, additionalSettings: sbt.Def.SettingsDefinition*): Project =
   Project(id = projectId, base = file(projectId))


### PR DESCRIPTION
## Purpose

Use the `interalProject` setup for the reference connector to not check Mima for it.

## References

#1860
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #xxxx

## Background Context

#1860 enabled Mima for the reference connector which isn't published, so it doesn't work.