### PR TITLE
Elasticsearch: store JSON strings

### DIFF
--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -151,6 +151,18 @@ Java
 : @@snip [snip](/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTest.java) { #run-flow }
 
 
+### Storing documents from Strings
+
+Elasticsearch requires the documents to be properly formatted JSON. If your data is available as JSON in Strings, you may use the pre-defined `StringMessageWriter` to avoid any conversions. For any other JSON technologies, implement a @scala[`MessageWriter[T]`]@java[`MessageWriter<T>`].
+
+Scala
+: @@snip [snip](/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala) { #string }
+
+Java
+: @@snip [snip](/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTest.java) { #string }
+
+
+
 ### Passing data through ElasticsearchFlow
 
 When streaming documents from Kafka, you might want to commit to Kafka **AFTER** the document has been written to Elastic.

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/WriteMessage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/WriteMessage.scala
@@ -168,10 +168,12 @@ trait MessageWriter[T] {
   def convert(message: T): String
 }
 
-class StringMessageWriter extends MessageWriter[String] {
+sealed class StringMessageWriter private () extends MessageWriter[String] {
   override def convert(message: String): String = message
 }
 
 object StringMessageWriter extends StringMessageWriter {
-  val INSTANCE: StringMessageWriter = StringMessageWriter
+
+  /** Java API: get the singleton instance of `StringMessageWriter` */
+  val getInstance: StringMessageWriter = StringMessageWriter
 }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/WriteMessage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/WriteMessage.scala
@@ -167,3 +167,11 @@ final class WriteResult[T2, C2] @InternalApi private[elasticsearch] (val message
 trait MessageWriter[T] {
   def convert(message: T): String
 }
+
+class StringMessageWriter extends MessageWriter[String] {
+  override def convert(message: String): String = message
+}
+
+object StringMessageWriter extends StringMessageWriter {
+  val INSTANCE: StringMessageWriter = StringMessageWriter
+}

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
@@ -24,6 +24,8 @@ object ElasticsearchFlow {
    * successful execution.
    *
    * Warning: When settings configure retrying, messages are emitted out-of-order when errors are detected.
+   *
+   * @param objectMapper Jackson object mapper converting type T` to JSON
    */
   def create[T](
       indexName: String,
@@ -32,15 +34,29 @@ object ElasticsearchFlow {
       elasticsearchClient: RestClient,
       objectMapper: ObjectMapper
   ): akka.stream.javadsl.Flow[WriteMessage[T, NotUsed], WriteResult[T, NotUsed], NotUsed] =
+    create(indexName, typeName, settings, elasticsearchClient, new JacksonWriter[T](objectMapper))
+
+  /**
+   * Create a flow to update Elasticsearch with [[akka.stream.alpakka.elasticsearch.WriteMessage WriteMessage]]s containing type `T`.
+   * The result status is part of the [[akka.stream.alpakka.elasticsearch.WriteResult WriteResult]] and must be checked for
+   * successful execution.
+   *
+   * Warning: When settings configure retrying, messages are emitted out-of-order when errors are detected.
+   *
+   * @param messageWriter converts type `T` to a `String` containing valid JSON
+   */
+  def create[T](
+      indexName: String,
+      typeName: String,
+      settings: ElasticsearchWriteSettings,
+      elasticsearchClient: RestClient,
+      messageWriter: MessageWriter[T]
+  ): akka.stream.javadsl.Flow[WriteMessage[T, NotUsed], WriteResult[T, NotUsed], NotUsed] =
     scaladsl
       .Flow[WriteMessage[T, NotUsed]]
       .batch(settings.bufferSize, immutable.Seq(_)) { case (seq, wm) => seq :+ wm }
       .via(
-        new impl.ElasticsearchFlowStage[T, NotUsed](indexName,
-                                                    typeName,
-                                                    elasticsearchClient,
-                                                    settings,
-                                                    new JacksonWriter[T](objectMapper))
+        new impl.ElasticsearchFlowStage[T, NotUsed](indexName, typeName, elasticsearchClient, settings, messageWriter)
       )
       .mapConcat(identity)
       .asJava
@@ -52,6 +68,8 @@ object ElasticsearchFlow {
    * successful execution.
    *
    * Warning: When settings configure retrying, messages are emitted out-of-order when errors are detected.
+   *
+   * @param objectMapper Jackson object mapper converting type `T` to JSON
    */
   def createWithPassThrough[T, C](
       indexName: String,
@@ -60,15 +78,30 @@ object ElasticsearchFlow {
       elasticsearchClient: RestClient,
       objectMapper: ObjectMapper
   ): akka.stream.javadsl.Flow[WriteMessage[T, C], WriteResult[T, C], NotUsed] =
+    createWithPassThrough(indexName, typeName, settings, elasticsearchClient, new JacksonWriter[T](objectMapper))
+
+  /**
+   * Create a flow to update Elasticsearch with [[akka.stream.alpakka.elasticsearch.WriteMessage WriteMessage]]s containing type `T`
+   * with `passThrough` of type `C`.
+   * The result status is part of the [[akka.stream.alpakka.elasticsearch.WriteResult WriteResult]] and must be checked for
+   * successful execution.
+   *
+   * Warning: When settings configure retrying, messages are emitted out-of-order when errors are detected.
+   *
+   * @param messageWriter converts type `T` to a `String` containing valid JSON
+   */
+  def createWithPassThrough[T, C](
+      indexName: String,
+      typeName: String,
+      settings: ElasticsearchWriteSettings,
+      elasticsearchClient: RestClient,
+      messageWriter: MessageWriter[T]
+  ): akka.stream.javadsl.Flow[WriteMessage[T, C], WriteResult[T, C], NotUsed] =
     scaladsl
       .Flow[WriteMessage[T, C]]
       .batch(settings.bufferSize, immutable.Seq(_)) { case (seq, wm) => seq :+ wm }
       .via(
-        new impl.ElasticsearchFlowStage[T, C](indexName,
-                                              typeName,
-                                              elasticsearchClient,
-                                              settings,
-                                              new JacksonWriter[T](objectMapper))
+        new impl.ElasticsearchFlowStage[T, C](indexName, typeName, elasticsearchClient, settings, messageWriter)
       )
       .mapConcat(identity)
       .asJava
@@ -79,6 +112,7 @@ object ElasticsearchFlow {
    * The result status is part of the [[akka.stream.alpakka.elasticsearch.WriteResult WriteResult]] and must be checked for
    * successful execution.
    *
+   * @param objectMapper Jackson object mapper converting type `T` to JSON
    * @throws IllegalArgumentException When settings configure retrying.
    */
   @ApiMayChange
@@ -89,15 +123,30 @@ object ElasticsearchFlow {
       elasticsearchClient: RestClient,
       objectMapper: ObjectMapper
   ): akka.stream.javadsl.FlowWithContext[WriteMessage[T, NotUsed], C, WriteResult[T, C], C, NotUsed] =
+    createWithContext(indexName, typeName, settings, elasticsearchClient, new JacksonWriter[T](objectMapper))
+
+  /**
+   * Create a flow to update Elasticsearch with [[akka.stream.alpakka.elasticsearch.WriteMessage WriteMessage]]s containing type `T`
+   * with `context` of type `C`.
+   * The result status is part of the [[akka.stream.alpakka.elasticsearch.WriteResult WriteResult]] and must be checked for
+   * successful execution.
+   *
+   * @param messageWriter converts type `T` to a `String` containing valid JSON
+   * @throws IllegalArgumentException When settings configure retrying.
+   */
+  @ApiMayChange
+  def createWithContext[T, C](
+      indexName: String,
+      typeName: String,
+      settings: ElasticsearchWriteSettings,
+      elasticsearchClient: RestClient,
+      messageWriter: MessageWriter[T]
+  ): akka.stream.javadsl.FlowWithContext[WriteMessage[T, NotUsed], C, WriteResult[T, C], C, NotUsed] =
     scaladsl
       .Flow[WriteMessage[T, C]]
       .batch(settings.bufferSize, immutable.Seq(_)) { case (seq, wm) => seq :+ wm }
       .via(
-        new impl.ElasticsearchFlowStage[T, C](indexName,
-                                              typeName,
-                                              elasticsearchClient,
-                                              settings,
-                                              new JacksonWriter[T](objectMapper))
+        new impl.ElasticsearchFlowStage[T, C](indexName, typeName, elasticsearchClient, settings, messageWriter)
       )
       .mapConcat(identity)
       .asFlowWithContext[WriteMessage[T, NotUsed], C, C]((res, c) => res.withPassThrough(c))(

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTest.java
@@ -304,7 +304,7 @@ public class ElasticsearchTest {
                     "_doc",
                     ElasticsearchWriteSettings.create().withBufferSize(5),
                     client,
-                    new StringMessageWriter()))
+                    StringMessageWriter.getInstance()))
             .runWith(Sink.seq(), materializer);
     // #string
 

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTest.java
@@ -7,6 +7,7 @@ package docs.javadsl;
 import akka.Done;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
+import akka.japi.Pair;
 import akka.stream.ActorMaterializer;
 // #init-client
 import akka.stream.alpakka.elasticsearch.*;
@@ -280,6 +281,54 @@ public class ElasticsearchTest {
             "Programming in Scala",
             "Scala Puzzlers",
             "Scala for Spark in Production");
+
+    Collections.sort(result2);
+    assertEquals(expect, result2);
+  }
+
+  @Test
+  public void stringFlow() throws Exception {
+    // Copy source/book to sink3/book through JsObject stream
+    // #string
+    String indexName = "sink3-0";
+    CompletionStage<List<WriteResult<String, NotUsed>>> write =
+        Source.from(
+                Arrays.asList(
+                    WriteMessage.createIndexMessage("1", "{\"title\": \"Das Parfum\"}"),
+                    WriteMessage.createIndexMessage("2", "{\"title\": \"Faust\"}"),
+                    WriteMessage.createIndexMessage(
+                        "3", "{\"title\": \"Die unendliche Geschichte\"}")))
+            .via(
+                ElasticsearchFlow.create(
+                    indexName,
+                    "_doc",
+                    ElasticsearchWriteSettings.create().withBufferSize(5),
+                    client,
+                    new StringMessageWriter()))
+            .runWith(Sink.seq(), materializer);
+    // #string
+
+    List<WriteResult<String, NotUsed>> result1 = write.toCompletableFuture().get();
+    flush(indexName);
+
+    for (WriteResult<String, NotUsed> aResult1 : result1) {
+      assertEquals(true, aResult1.success());
+    }
+
+    CompletionStage<List<String>> f2 =
+        ElasticsearchSource.typed(
+                indexName,
+                "_doc",
+                "{\"match_all\": {}}",
+                ElasticsearchSourceSettings.create().withBufferSize(5),
+                client,
+                Book.class)
+            .map(m -> m.source().title)
+            .runWith(Sink.seq(), materializer);
+
+    List<String> result2 = new ArrayList<>(f2.toCompletableFuture().get());
+
+    List<String> expect = Arrays.asList("Das Parfum", "Die unendliche Geschichte", "Faust");
 
     Collections.sort(result2);
     assertEquals(expect, result2);

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
@@ -11,7 +11,6 @@ import akka.{Done, NotUsed}
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.alpakka.elasticsearch.scaladsl._
-import akka.stream.alpakka.elasticsearch.testkit.MessageFactory
 import akka.stream.alpakka.elasticsearch._
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -110,12 +109,13 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll wi
       new BasicHeader("Content-Type", "application/json")
     )
 
-  private def documentation: Unit = {
+  def documentation(): Unit = {
     //#source-settings
     val sourceSettings = ElasticsearchSourceSettings()
       .withBufferSize(10)
       .withScrollDuration(5.minutes)
     //#source-settings
+    sourceSettings.toString should startWith("ElasticsearchSourceSettings(")
     //#sink-settings
     val sinkSettings =
       ElasticsearchWriteSettings()
@@ -123,6 +123,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll wi
         .withVersionType("internal")
         .withRetryLogic(RetryAtFixedRate(maxRetries = 5, retryInterval = 1.second))
     //#sink-settings
+    sinkSettings.toString should startWith("ElasticsearchWriteSettings(")
   }
 
   private def readTitlesFrom(indexName: String): Future[immutable.Seq[String]] =
@@ -951,6 +952,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll wi
       .createIndexMessage(doc)
       .withCustomMetadata(Map("pipeline" -> "myPipeline"))
     //#custom-metadata-example
+    msg.customMetadata should contain("pipeline")
   }
 
 }


### PR DESCRIPTION
## Purpose

Document (Scala) and enable (Java) how to use properly formatted JSON documents without Spray or Jackson.

## References

Implements #1825 

## Changes

* Provide predefined `StringMessageWriter`
* Allow passing `MessageWriter` in the Java API
* Add sample use for Scala and Java

## Background Context

#1825 asked for this support, which was available with the Scala DSL, but not the Java DSL.
