### PR TITLE
DynamoDB: Add TransactionCanceledException

### DIFF
--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoProtocol.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/DynamoProtocol.scala
@@ -42,7 +42,10 @@ private[dynamodb] trait DynamoProtocol {
           .withModeledClass(classOf[InternalServerErrorException]),
         new JsonErrorShapeMetadata()
           .withErrorCode("LimitExceededException")
-          .withModeledClass(classOf[LimitExceededException])
+          .withModeledClass(classOf[LimitExceededException]),
+        new JsonErrorShapeMetadata()
+          .withErrorCode("TransactionCanceledException")
+          .withModeledClass(classOf[TransactionCanceledException])
       )
       .withBaseServiceExceptionClass(classOf[com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException])
   )


### PR DESCRIPTION

<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

TransactionCanceledException was not previously parsable, resulting in
generic AmazonDynamoDBExceptions being returned with no ability
for users to extract specifics as to why the transaction has been
canceled.

<!-- What does this PR do? -->

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #1847 

## Changes

<!-- Bullets for important changes in this PR -->

* Introduced a new shape capable of parsing `TransactionCanceledException`s.

## Background Context

Given this update was so trivial, I feel there was no other approach that can be justified.

`TransactionCanceledException` was simply not added when transaction support was originally introduced.
