### PR TITLE
Scaladoc: exclude jwt-core 3.0.1 during unidoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,6 +74,7 @@ lazy val alpakka = project
       (ScalaUnidoc / unidoc / fullClasspath).value
         .filterNot(_.data.getAbsolutePath.contains("protobuf-java-2.5.0.jar"))
         .filterNot(_.data.getAbsolutePath.contains("guava-27.1-android.jar"))
+        .filterNot(_.data.getAbsolutePath.contains("jwt-core_2.12-3.0.1.jar"))
     },
     ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(`doc-examples`),
     crossScalaVersions := List() // workaround for https://github.com/sbt/sbt/issues/3465


### PR DESCRIPTION
## Purpose

Exclude a conflicting version during the unidoc task to avoid compilation errors due to classpath order.