### PR TITLE
Enable fatal warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,12 @@ jobs:
     - script: sbt scalafmtSbtCheck || { echo "[error] Unformatted sbt code found. Please run 'scalafmtSbt' and commit the reformatted code."; false; }
       name: "Build code style check (fixed with `sbt scalafmtSbt`)"
     - env: CMD="++2.11.12 Test/compile"
-      name: "Compile all tests (with Scala 2.11)"
+      name: "Compile all code with Scala 2.11"
       if: type != cron
+    - env: CMD="++2.12.7 Test/compile"
+      name: "Compile all code with Scala 2.12 and fatal warnings enabled. Run locally with: env CI=true sbt ++2.12.7 Test/compile"
     - env: CMD="++2.13.0 Test/compile"
-      name: "Compile all tests (with Scala 2.13)"
+      name: "Compile all code with Scala 2.13"
     - env: CMD="unidoc"
       name: "Create all API docs"
     - env: CMD="docs/paradox"

--- a/build.sbt
+++ b/build.sbt
@@ -243,7 +243,8 @@ lazy val orientdb = alpakkaProject("orientdb",
                                    "orientdb",
                                    Dependencies.OrientDB,
                                    fork in Test := true,
-                                   parallelExecution in Test := false)
+                                   parallelExecution in Test := false,
+                                   fatalWarnings := false)
 
 lazy val reference = internalProject("reference", Dependencies.Reference)
 

--- a/build.sbt
+++ b/build.sbt
@@ -193,18 +193,23 @@ lazy val hdfs = alpakkaProject("hdfs",
                                crossScalaVersions -= Dependencies.Scala213 // Requires upgrade of cats-core
 )
 
-lazy val influxdb =
-  alpakkaProject("influxdb", "influxdb", Dependencies.InfluxDB, crossScalaVersions -= Dependencies.Scala211)
+lazy val influxdb = alpakkaProject("influxdb",
+                                   "influxdb",
+                                   Dependencies.InfluxDB,
+                                   crossScalaVersions -= Dependencies.Scala211,
+                                   fatalWarnings := false)
 
 lazy val ironmq = alpakkaProject(
   "ironmq",
   "ironmq",
   Dependencies.IronMq,
   fork in Test := true,
-  crossScalaVersions -= Dependencies.Scala213 // https://github.com/hseeberger/akka-http-json/issues/253
+  crossScalaVersions -= Dependencies.Scala213, // https://github.com/hseeberger/akka-http-json/issues/253
+  fatalWarnings := false
 )
 
-lazy val jms = alpakkaProject("jms", "jms", Dependencies.Jms, parallelExecution in Test := false)
+lazy val jms =
+  alpakkaProject("jms", "jms", Dependencies.Jms, parallelExecution in Test := false, fatalWarnings := false)
 
 lazy val jsonStreaming = alpakkaProject("json-streaming", "json.streaming", Dependencies.JsonStreaming)
 
@@ -212,7 +217,8 @@ lazy val kinesis = alpakkaProject("kinesis",
                                   "aws.kinesis",
                                   Dependencies.Kinesis,
                                   // For mockito https://github.com/akka/alpakka/issues/390
-                                  parallelExecution in Test := false)
+                                  parallelExecution in Test := false,
+                                  fatalWarnings := false)
 
 lazy val kudu = alpakkaProject("kudu", "kudu", Dependencies.Kudu, fork in Test := false)
 

--- a/build.sbt
+++ b/build.sbt
@@ -213,12 +213,14 @@ lazy val jms =
 
 lazy val jsonStreaming = alpakkaProject("json-streaming", "json.streaming", Dependencies.JsonStreaming)
 
-lazy val kinesis = alpakkaProject("kinesis",
-                                  "aws.kinesis",
-                                  Dependencies.Kinesis,
-                                  // For mockito https://github.com/akka/alpakka/issues/390
-                                  parallelExecution in Test := false,
-                                  fatalWarnings := false)
+lazy val kinesis = alpakkaProject(
+  "kinesis",
+  "aws.kinesis",
+  Dependencies.Kinesis,
+  // For mockito https://github.com/akka/alpakka/issues/390
+  parallelExecution in Test := false,
+  fatalWarnings := false
+)
 
 lazy val kudu = alpakkaProject("kudu", "kudu", Dependencies.Kudu, fork in Test := false)
 

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraFlow.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraFlow.scala
@@ -14,8 +14,6 @@ import com.datastax.driver.core.{BoundStatement, PreparedStatement, Session}
 import akka.stream.alpakka.cassandra.scaladsl.{CassandraFlow => ScalaCFlow}
 import akka.stream.javadsl.Flow
 
-import scala.concurrent.ExecutionContext
-
 @ApiMayChange // https://github.com/akka/alpakka/issues/1213
 object CassandraFlow {
   def createWithPassThrough[T](parallelism: Int,

--- a/file/src/main/java/akka/stream/alpakka/file/impl/FileTailSource.java
+++ b/file/src/main/java/akka/stream/alpakka/file/impl/FileTailSource.java
@@ -36,7 +36,8 @@ import java.nio.file.StandardOpenOption;
  *
  * <p>Aborting the stage can be done by combining with a [[akka.stream.KillSwitch]]
  *
- * <p>To use the stage from Scala see the factory methods in {@link akka.stream.alpakka.file.scaladsl.FileTailSource}
+ * <p>To use the stage from Scala see the factory methods in {@link
+ * akka.stream.alpakka.file.scaladsl.FileTailSource}
  */
 @InternalApi
 public final class FileTailSource extends GraphStage<SourceShape<ByteString>> {

--- a/file/src/main/java/akka/stream/alpakka/file/javadsl/FileTailSource.java
+++ b/file/src/main/java/akka/stream/alpakka/file/javadsl/FileTailSource.java
@@ -23,7 +23,8 @@ import java.nio.file.Path;
  *
  * <p>Aborting the stage can be done by combining with a [[akka.stream.KillSwitch]]
  *
- * <p>To use the stage from Scala see the factory methods in {@link akka.stream.alpakka.file.scaladsl.FileTailSource}
+ * <p>To use the stage from Scala see the factory methods in {@link
+ * akka.stream.alpakka.file.scaladsl.FileTailSource}
  */
 public final class FileTailSource {
 

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GoogleTokenApiSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GoogleTokenApiSpec.scala
@@ -16,7 +16,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 import pdi.jwt.{Jwt, JwtAlgorithm}
 

--- a/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSourceSpec.scala
+++ b/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSourceSpec.scala
@@ -275,10 +275,12 @@ class GCStorageSourceSpec
       val downloadSource: Source[Option[Source[ByteString, NotUsed]], NotUsed] =
         GCStorage.download(bucketName, fileName)
 
-      val Some(data: Source[ByteString, _]): Option[Source[ByteString, NotUsed]] =
-        downloadSource.runWith(Sink.head).futureValue
+      val data: Future[Option[Source[ByteString, NotUsed]]] =
+        downloadSource.runWith(Sink.head)
 
-      val result: Future[Seq[String]] = data.map(_.utf8String).runWith(Sink.seq)
+      import system.dispatcher
+      val result: Future[Seq[String]] = data
+        .flatMap(_.getOrElse(Source.empty).map(_.utf8String).runWith(Sink.seq[String]))
 
       //#download
 

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/javadsl/HdfsSource.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/javadsl/HdfsSource.scala
@@ -9,7 +9,6 @@ import java.util.concurrent.CompletionStage
 import akka.NotUsed
 import akka.japi.Pair
 import akka.stream.alpakka.hdfs.scaladsl.{HdfsSource => ScalaHdfsSource}
-import akka.stream.javadsl.Source
 import akka.stream.{javadsl, IOResult}
 import akka.util.ByteString
 import org.apache.hadoop.fs.{FileSystem, Path}

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/scaladsl/HdfsSource.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/scaladsl/HdfsSource.scala
@@ -64,8 +64,8 @@ object HdfsSource {
     val reader: SequenceFile.Reader = new SequenceFile.Reader(fs.getConf, SequenceFile.Reader.file(path))
     val it = Iterator
       .continually {
-        val key = classK.newInstance()
-        val value = classV.newInstance()
+        val key = classK.getDeclaredConstructor().newInstance()
+        val value = classV.getDeclaredConstructor().newInstance()
         val hasCurrent = reader.next(key, value)
         (hasCurrent, (key, value))
       }

--- a/hdfs/src/test/scala/docs/scaladsl/HdfsWriterSpec.scala
+++ b/hdfs/src/test/scala/docs/scaladsl/HdfsWriterSpec.scala
@@ -519,7 +519,7 @@ class HdfsWriterSpec extends WordSpecLike with Matchers with BeforeAndAfterAll w
 
   private def output(s: String): String = s"$destination$s"
 
-  private def documentation(): Unit = {
+  private def documentation(): HdfsWritingSettings = {
     //#define-generator
     val pathGenerator =
       FilePathGenerator(
@@ -534,5 +534,7 @@ class HdfsWriterSpec extends WordSpecLike with Matchers with BeforeAndAfterAll w
         .withLineSeparator(System.getProperty("line.separator"))
         .withPathGenerator(pathGenerator)
     //#define-settings
+    settings
   }
+  documentation()
 }

--- a/influxdb/src/main/scala/akka/stream/alpakka/influxdb/InfluxDbReadSettings.scala
+++ b/influxdb/src/main/scala/akka/stream/alpakka/influxdb/InfluxDbReadSettings.scala
@@ -28,7 +28,7 @@ final class InfluxDbReadSettings private (val precision: TimeUnit) {
   def withPrecision(precision: TimeUnit): InfluxDbReadSettings = copy(precision = precision)
 
   private def copy(
-      precision: TimeUnit = precision
+      precision: TimeUnit
   ): InfluxDbReadSettings = new InfluxDbReadSettings(
     precision = precision
   )

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
@@ -12,7 +12,6 @@ import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import com.mongodb.reactivestreams.client.MongoClients
 import org.bson.Document
-import org.bson.codecs.configuration.CodecRegistries.{fromProviders, fromRegistries}
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 

--- a/mqtt/src/main/scala/akka/stream/alpakka/mqtt/javadsl/MqttFlow.scala
+++ b/mqtt/src/main/scala/akka/stream/alpakka/mqtt/javadsl/MqttFlow.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.mqtt.javadsl
 import java.util.concurrent.CompletionStage
 
 import akka.Done
-import akka.stream.alpakka.mqtt.{javadsl, _}
+import akka.stream.alpakka.mqtt._
 import akka.stream.javadsl.Flow
 
 import scala.compat.java8.FutureConverters._

--- a/mqtt/src/main/scala/akka/stream/alpakka/mqtt/model.scala
+++ b/mqtt/src/main/scala/akka/stream/alpakka/mqtt/model.scala
@@ -4,8 +4,6 @@
 
 package akka.stream.alpakka.mqtt
 
-import scala.compat.java8.OptionConverters._
-
 final class MqttMessage private (val topic: String,
                                  val payload: akka.util.ByteString,
                                  val qos: Option[MqttQoS],

--- a/mqtt/src/main/scala/akka/stream/alpakka/mqtt/settings.scala
+++ b/mqtt/src/main/scala/akka/stream/alpakka/mqtt/settings.scala
@@ -161,8 +161,7 @@ final class MqttConnectionSettings private (val broker: String,
                                             val serverUris: immutable.Seq[String],
                                             val sslHostnameVerifier: Option[javax.net.ssl.HostnameVerifier],
                                             val sslProperties: Map[String, String],
-                                            val offlinePersistenceSettings: Option[MqttOfflinePersistenceSettings] =
-                                              None) {
+                                            val offlinePersistenceSettings: Option[MqttOfflinePersistenceSettings]) {
 
   def withBroker(value: String): MqttConnectionSettings = copy(broker = value)
   def withClientId(clientId: String): MqttConnectionSettings = copy(clientId = clientId)

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/OrientDbWriteSettings.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/OrientDbWriteSettings.scala
@@ -15,7 +15,7 @@ final class OrientDbWriteSettings private (
   ): OrientDbWriteSettings = copy(oDatabasePool = value)
 
   private def copy(
-      oDatabasePool: com.orientechnologies.orient.core.db.OPartitionedDatabasePool = oDatabasePool
+      oDatabasePool: com.orientechnologies.orient.core.db.OPartitionedDatabasePool
   ): OrientDbWriteSettings = new OrientDbWriteSettings(
     oDatabasePool = oDatabasePool
   )

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/impl/OrientDbFlowStage.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/impl/OrientDbFlowStage.scala
@@ -103,10 +103,12 @@ private[orientdb] class OrientDbFlowStage[T, C](
             }
           document.setClassName(className)
           client.save(document)
+          ()
         case OrientDbWriteMessage(oRecord: ORecord, _) =>
           client.save(oRecord)
-        case m @ OrientDbWriteMessage(_, _) =>
-          failStage(new RuntimeException(s"unexpected type [${m.oDocument.getClass()}], ORecord required"))
+          ()
+        case OrientDbWriteMessage(others: AnyRef, _) =>
+          failStage(new RuntimeException(s"unexpected type [${others.getClass()}], ORecord required"))
       }
   }
 
@@ -121,6 +123,7 @@ private[orientdb] class OrientDbFlowStage[T, C](
       messages.foreach {
         case OrientDbWriteMessage(typeRecord: Any, _) =>
           oObjectClient.save(typeRecord)
+          ()
       }
 
   }

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/impl/OrientDbFlowStage.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/impl/OrientDbFlowStage.scala
@@ -103,12 +103,10 @@ private[orientdb] class OrientDbFlowStage[T, C](
             }
           document.setClassName(className)
           client.save(document)
-          ()
         case OrientDbWriteMessage(oRecord: ORecord, _) =>
           client.save(oRecord)
-          ()
-        case OrientDbWriteMessage(others: AnyRef, _) =>
-          failStage(new RuntimeException(s"unexpected type [${others.getClass()}], ORecord required"))
+        case m @ OrientDbWriteMessage(_, _) =>
+          failStage(new RuntimeException(s"unexpected type [${m.oDocument.getClass()}], ORecord required"))
       }
   }
 
@@ -123,7 +121,6 @@ private[orientdb] class OrientDbFlowStage[T, C](
       messages.foreach {
         case OrientDbWriteMessage(typeRecord: Any, _) =>
           oObjectClient.save(typeRecord)
-          ()
       }
 
   }

--- a/reference/src/main/scala/akka/stream/alpakka/reference/settings.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/settings.scala
@@ -136,7 +136,7 @@ object Authentication {
     def withVerifierPredicate(verifier: Predicate[String]): Provided =
       copy(verifier = verifier.asScala)
 
-    private def copy(verifier: String => Boolean = verifier) =
+    private def copy(verifier: String => Boolean) =
       new Provided(verifier)
 
     override def toString: String =

--- a/reference/src/test/scala/docs/scaladsl/ReferenceSpec.scala
+++ b/reference/src/test/scala/docs/scaladsl/ReferenceSpec.scala
@@ -54,6 +54,8 @@ class ReferenceSpec extends WordSpec with BeforeAndAfterAll with ScalaFutures wi
       val source: Source[ReferenceReadResult, Future[Done]] =
         Reference.source(settings)
       // #source
+
+      source
     }
 
     "compile flow" in {
@@ -62,9 +64,7 @@ class ReferenceSpec extends WordSpec with BeforeAndAfterAll with ScalaFutures wi
         Reference.flow()
       // #flow
 
-      implicit val ec = scala.concurrent.ExecutionContext.global
-      val flow2: Flow[ReferenceWriteMessage, ReferenceWriteResult, NotUsed] =
-        Reference.flow()
+      flow
     }
 
     "run source" in {

--- a/slick/src/test/java/docs/javadsl/DocSnippetFlowWithPassThrough.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetFlowWithPassThrough.java
@@ -49,7 +49,7 @@ public class DocSnippetFlowWithPassThrough {
     }
 
     public <B> KafkaMessage<B> map(Function<A, B> f) {
-      return new KafkaMessage(f.apply(msg), offset);
+      return new KafkaMessage<>(f.apply(msg), offset);
     }
   }
 

--- a/slick/src/test/java/docs/javadsl/SlickTest.java
+++ b/slick/src/test/java/docs/javadsl/SlickTest.java
@@ -303,7 +303,7 @@ public class SlickTest {
     }
 
     public <B> KafkaMessage<B> map(Function<A, B> f) {
-      return new KafkaMessage(f.apply(msg), offset);
+      return new KafkaMessage<>(f.apply(msg), offset);
     }
   }
 }

--- a/slick/src/test/scala/docs/scaladsl/SlickSpec.scala
+++ b/slick/src/test/scala/docs/scaladsl/SlickSpec.scala
@@ -33,13 +33,6 @@ class SlickSpec extends WordSpec with ScalaFutures with BeforeAndAfterEach with 
   implicit val session = SlickSession.forConfig("slick-h2")
   //#init-session
 
-  private def documentation: Unit = {
-    //#init-db-config-session
-    val databaseConfig = DatabaseConfig.forConfig[JdbcProfile]("slick-h2")
-    implicit val session = SlickSession.forConfig(databaseConfig)
-    //#init-db-config-session
-  }
-
   import session.profile.api._
 
   case class User(id: Int, name: String)
@@ -132,6 +125,11 @@ class SlickSpec extends WordSpec with ScalaFutures with BeforeAndAfterEach with 
 
   "Slick.flow(..)" must {
     "insert 40 records into a table (no parallelism)" in {
+      //#init-db-config-session
+      val databaseConfig = DatabaseConfig.forConfig[JdbcProfile]("slick-h2")
+      implicit val session = SlickSession.forConfig(databaseConfig)
+      //#init-db-config-session
+
       val inserted = Source(users)
         .via(Slick.flow(insertUser))
         .runWith(Sink.seq)

--- a/sns/src/test/scala/akka/stream/alpakka/sns/DefaultTestContext.scala
+++ b/sns/src/test/scala/akka/stream/alpakka/sns/DefaultTestContext.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.sns
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
 import org.mockito.Mockito.reset
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 import software.amazon.awssdk.services.sns.SnsAsyncClient
 

--- a/solr/src/main/scala/akka/stream/alpakka/solr/SolrUpdateSettings.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/SolrUpdateSettings.scala
@@ -14,7 +14,7 @@ final class SolrUpdateSettings private (
   def withCommitWithin(value: Int): SolrUpdateSettings = copy(commitWithin = value)
 
   private def copy(
-      commitWithin: Int = commitWithin
+      commitWithin: Int
   ): SolrUpdateSettings = new SolrUpdateSettings(
     commitWithin = commitWithin
   )

--- a/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
+++ b/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
@@ -8,7 +8,7 @@ import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.{Arrays, Optional}
 
-import akka.{Done, NotUsed}
+import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.alpakka.solr._
 import akka.stream.alpakka.solr.scaladsl.{SolrFlow, SolrSink, SolrSource}

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckBatchSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckBatchSettings.scala
@@ -10,7 +10,7 @@ final class SqsAckBatchSettings private (val concurrentRequests: Int) {
 
   def withConcurrentRequests(value: Int): SqsAckBatchSettings = copy(concurrentRequests = value)
 
-  private def copy(concurrentRequests: Int = concurrentRequests): SqsAckBatchSettings =
+  private def copy(concurrentRequests: Int): SqsAckBatchSettings =
     new SqsAckBatchSettings(concurrentRequests = concurrentRequests)
 
   override def toString =

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsAckSettings.scala
@@ -10,7 +10,7 @@ final class SqsAckSettings private (val maxInFlight: Int) {
 
   def withMaxInFlight(value: Int): SqsAckSettings = copy(maxInFlight = value)
 
-  private def copy(maxInFlight: Int = maxInFlight): SqsAckSettings =
+  private def copy(maxInFlight: Int): SqsAckSettings =
     new SqsAckSettings(maxInFlight = maxInFlight)
 
   override def toString =

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsPublishBatchSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsPublishBatchSettings.scala
@@ -8,7 +8,7 @@ final class SqsPublishBatchSettings private (val concurrentRequests: Int) {
 
   def withConcurrentRequests(value: Int): SqsPublishBatchSettings = copy(concurrentRequests = value)
 
-  private def copy(concurrentRequests: Int = concurrentRequests): SqsPublishBatchSettings =
+  private def copy(concurrentRequests: Int): SqsPublishBatchSettings =
     new SqsPublishBatchSettings(concurrentRequests = concurrentRequests)
 
   override def toString =

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsPublishSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsPublishSettings.scala
@@ -9,7 +9,7 @@ final class SqsPublishSettings private (val maxInFlight: Int) {
 
   def withMaxInFlight(maxInFlight: Int): SqsPublishSettings = copy(maxInFlight = maxInFlight)
 
-  private def copy(maxInFlight: Int = maxInFlight) = new SqsPublishSettings(maxInFlight)
+  private def copy(maxInFlight: Int) = new SqsPublishSettings(maxInFlight)
 
   override def toString: String =
     "SqsPublishSettings(" +

--- a/udp/src/test/scala/docs/scaladsl/UdpSpec.scala
+++ b/udp/src/test/scala/docs/scaladsl/UdpSpec.scala
@@ -60,6 +60,7 @@ class UdpSpec
         // #send-datagrams
         val destination = new InetSocketAddress("my.server", 27015)
         // #send-datagrams
+        destination
       }
 
       // #send-datagrams


### PR DESCRIPTION
## Purpose

Enables fatal warnings by default with selective opt-out for the modules that still have compilation warnings.

## References

Fixes #1875 

## Notes

Quite a few fixed warnings where unused parameter warnings in `copy` methods that only had a single parameter. Having a default parameter on the single argument copy method is not reasonable, as copy is always called with at least one parameter.
