### PR TITLE
COUCHBASE: Add bucket replace functionality

### DIFF
--- a/couchbase/src/main/mima-filters/1.1.1.backwards.excludes
+++ b/couchbase/src/main/mima-filters/1.1.1.backwards.excludes
@@ -1,0 +1,3 @@
+# Added replace to CouchbaseSession
+ProblemFilters.exclude[Problem]("akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession.replace*")
+ProblemFilters.exclude[Problem]("akka.stream.alpakka.couchbase.javadsl.CouchbaseSession.replace*")

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/impl/CouchbaseSessionImpl.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/impl/CouchbaseSessionImpl.scala
@@ -83,6 +83,22 @@ final private[couchbase] class CouchbaseSessionImpl(asyncBucket: AsyncBucket, cl
                                                 TimeUnit.MILLISECONDS),
                              document.id)
 
+  def replace(document: JsonDocument): Future[JsonDocument] = replaceDoc(document)
+
+  def replaceDoc[T <: Document[_]](document: T): Future[T] =
+    singleObservableToFuture(asyncBucket.replace(document), document.id)
+
+  def replace(document: JsonDocument, writeSettings: CouchbaseWriteSettings): Future[JsonDocument] =
+    replaceDoc(document, writeSettings)
+
+  def replaceDoc[T <: Document[_]](document: T, writeSettings: CouchbaseWriteSettings): Future[T] =
+    singleObservableToFuture(asyncBucket.replace(document,
+                                                 writeSettings.persistTo,
+                                                 writeSettings.replicateTo,
+                                                 writeSettings.timeout.toMillis,
+                                                 TimeUnit.MILLISECONDS),
+                             document.id)
+
   def remove(id: String): Future[Done] =
     singleObservableToFuture(asyncBucket.remove(id), id)
       .map(_ => Done)(ExecutionContexts.sameThreadExecutionContext)

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/impl/CouchbaseSessionJavaAdapter.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/impl/CouchbaseSessionJavaAdapter.scala
@@ -73,6 +73,16 @@ private[couchbase] final class CouchbaseSessionJavaAdapter(delegate: scaladsl.Co
   override def upsertDoc[T <: Document[_]](document: T, writeSettings: CouchbaseWriteSettings): CompletionStage[T] =
     delegate.upsertDoc(document, writeSettings).toJava
 
+  override def replace(document: JsonDocument): CompletionStage[JsonDocument] = delegate.replace(document).toJava
+
+  override def replaceDoc[T <: Document[_]](document: T): CompletionStage[T] = delegate.replaceDoc(document).toJava
+
+  override def replace(document: JsonDocument, writeSettings: CouchbaseWriteSettings): CompletionStage[JsonDocument] =
+    delegate.replace(document, writeSettings).toJava
+
+  override def replaceDoc[T <: Document[_]](document: T, writeSettings: CouchbaseWriteSettings): CompletionStage[T] =
+    delegate.replaceDoc(document, writeSettings).toJava
+
   override def remove(id: String): CompletionStage[Done] = delegate.remove(id).toJava
 
   override def remove(id: String, writeSettings: CouchbaseWriteSettings): CompletionStage[Done] =

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/javadsl/CouchbaseFlow.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/javadsl/CouchbaseFlow.scala
@@ -54,6 +54,31 @@ object CouchbaseFlow {
     scaladsl.CouchbaseFlow.upsertDocWithResult(sessionSettings, writeSettings, bucketName).asJava
 
   /**
+   * Create a flow to replace a Couchbase [[com.couchbase.client.java.document.JsonDocument JsonDocument]].
+   */
+  def replace(sessionSettings: CouchbaseSessionSettings,
+              writeSettings: CouchbaseWriteSettings,
+              bucketName: String): Flow[JsonDocument, JsonDocument, NotUsed] =
+    scaladsl.CouchbaseFlow.replace(sessionSettings, writeSettings, bucketName).asJava
+
+  /**
+   * Create a flow to replace a Couchbase document of the given class.
+   */
+  def replaceDoc[T <: Document[_]](sessionSettings: CouchbaseSessionSettings,
+                                   writeSettings: CouchbaseWriteSettings,
+                                   bucketName: String): Flow[T, T, NotUsed] =
+    scaladsl.CouchbaseFlow.replaceDoc(sessionSettings, writeSettings, bucketName).asJava
+
+  /**
+   * Create a flow to replace a Couchbase document of the given class and emit a result so that write failures
+   * can be handled in-stream.
+   */
+  def replaceDocWithResult[T <: Document[_]](sessionSettings: CouchbaseSessionSettings,
+                                             writeSettings: CouchbaseWriteSettings,
+                                             bucketName: String): Flow[T, CouchbaseWriteResult[T], NotUsed] =
+    scaladsl.CouchbaseFlow.replaceDocWithResult(sessionSettings, writeSettings, bucketName).asJava
+
+  /**
    * Create a flow to delete documents from Couchbase by `id`. Emits the same `id`.
    */
   def delete(sessionSettings: CouchbaseSessionSettings,

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/javadsl/CouchbaseSession.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/javadsl/CouchbaseSession.scala
@@ -179,6 +179,41 @@ abstract class CouchbaseSession {
   def upsertDoc[T <: Document[_]](document: T, writeSettings: CouchbaseWriteSettings): CompletionStage[T]
 
   /**
+   * Replace using the default write settings
+   *
+   * For replacing other types of documents see `replaceDoc`.
+   *
+   * @return a CompletionStage that completes when the replace is done
+   */
+  def replace(document: JsonDocument): CompletionStage[JsonDocument]
+
+  /**
+   * Replace using the default write settings.
+   * Separate from `replace` to make the most common case smoother with the type inference
+   *
+   * @return a CompletionStage that completes when the replace is done
+   */
+  def replaceDoc[T <: Document[_]](document: T): CompletionStage[T]
+
+  /**
+   * Replace using the given write settings.
+   *
+   * For replacing other types of documents see `replaceDoc`.
+   *
+   * @return a CompletionStage that completes when the replace done
+   */
+  def replace(document: JsonDocument, writeSettings: CouchbaseWriteSettings): CompletionStage[JsonDocument]
+
+  /**
+   * Replace using the given write settings.
+   *
+   * Separate from `replace` to make the most common case smoother with the type inference
+   *
+   * @return a CompletionStage that completes when the replace is done
+   */
+  def replaceDoc[T <: Document[_]](document: T, writeSettings: CouchbaseWriteSettings): CompletionStage[T]
+
+  /**
    * Remove a document by id using the default write settings.
    *
    * @return CompletionStage that completes when the document has been removed, if there is no such document

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/javadsl/CouchbaseSink.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/javadsl/CouchbaseSink.scala
@@ -37,6 +37,26 @@ object CouchbaseSink {
       .toMat(Sink.ignore(), Keep.right[NotUsed, CompletionStage[Done]])
 
   /**
+   * Create a sink to replace a Couchbase [[com.couchbase.client.java.document.JsonDocument JsonDocument]].
+   */
+  def replace(sessionSettings: CouchbaseSessionSettings,
+              writeSettings: CouchbaseWriteSettings,
+              bucketName: String): Sink[JsonDocument, CompletionStage[Done]] =
+    CouchbaseFlow
+      .replace(sessionSettings, writeSettings, bucketName)
+      .toMat(Sink.ignore(), Keep.right[NotUsed, CompletionStage[Done]])
+
+  /**
+   * Create a sink to replace a Couchbase document of the given class.
+   */
+  def replaceDoc[T <: Document[_]](sessionSettings: CouchbaseSessionSettings,
+                                   writeSettings: CouchbaseWriteSettings,
+                                   bucketName: String): Sink[T, CompletionStage[Done]] =
+    CouchbaseFlow
+      .replaceDoc[T](sessionSettings, writeSettings, bucketName)
+      .toMat(Sink.ignore(), Keep.right[NotUsed, CompletionStage[Done]])
+
+  /**
    * Create a sink to delete documents from Couchbase by `id`.
    */
   def delete(sessionSettings: CouchbaseSessionSettings,

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/scaladsl/CouchbaseSession.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/scaladsl/CouchbaseSession.scala
@@ -181,6 +181,42 @@ trait CouchbaseSession {
   def upsertDoc[T <: Document[_]](document: T, writeSettings: CouchbaseWriteSettings): Future[T]
 
   /**
+   * Replace using the default write settings.
+   *
+   * For replacing other types of documents see `replaceDoc`.
+   *
+   * @return a future that completes when the replace is done
+   */
+  def replace(document: JsonDocument): Future[JsonDocument]
+
+  /**
+   * Replace using the default write settings.
+   *
+   * Separate from `replace` to make the most common case smoother with the type inference
+   *
+   * @return a future that completes when the replace is done
+   */
+  def replaceDoc[T <: Document[_]](document: T): Future[T]
+
+  /**
+   * Replace using the given write settings
+   *
+   * For replacing other types of documents see `replaceDoc`.
+   *
+   * @return a future that completes when the replace is done
+   */
+  def replace(document: JsonDocument, writeSettings: CouchbaseWriteSettings): Future[JsonDocument]
+
+  /**
+   * Replace using the given write settings
+   *
+   * Separate from `replace` to make the most common case smoother with the type inference
+   *
+   * @return a future that completes when the replace is done
+   */
+  def replaceDoc[T <: Document[_]](document: T, writeSettings: CouchbaseWriteSettings): Future[T]
+
+  /**
    * Remove a document by id using the default write settings.
    *
    * @return Future that completes when the document has been removed, if there is no such document

--- a/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
+++ b/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
@@ -31,6 +31,9 @@ import com.couchbase.client.java.document.json.JsonObject;
 import com.couchbase.client.java.env.CouchbaseEnvironment;
 import com.couchbase.client.java.env.DefaultCouchbaseEnvironment;
 // #registry
+// #replace
+import com.couchbase.client.java.error.DocumentDoesNotExistException;
+// #replace
 // #n1ql
 import com.couchbase.client.java.query.N1qlParams;
 import com.couchbase.client.java.query.N1qlQuery;
@@ -43,6 +46,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -175,7 +179,7 @@ public class CouchbaseExamplesTest {
 
   @Test
   public void statement() throws Exception {
-    support.upsertSampleData();
+    support.upsertSampleData(queryBucketName);
     // #statement
 
     CompletionStage<List<JsonObject>> resultCompletionStage =
@@ -190,7 +194,7 @@ public class CouchbaseExamplesTest {
 
   @Test
   public void n1ql() throws Exception {
-    support.upsertSampleData();
+    support.upsertSampleData(queryBucketName);
     // #n1ql
 
     N1qlParams params = N1qlParams.build().adhoc(false);
@@ -220,7 +224,7 @@ public class CouchbaseExamplesTest {
 
   @Test
   public void fromId() throws Exception {
-    support.upsertSampleData();
+    support.upsertSampleData(queryBucketName);
     // #fromId
     List<String> ids = Arrays.asList("First", "Second", "Third", "Fourth");
 
@@ -235,38 +239,47 @@ public class CouchbaseExamplesTest {
   }
 
   @Test
-  public void upsert() {
-    // #upsert
+  public void upsert() throws Exception {
+
     TestObject obj = new TestObject("First", "First");
 
     CouchbaseWriteSettings writeSettings = CouchbaseWriteSettings.create();
 
-    CompletionStage<Done> jsonDocumentUpsert =
+    // #upsert
+    CompletionStage<JsonDocument> jsonDocumentUpsert =
         Source.single(obj)
             .map(support::toJsonDocument)
             .via(CouchbaseFlow.upsert(sessionSettings, writeSettings, bucketName))
-            .runWith(Sink.ignore(), materializer);
+            .runWith(Sink.head(), materializer);
     // #upsert
+
+    JsonDocument document = jsonDocumentUpsert.toCompletableFuture().get(3, TimeUnit.SECONDS);
+
+    assert (document.content().get("value") == "First");
   }
 
   @Test
-  public void upsertDoc() {
+  public void upsertDoc() throws Exception {
     CouchbaseWriteSettings writeSettings = CouchbaseWriteSettings.create();
-    // #upsert
 
-    CompletionStage<Done> stringDocumentUpsert =
+    // #upsertDoc
+    CompletionStage<StringDocument> stringDocumentUpsert =
         Source.single(sampleData)
             .map(support::toStringDocument)
             .via(CouchbaseFlow.upsertDoc(sessionSettings, writeSettings, bucketName))
-            .runWith(Sink.ignore(), materializer);
-    // #upsert
+            .runWith(Sink.head(), materializer);
+    // #upsertDoc
+
+    StringDocument document = stringDocumentUpsert.toCompletableFuture().get(3, TimeUnit.SECONDS);
+
+    assert (document.content().equals("{\"id\":\"First\",\"value\":\"First\"}"));
   }
 
   @Test
-  public void upsertDocWitResult() throws Exception {
+  public void upsertDocWithResult() throws Exception {
     CouchbaseWriteSettings writeSettings = CouchbaseWriteSettings.create();
-    // #upsertDocWithResult
 
+    // #upsertDocWithResult
     CompletionStage<List<CouchbaseWriteResult<StringDocument>>> upsertResults =
         Source.from(sampleSequence)
             .map(support::toStringDocument)
@@ -281,19 +294,126 @@ public class CouchbaseExamplesTest {
             .map(res -> (CouchbaseWriteFailure<StringDocument>) res)
             .collect(Collectors.toList());
     // #upsertDocWithResult
+
     assertThat(writeResults.size(), is(sampleSequence.size()));
     assertTrue("unexpected failed writes", failedDocs.isEmpty());
   }
 
   @Test
-  public void delete() {
+  public void replace() throws Exception {
+
+    support.upsertSampleData(bucketName);
+
+    TestObject obj = new TestObject("First", "FirstReplace");
+
+    CouchbaseWriteSettings writeSettings = CouchbaseWriteSettings.create();
+
+    // #replace
+    CompletionStage<JsonDocument> jsonDocumentReplace =
+        Source.single(obj)
+            .map(support::toJsonDocument)
+            .via(CouchbaseFlow.replace(sessionSettings, writeSettings, bucketName))
+            .runWith(Sink.head(), materializer);
+    // #replace
+
+    JsonDocument document = jsonDocumentReplace.toCompletableFuture().get(3, TimeUnit.SECONDS);
+
+    assert (document.content().get("value") == "FirstReplace");
+  }
+
+  @Test(expected = DocumentDoesNotExistException.class)
+  public void replaceFailsWhenDocumentDoesntExists() throws Throwable {
+
+    support.cleanAllInBucket(bucketName);
+
+    TestObject obj = new TestObject("First", "FirstReplace");
+
+    CouchbaseWriteSettings writeSettings = CouchbaseWriteSettings.create();
+
+    // #replace
+    CompletionStage<JsonDocument> jsonDocumentReplace =
+        Source.single(obj)
+            .map(support::toJsonDocument)
+            .via(CouchbaseFlow.replace(sessionSettings, writeSettings, bucketName))
+            .runWith(Sink.head(), materializer);
+    // #replace
+
+    try {
+      jsonDocumentReplace.toCompletableFuture().get(3, TimeUnit.SECONDS);
+    } catch (ExecutionException ex) {
+      throw ex.getCause();
+    }
+  }
+
+  @Test
+  public void replaceDoc() throws Exception {
+
+    support.upsertSampleData(bucketName);
+
+    CouchbaseWriteSettings writeSettings = CouchbaseWriteSettings.create();
+
+    TestObject obj = new TestObject("First", "FirstReplace");
+
+    // #replaceDoc
+    CompletionStage<StringDocument> stringDocumentReplace =
+        Source.single(obj)
+            .map(support::toStringDocument)
+            .via(CouchbaseFlow.replaceDoc(sessionSettings, writeSettings, bucketName))
+            .runWith(Sink.head(), materializer);
+    // #replaceDoc
+
+    StringDocument document = stringDocumentReplace.toCompletableFuture().get(3, TimeUnit.SECONDS);
+
+    assert (document.content().equals("{\"id\":\"First\",\"value\":\"FirstReplace\"}"));
+  }
+
+  @Test
+  public void replaceDocWithResult() throws Exception {
+
+    support.upsertSampleData(bucketName);
+
+    CouchbaseWriteSettings writeSettings = CouchbaseWriteSettings.create();
+
+    List<TestObject> list = new ArrayList<TestObject>();
+    list.add(new TestObject("First", "FirstReplace"));
+    list.add(new TestObject("Second", "SecondReplace"));
+    list.add(new TestObject("Third", "ThirdReplace"));
+    list.add(new TestObject("NotExisting", "Nothing")); // should fail
+    list.add(new TestObject("Fourth", "FourthReplace"));
+
+    // #replaceDocWithResult
+    CompletionStage<List<CouchbaseWriteResult<StringDocument>>> replaceResults =
+        Source.from(list)
+            .map(support::toStringDocument)
+            .via(CouchbaseFlow.replaceDocWithResult(sessionSettings, writeSettings, bucketName))
+            .runWith(Sink.seq(), materializer);
+
+    List<CouchbaseWriteResult<StringDocument>> writeResults =
+        replaceResults.toCompletableFuture().get(3, TimeUnit.SECONDS);
+    List<CouchbaseWriteFailure<StringDocument>> failedDocs =
+        writeResults.stream()
+            .filter(CouchbaseWriteResult::isFailure)
+            .map(res -> (CouchbaseWriteFailure<StringDocument>) res)
+            .collect(Collectors.toList());
+    // #replaceDocWithResult
+
+    assertThat(writeResults.size(), is(list.size()));
+    assertThat(failedDocs.size(), is(1));
+  }
+
+  @Test
+  public void delete() throws Exception {
     CouchbaseWriteSettings writeSettings = CouchbaseWriteSettings.create();
     // #delete
-    CompletionStage<Done> result =
+    CompletionStage<String> result =
         Source.single(sampleData.id())
             .via(CouchbaseFlow.delete(sessionSettings, writeSettings, bucketName))
-            .runWith(Sink.ignore(), materializer);
+            .runWith(Sink.head(), materializer);
     // #delete
+
+    String id = result.toCompletableFuture().get(3, TimeUnit.SECONDS);
+
+    assertSame(sampleData.id(), id);
   }
 
   @Test

--- a/couchbase/src/test/scala/akka/stream/alpakka/couchbase/testing/CouchbaseSupport.scala
+++ b/couchbase/src/test/scala/akka/stream/alpakka/couchbase/testing/CouchbaseSupport.scala
@@ -74,15 +74,18 @@ trait CouchbaseSupport {
     BinaryDocument.create(testObject.id, toWrite)
   }
 
-  def upsertSampleData(): Unit = {
+  def upsertSampleData(bucketName: String): Unit = {
     val bulkUpsertResult: Future[Done] = Source(sampleSequence)
       .map(toJsonDocument)
-      .via(CouchbaseFlow.upsert(sessionSettings, CouchbaseWriteSettings.inMemory, queryBucketName))
+      .via(CouchbaseFlow.upsert(sessionSettings, CouchbaseWriteSettings.inMemory, bucketName))
       .runWith(Sink.ignore)
     Await.result(bulkUpsertResult, 5.seconds)
     //all queries are Eventual Consistent, se we need to wait for index refresh!!
     Thread.sleep(2000)
   }
+
+  def cleanAllInBucket(bucketName: String): Unit =
+    cleanAllInBucket(sampleSequence.map(_.id), bucketName)
 
   def cleanAllInBucket(ids: Seq[String], bucketName: String): Unit = {
     val result: Future[Done] =

--- a/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala
@@ -254,6 +254,25 @@ class CouchbaseFlowSpec
       resultsAsFuture.futureValue.map(_.id()) shouldBe Seq("First", "Second", "Third", "Fourth")
     }
 
+    "fails stream when ReplicateTo higher then #of nodes" in assertAllStagesStopped {
+      val bulkUpsertResult: Future[immutable.Seq[JsonDocument]] = Source(sampleSequence)
+        .map(toJsonDocument)
+        .via(
+          CouchbaseFlow.upsert(sessionSettings,
+                               writeSettings
+                                 .withParallelism(2)
+                                 .withPersistTo(PersistTo.THREE)
+                                 .withTimeout(1.seconds),
+                               bucketName)
+        )
+        .runWith(Sink.seq)
+
+      bulkUpsertResult.failed.futureValue shouldBe a[com.couchbase.client.java.error.DurabilityException]
+    }
+  }
+
+  "Couchbase delete" should {
+
     "delete single element" in assertAllStagesStopped {
       val upsertFuture: Future[Done] =
         Source
@@ -329,9 +348,12 @@ class CouchbaseFlowSpec
           .runWith(Sink.seq)
       getFuture.futureValue shouldBe 'empty
     }
+  }
+
+  "Couchbase get" should {
 
     "get document in flow" in assertAllStagesStopped {
-      upsertSampleData()
+      upsertSampleData(queryBucketName)
 
       val id = "First"
 
@@ -355,39 +377,127 @@ class CouchbaseFlowSpec
     }
 
     "get bulk of documents as part of the flow" in assertAllStagesStopped {
-      upsertSampleData()
+      upsertSampleData(queryBucketName)
 
       val result: Future[Seq[JsonDocument]] = Source(sampleSequence.map(_.id))
         .via(CouchbaseFlow.fromId(sessionSettings, queryBucketName))
         .runWith(Sink.seq)
       result.futureValue.map(_.id) shouldBe Seq("First", "Second", "Third", "Fourth")
-
-    }
-
-    "fails stream when ReplicateTo higher then #of nodes" in assertAllStagesStopped {
-      val bulkUpsertResult: Future[immutable.Seq[JsonDocument]] = Source(sampleSequence)
-        .map(toJsonDocument)
-        .via(
-          CouchbaseFlow.upsert(sessionSettings,
-                               writeSettings
-                                 .withParallelism(2)
-                                 .withPersistTo(PersistTo.THREE)
-                                 .withTimeout(1.seconds),
-                               bucketName)
-        )
-        .runWith(Sink.seq)
-
-      bulkUpsertResult.failed.futureValue shouldBe a[com.couchbase.client.java.error.DurabilityException]
     }
 
     "get bulk of documents as part of the flow where not all ids exist" in assertAllStagesStopped {
-      upsertSampleData()
+      upsertSampleData(queryBucketName)
 
       val result: Future[Seq[JsonDocument]] = Source
         .apply(sampleSequence.map(_.id) :+ "Not Existing Id")
         .via(CouchbaseFlow.fromId(sessionSettings, queryBucketName))
         .runWith(Sink.seq)
       result.futureValue.map(_.id) shouldBe Seq("First", "Second", "Third", "Fourth")
+    }
+  }
+
+  "Couchbase replace" should {
+
+    "replace single element" in assertAllStagesStopped {
+      upsertSampleData(bucketName)
+
+      val obj = TestObject("Second", "SecondReplace")
+
+      // #replace
+      val replaceFuture: Future[Done] =
+        Source
+          .single(obj)
+          .map(toJsonDocument)
+          .via(
+            CouchbaseFlow.replace(
+              sessionSettings,
+              writeSettings,
+              bucketName
+            )
+          )
+          .runWith(Sink.ignore)
+      // #replace
+      replaceFuture.futureValue
+
+      Thread.sleep(1000)
+
+      val msgFuture: Future[Option[JsonDocument]] = session.get(obj.id)
+      msgFuture.futureValue.get.content().get("value") shouldEqual obj.value
+    }
+
+    "replace multiple RawJsonDocuments" in assertAllStagesStopped {
+
+      val replaceSequence: Seq[TestObject] = sampleData +: Seq[TestObject](TestObject("Second", "SecondReplace"),
+                                                                           TestObject("Third", "ThirdReplace"))
+
+      upsertSampleData(bucketName)
+
+      val bulkReplaceResult: Future[Done] = Source(replaceSequence)
+        .map(toRawJsonDocument)
+        .via(
+          CouchbaseFlow.replaceDoc(
+            sessionSettings,
+            writeSettings.withParallelism(2),
+            bucketName
+          )
+        )
+        .runWith(Sink.ignore)
+
+      bulkReplaceResult.futureValue
+
+      val resultsAsFuture: Future[immutable.Seq[JsonDocument]] =
+        Source(sampleSequence.map(_.id))
+          .via(CouchbaseFlow.fromId(sessionSettings, bucketName))
+          .runWith(Sink.seq)
+
+      resultsAsFuture.futureValue.map(doc => doc.content().get("value")) should contain inOrderOnly ("First", "SecondReplace", "ThirdReplace", "Fourth")
+    }
+
+    "replace RawJsonDocument" in assertAllStagesStopped {
+
+      upsertSampleData(bucketName)
+
+      val obj = TestObject("Second", "SecondReplace")
+
+      // #replaceDoc
+      val replaceDocFuture: Future[Done] = Source
+        .single(obj)
+        .map(toJsonDocument)
+        .via(
+          CouchbaseFlow.replaceDoc(
+            sessionSettings,
+            writeSettings,
+            bucketName
+          )
+        )
+        .runWith(Sink.ignore)
+      // #replaceDocreplace
+
+      replaceDocFuture.futureValue
+
+      Thread.sleep(1000)
+
+      val msgFuture: Future[Option[JsonDocument]] = session.get(obj.id)
+      msgFuture.futureValue.get.content().get("value") shouldEqual obj.value
+    }
+
+    "fails stream when ReplicateTo higher then #of nodes" in assertAllStagesStopped {
+
+      upsertSampleData(bucketName)
+
+      val bulkReplaceResult: Future[immutable.Seq[JsonDocument]] = Source(sampleSequence)
+        .map(toJsonDocument)
+        .via(
+          CouchbaseFlow.replace(sessionSettings,
+                                writeSettings
+                                  .withParallelism(2)
+                                  .withPersistTo(PersistTo.THREE)
+                                  .withTimeout(1.seconds),
+                                bucketName)
+        )
+        .runWith(Sink.seq)
+
+      bulkReplaceResult.failed.futureValue shouldBe a[com.couchbase.client.java.error.DurabilityException]
     }
   }
 
@@ -477,6 +587,62 @@ class CouchbaseFlowSpec
       deleteResult.futureValue shouldBe a[CouchbaseDeleteFailure]
       deleteResult.futureValue.id shouldBe "non-existent"
       deleteResult.mapTo[CouchbaseDeleteFailure].futureValue.failure shouldBe a[DocumentDoesNotExistException]
+    }
+  }
+
+  "replace with result" should {
+    "replace documents" in assertAllStagesStopped {
+
+      upsertSampleData(bucketName)
+
+      // #replaceDocWithResult
+      import akka.stream.alpakka.couchbase.{CouchbaseWriteFailure, CouchbaseWriteResult}
+
+      val result: Future[immutable.Seq[CouchbaseWriteResult[RawJsonDocument]]] =
+        Source(sampleSequence)
+          .map(toRawJsonDocument)
+          .via(
+            CouchbaseFlow.replaceDocWithResult(
+              sessionSettings,
+              writeSettings,
+              bucketName
+            )
+          )
+          .runWith(Sink.seq)
+
+      val failedDocs: immutable.Seq[CouchbaseWriteFailure[RawJsonDocument]] = result.futureValue.collect {
+        case res: CouchbaseWriteFailure[RawJsonDocument] => res
+      }
+      // #replaceDocWithResult
+
+      result.futureValue should have size sampleSequence.size
+      failedDocs shouldBe 'empty
+      forAll(result.futureValue)(_ shouldBe 'success)
+    }
+
+    "expose failures in-stream" in assertAllStagesStopped {
+
+      cleanAllInBucket(bucketName)
+
+      import akka.stream.alpakka.couchbase.{CouchbaseWriteFailure, CouchbaseWriteResult}
+
+      val result: Future[immutable.Seq[CouchbaseWriteResult[JsonDocument]]] = Source(sampleSequence)
+        .map(toJsonDocument)
+        .via(
+          CouchbaseFlow.replaceDocWithResult(sessionSettings,
+                                             writeSettings
+                                               .withParallelism(2)
+                                               .withPersistTo(PersistTo.THREE)
+                                               .withTimeout(1.seconds),
+                                             bucketName)
+        )
+        .runWith(Sink.seq)
+
+      result.futureValue should have size sampleSequence.size
+      val failedDocs: immutable.Seq[CouchbaseWriteFailure[JsonDocument]] = result.futureValue.collect {
+        case res: CouchbaseWriteFailure[JsonDocument] => res
+      }
+      failedDocs.head.failure shouldBe a[com.couchbase.client.java.error.DocumentDoesNotExistException]
     }
   }
 }

--- a/couchbase/src/test/scala/docs/scaladsl/CouchbaseSourceSpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/CouchbaseSourceSpec.scala
@@ -85,11 +85,11 @@ class CouchbaseSourceSpec
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    upsertSampleData()
+    upsertSampleData(queryBucketName)
   }
 
   override def afterAll(): Unit = {
-    cleanAllInBucket(sampleSequence.map(_.id), queryBucketName)
+    cleanAllInBucket(queryBucketName)
     super.afterAll()
   }
 

--- a/docs/src/main/paradox/couchbase.md
+++ b/docs/src/main/paradox/couchbase.md
@@ -148,6 +148,34 @@ Scala
 Java
 : @@snip [snip](/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #upsertDocWithResult }
 
+## Replace
+
+The `CouchbaseFlow` and `CouchbaseSink` offer factories for replacing documents in Couchbase. `replace` is used for the most commonly used `JsonDocument`, and `replaceDoc` has as type parameter to support any variants of @scala[`Document[T]`]@java[`Document<T>`] which may be `RawJsonDocument`, `StringDocument` or `BinaryDocument`.
+
+The `replace` and `replaceDoc` operators fail the stream on any error when writing to Couchbase. To handle failures in-stream use `replaceDocWithResult` shown below. 
+
+A `replace` action will fail if the original Document can't be found in Couchbase with a `DocumentDoesNotExistException`.
+
+Scala
+: @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala) { #replace }
+
+Java
+: @@snip [snip](/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #replace }
+
+
+@@@ note
+
+For single document modifications you may consider using the `CouchbaseSession` methods directly, they offer a @scala[future-based]@java[CompletionStage-based] API which in many cases might be simpler than using Akka Streams with just one element (see [below](#using-couchbasesession-directly))
+
+@@@
+
+Couchbase writes may fail temporarily for a particular node. If you want to handle such failures without restarting the whole stream, the `replaceDocWithResult` operator captures failures from Couchbase and emits `CouchbaseWriteResult` sub-classes `CouchbaseWriteSuccess` and `CouchbaseWriteFailure` downstream.
+
+Scala
+: @@snip [snip](/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala) { #upsertDocWithResult }
+
+Java
+: @@snip [snip](/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #upsertDocWithResult }
 
 ## Delete
 


### PR DESCRIPTION
## Purpose

The Couchebase API provides replace (Replace a Document if it does already exist.). This was not implemented in Alpakka Couchbase before.

## References

References #1884

## Changes

* Added `replace` implementation
* Added tests

## Background Context

* I've tried to follow the `upsert` implementation for `replace`
* I've added `bucketName` to `upsertSampleData` because you need documents in Couchbase for `replace` to work
* I've added assertions in `CouchbaseExamplesTest.java` to the `upsert` tests as well
* I've rearranged `CouchbaseFlowSpec` because there were `delete` tests under `upsert` which was confusing