### PR TITLE
Expect correct exception in Akka 2.6

### DIFF
--- a/file/src/main/java/akka/stream/alpakka/file/impl/FileTailSource.java
+++ b/file/src/main/java/akka/stream/alpakka/file/impl/FileTailSource.java
@@ -36,7 +36,8 @@ import java.nio.file.StandardOpenOption;
  *
  * <p>Aborting the stage can be done by combining with a [[akka.stream.KillSwitch]]
  *
- * <p>To use the stage from Scala see the factory methods in {@link akka.stream.alpakka.file.scaladsl.FileTailSource}
+ * <p>To use the stage from Scala see the factory methods in {@link
+ * akka.stream.alpakka.file.scaladsl.FileTailSource}
  */
 @InternalApi
 public final class FileTailSource extends GraphStage<SourceShape<ByteString>> {

--- a/file/src/main/java/akka/stream/alpakka/file/javadsl/FileTailSource.java
+++ b/file/src/main/java/akka/stream/alpakka/file/javadsl/FileTailSource.java
@@ -23,7 +23,8 @@ import java.nio.file.Path;
  *
  * <p>Aborting the stage can be done by combining with a [[akka.stream.KillSwitch]]
  *
- * <p>To use the stage from Scala see the factory methods in {@link akka.stream.alpakka.file.scaladsl.FileTailSource}
+ * <p>To use the stage from Scala see the factory methods in {@link
+ * akka.stream.alpakka.file.scaladsl.FileTailSource}
  */
 public final class FileTailSource {
 

--- a/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
@@ -283,7 +283,16 @@ class LogRotatorSinkSpec
       probe.sendNext(ByteString("test"))
       probe.sendNext(ByteString("test"))
       probe.expectCancellation()
-      the[Exception] thrownBy Await.result(completion, 3.seconds) shouldBe a[NonWritableChannelException]
+
+      val exception = intercept[Exception] {
+        Await.result(completion, 3.seconds)
+      }
+
+      exactly(
+        1,
+        List(exception, // Akka 2.5 throws nio exception directly
+             exception.getCause) // Akka 2.6 wraps nio exception in a akka.stream.IOOperationIncompleteException
+      ) shouldBe a[java.nio.channels.NonWritableChannelException]
     }
 
   }


### PR DESCRIPTION
## Purpose

Akka 2.6 changes what exception is being thrown in case of FileIO failure. This PR adapts the testcase to expect a correct exception.