### PR TITLE
Update to Scala 2.13 supported MongoDb dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -225,11 +225,7 @@ lazy val kinesis = alpakkaProject(
 lazy val kudu = alpakkaProject("kudu", "kudu", Dependencies.Kudu, fork in Test := false)
 
 lazy val mongodb =
-  alpakkaProject("mongodb",
-                 "mongodb",
-                 Dependencies.MongoDb,
-                 crossScalaVersions -= Dependencies.Scala213 // https://jira.mongodb.org/browse/SCALA-506
-  )
+  alpakkaProject("mongodb", "mongodb", Dependencies.MongoDb)
 
 lazy val mqtt = alpakkaProject("mqtt", "mqtt", Dependencies.Mqtt)
 

--- a/mongodb/src/main/scala/akka/stream/alpakka/mongodb/javadsl/MongoFlow.scala
+++ b/mongodb/src/main/scala/akka/stream/alpakka/mongodb/javadsl/MongoFlow.scala
@@ -58,7 +58,7 @@ object MongoFlow {
                     options: InsertManyOptions): Flow[java.util.List[T], java.util.List[T], NotUsed] =
     akka.stream.scaladsl
       .Flow[java.util.List[T]]
-      .map(_.asScala)
+      .map(_.asScala.toIndexedSeq)
       .via(scaladsl.MongoFlow.insertMany(collection, options))
       .map(_.asJava)
       .asJava

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -291,8 +291,8 @@ object Dependencies {
 
   val MongoDb = Seq(
     libraryDependencies ++= Seq(
-        "org.mongodb" % "mongodb-driver-reactivestreams" % "1.11.0", // ApacheV2
-        "org.mongodb.scala" %% "mongo-scala-bson" % "2.4.2" % "test" // ApacheV2
+        "org.mongodb" % "mongodb-driver-reactivestreams" % "1.12.0", // ApacheV2
+        "org.mongodb.scala" %% "mongo-scala-bson" % "2.7.0" % "test" // ApacheV2
       )
   )
 


### PR DESCRIPTION
## Purpose

Enables Scala 2.13 build for the MongoDb connector.

## References

Fixes #1535