### PR TITLE
Enable Scala 2.13 build for Google Cloud Pub/Sub gRPC connector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -168,7 +168,7 @@ lazy val googleCloudPubSubGrpc = alpakkaProject(
   // for the ExampleApp in the tests
   connectInput in run := true,
   Compile / compile / scalacOptions += "-P:silencer:pathFilters=src_managed",
-  crossScalaVersions --= Seq(Dependencies.Scala211, Dependencies.Scala213) // https://github.com/akka/akka-grpc/pull/599
+  crossScalaVersions --= Seq(Dependencies.Scala211) // 2.11 is not supported since Akka gRPC 0.6
 ).enablePlugins(AkkaGrpcPlugin, JavaAgent)
 
 lazy val googleCloudStorage =


### PR DESCRIPTION
## Purpose

Enables Scala 2.13 build for Google Cloud Pub/Sub gRPC connector

## References

Fixes #1533