### PR TITLE
DynamoDb: AWS SDK2; Add tryFlow to be used with RetryFlow

### DIFF
--- a/docs/src/main/paradox/dynamodb.md
+++ b/docs/src/main/paradox/dynamodb.md
@@ -17,7 +17,24 @@ The table below shows direct dependencies of this module and the second tab show
 @@dependencies { projectId="dynamodb" }
 
 
-## Usage
+## Setup
+
+This connector requires a @javadoc[DynamoDbAsyncClient](software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient) instance to communicate with AWS DynamoDB.
+
+It is your code's responsibility to call `close` to free any resources held by the client. In this example it will be called when the actor system is terminated.
+
+Scala
+: @@snip [snip](/dynamodb/src/test/scala/docs/scaladsl/ExampleSpec.scala) { #init-client }
+
+Java
+: @@snip [snip](/dynamodb/src/test/java/docs/javadsl/ExampleTest.java) { #init-client }
+
+This connector is set up to use @extref:[Akka HTTP](akka-http:) as default HTTP client via the thin adapter library [AWS Akka-Http SPI implementation](https://github.com/matsluni/aws-spi-akka-http). By setting the `httpClient` explicitly (as above) the Akka actor system is reused, if not set explicitly a separate actor system will be created internally.
+
+It is possible to configure the use of Netty instead, which is Amazon's default. Add an appropriate Netty version to the dependencies and configure @javadoc[`NettyNioAsyncHttpClient`](software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient).
+
+
+## Sending requests and receiving responses
 
 For simple operations you can issue a single request, and get back the result in a @scala[`Future`]@java[`CompletionStage`].
 
@@ -43,6 +60,32 @@ Scala
 
 Java
 : @@snip [snip](/dynamodb/src/test/java/docs/javadsl/ExampleTest.java) { #paginated }
+
+
+## Handling failed requests
+
+By default the stream is stopped if a request fails with server error, or the response can not be parsed.
+
+To handle failed requests later in the stream use @scala[@scaladoc[DynamoDb.tryFlow](akka.stream.alpakka.dynamodb.scaladsl.DynamoDb$)]@java[@scaladoc[DynamoDb.tryFlow](akka.stream.alpakka.dynamodb.javadsl.DynamoDb$)]. The responses will be wrapped with a @scaladoc[Try](scala.util.Try).
+
+This flow composes easily with a Akka Stream RetryFlow, that allows to selectively retry requests with a backoff.
+
+For example to retry all of the failed requests, wrap the `DynamoDb.tryFlow` with `RetryFlow.withBackoff` like so:
+
+Scala
+: @@snip [snip](/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala) { #create-retry-flow }
+
+Java
+: @@snip [snip](/dynamodb/src/test/java/docs/javadsl/RetryTest.java) { #create-retry-flow }
+
+And then use the new flow to send the requests through:
+
+Scala
+: @@snip [snip](/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala) { #use-retry-flow }
+
+Java
+: @@snip [snip](/dynamodb/src/test/java/docs/javadsl/RetryTest.java) { #use-retry-flow }
+
 
 ## Running the example code
 

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/javadsl/RetryFlow.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/javadsl/RetryFlow.scala
@@ -12,7 +12,6 @@ import akka.stream.alpakka.dynamodb.impl.scaladsl
 import akka.stream.javadsl.{Flow, FlowWithContext, Keep}
 
 import scala.concurrent.duration._
-import scala.runtime.AbstractPartialFunction
 import scala.util.Try
 import scala.collection.JavaConverters._
 
@@ -48,7 +47,7 @@ object RetryFlow {
       maxBackoff: java.time.Duration,
       randomFactor: Double,
       flow: Flow[Pair[In, State], Pair[Try[Out], State], Mat],
-      retryWith: AbstractPartialFunction[Pair[Try[Out], State], akka.japi.Option[util.Collection[Pair[In, State]]]]
+      retryWith: java.util.function.Function[Pair[Try[Out], State], akka.japi.Option[util.Collection[Pair[In, State]]]]
   ): Flow[akka.japi.Pair[In, State], akka.japi.Pair[Try[Out], State], Mat] = {
     val retryFlow = scaladsl.RetryFlow
       .withBackoffAndContext(parallelism,

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/javadsl/RetryFlow.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/javadsl/RetryFlow.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.dynamodb.impl.javadsl
+
+import java.util
+
+import akka.NotUsed
+import akka.japi.Pair
+import akka.stream.alpakka.dynamodb.impl.scaladsl
+import akka.stream.javadsl.{Flow, FlowWithContext, Keep}
+
+import scala.concurrent.duration._
+import scala.runtime.AbstractPartialFunction
+import scala.util.Try
+import scala.collection.JavaConverters._
+
+object RetryFlow {
+
+  /**
+   * Allows retrying individual elements in the stream with exponential backoff.
+   *
+   * The retry condition is controlled by the `retryWith` partial function. It takes an output element of the wrapped
+   * flow and should return one or more requests to be retried.
+   *
+   * A successful or failed response will be propagated downstream if it is not matched by the `retryFlow` function.
+   *
+   * If a successful response is matched and issued a retry, the response is still propagated downstream.
+   *
+   * The implementation of the RetryFlow assumes that `flow` follows one-in-out-out element semantics.
+   *
+   * The wrapped `flow` and `retryWith` takes an additional `State` parameter which can be used to correlate a request
+   * with a response.
+   *
+   * Backoff state is tracked separately per-element coming into the wrapped `flow`.
+   *
+   * @param parallelism controls the number of in-flight requests in the wrapped flow
+   * @param minBackoff minimum duration to backoff between issuing retries
+   * @param maxBackoff maximum duration to backoff between issuing retries
+   * @param randomFactor adds jitter to the retry delay. Use 0 for no jitter
+   * @param flow a flow to retry elements from
+   * @param retryWith retry condition decision partial function
+   */
+  def withBackoff[In, Out, State, Mat](
+      parallelism: Int,
+      minBackoff: java.time.Duration,
+      maxBackoff: java.time.Duration,
+      randomFactor: Double,
+      flow: Flow[Pair[In, State], Pair[Try[Out], State], Mat],
+      retryWith: AbstractPartialFunction[Pair[Try[Out], State], akka.japi.Option[util.Collection[Pair[In, State]]]]
+  ): Flow[akka.japi.Pair[In, State], akka.japi.Pair[Try[Out], State], Mat] = {
+    val retryFlow = scaladsl.RetryFlow
+      .withBackoffAndContext(parallelism,
+                             Duration.fromNanos(minBackoff.toNanos),
+                             Duration.fromNanos(maxBackoff.toNanos),
+                             randomFactor,
+                             FlowWithContext.fromPairs(flow).asScala) {
+        case (t, s) =>
+          retryWith(Pair.create(t, s))
+            .map(coll => coll.asScala.toIndexedSeq.map(pair => (pair.first, pair.second)))
+      }
+      .asFlow
+
+    Flow
+      .create[akka.japi.Pair[In, State]]()
+      .map(func(p => (p.first, p.second)))
+      .viaMat(retryFlow, Keep.right[NotUsed, Mat])
+      .map(func(t => akka.japi.Pair.create(t._1, t._2)))
+  }
+
+  private def func[T, R](f: T => R) = new akka.japi.function.Function[T, R] {
+    override def apply(param: T): R = f(param)
+  }
+
+}

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/scaladsl/RetryFlow.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/impl/scaladsl/RetryFlow.scala
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.dynamodb.impl.scaladsl
+
+import akka.pattern.BackoffSupervisor
+import akka.stream.alpakka.dynamodb.impl.scaladsl.RetryFlowCoordinator.InternalState
+import akka.stream.scaladsl.{Broadcast, Flow, FlowWithContext, GraphDSL, ZipWith2}
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler, TimerGraphStageLogic}
+import akka.stream.{Attributes, BidiShape, FlowShape, Inlet, Outlet}
+
+import scala.collection.immutable
+import scala.concurrent.duration._
+import scala.util.Try
+
+object RetryFlow {
+
+  /**
+   * Allows retrying individual elements in the stream with exponential backoff.
+   *
+   * The retry condition is controlled by the `retryWith` partial function. It takes an output element of the wrapped
+   * flow and should return one or more requests to be retried. For example:
+   *
+   * case Failure(_) => Some(List(..., ..., ...)) - for every failed response will issue three requests to retry
+   *
+   * case Failure(_) => Some(Nil) - every failed response will be ignored
+   *
+   * case Failure(_) => None - every failed response will be propagated downstream
+   *
+   * case Success(_) => Some(List(...)) - for every successful response a single retry will be issued
+   *
+   * A successful or failed response will be propagated downstream if it is not matched by the `retryFlow` function.
+   *
+   * If a successful response is matched and issued a retry, the response is still propagated downstream.
+   *
+   * The implementation of the RetryFlow assumes that `flow` follows one-in-out-out element semantics.
+   *
+   * The wrapped `flow` and `retryWith` takes an additional `State` parameter which can be used to correlate a request
+   * with a response.
+   *
+   * Backoff state is tracked separately per-element coming into the wrapped `flow`.
+   *
+   * @param parallelism controls the number of in-flight requests in the wrapped flow
+   * @param minBackoff minimum duration to backoff between issuing retries
+   * @param maxBackoff maximum duration to backoff between issuing retries
+   * @param randomFactor adds jitter to the retry delay. Use 0 for no jitter
+   * @param flow a flow to retry elements from
+   * @param retryWith retry condition decision partial function
+   */
+  def withBackoff[In, Out, State, Mat](parallelism: Int,
+                                       minBackoff: FiniteDuration,
+                                       maxBackoff: FiniteDuration,
+                                       randomFactor: Double,
+                                       flow: Flow[(In, State), (Try[Out], State), Mat])(
+      retryWith: PartialFunction[(Try[Out], State), Option[immutable.Iterable[(In, State)]]]
+  ): Flow[(In, State), (Try[Out], State), Mat] =
+    withBackoffAndContext(parallelism, minBackoff, maxBackoff, randomFactor, FlowWithContext.fromTuples(flow))(
+      retryWith
+    ).asFlow
+
+  /**
+   * Allows retrying individual elements in the stream with exponential backoff.
+   *
+   * The retry condition is controlled by the `retryWith` partial function. It takes an output element of the wrapped
+   * flow and should return one or more requests to be retried. For example:
+   *
+   * case Failure(_) => Some(List(..., ..., ...)) - for every failed response will issue three requests to retry
+   *
+   * case Failure(_) => Some(Nil) - every failed response will be ignored
+   *
+   * case Failure(_) => None - every failed response will be propagated downstream
+   *
+   * case Success(_) => Some(List(...)) - for every successful response a single retry will be issued
+   *
+   * A successful or failed response will be propagated downstream if it is not matched by the `retryFlow` function.
+   *
+   * If a successful response is matched and issued a retry, the response is still propagated downstream.
+   *
+   * The implementation of the RetryFlow assumes that `flow` follows one-in-out-out element semantics.
+   *
+   * The wrapped `flow` and `retryWith` takes an additional `State` parameter which can be used to correlate a request
+   * with a response.
+   *
+   * Backoff state is tracked separately per-element coming into the wrapped `flow`.
+   *
+   * @param parallelism controls the number of in-flight requests in the wrapped flow
+   * @param minBackoff minimum duration to backoff between issuing retries
+   * @param maxBackoff maximum duration to backoff between issuing retries
+   * @param randomFactor adds jitter to the retry delay. Use 0 for no jitter
+   * @param flow a flow with context to retry elements from
+   * @param retryWith retry condition decision partial function
+   */
+  def withBackoffAndContext[In, Out, State, Mat](parallelism: Int,
+                                                 minBackoff: FiniteDuration,
+                                                 maxBackoff: FiniteDuration,
+                                                 randomFactor: Double,
+                                                 flow: FlowWithContext[In, State, Try[Out], State, Mat])(
+      retryWith: PartialFunction[(Try[Out], State), Option[immutable.Iterable[(In, State)]]]
+  ): FlowWithContext[In, State, Try[Out], State, Mat] =
+    FlowWithContext.fromTuples {
+      Flow.fromGraph {
+        GraphDSL.create(flow) { implicit b => origFlow =>
+          import GraphDSL.Implicits._
+
+          val retry =
+            b.add(
+              new RetryFlowCoordinator[In, State, Out](parallelism, retryWith, minBackoff, maxBackoff, randomFactor)
+            )
+          val broadcast = b.add(new Broadcast[(In, State, InternalState)](outputPorts = 2, eagerCancel = true))
+          val zip =
+            b.add(
+              new ZipWith2[(Try[Out], State), InternalState, (Try[Out], State, InternalState)](
+                (el, state) => (el._1, el._2, state)
+              )
+            )
+
+          retry.out2 ~> broadcast.in
+
+          broadcast.out(0).map(msg => (msg._1, msg._2)) ~> origFlow ~> zip.in0
+          broadcast.out(1).map(msg => msg._3) ~> zip.in1
+
+          zip.out ~> retry.in2
+
+          FlowShape(retry.in1, retry.out1)
+        }
+      }
+    }
+}
+
+private object RetryFlowCoordinator {
+  class InternalState(val numberOfRestarts: Int, val retryDeadline: Long)
+  case object InternalState {
+    def apply(): InternalState = new InternalState(0, System.currentTimeMillis())
+  }
+  case object RetryTimer
+}
+
+private class RetryFlowCoordinator[In, State, Out](
+    parallelism: Long,
+    retryWith: PartialFunction[(Try[Out], State), Option[immutable.Iterable[(In, State)]]],
+    minBackoff: FiniteDuration,
+    maxBackoff: FiniteDuration,
+    randomFactor: Double
+) extends GraphStage[
+      BidiShape[(In, State), (Try[Out], State), (Try[Out], State, InternalState), (In, State, InternalState)]
+    ] {
+
+  private val externalIn = Inlet[(In, State)]("RetryFlow.externalIn")
+  private val externalOut = Outlet[(Try[Out], State)]("RetryFlow.externalOut")
+
+  private val internalIn = Inlet[(Try[Out], State, InternalState)]("RetryFlow.internalIn")
+  private val internalOut = Outlet[(In, State, InternalState)]("RetryFlow.internalOut")
+
+  override val shape
+      : BidiShape[(In, State), (Try[Out], State), (Try[Out], State, InternalState), (In, State, InternalState)] =
+    BidiShape(externalIn, externalOut, internalIn, internalOut)
+
+  override def createLogic(attributes: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) {
+    private var numElementsInCycle = 0
+    private var queueRetries =
+      scala.collection.immutable.SortedSet.empty[(In, State, InternalState)](Ordering.fromLessThan { (e1, e2) =>
+        if (e1._3.retryDeadline != e2._3.retryDeadline) e1._3.retryDeadline < e2._3.retryDeadline
+        else e1.hashCode < e2.hashCode
+      })
+    private val queueOut = scala.collection.mutable.Queue.empty[(Try[Out], State)]
+
+    private final val RetryTimer = "retry_timer"
+
+    setHandler(
+      externalIn,
+      new InHandler {
+        override def onPush(): Unit = {
+          val is = {
+            val in = grab(externalIn)
+            (in._1, in._2, InternalState())
+          }
+          if (isAvailable(internalOut)) {
+            push(internalOut, is)
+            numElementsInCycle += 1
+          } else {
+            queueRetries += is
+          }
+        }
+
+        override def onUpstreamFinish(): Unit =
+          if (numElementsInCycle == 0 && queueRetries.isEmpty) {
+            if (queueOut.isEmpty) completeStage()
+            else emitMultiple(externalOut, queueOut.iterator, () => completeStage())
+          }
+      }
+    )
+
+    setHandler(
+      externalOut,
+      new OutHandler {
+        override def onPull(): Unit =
+          // prioritize pushing queued element if available
+          if (queueOut.isEmpty) {
+            if (!hasBeenPulled(internalIn)) pull(internalIn)
+          } else push(externalOut, queueOut.dequeue())
+      }
+    )
+
+    setHandler(
+      internalIn,
+      new InHandler {
+        override def onPush(): Unit = {
+          numElementsInCycle -= 1
+          grab(internalIn) match {
+            case (out, s, internalState) =>
+              retryWith
+                .applyOrElse[(Try[Out], State), Option[immutable.Iterable[(In, State)]]]((out, s), _ => None)
+                .fold(pushAndCompleteIfLast((out, s))) {
+                  xs =>
+                    val current = System.currentTimeMillis()
+                    xs.foreach {
+                      case (in, state) =>
+                        val numRestarts = internalState.numberOfRestarts + 1
+                        val delay = BackoffSupervisor.calculateDelay(numRestarts, minBackoff, maxBackoff, randomFactor)
+                        queueRetries += ((in, state, new InternalState(numRestarts, current + delay.toMillis)))
+                    }
+
+                    out.foreach { _ =>
+                      pushAndCompleteIfLast((out, s))
+                    }
+
+                    if (queueRetries.isEmpty) {
+                      if (isClosed(externalIn) && queueOut.isEmpty) completeStage()
+                      else pull(internalIn)
+                    } else {
+                      pull(internalIn)
+                      scheduleRetryTimer()
+                    }
+                }
+          }
+        }
+      }
+    )
+
+    override def onTimer(timerKey: Any): Unit = timerKey match {
+      case `RetryTimer` =>
+        if (isAvailable(internalOut)) {
+          val elem = queueRetries.head
+          queueRetries = queueRetries.tail
+
+          push(internalOut, elem)
+          numElementsInCycle += 1
+        }
+    }
+
+    private def pushAndCompleteIfLast(elem: (Try[Out], State)): Unit = {
+      if (isAvailable(externalOut) && queueOut.isEmpty) {
+        push(externalOut, elem)
+      } else if (queueOut.size + 1 > parallelism) {
+        failStage(new IllegalStateException(s"Buffer limit of $parallelism has been exceeded"))
+      } else {
+        queueOut.enqueue(elem)
+      }
+
+      if (isClosed(externalIn) && queueRetries.isEmpty && numElementsInCycle == 0 && queueOut.isEmpty) {
+        completeStage()
+      }
+    }
+
+    setHandler(
+      internalOut,
+      new OutHandler {
+        override def onPull(): Unit =
+          if (queueRetries.isEmpty) {
+            if (!hasBeenPulled(externalIn) && !isClosed(externalIn)) {
+              pull(externalIn)
+            }
+          } else {
+            scheduleRetryTimer()
+          }
+
+        override def onDownstreamFinish(): Unit =
+          // waiting for the failure from the upstream
+          setKeepGoing(true)
+      }
+    )
+
+    private def smallestRetryDelay() =
+      (queueRetries.head._3.retryDeadline - System.currentTimeMillis()).millis
+
+    private def scheduleRetryTimer() = {
+      cancelTimer(RetryTimer)
+      scheduleOnce(RetryTimer, smallestRetryDelay())
+    }
+  }
+}

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/javadsl/DynamoDb.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/javadsl/DynamoDb.scala
@@ -14,6 +14,8 @@ import software.amazon.awssdk.core.async.SdkPublisher
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.{DynamoDbRequest, DynamoDbResponse}
 
+import scala.util.Try
+
 /**
  * Factory of DynamoDb Akka Stream operators.
  */
@@ -26,6 +28,22 @@ object DynamoDb {
                                                            operation: DynamoDbOp[In, Out],
                                                            parallelism: Int): Flow[In, Out, NotUsed] =
     scaladsl.DynamoDb.flow(parallelism)(client, operation).asJava
+
+  /**
+   * Create a Flow that emits a response for every request to DynamoDB.
+   * A successful response is wrapped in [scala.util.success] and a failed
+   * response is wrapped in [scala.util.Failure].
+   */
+  def tryFlow[In <: DynamoDbRequest, Out <: DynamoDbResponse, State](
+      client: DynamoDbAsyncClient,
+      operation: DynamoDbOp[In, Out],
+      parallelism: Int
+  ): Flow[akka.japi.Pair[In, State], akka.japi.Pair[Try[Out], State], NotUsed] =
+    Flow
+      .create[akka.japi.Pair[In, State]]()
+      .map(func(p => (p.first, p.second)))
+      .via(scaladsl.DynamoDb.tryFlow(parallelism)(client, operation))
+      .map(func(t => akka.japi.Pair.create(t._1, t._2)))
 
   /**
    * Create a Source that will emit potentially multiple responses for a given request.
@@ -46,4 +64,8 @@ object DynamoDb {
                                                              request: In,
                                                              mat: Materializer): CompletionStage[Out] =
     Source.single(request).via(flow(client, operation, 1)).runWith(Sink.head(), mat)
+
+  private def func[T, R](f: T => R) = new akka.japi.function.Function[T, R] {
+    override def apply(param: T): R = f(param)
+  }
 }

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/javadsl/DynamoDb.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/javadsl/DynamoDb.scala
@@ -23,6 +23,8 @@ object DynamoDb {
 
   /**
    * Create a Flow that emits a response for every request.
+   *
+   * @param parallelism maximum number of in-flight requests at any given time
    */
   def flow[In <: DynamoDbRequest, Out <: DynamoDbResponse](client: DynamoDbAsyncClient,
                                                            operation: DynamoDbOp[In, Out],
@@ -31,8 +33,20 @@ object DynamoDb {
 
   /**
    * Create a Flow that emits a response for every request to DynamoDB.
-   * A successful response is wrapped in [scala.util.success] and a failed
+   * A successful response is wrapped in [scala.util.Success] and a failed
    * response is wrapped in [scala.util.Failure].
+   *
+   * The returned flow is meant to compose easily with an Akka Stream RetryFlow
+   * which can retry requests, that have responses wrapped in [scala.util.Try].
+   *
+   * @param parallelism maximum number of in-flight requests at any given time
+   *
+   * @tparam State the type of the pass-through value that is taken together with
+   *               requests and is emitted together with responses. Can be used,
+   *               for example:
+   *                 * to correlate a request with a response
+   *                 * to track number of retries
+   *                 * to store request to be issued in the case of retry
    */
   def tryFlow[In <: DynamoDbRequest, Out <: DynamoDbResponse, State](
       client: DynamoDbAsyncClient,

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoDb.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoDb.scala
@@ -22,6 +22,8 @@ object DynamoDb {
 
   /**
    * Create a Flow that emits a response for every request to DynamoDB.
+   *
+   * @param parallelism maximum number of in-flight requests at any given time
    */
   def flow[In <: DynamoDbRequest, Out <: DynamoDbResponse](
       parallelism: Int
@@ -30,8 +32,20 @@ object DynamoDb {
 
   /**
    * Create a Flow that emits a response for every request to DynamoDB.
-   * A successful response is wrapped in [scala.util.success] and a failed
+   * A successful response is wrapped in [scala.util.Success] and a failed
    * response is wrapped in [scala.util.Failure].
+   *
+   * The returned flow is meant to compose easily with an Akka Stream RetryFlow
+   * which can retry requests, that have responses wrapped in [scala.util.Try].
+   *
+   * @param parallelism maximum number of in-flight requests at any given time
+   *
+   * @tparam State the type of the pass-through value that is taken together with
+   *               requests and is emitted together with responses. Can be used,
+   *               for example:
+   *                 * to correlate a request with a response
+   *                 * to track number of retries
+   *                 * to store request to be issued in the case of retry
    */
   def tryFlow[In <: DynamoDbRequest, Out <: DynamoDbResponse, State](
       parallelism: Int

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoDb.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoDb.scala
@@ -5,14 +5,15 @@
 package akka.stream.alpakka.dynamodb.scaladsl
 
 import akka.NotUsed
-import akka.stream.Materializer
+import akka.stream.{FlowShape, Materializer}
 import akka.stream.alpakka.dynamodb.{DynamoDbOp, DynamoDbPaginatedOp}
-import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL, Sink, Source, ZipWith2}
 import software.amazon.awssdk.core.async.SdkPublisher
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model._
 
 import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
 
 /**
  * Factory of DynamoDb Akka Stream operators.
@@ -26,6 +27,38 @@ object DynamoDb {
       parallelism: Int
   )(implicit client: DynamoDbAsyncClient, operation: DynamoDbOp[In, Out]): Flow[In, Out, NotUsed] =
     Flow[In].mapAsync(parallelism)(operation.execute(_))
+
+  /**
+   * Create a Flow that emits a response for every request to DynamoDB.
+   * A successful response is wrapped in [scala.util.success] and a failed
+   * response is wrapped in [scala.util.Failure].
+   */
+  def tryFlow[In <: DynamoDbRequest, Out <: DynamoDbResponse, State](
+      parallelism: Int
+  )(implicit client: DynamoDbAsyncClient,
+    operation: DynamoDbOp[In, Out]): Flow[(In, State), (Try[Out], State), NotUsed] =
+    Flow
+      .setup { (mat, _) =>
+        implicit val ec = mat.system.dispatcher
+        val operationFlow = Flow[In].mapAsync(parallelism)(
+          // after 2.11 is dropped, replace this with operation.execute(_).transformWith(Future.successful)
+          operation.execute(_).map(Success.apply).recover { case t => Failure(t) }
+        )
+        Flow.fromGraph {
+          GraphDSL.create(operationFlow) { implicit b => flow =>
+            import GraphDSL.Implicits._
+            val broadcast = b.add(new Broadcast[(In, State)](outputPorts = 2, eagerCancel = true))
+            val zip = b.add(new ZipWith2[Try[Out], State, (Try[Out], State)]((out, state) => (out, state)))
+
+            broadcast.out(0).map(_._1) ~> flow ~> zip.in0
+            broadcast.out(1).map(_._2) ~> zip.in1
+
+            FlowShape(broadcast.in, zip.out)
+          }
+        }
+
+      }
+      .mapMaterializedValue(_ => NotUsed)
 
   /**
    * Create a Source that will emit potentially multiple responses for a given request.

--- a/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
@@ -5,9 +5,12 @@
 package docs.javadsl;
 
 import akka.NotUsed;
+// #init-client
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
+
+// #init-client
 import akka.stream.alpakka.dynamodb.DynamoDbOp;
 import akka.stream.alpakka.dynamodb.javadsl.DynamoDb;
 import akka.stream.javadsl.Sink;
@@ -17,10 +20,14 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+// #init-client
+import com.github.matsluni.akkahttpspi.AkkaHttpClient;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+
+// #init-client
 import software.amazon.awssdk.services.dynamodb.model.*;
 
 import java.net.URI;
@@ -40,6 +47,8 @@ public class ExampleTest {
 
   @BeforeClass
   public static void setup() throws Exception {
+
+    // #init-client
     final ActorSystem system = ActorSystem.create();
     final Materializer materializer = ActorMaterializer.create(system);
     final DynamoDbAsyncClient client =
@@ -47,8 +56,13 @@ public class ExampleTest {
             .credentialsProvider(
                 StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
             .region(Region.AWS_GLOBAL)
+            .httpClient(AkkaHttpClient.builder().withActorSystem(system).build())
             .endpointOverride(new URI("http://localhost:8001/"))
             .build();
+
+    system.registerOnTermination(() -> client.close());
+
+    // #init-client
 
     ExampleTest.system = system;
     ExampleTest.materializer = materializer;
@@ -57,7 +71,6 @@ public class ExampleTest {
 
   @AfterClass
   public static void tearDown() {
-    client.close();
     system.terminate();
   }
 

--- a/dynamodb/src/test/java/docs/javadsl/RetryTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/RetryTest.java
@@ -7,6 +7,7 @@ package docs.javadsl;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.japi.JavaPartialFunction;
+import akka.japi.Option;
 import akka.japi.Pair;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
@@ -27,6 +28,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
+import static akka.japi.Option.*;
 import static org.junit.Assert.*;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -104,27 +106,27 @@ public class RetryTest extends ItemSpecOps {
 
     final JavaPartialFunction<
             Pair<Try<BatchGetItemResponse>, NotUsed>,
-            akka.japi.Option<Collection<Pair<BatchGetItemRequest, NotUsed>>>>
+            Option<Collection<Pair<BatchGetItemRequest, NotUsed>>>>
         retryMatcher =
             new JavaPartialFunction<
                 Pair<Try<BatchGetItemResponse>, NotUsed>,
-                akka.japi.Option<Collection<Pair<BatchGetItemRequest, NotUsed>>>>() {
-              public akka.japi.Option<Collection<Pair<BatchGetItemRequest, NotUsed>>> apply(
+                Option<Collection<Pair<BatchGetItemRequest, NotUsed>>>>() {
+              public Option<Collection<Pair<BatchGetItemRequest, NotUsed>>> apply(
                   Pair<Try<BatchGetItemResponse>, NotUsed> in, boolean isCheck) {
                 final Try<BatchGetItemResponse> response = in.first();
                 if (response.isSuccess()) {
                   final BatchGetItemResponse result = response.get();
                   if (result.unprocessedKeys().size() > 0) {
-                    return akka.japi.Option.some(
+                    return some(
                         Collections.singleton(
                             Pair.create(
                                 batchGetItemRequest(result.unprocessedKeys()),
                                 NotUsed.getInstance())));
                   } else {
-                    return akka.japi.Option.none();
+                    return none();
                   }
                 } else {
-                  return akka.japi.Option.none();
+                  return none();
                 }
               }
             };
@@ -155,21 +157,19 @@ public class RetryTest extends ItemSpecOps {
   @Test
   public void retryFailedRequests() throws Exception {
     final JavaPartialFunction<
-            Pair<Try<GetItemResponse>, Integer>,
-            akka.japi.Option<Collection<Pair<GetItemRequest, Integer>>>>
+            Pair<Try<GetItemResponse>, Integer>, Option<Collection<Pair<GetItemRequest, Integer>>>>
         retryMatcher =
             new JavaPartialFunction<
                 Pair<Try<GetItemResponse>, Integer>,
-                akka.japi.Option<Collection<Pair<GetItemRequest, Integer>>>>() {
-              public akka.japi.Option<Collection<Pair<GetItemRequest, Integer>>> apply(
+                Option<Collection<Pair<GetItemRequest, Integer>>>>() {
+              public Option<Collection<Pair<GetItemRequest, Integer>>> apply(
                   Pair<Try<GetItemResponse>, Integer> in, boolean isCheck) {
                 final Try<GetItemResponse> response = in.first();
                 final Integer retries = in.second();
                 if (response.isFailure()) {
-                  return akka.japi.Option.some(
-                      Collections.singleton(Pair.create(getItemRequest(), retries + 1)));
+                  return some(Collections.singleton(Pair.create(getItemRequest(), retries + 1)));
                 } else {
-                  return akka.japi.Option.none();
+                  return none();
                 }
               }
             };

--- a/dynamodb/src/test/java/docs/javadsl/RetryTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/RetryTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.javadsl;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.japi.JavaPartialFunction;
+import akka.japi.Pair;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.alpakka.dynamodb.DynamoDbOp;
+import akka.stream.alpakka.dynamodb.ItemSpecOps;
+import akka.stream.alpakka.dynamodb.impl.javadsl.RetryFlow;
+import akka.stream.alpakka.dynamodb.javadsl.DynamoDb;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.stream.testkit.javadsl.StreamTestKit;
+import org.junit.*;
+import scala.util.Try;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+
+public class RetryTest extends ItemSpecOps {
+
+  static ActorSystem system;
+  static Materializer materializer;
+  static DynamoDbAsyncClient client;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    System.setProperty("aws.accessKeyId", "someKeyId");
+    System.setProperty("aws.secretKey", "someSecretKey");
+
+    final ActorSystem system = ActorSystem.create();
+    final Materializer materializer = ActorMaterializer.create(system);
+    final DynamoDbAsyncClient client =
+        DynamoDbAsyncClient.builder()
+            .credentialsProvider(
+                StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
+            .region(Region.AWS_GLOBAL)
+            .endpointOverride(new URI("http://localhost:8001/"))
+            .build();
+
+    RetryTest.system = system;
+    RetryTest.materializer = materializer;
+    RetryTest.client = client;
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    StreamTestKit.assertAllStagesStopped(materializer);
+
+    client.close();
+    system.terminate();
+  }
+
+  @Before
+  public void createTable() throws Exception {
+    DynamoDb.single(client, DynamoDbOp.createTable(), createTableRequest(), materializer)
+        .toCompletableFuture()
+        .get(5, TimeUnit.SECONDS);
+  }
+
+  @After
+  public void deleteTable() throws Exception {
+    DynamoDb.single(client, DynamoDbOp.deleteTable(), deleteTableRequest(), materializer)
+        .toCompletableFuture()
+        .get(5, TimeUnit.SECONDS);
+  }
+
+  @Override
+  public String tableName() {
+    return "RetryTest";
+  }
+
+  @Test
+  public void retrySuccessfulRequests() throws Exception {
+    DynamoDb.single(
+            client, DynamoDbOp.batchWriteItem(), batchWriteLargeItemRequest(1, 25), materializer)
+        .toCompletableFuture()
+        .get(5, TimeUnit.SECONDS);
+    DynamoDb.single(
+            client, DynamoDbOp.batchWriteItem(), batchWriteLargeItemRequest(26, 50), materializer)
+        .toCompletableFuture()
+        .get(5, TimeUnit.SECONDS);
+
+    final JavaPartialFunction<
+            Pair<Try<BatchGetItemResponse>, NotUsed>,
+            akka.japi.Option<Collection<Pair<BatchGetItemRequest, NotUsed>>>>
+        retryMatcher =
+            new JavaPartialFunction<
+                Pair<Try<BatchGetItemResponse>, NotUsed>,
+                akka.japi.Option<Collection<Pair<BatchGetItemRequest, NotUsed>>>>() {
+              public akka.japi.Option<Collection<Pair<BatchGetItemRequest, NotUsed>>> apply(
+                  Pair<Try<BatchGetItemResponse>, NotUsed> in, boolean isCheck) {
+                final Try<BatchGetItemResponse> response = in.first();
+                if (response.isSuccess()) {
+                  final BatchGetItemResponse result = response.get();
+                  if (result.unprocessedKeys().size() > 0) {
+                    return akka.japi.Option.some(
+                        Collections.singleton(
+                            Pair.create(
+                                batchGetItemRequest(result.unprocessedKeys()),
+                                NotUsed.getInstance())));
+                  } else {
+                    return akka.japi.Option.none();
+                  }
+                } else {
+                  return akka.japi.Option.none();
+                }
+              }
+            };
+
+    Flow<
+            akka.japi.Pair<BatchGetItemRequest, NotUsed>,
+            akka.japi.Pair<Try<BatchGetItemResponse>, NotUsed>,
+            NotUsed>
+        retryFlow =
+            RetryFlow.withBackoff(
+                8,
+                Duration.ofMillis(10),
+                Duration.ofSeconds(5),
+                0,
+                DynamoDb.tryFlow(client, DynamoDbOp.batchGetItem(), 1),
+                retryMatcher);
+
+    final long responses =
+        Source.single(Pair.create(batchGetLargeItemRequest(1, 50), NotUsed.getInstance()))
+            .via(retryFlow)
+            .runFold(0, (cnt, i) -> cnt + 1, materializer)
+            .toCompletableFuture()
+            .get(30, TimeUnit.SECONDS);
+
+    assertEquals(2, responses);
+  }
+
+  @Test
+  public void retryFailedRequests() throws Exception {
+    final JavaPartialFunction<
+            Pair<Try<GetItemResponse>, Integer>,
+            akka.japi.Option<Collection<Pair<GetItemRequest, Integer>>>>
+        retryMatcher =
+            new JavaPartialFunction<
+                Pair<Try<GetItemResponse>, Integer>,
+                akka.japi.Option<Collection<Pair<GetItemRequest, Integer>>>>() {
+              public akka.japi.Option<Collection<Pair<GetItemRequest, Integer>>> apply(
+                  Pair<Try<GetItemResponse>, Integer> in, boolean isCheck) {
+                final Try<GetItemResponse> response = in.first();
+                final Integer retries = in.second();
+                if (response.isFailure()) {
+                  return akka.japi.Option.some(
+                      Collections.singleton(Pair.create(getItemRequest(), retries + 1)));
+                } else {
+                  return akka.japi.Option.none();
+                }
+              }
+            };
+
+    Flow<
+            akka.japi.Pair<GetItemRequest, Integer>,
+            akka.japi.Pair<Try<GetItemResponse>, Integer>,
+            NotUsed>
+        retryFlow =
+            RetryFlow.withBackoff(
+                8,
+                Duration.ofMillis(10),
+                Duration.ofSeconds(5),
+                0,
+                DynamoDb.tryFlow(client, DynamoDbOp.getItem(), 1),
+                retryMatcher);
+
+    final Pair<Try<GetItemResponse>, Integer> responsePair =
+        Source.single(Pair.create(getItemMalformedRequest(), 0))
+            .via(retryFlow)
+            .runWith(Sink.head(), materializer)
+            .toCompletableFuture()
+            .get(30, TimeUnit.SECONDS);
+
+    final Try<GetItemResponse> response = responsePair.first();
+    final long retries = responsePair.second();
+
+    assertTrue(response.isSuccess());
+    assertEquals(1, retries);
+  }
+}

--- a/dynamodb/src/test/resources/application.conf
+++ b/dynamodb/src/test/resources/application.conf
@@ -3,3 +3,5 @@ akka {
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   loglevel = "DEBUG"
 }
+
+akka.http.client.parsing.max-content-length = 20m

--- a/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala
+++ b/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala
@@ -90,13 +90,17 @@ class RetrySpec
     }
 
     "retry failed requests" in {
+      //#create-retry-flow
       val retryFlow =
         RetryFlow.withBackoff(8, 10.millis, 5.seconds, 1, DynamoDb.tryFlow[GetItemRequest, GetItemResponse, Int](1)) {
           case (Failure(_), retries) => Some(List((getItemRequest, retries + 1)))
         }
+      //#create-retry-flow
 
+      //#use-retry-flow
       val (response, retries) =
         Source.single((getItemMalformedRequest, 0)).via(retryFlow).runWith(Sink.head).futureValue
+      //#use-retry-flow
 
       response shouldBe a[Success[_]]
       retries shouldBe 1

--- a/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala
+++ b/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.scaladsl
+
+import java.net.URI
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.dynamodb.ItemSpecOps
+import akka.stream.alpakka.dynamodb.impl.scaladsl.RetryFlow
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoDb
+import akka.stream.scaladsl.{Sink, Source}
+import akka.testkit.TestKit
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Matchers, WordSpecLike}
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.model.{
+  BatchGetItemRequest,
+  BatchGetItemResponse,
+  GetItemRequest,
+  GetItemResponse
+}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+class RetrySpec
+    extends TestKit(ActorSystem("RetrySpec"))
+    with WordSpecLike
+    with Matchers
+    with BeforeAndAfter
+    with BeforeAndAfterAll
+    with ScalaFutures {
+
+  import ItemSpecOps._
+
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
+
+  implicit val client: DynamoDbAsyncClient = DynamoDbAsyncClient
+    .builder()
+    .region(Region.AWS_GLOBAL)
+    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
+    .endpointOverride(new URI("http://localhost:8001/"))
+    .build()
+
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(30.seconds, 100.millis)
+
+  override def beforeAll(): Unit = {
+    System.setProperty("aws.accessKeyId", "someKeyId")
+    System.setProperty("aws.secretKey", "someSecretKey")
+  }
+
+  override def afterAll(): Unit =
+    client.close()
+
+  before {
+    DynamoDb.single(createTableRequest).futureValue
+  }
+
+  "DynamoDb connector" should {
+
+    "retry successful requests" in {
+      DynamoDb.single(batchWriteLargeItemRequest(1, 25)).futureValue
+      DynamoDb.single(batchWriteLargeItemRequest(26, 50)).futureValue
+
+      val retryFlow =
+        RetryFlow.withBackoff(8,
+                              10.millis,
+                              5.seconds,
+                              1,
+                              DynamoDb.tryFlow[BatchGetItemRequest, BatchGetItemResponse, NotUsed](1)) {
+          case (Success(resp), _) if resp.unprocessedKeys.size() > 0 =>
+            Some(List((batchGetItemRequest(resp.unprocessedKeys), NotUsed)))
+        }
+
+      val responses = Source
+        .single((batchGetLargeItemRequest(1, 50), NotUsed))
+        .via(retryFlow)
+        .runFold(0)((cnt, _) => cnt + 1)
+        .futureValue
+
+      responses shouldBe 2
+    }
+
+    "retry failed requests" in {
+      val retryFlow =
+        RetryFlow.withBackoff(8, 10.millis, 5.seconds, 1, DynamoDb.tryFlow[GetItemRequest, GetItemResponse, Int](1)) {
+          case (Failure(_), retries) => Some(List((getItemRequest, retries + 1)))
+        }
+
+      val (response, retries) =
+        Source.single((getItemMalformedRequest, 0)).via(retryFlow).runWith(Sink.head).futureValue
+
+      response shouldBe a[Success[_]]
+      retries shouldBe 1
+    }
+
+    after {
+      DynamoDb.single(deleteTableRequest).futureValue
+    }
+
+  }
+}


### PR DESCRIPTION
*This is a continuation of #1876. ~Built on top of #1725 and therefore Draft until it gets merged~*

## Purpose

Adds a `DynamoDb.tryFlow` of the shape `Req => Try[Resp]`. This allows composition with a RetryFlow (https://github.com/akka/akka/pull/27461).

To let the tests pass, RetryFlow is now included verbatim in this PR.

## References

Supersedes https://github.com/akka/alpakka/pull/1712
Fixes #1682