### PR TITLE
Do not enable fatal warnings on nightly

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -55,7 +55,8 @@ object Common extends AutoPlugin {
           case _ => Seq("-Xfuture", "-Yno-adapted-args")
         }),
       scalacOptions ++= (scalaVersion.value match {
-          case Dependencies.Scala212 if insideCI.value && fatalWarnings.value => Seq("-Xfatal-warnings")
+          case Dependencies.Scala212 if insideCI.value && fatalWarnings.value && !Dependencies.Nightly =>
+            Seq("-Xfatal-warnings")
           case _ => Seq.empty
         }),
       Compile / doc / scalacOptions := scalacOptions.value ++ Seq(


### PR DESCRIPTION
## Purpose

Disables fatal warnings when CI is running a nightly build. Fatal warnings are still enabled in PR builds and regular master builds.

Alpakka nightly builds switch to the latest milestone of Akka 2.6. Some of the APIs in the 2.6 milestones are deprecated which prevents running nightly builds with fatal warnings.