### PR TITLE
Scaladoc: link to source and canonical

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -296,9 +296,6 @@ lazy val docs = project
     previewPath := (Paradox / siteSubdirName).value,
     Preprocess / siteSubdirName := s"api/alpakka/${projectInfoVersion.value}",
     Preprocess / sourceDirectory := (LocalRootProject / ScalaUnidoc / unidoc / target).value,
-    Preprocess / preprocessRules := Seq(
-        ("\\.java\\.scala".r, _ => ".java")
-      ),
     Paradox / siteSubdirName := s"docs/alpakka/${projectInfoVersion.value}",
     paradoxProperties ++= Map(
         "akka.version" -> Dependencies.AkkaVersion,

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -66,12 +66,6 @@ object Common extends AutoPlugin {
           version.value,
           "-sourcepath",
           (baseDirectory in ThisBuild).value.toString,
-          "-doc-source-url", {
-            val branch = if (isSnapshot.value) "master" else s"v${version.value}"
-            s"https://github.com/akka/alpakka/tree/${branch}€{FILE_PATH_EXT}#L€{FILE_LINE}"
-          },
-          "-doc-canonical-base-url",
-          "https://doc.akka.io/api/alpakka/current/",
           "-skip-packages",
           "akka.pattern:" + // for some reason Scaladoc creates this
           "org.mongodb.scala:" + // this one is a mystery as well
@@ -79,6 +73,24 @@ object Common extends AutoPlugin {
           "com.google.api:com.google.cloud:com.google.iam:com.google.logging:" +
           "com.google.longrunning:com.google.protobuf:com.google.rpc:com.google.type"
         ),
+      Compile / doc / scalacOptions ++= (scalaVersion.value match {
+          case Dependencies.Scala211 =>
+            Seq(
+              "-doc-source-url", {
+                val branch = if (isSnapshot.value) "master" else s"v${version.value}"
+                s"https://github.com/akka/alpakka/tree/${branch}€{FILE_PATH}.scala#L1"
+              }
+            )
+          case _ =>
+            Seq(
+              "-doc-source-url", {
+                val branch = if (isSnapshot.value) "master" else s"v${version.value}"
+                s"https://github.com/akka/alpakka/tree/${branch}€{FILE_PATH_EXT}#L€{FILE_LINE}"
+              },
+              "-doc-canonical-base-url",
+              "https://doc.akka.io/api/alpakka/current/"
+            )
+        }),
       Compile / doc / scalacOptions -= "-Xfatal-warnings",
       compile / javacOptions ++= Seq(
           "-Xlint:unchecked"

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -68,8 +68,10 @@ object Common extends AutoPlugin {
           (baseDirectory in ThisBuild).value.toString,
           "-doc-source-url", {
             val branch = if (isSnapshot.value) "master" else s"v${version.value}"
-            s"https://github.com/akka/alpakka/tree/${branch}€{FILE_PATH}.scala#L1"
+            s"https://github.com/akka/alpakka/tree/${branch}€{FILE_PATH_EXT}#L€{FILE_LINE}"
           },
+          "-doc-canonical-base-url",
+          "https://doc.akka.io/api/alpakka/current/",
           "-skip-packages",
           "akka.pattern:" + // for some reason Scaladoc creates this
           "org.mongodb.scala:" + // this one is a mystery as well


### PR DESCRIPTION
* Use new Scaladoc flags from Scala 2.12.9.
* Remove hack to get correct links to Java sources.