### PR TITLE
Migrate S3 connector to AWS SDK 2

### DIFF
--- a/docs/src/main/paradox/s3.md
+++ b/docs/src/main/paradox/s3.md
@@ -20,7 +20,7 @@ The table below shows direct dependencies of this module and the second tab show
 ## Configuration
 
 The settings for the S3 connector are read by default from `alpakka.s3` configuration section.
-Credentials are loaded as described in the @javadoc[DefaultAWSCredentialsProviderChain](com.amazonaws.auth.DefaultAWSCredentialsProviderChain) documentation.
+Credentials are loaded as described in the @javadoc[DefaultCredentialsProvider](software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider) documentation.
 Therefore, if you are using Alpakka S3 connector in a standard environment, no configuration changes should be necessary.
 However, if you use a non-standard configuration path or need multiple different configurations, please refer to @ref[the attributes section below](s3.md#apply-s3-settings-to-a-part-of-the-stream) to see how to apply different configuration to different parts of the stream.
 All of the available configuration settings can be found in the @github[reference.conf](/s3/src/main/resources/reference.conf).

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -334,7 +334,9 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-xml" % AkkaHttpVersion,
-        "com.amazonaws" % "aws-java-sdk-core" % AwsSdkVersion, // ApacheV2
+        "software.amazon.awssdk" % "auth" % AwsSdk2Version,
+        // overriding AWS SDK version to avoid security issues
+        "com.fasterxml.jackson.core" % "jackson-databind" % JacksonDatabindVersion,
         // in-memory filesystem for file related tests
         "com.google.jimfs" % "jimfs" % "1.1" % Test, // ApacheV2
         "com.github.tomakehurst" % "wiremock" % "2.18.0" % Test // ApacheV2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0-RC4
+sbt.version=1.2.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.0-RC4

--- a/s3/src/main/mima-filters/1.1.x.backwards.excludes
+++ b/s3/src/main/mima-filters/1.1.x.backwards.excludes
@@ -1,0 +1,10 @@
+# Migration to AWS SDK 2 #1905
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.alpakka.s3.S3Settings.apply")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.alpakka.s3.S3Settings.create")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.alpakka.s3.S3Settings.credentialsProvider")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.alpakka.s3.S3Settings.getCredentialsProvider")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.alpakka.s3.S3Settings.withCredentialsProvider")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.alpakka.s3.S3Settings.s3RegionProvider")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.alpakka.s3.S3Settings.getS3RegionProvider")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.alpakka.s3.S3Settings.withS3RegionProvider")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.alpakka.s3.S3Settings.this")

--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -42,7 +42,7 @@ alpakka.s3 {
       # secret-access-key = ""
       # token = "" # optional
 
-      # default: as described in com.amazonaws.auth.DefaultAWSCredentialsProviderChain docs,
+      # default: as described in software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider docs,
       # attempts to get the credentials from either:
       #   - environment variables
       #   - system properties
@@ -60,7 +60,7 @@ alpakka.s3 {
       # provider = static
       # default-region = ""
 
-      # default: as described in com.amazonaws.regions.AwsRegionProvider.DefaultAwsRegionProviderChain docs,
+      # default: as described in software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain docs,
       # attempts to get the region from either:
       #   - environment variables
       #   - system properties

--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -58,6 +58,9 @@ alpakka.s3 {
       # static credentials
       #
       # provider = static
+      #
+      # This can be set to the `id` value of any of the regions defined in
+      # software.amazon.awssdk.regions.Region
       # default-region = ""
 
       # default: as described in software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain docs,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/headers/ServerSideEncryption.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/headers/ServerSideEncryption.scala
@@ -9,7 +9,8 @@ import akka.annotation.InternalApi
 import akka.http.scaladsl.model.HttpHeader
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.stream.alpakka.s3.impl._
-import com.amazonaws.util.{Base64, Md5Utils}
+import software.amazon.awssdk.utils.BinaryUtils
+import software.amazon.awssdk.utils.Md5Utils
 
 import scala.collection.immutable
 
@@ -118,7 +119,7 @@ final class CustomerKeys private[headers] (val key: String, val md5: Option[Stri
     RawHeader("x-amz-server-side-encryption-customer-algorithm", "AES256") ::
     RawHeader("x-amz-server-side-encryption-customer-key", key) ::
     RawHeader("x-amz-server-side-encryption-customer-key-MD5", md5.getOrElse({
-      val decodedKey = Base64.decode(key)
+      val decodedKey = BinaryUtils.fromBase64(key)
       val md5 = Md5Utils.md5AsBase64(decodedKey)
       md5
     })) :: Nil
@@ -133,7 +134,7 @@ final class CustomerKeys private[headers] (val key: String, val md5: Option[Stri
         RawHeader(
           "x-amz-copy-source-server-side-encryption-customer-key-MD5",
           md5.getOrElse({
-            val decodedKey = Base64.decode(key)
+            val decodedKey = BinaryUtils.fromBase64(key)
             val md5 = Md5Utils.md5AsBase64(decodedKey)
             md5
           })

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -16,6 +16,7 @@ import akka.http.scaladsl.model.{ContentTypes, RequestEntity, _}
 import akka.stream.alpakka.s3.{ApiVersion, S3Settings}
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import software.amazon.awssdk.regions.Region
 
 import scala.collection.immutable.Seq
 import scala.concurrent.{ExecutionContext, Future}
@@ -163,7 +164,7 @@ import scala.concurrent.{ExecutionContext, Future}
   }
 
   @throws(classOf[IllegalUriException])
-  private[this] def requestAuthority(bucket: String, region: String)(implicit conf: S3Settings): Authority =
+  private[this] def requestAuthority(bucket: String, region: Region)(implicit conf: S3Settings): Authority =
     conf.endpointUrl match {
       case Some(endpointUrl) => Uri(endpointUrl).authority
       case None =>
@@ -181,7 +182,7 @@ import scala.concurrent.{ExecutionContext, Future}
           }
         }
         region match {
-          case "us-east-1" =>
+          case Region.US_EAST_1 =>
             if (conf.pathStyleAccess) {
               Authority(Uri.Host("s3.amazonaws.com"))
             } else {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/auth/SigningKey.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/auth/SigningKey.scala
@@ -10,29 +10,26 @@ import java.time.format.DateTimeFormatter
 import akka.annotation.InternalApi
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
-import com.amazonaws.auth.{
-  AWSCredentialsProvider,
-  AWSCredentials => AmzAWSCredentials,
-  AWSSessionCredentials => AmzAWSSessionCredentials
-}
+import software.amazon.awssdk.auth.credentials._
+import software.amazon.awssdk.regions.Region
 
-@InternalApi private[impl] final case class CredentialScope(date: LocalDate, awsRegion: String, awsService: String) {
+@InternalApi private[impl] final case class CredentialScope(date: LocalDate, awsRegion: Region, awsService: String) {
   lazy val formattedDate: String = date.format(DateTimeFormatter.BASIC_ISO_DATE)
 
   def scopeString = s"$formattedDate/$awsRegion/$awsService/aws4_request"
 }
 
 @InternalApi private[impl] final case class SigningKey(requestDate: ZonedDateTime,
-                                                       credProvider: AWSCredentialsProvider,
+                                                       credProvider: AwsCredentialsProvider,
                                                        scope: CredentialScope,
                                                        algorithm: String = "HmacSHA256") {
 
-  private val credentials: AmzAWSCredentials = credProvider.getCredentials
+  private val credentials: AwsCredentials = credProvider.resolveCredentials
 
-  val rawKey = new SecretKeySpec(s"AWS4${credentials.getAWSSecretKey}".getBytes, algorithm)
+  val rawKey = new SecretKeySpec(s"AWS4${credentials.secretAccessKey}".getBytes, algorithm)
 
   val sessionToken: Option[String] = credentials match {
-    case c: AmzAWSSessionCredentials => Some(c.getSessionToken)
+    case c: AwsSessionCredentials => Some(c.sessionToken)
     case _ => None
   }
 
@@ -40,7 +37,7 @@ import com.amazonaws.auth.{
 
   def hexEncodedSignature(message: Array[Byte]): String = encodeHex(signature(message))
 
-  def credentialString: String = s"${credentials.getAWSAccessKeyId}/${scope.scopeString}"
+  def credentialString: String = s"${credentials.accessKeyId}/${scope.scopeString}"
 
   lazy val key: SecretKeySpec =
     wrapSignature(dateRegionServiceKey, "aws4_request".getBytes)
@@ -49,7 +46,7 @@ import com.amazonaws.auth.{
     wrapSignature(dateRegionKey, scope.awsService.getBytes)
 
   lazy val dateRegionKey: SecretKeySpec =
-    wrapSignature(dateKey, scope.awsRegion.getBytes)
+    wrapSignature(dateKey, scope.awsRegion.id.getBytes)
 
   lazy val dateKey: SecretKeySpec =
     wrapSignature(rawKey, scope.formattedDate.getBytes)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
@@ -13,10 +13,11 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.TestKit
 import akka.util.ByteString
-import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
-import com.amazonaws.regions.AwsRegionProvider
+import software.amazon.awssdk.auth.credentials._
+import software.amazon.awssdk.regions.providers._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FlatSpecLike, Matchers, PrivateMethodTester}
+import software.amazon.awssdk.regions.Region
 
 import scala.concurrent.Future
 
@@ -36,14 +37,14 @@ class S3StreamSpec(_system: ActorSystem)
   "Non-ranged downloads" should "have two (host and synthetic raw-request-uri) headers" in {
 
     val requestHeaders = PrivateMethod[HttpRequest]('requestHeaders)
-    val credentialsProvider = new AWSStaticCredentialsProvider(
-      new BasicAWSCredentials(
+    val credentialsProvider = StaticCredentialsProvider.create(
+      AwsBasicCredentials.create(
         "test-Id",
         "test-key"
       )
     )
     val regionProvider = new AwsRegionProvider {
-      def getRegion = "us-east-1"
+      def getRegion = Region.US_EAST_1
     }
     val location = S3Location("test-bucket", "test-key")
 
@@ -60,15 +61,15 @@ class S3StreamSpec(_system: ActorSystem)
 
     val requestHeaders = PrivateMethod[HttpRequest]('requestHeaders)
     val credentialsProvider =
-      new AWSStaticCredentialsProvider(
-        new BasicAWSCredentials(
+      StaticCredentialsProvider.create(
+        AwsBasicCredentials.create(
           "test-Id",
           "test-key"
         )
       )
     val regionProvider =
       new AwsRegionProvider {
-        def getRegion: String = "us-east-1"
+        def getRegion: Region = Region.US_EAST_1
       }
     val location = S3Location("test-bucket", "test-key")
     val range = ByteRange(1, 4)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SignerSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SignerSpec.scala
@@ -12,17 +12,12 @@ import akka.http.scaladsl.model.headers.{`Raw-Request-URI`, Host, RawHeader}
 import akka.stream.scaladsl.Sink
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.TestKit
-import com.amazonaws.auth
-import com.amazonaws.auth.{
-  AWSCredentialsProvider,
-  AWSStaticCredentialsProvider,
-  BasicAWSCredentials,
-  BasicSessionCredentials
-}
+import software.amazon.awssdk.auth.credentials._
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.OptionValues._
 import org.scalatest.time.{Millis, Seconds, Span}
+import software.amazon.awssdk.regions.Region
 
 import scala.compat.java8.OptionConverters._
 
@@ -34,12 +29,12 @@ class SignerSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLik
 
   implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system).withDebugLogging(true))
 
-  val credentials = new AWSStaticCredentialsProvider(
-    new BasicAWSCredentials("AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
+  val credentials = StaticCredentialsProvider.create(
+    AwsBasicCredentials.create("AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
   )
 
   def signingKey(dateTime: ZonedDateTime) =
-    SigningKey(dateTime, credentials, CredentialScope(dateTime.toLocalDate, "us-east-1", "iam"))
+    SigningKey(dateTime, credentials, CredentialScope(dateTime.toLocalDate, Region.US_EAST_1, "iam"))
 
   val cr = CanonicalRequest(
     "GET",
@@ -105,37 +100,20 @@ class SignerSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLik
       .withUri("https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08")
 
     val date = LocalDateTime.of(2017, 12, 31, 12, 36, 0).atZone(ZoneOffset.UTC)
-    val initialCredentials = new BasicSessionCredentials(
+    val sessionCredentials = AwsSessionCredentials.create(
       "AKIDEXAMPLE",
       "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
       "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE"
     )
-    val refreshedCredentials = new BasicSessionCredentials(
-      "AKIDEXAMPL2",
-      "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPL2KEY",
-      "AQoEXAMPL2H4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPL2/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE"
-    )
-    val sessionCredentialsProvider = new AWSCredentialsProvider {
-      var refreshed = false
 
-      override def getCredentials: auth.AWSCredentials =
-        if (!refreshed) {
-          initialCredentials
-        } else {
-          refreshedCredentials
-        }
-
-      override def refresh(): Unit = refreshed = true
-    }
-    val key = SigningKey(date, sessionCredentialsProvider, CredentialScope(date.toLocalDate, "us-east-1", "iam"))
-
-    sessionCredentialsProvider.refresh()
+    val sessionCredentialsProvider = StaticCredentialsProvider.create(sessionCredentials)
+    val key = SigningKey(date, sessionCredentialsProvider, CredentialScope(date.toLocalDate, Region.US_EAST_1, "iam"))
 
     val srFuture =
       Signer.signedRequest(req, key).runWith(Sink.head)
 
     whenReady(srFuture) { signedRequest =>
-      signedRequest.getHeader("x-amz-security-token").get.value should equal(initialCredentials.getSessionToken)
+      signedRequest.getHeader("x-amz-security-token").get.value should equal(sessionCredentials.sessionToken)
     }
   }
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SigningKeySpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SigningKeySpec.scala
@@ -6,19 +6,20 @@ package akka.stream.alpakka.s3.impl.auth
 
 import java.time.{ZoneId, ZonedDateTime}
 
-import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
+import software.amazon.awssdk.auth.credentials._
 import org.scalatest.{FlatSpec, Matchers}
+import software.amazon.awssdk.regions.Region
 
 class SigningKeySpec extends FlatSpec with Matchers {
   behavior of "A Signing Key"
 
-  val credentials = new AWSStaticCredentialsProvider(
-    new BasicAWSCredentials("AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
+  val credentials = StaticCredentialsProvider.create(
+    AwsBasicCredentials.create("AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
   )
 
   val signingKey = {
     val requestDate = ZonedDateTime.of(2015, 8, 30, 1, 2, 3, 4, ZoneId.of("UTC"))
-    SigningKey(requestDate, credentials, CredentialScope(requestDate.toLocalDate, "us-east-1", "iam"))
+    SigningKey(requestDate, credentials, CredentialScope(requestDate.toLocalDate, Region.US_EAST_1, "iam"))
   }
 
   it should "produce a signing key" in {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -14,14 +14,15 @@ import akka.stream.alpakka.s3.BucketAccess.{AccessGranted, NotExists}
 import akka.stream.alpakka.s3._
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.util.ByteString
-import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
+import software.amazon.awssdk.auth.credentials._
+import software.amazon.awssdk.regions.providers._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest._
+import software.amazon.awssdk.regions.Region
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
-import com.amazonaws.regions.AwsRegionProvider
 
 trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures with OptionValues {
 
@@ -36,9 +37,9 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
 
   val defaultRegionBucket = "my-test-us-east-1"
 
-  val otherRegion = "eu-central-1"
+  val otherRegion = Region.EU_CENTRAL_1
   val otherRegionProvider = new AwsRegionProvider {
-    val getRegion: String = otherRegion
+    val getRegion: Region = otherRegion
   }
   val otherRegionBucket = "my.test.frankfurt" // with dots forcing path style access
 
@@ -485,12 +486,12 @@ class AWSS3IntegrationSpec extends S3IntegrationSpec
 class MinioS3IntegrationSpec extends S3IntegrationSpec {
   import MinioS3IntegrationSpec._
 
-  val staticProvider = new AWSStaticCredentialsProvider(
-    new BasicAWSCredentials(accessKey, secret)
+  val staticProvider = StaticCredentialsProvider.create(
+    AwsBasicCredentials.create(accessKey, secret)
   )
 
-  val invalidCredentialsProvider = new AWSStaticCredentialsProvider(
-    new BasicAWSCredentials(invalidAccessKey, invalidSecret)
+  val invalidCredentialsProvider = StaticCredentialsProvider.create(
+    AwsBasicCredentials.create(invalidAccessKey, invalidSecret)
   )
 
   override val defaultRegionContentCount = 0
@@ -532,6 +533,6 @@ object MinioS3IntegrationSpec {
   val secret = "TESTSECRET"
   val endpointUrl = "http://localhost:9000"
 
-  val invalidAccessKey = ""
-  val invalidSecret = ""
+  val invalidAccessKey = "invalid"
+  val invalidSecret = "invalid"
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -17,6 +17,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
 import com.github.tomakehurst.wiremock.matching.{ContainsPattern, EqualToPattern}
 import com.github.tomakehurst.wiremock.stubbing.Scenario
 import com.typesafe.config.ConfigFactory
+import software.amazon.awssdk.regions.Region
 
 abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockServer) extends TestKit(_system) {
 
@@ -115,11 +116,11 @@ abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockSer
         )
       )
 
-  def mockDownload(region: String): Unit =
+  def mockDownload(region: Region): Unit =
     mock
       .register(
         get(urlEqualTo(s"/$bucketKey"))
-          .withHeader("Authorization", new ContainsPattern(region))
+          .withHeader("Authorization", new ContainsPattern(region.id))
           .willReturn(
             aResponse()
               .withStatus(200)

--- a/s3/src/test/scala/docs/scaladsl/S3SourceSpec.scala
+++ b/s3/src/test/scala/docs/scaladsl/S3SourceSpec.scala
@@ -14,7 +14,8 @@ import akka.stream.alpakka.s3.scaladsl.{S3, S3ClientIntegrationSpec, S3WireMockB
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import akka.{Done, NotUsed}
-import com.amazonaws.regions.AwsRegionProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.regions.providers._
 
 import scala.concurrent.Future
 
@@ -56,13 +57,13 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
 
   "S3Source" should "use custom settings when downloading a file" in {
 
-    val region = "my-custom-region"
+    val region = Region.AP_NORTHEAST_1
 
     mockDownload(region)
 
     val customRegion = S3Ext(system).settings
       .withS3RegionProvider(new AwsRegionProvider {
-        override def getRegion: String = region
+        override def getRegion: Region = region
       })
 
     val Some((data: Source[ByteString, _], _)) = S3


### PR DESCRIPTION
## Purpose

Upgrades S3 connector to use AWS SDK 2.

## References

Fixes #1342

## Changes

Credentials, Region and some utility AWS classes have been migrated to AWS SDK 2. All of the other machinery is implemented directly using akka-http and akka-stream.

Test verifying credential refresh functionality has been removed, as refreshing credentials is no longer supported.

https://docs.amazonaws.cn/en_us/sdk-for-java/v2/migration-guide/client-credential.html#credentials-changes-mapping