### PR TITLE
Upgrade to scalafmt 2.0.1 / sbt-scalafmt 2.0.4

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 2.0.0-RC8
+version = 2.0.1
 
 style = defaultWithAlign
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.3")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.1")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "1.1.2")


### PR DESCRIPTION
## Purpose

Upgrades to the latest scalafmt formatter and sbt plugin.

## References

https://github.com/scalameta/sbt-scalafmt/releases/tag/v2.0.4
https://github.com/scalameta/scalafmt/releases/tag/v2.0.1