### PR TITLE
FTP - Add proxy support to FTP, SFTP, and FTPS connectors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
       - DIR=file
     - env:
       - DIR=ftp
-      - PRE_CMD="docker-compose up -d ftp sftp"
+      - PRE_CMD="docker-compose up -d ftp sftp squid"
     - env:
       - DIR=geode
       - PRE_CMD="docker-compose up -d geode"

--- a/build.sbt
+++ b/build.sbt
@@ -74,6 +74,7 @@ lazy val alpakka = project
       (ScalaUnidoc / unidoc / fullClasspath).value
         .filterNot(_.data.getAbsolutePath.contains("protobuf-java-2.5.0.jar"))
         .filterNot(_.data.getAbsolutePath.contains("guava-27.1-android.jar"))
+        .filterNot(_.data.getAbsolutePath.contains("commons-net-3.1.jar"))
     },
     ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(`doc-examples`),
     crossScalaVersions := List() // workaround for https://github.com/sbt/sbt/issues/3465

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -230,3 +230,10 @@ services:
     ports:
       - "2222:22"
     command: username:userpass:2000:2000
+  squid:
+    network_mode: host # required for route back to localhost
+    image: datadog/squid
+    volumes:
+      - ./ftp/src/test/resources/squid.conf:/etc/squid/squid.conf
+    ports:
+      - "3128:3128"

--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -37,7 +37,7 @@ The example demonstrates optional use of `configureConnection` option available 
 
 For non-anonymous connection, please provide an instance of @scaladoc[NonAnonFtpCredentials](akka.stream.alpakka.ftp.FtpCredentials$$NonAnonFtpCredentials) instead.
 
-For connection via a proxy, please provide an instance of `java.net.Proxy`.
+For connection via a proxy, please provide an instance of `java.net.Proxy` by using the `withProxy` method.
 
 For connection using a private key, please provide an instance of @scaladoc[SftpIdentity](akka.stream.alpakka.ftp.SftpIdentity) to @scaladoc[SftpSettings](akka.stream.alpakka.ftp.SftpSettings).
 

--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -37,6 +37,8 @@ The example demonstrates optional use of `configureConnection` option available 
 
 For non-anonymous connection, please provide an instance of @scaladoc[NonAnonFtpCredentials](akka.stream.alpakka.ftp.FtpCredentials$$NonAnonFtpCredentials) instead.
 
+For connection via a proxy, please provide an instance of `java.net.Proxy`.
+
 For connection using a private key, please provide an instance of @scaladoc[SftpIdentity](akka.stream.alpakka.ftp.SftpIdentity) to @scaladoc[SftpSettings](akka.stream.alpakka.ftp.SftpSettings).
 
 In order to use a custom SSH client for SFTP please provide an instance of [SSHClient](https://static.javadoc.io/com.hierynomus/sshj/0.26.0/net/schmizz/sshj/SSHClient.html).

--- a/ftp/src/main/mima-filters/1.1.1.backwards.excludes
+++ b/ftp/src/main/mima-filters/1.1.1.backwards.excludes
@@ -1,0 +1,5 @@
+# Allow changes to all [S]FTP[S]Settings
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.ftp.FtpSettings.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.ftp.SftpSettings.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.ftp.FtpsSettings.this")
+

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
@@ -17,6 +17,8 @@ import scala.util.Try
 private[ftp] trait FtpOperations extends CommonFtpOperations { _: FtpLike[FTPClient, FtpSettings] =>
 
   def connect(connectionSettings: FtpSettings)(implicit ftpClient: FTPClient): Try[Handler] = Try {
+    connectionSettings.proxy.foreach(ftpClient.setProxy)
+
     ftpClient.connect(connectionSettings.host, connectionSettings.port)
 
     connectionSettings.configureConnection(ftpClient)

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
@@ -17,6 +17,8 @@ import scala.util.Try
 private[ftp] trait FtpsOperations extends CommonFtpOperations { _: FtpLike[FTPSClient, FtpsSettings] =>
 
   def connect(connectionSettings: FtpsSettings)(implicit ftpClient: FTPSClient): Try[Handler] = Try {
+    connectionSettings.proxy.foreach(ftpClient.setProxy)
+
     ftpClient.connect(connectionSettings.host, connectionSettings.port)
 
     connectionSettings.configureConnection(ftpClient)

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
@@ -15,6 +15,7 @@ import net.schmizz.sshj.transport.verification.PromiscuousVerifier
 import net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile
 import net.schmizz.sshj.userauth.password.PasswordUtils
 import net.schmizz.sshj.xfer.FilePermission
+import org.apache.commons.net.DefaultSocketFactory
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
@@ -30,6 +31,8 @@ private[ftp] trait SftpOperations { _: FtpLike[SSHClient, SftpSettings] =>
 
   def connect(connectionSettings: SftpSettings)(implicit ssh: SSHClient): Try[Handler] = Try {
     import connectionSettings._
+
+    proxy.foreach(p => ssh.setSocketFactory(new DefaultSocketFactory(p)))
 
     if (!strictHostKeyChecking)
       ssh.addHostKeyVerifier(new PromiscuousVerifier)

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -112,7 +112,14 @@ final class FtpSettings private (
   )
 
   override def toString =
-    s"""FtpSettings(host=$host,port=$port,credentials=$credentials,binary=$binary,passiveMode=$passiveMode,configureConnection=$configureConnection),proxy=$proxy"""
+    "FtpSettings(" +
+      s"host=$host," +
+      s"port=$port," +
+      s"credentials=$credentials," +
+      s"binary=$binary," +
+      s"passiveMode=$passiveMode," +
+      s"configureConnection=$configureConnection," +
+      s"proxy=$proxy)"
 }
 
 /**
@@ -205,7 +212,14 @@ final class FtpsSettings private (
   )
 
   override def toString =
-    s"""FtpsSettings(host=$host,port=$port,credentials=$credentials,binary=$binary,passiveMode=$passiveMode,configureConnection=$configureConnection),proxy=$proxy"""
+    "FtpsSettings(" +
+      s"host=$host," +
+      s"port=$port," +
+      s"credentials=$credentials," +
+      s"binary=$binary," +
+      s"passiveMode=$passiveMode," +
+      s"configureConnection=$configureConnection," +
+      s"proxy=$proxy)"
 }
 
 /**
@@ -286,7 +300,14 @@ final class SftpSettings private (
   )
 
   override def toString =
-    s"""SftpSettings(host=$host,port=$port,credentials=$credentials,strictHostKeyChecking=$strictHostKeyChecking,knownHosts=$knownHosts,sftpIdentity=$sftpIdentity,proxy=$proxy)"""
+    "SftpSettings(" +
+      s"host=$host," +
+      s"port=$port," +
+      s"credentials=$credentials," +
+      s"strictHostKeyChecking=$strictHostKeyChecking," +
+      s"knownHosts=$knownHosts," +
+      s"sftpIdentity=$sftpIdentity," +
+      s"proxy=$proxy)"
 }
 
 /**

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.ftp
 
 import java.net.InetAddress
+import java.net.Proxy
 import java.nio.file.attribute.PosixFilePermission
 
 import akka.annotation.InternalApi
@@ -59,6 +60,7 @@ sealed abstract class FtpFileSettings extends RemoteFileSettings {
  * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
  * @param configureConnection A function which will be called after connecting to the server. Use this for
  *                            any custom configuration required by the server you are connecting to.
+ * @param proxy An optional proxy to use when connecting with these settings
  */
 final class FtpSettings private (
     val host: java.net.InetAddress,
@@ -66,7 +68,8 @@ final class FtpSettings private (
     val credentials: FtpCredentials,
     val binary: Boolean,
     val passiveMode: Boolean,
-    val configureConnection: FTPClient => Unit
+    val configureConnection: FTPClient => Unit,
+    val proxy: Option[Proxy]
 ) extends FtpFileSettings {
 
   def withHost(value: java.net.InetAddress): FtpSettings = copy(host = value)
@@ -74,6 +77,7 @@ final class FtpSettings private (
   def withCredentials(value: FtpCredentials): FtpSettings = copy(credentials = value)
   def withBinary(value: Boolean): FtpSettings = if (binary == value) this else copy(binary = value)
   def withPassiveMode(value: Boolean): FtpSettings = if (passiveMode == value) this else copy(passiveMode = value)
+  def withProxy(value: Proxy): FtpSettings = copy(proxy = Some(value))
 
   /**
    * Scala API:
@@ -95,18 +99,20 @@ final class FtpSettings private (
       credentials: FtpCredentials = credentials,
       binary: Boolean = binary,
       passiveMode: Boolean = passiveMode,
-      configureConnection: FTPClient => Unit = configureConnection
+      configureConnection: FTPClient => Unit = configureConnection,
+      proxy: Option[Proxy] = None
   ): FtpSettings = new FtpSettings(
     host = host,
     port = port,
     credentials = credentials,
     binary = binary,
     passiveMode = passiveMode,
-    configureConnection = configureConnection
+    configureConnection = configureConnection,
+    proxy = proxy
   )
 
   override def toString =
-    s"""FtpSettings(host=$host,port=$port,credentials=$credentials,binary=$binary,passiveMode=$passiveMode,configureConnection=$configureConnection)"""
+    s"""FtpSettings(host=$host,port=$port,credentials=$credentials,binary=$binary,passiveMode=$passiveMode,configureConnection=$configureConnection),proxy=$proxy"""
 }
 
 /**
@@ -126,7 +132,8 @@ object FtpSettings {
     credentials = FtpCredentials.AnonFtpCredentials,
     binary = false,
     passiveMode = false,
-    configureConnection = _ => ()
+    configureConnection = _ => (),
+    proxy = None
   )
 
   /** Java API */
@@ -147,6 +154,7 @@ object FtpSettings {
  * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
  * @param configureConnection A function which will be called after connecting to the server. Use this for
  *                            any custom configuration required by the server you are connecting to.
+ * @param proxy An optional proxy to use when connecting with these settings
  */
 final class FtpsSettings private (
     val host: java.net.InetAddress,
@@ -154,7 +162,8 @@ final class FtpsSettings private (
     val credentials: FtpCredentials,
     val binary: Boolean,
     val passiveMode: Boolean,
-    val configureConnection: FTPSClient => Unit
+    val configureConnection: FTPSClient => Unit,
+    val proxy: Option[Proxy]
 ) extends FtpFileSettings {
 
   def withHost(value: java.net.InetAddress): FtpsSettings = copy(host = value)
@@ -162,6 +171,7 @@ final class FtpsSettings private (
   def withCredentials(value: FtpCredentials): FtpsSettings = copy(credentials = value)
   def withBinary(value: Boolean): FtpsSettings = if (binary == value) this else copy(binary = value)
   def withPassiveMode(value: Boolean): FtpsSettings = if (passiveMode == value) this else copy(passiveMode = value)
+  def withProxy(value: Proxy): FtpsSettings = copy(proxy = Some(value))
 
   /**
    * Scala API:
@@ -182,18 +192,20 @@ final class FtpsSettings private (
       credentials: FtpCredentials = credentials,
       binary: Boolean = binary,
       passiveMode: Boolean = passiveMode,
-      configureConnection: FTPSClient => Unit = configureConnection
+      configureConnection: FTPSClient => Unit = configureConnection,
+      proxy: Option[Proxy] = None
   ): FtpsSettings = new FtpsSettings(
     host = host,
     port = port,
     credentials = credentials,
     binary = binary,
     passiveMode = passiveMode,
-    configureConnection = configureConnection
+    configureConnection = configureConnection,
+    proxy = proxy
   )
 
   override def toString =
-    s"""FtpsSettings(host=$host,port=$port,credentials=$credentials,binary=$binary,passiveMode=$passiveMode,configureConnection=$configureConnection)"""
+    s"""FtpsSettings(host=$host,port=$port,credentials=$credentials,binary=$binary,passiveMode=$passiveMode,configureConnection=$configureConnection),proxy=$proxy"""
 }
 
 /**
@@ -213,7 +225,8 @@ object FtpsSettings {
     FtpCredentials.AnonFtpCredentials,
     binary = false,
     passiveMode = false,
-    configureConnection = _ => ()
+    configureConnection = _ => (),
+    proxy = None
   )
 
   /** Java API */
@@ -233,6 +246,7 @@ object FtpsSettings {
  * @param strictHostKeyChecking sets whether to use strict host key checking.
  * @param knownHosts known hosts file to be used when connecting
  * @param sftpIdentity private/public key config to use when connecting
+ * @param proxy An optional proxy to use when connecting with these settings
  */
 final class SftpSettings private (
     val host: java.net.InetAddress,
@@ -240,7 +254,8 @@ final class SftpSettings private (
     val credentials: FtpCredentials,
     val strictHostKeyChecking: Boolean,
     val knownHosts: Option[String],
-    val sftpIdentity: Option[SftpIdentity]
+    val sftpIdentity: Option[SftpIdentity],
+    val proxy: Option[Proxy]
 ) extends RemoteFileSettings {
 
   def withHost(value: java.net.InetAddress): SftpSettings = copy(host = value)
@@ -250,6 +265,7 @@ final class SftpSettings private (
     if (strictHostKeyChecking == value) this else copy(strictHostKeyChecking = value)
   def withKnownHosts(value: String): SftpSettings = copy(knownHosts = Option(value))
   def withSftpIdentity(value: SftpIdentity): SftpSettings = copy(sftpIdentity = Option(value))
+  def withProxy(value: Proxy): SftpSettings = copy(proxy = Some(value))
 
   private def copy(
       host: java.net.InetAddress = host,
@@ -257,18 +273,20 @@ final class SftpSettings private (
       credentials: FtpCredentials = credentials,
       strictHostKeyChecking: Boolean = strictHostKeyChecking,
       knownHosts: Option[String] = knownHosts,
-      sftpIdentity: Option[SftpIdentity] = sftpIdentity
+      sftpIdentity: Option[SftpIdentity] = sftpIdentity,
+      proxy: Option[Proxy] = None
   ): SftpSettings = new SftpSettings(
     host = host,
     port = port,
     credentials = credentials,
     strictHostKeyChecking = strictHostKeyChecking,
     knownHosts = knownHosts,
-    sftpIdentity = sftpIdentity
+    sftpIdentity = sftpIdentity,
+    proxy = proxy
   )
 
   override def toString =
-    s"""SftpSettings(host=$host,port=$port,credentials=$credentials,strictHostKeyChecking=$strictHostKeyChecking,knownHosts=$knownHosts,sftpIdentity=$sftpIdentity)"""
+    s"""SftpSettings(host=$host,port=$port,credentials=$credentials,strictHostKeyChecking=$strictHostKeyChecking,knownHosts=$knownHosts,sftpIdentity=$sftpIdentity,proxy=$proxy)"""
 }
 
 /**
@@ -288,7 +306,8 @@ object SftpSettings {
     FtpCredentials.AnonFtpCredentials,
     strictHostKeyChecking = true,
     knownHosts = None,
-    sftpIdentity = None
+    sftpIdentity = None,
+    proxy = None
   )
 
   /** Java API */

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -100,7 +100,7 @@ final class FtpSettings private (
       binary: Boolean = binary,
       passiveMode: Boolean = passiveMode,
       configureConnection: FTPClient => Unit = configureConnection,
-      proxy: Option[Proxy] = None
+      proxy: Option[Proxy] = proxy
   ): FtpSettings = new FtpSettings(
     host = host,
     port = port,

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -193,7 +193,7 @@ final class FtpsSettings private (
       binary: Boolean = binary,
       passiveMode: Boolean = passiveMode,
       configureConnection: FTPSClient => Unit = configureConnection,
-      proxy: Option[Proxy] = None
+      proxy: Option[Proxy] = proxy
   ): FtpsSettings = new FtpsSettings(
     host = host,
     port = port,

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -113,13 +113,13 @@ final class FtpSettings private (
 
   override def toString =
     "FtpSettings(" +
-      s"host=$host," +
-      s"port=$port," +
-      s"credentials=$credentials," +
-      s"binary=$binary," +
-      s"passiveMode=$passiveMode," +
-      s"configureConnection=$configureConnection," +
-      s"proxy=$proxy)"
+    s"host=$host," +
+    s"port=$port," +
+    s"credentials=$credentials," +
+    s"binary=$binary," +
+    s"passiveMode=$passiveMode," +
+    s"configureConnection=$configureConnection," +
+    s"proxy=$proxy)"
 }
 
 /**
@@ -213,13 +213,13 @@ final class FtpsSettings private (
 
   override def toString =
     "FtpsSettings(" +
-      s"host=$host," +
-      s"port=$port," +
-      s"credentials=$credentials," +
-      s"binary=$binary," +
-      s"passiveMode=$passiveMode," +
-      s"configureConnection=$configureConnection," +
-      s"proxy=$proxy)"
+    s"host=$host," +
+    s"port=$port," +
+    s"credentials=$credentials," +
+    s"binary=$binary," +
+    s"passiveMode=$passiveMode," +
+    s"configureConnection=$configureConnection," +
+    s"proxy=$proxy)"
 }
 
 /**
@@ -301,13 +301,13 @@ final class SftpSettings private (
 
   override def toString =
     "SftpSettings(" +
-      s"host=$host," +
-      s"port=$port," +
-      s"credentials=$credentials," +
-      s"strictHostKeyChecking=$strictHostKeyChecking," +
-      s"knownHosts=$knownHosts," +
-      s"sftpIdentity=$sftpIdentity," +
-      s"proxy=$proxy)"
+    s"host=$host," +
+    s"port=$port," +
+    s"credentials=$credentials," +
+    s"strictHostKeyChecking=$strictHostKeyChecking," +
+    s"knownHosts=$knownHosts," +
+    s"sftpIdentity=$sftpIdentity," +
+    s"proxy=$proxy)"
 }
 
 /**

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -274,7 +274,7 @@ final class SftpSettings private (
       strictHostKeyChecking: Boolean = strictHostKeyChecking,
       knownHosts: Option[String] = knownHosts,
       sftpIdentity: Option[SftpIdentity] = sftpIdentity,
-      proxy: Option[Proxy] = None
+      proxy: Option[Proxy] = proxy
   ): SftpSettings = new SftpSettings(
     host = host,
     port = port,

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpWithProxyStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpWithProxyStageTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.ftp;
+
+import akka.NotUsed;
+import akka.stream.IOResult;
+import akka.stream.alpakka.ftp.javadsl.Ftp;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+public class FtpWithProxyStageTest extends BaseFtpSupport implements CommonFtpStageTest {
+
+  private final Integer PROXYPORT = 3128;
+  private final Proxy PROXY = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(HOSTNAME, PROXYPORT));
+
+  @Test
+  public void listFiles() throws Exception {
+    CommonFtpStageTest.super.listFiles();
+  }
+
+  @Test
+  public void fromPath() throws Exception {
+    CommonFtpStageTest.super.fromPath();
+  }
+
+  @Test
+  public void toPath() throws Exception {
+    CommonFtpStageTest.super.toPath();
+  }
+
+  @Test
+  public void remove() throws Exception {
+    CommonFtpStageTest.super.remove();
+  }
+
+  @Test
+  public void move() throws Exception {
+    CommonFtpStageTest.super.move();
+  }
+
+  public Source<FtpFile, NotUsed> getBrowserSource(String basePath) throws Exception {
+    return Ftp.ls(basePath, settings());
+  }
+
+  public Source<ByteString, CompletionStage<IOResult>> getIOSource(String path) throws Exception {
+    return Ftp.fromPath(path, settings());
+  }
+
+  public Sink<ByteString, CompletionStage<IOResult>> getIOSink(String path) throws Exception {
+    return Ftp.toPath(path, settings());
+  }
+
+  public Sink<FtpFile, CompletionStage<IOResult>> getRemoveSink() throws Exception {
+    return Ftp.remove(settings());
+  }
+
+  public Sink<FtpFile, CompletionStage<IOResult>> getMoveSink(
+      Function<FtpFile, String> destinationPath) throws Exception {
+    return Ftp.move(destinationPath, settings());
+  }
+
+  private FtpSettings settings() throws Exception {
+    return FtpSettings.create(InetAddress.getByName(HOSTNAME))
+        .withPort(PORT)
+        .withCredentials(CREDENTIALS)
+        .withBinary(false)
+        .withPassiveMode(true)
+        .withProxy(PROXY);
+  }
+}

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsWithProxyStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsWithProxyStageTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.ftp;
+
+import akka.NotUsed;
+import akka.stream.IOResult;
+import akka.stream.alpakka.ftp.javadsl.Ftps;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+public class FtpsWithProxyStageTest extends BaseFtpSupport implements CommonFtpStageTest {
+
+  private final Integer PROXYPORT = 3128;
+  private final Proxy PROXY = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(HOSTNAME, PROXYPORT));
+
+  @Test
+  public void listFiles() throws Exception {
+    CommonFtpStageTest.super.listFiles();
+  }
+
+  @Test
+  public void fromPath() throws Exception {
+    CommonFtpStageTest.super.fromPath();
+  }
+
+  @Test
+  public void toPath() throws Exception {
+    CommonFtpStageTest.super.toPath();
+  }
+
+  @Test
+  public void remove() throws Exception {
+    CommonFtpStageTest.super.remove();
+  }
+
+  @Test
+  public void move() throws Exception {
+    CommonFtpStageTest.super.move();
+  }
+
+  public Source<FtpFile, NotUsed> getBrowserSource(String basePath) throws Exception {
+    return Ftps.ls(basePath, settings());
+  }
+
+  public Source<ByteString, CompletionStage<IOResult>> getIOSource(String path) throws Exception {
+    return Ftps.fromPath(path, settings());
+  }
+
+  public Sink<ByteString, CompletionStage<IOResult>> getIOSink(String path) throws Exception {
+    return Ftps.toPath(path, settings());
+  }
+
+  public Sink<FtpFile, CompletionStage<IOResult>> getRemoveSink() throws Exception {
+    return Ftps.remove(settings());
+  }
+
+  public Sink<FtpFile, CompletionStage<IOResult>> getMoveSink(
+      Function<FtpFile, String> destinationPath) throws Exception {
+    return Ftps.move(destinationPath, settings());
+  }
+
+  private FtpsSettings settings() throws Exception {
+    return FtpsSettings.create(InetAddress.getByName(HOSTNAME))
+        .withPort(PORT)
+        .withCredentials(CREDENTIALS)
+        .withBinary(false)
+        .withPassiveMode(true)
+        .withProxy(PROXY);
+  }
+}

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/SftpWithProxyStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/SftpWithProxyStageTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.ftp;
+
+import akka.NotUsed;
+import akka.stream.IOResult;
+import akka.stream.alpakka.ftp.javadsl.Sftp;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+public class SftpWithProxyStageTest extends BaseSftpSupport implements CommonFtpStageTest {
+
+    private final Integer PROXYPORT = 3128;
+    private final Proxy PROXY = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(HOSTNAME, PROXYPORT));
+
+    @Test
+    public void listFiles() throws Exception {
+        CommonFtpStageTest.super.listFiles();
+    }
+
+    @Test
+    public void fromPath() throws Exception {
+        CommonFtpStageTest.super.fromPath();
+    }
+
+    @Test
+    public void toPath() throws Exception {
+        CommonFtpStageTest.super.toPath();
+    }
+
+    @Test
+    public void remove() throws Exception {
+        CommonFtpStageTest.super.remove();
+    }
+
+    @Test
+    public void move() throws Exception {
+        CommonFtpStageTest.super.move();
+    }
+
+    public Source<FtpFile, NotUsed> getBrowserSource(String basePath) throws Exception {
+        return Sftp.ls(ROOT_PATH + basePath, settings());
+    }
+
+    public Source<ByteString, CompletionStage<IOResult>> getIOSource(String path) throws Exception {
+        return Sftp.fromPath(ROOT_PATH + path, settings());
+    }
+
+    public Sink<ByteString, CompletionStage<IOResult>> getIOSink(String path) throws Exception {
+        return Sftp.toPath(ROOT_PATH + path, settings());
+    }
+
+    public Sink<FtpFile, CompletionStage<IOResult>> getRemoveSink() throws Exception {
+        return Sftp.remove(settings());
+    }
+
+    public Sink<FtpFile, CompletionStage<IOResult>> getMoveSink(
+            Function<FtpFile, String> destinationPath) throws Exception {
+        return Sftp.move(f -> ROOT_PATH + destinationPath.apply(f), settings());
+    }
+
+    private SftpSettings settings() throws Exception {
+        return SftpSettings.create(
+                InetAddress.getByName(HOSTNAME))
+                .withPort(PORT)
+                .withCredentials(CREDENTIALS)
+                .withStrictHostKeyChecking(false)
+                .withProxy(PROXY);
+    }
+
+}

--- a/ftp/src/test/resources/squid.conf
+++ b/ftp/src/test/resources/squid.conf
@@ -1,0 +1,7 @@
+debug_options ALL,2
+
+http_port 3128
+acl http_ports port 443 80
+acl ftp_ports port 21 21000 1025-65353
+acl sftp_ports port 22 2222
+http_access deny !http_ports !ftp_ports !sftp_ports

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -143,7 +143,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "org.apache.parquet" % "parquet-avro" % "1.10.0", //Apache2
         "org.apache.hadoop" % "hadoop-client" % "3.2.0" % Test exclude ("log4j", "log4j"), //Apache2
-        "org.apache.hadoop" % "hadoop-common" % "3.2.0" % Test exclude ("log4j", "log4j"),
+        "org.apache.hadoop" % "hadoop-common" % "3.2.0" % Test exclude ("log4j", "log4j"), //Apache2
         "org.specs2" %% "specs2-core" % "4.5.1" % Test, //MIT like: https://github.com/etorreborre/specs2/blob/master/LICENSE.txt
         "org.slf4j" % "log4j-over-slf4j" % log4jOverSlf4jVersion % Test // MIT like: http://www.slf4j.org/license.html
       )
@@ -220,8 +220,7 @@ object Dependencies {
           // TODO: remove direct dependency ^^ when updating from these very old versions
           "org.apache.hbase" % "hbase-shaded-client" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
           "org.apache.hbase" % "hbase-common" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
-          "org.apache.hadoop" % "hadoop-common" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12") exclude ("commons-net", "commons-net"), // ApacheV2,
-          "commons-net" % "commons-net" % "3.6",
+          "org.apache.hadoop" % "hadoop-common" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
           "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
           "org.slf4j" % "log4j-over-slf4j" % log4jOverSlf4jVersion % Test // MIT like: http://www.slf4j.org/license.html
         )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -143,7 +143,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "org.apache.parquet" % "parquet-avro" % "1.10.0", //Apache2
         "org.apache.hadoop" % "hadoop-client" % "3.2.0" % Test exclude ("log4j", "log4j"), //Apache2
-        "org.apache.hadoop" % "hadoop-common" % "3.2.0" % Test exclude ("log4j", "log4j"), //Apache2
+        "org.apache.hadoop" % "hadoop-common" % "3.2.0" % Test exclude ("log4j", "log4j"),
         "org.specs2" %% "specs2-core" % "4.5.1" % Test, //MIT like: https://github.com/etorreborre/specs2/blob/master/LICENSE.txt
         "org.slf4j" % "log4j-over-slf4j" % log4jOverSlf4jVersion % Test // MIT like: http://www.slf4j.org/license.html
       )
@@ -220,7 +220,8 @@ object Dependencies {
           // TODO: remove direct dependency ^^ when updating from these very old versions
           "org.apache.hbase" % "hbase-shaded-client" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
           "org.apache.hbase" % "hbase-common" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
-          "org.apache.hadoop" % "hadoop-common" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
+          "org.apache.hadoop" % "hadoop-common" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12") exclude("commons-net", "commons-net"), // ApacheV2,
+          "commons-net" % "commons-net" % "3.6",
           "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
           "org.slf4j" % "log4j-over-slf4j" % log4jOverSlf4jVersion % Test // MIT like: http://www.slf4j.org/license.html
         )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -220,7 +220,7 @@ object Dependencies {
           // TODO: remove direct dependency ^^ when updating from these very old versions
           "org.apache.hbase" % "hbase-shaded-client" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
           "org.apache.hbase" % "hbase-common" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
-          "org.apache.hadoop" % "hadoop-common" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12") exclude("commons-net", "commons-net"), // ApacheV2,
+          "org.apache.hadoop" % "hadoop-common" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12") exclude ("commons-net", "commons-net"), // ApacheV2,
           "commons-net" % "commons-net" % "3.6",
           "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
           "org.slf4j" % "log4j-over-slf4j" % log4jOverSlf4jVersion % Test // MIT like: http://www.slf4j.org/license.html


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->
## Purpose

Adds proxy support to FTP, SFTP, and FTPS connectors

## References

References #600

## Changes

 * Add `withProxy` method on all three FTPSettings builders that takes a `java.net.Proxy` object
 * Pass the proxy object to the underlying client before the connection is made
 * Added tests for the three supported protocols via a proxy
 * Added squid proxy and configuration to docker-compose so this can be tested. 

## Background Context

The approach is relatively straight forward. The extra option fits neatly into to existing builder pattern and passing the proxy to the client at the start of the connect operation is the natural place for it to go. 

I've chosen to use a squid proxy in the testing as this is a widely used proxy.
