### PR TITLE
AWS S3: make raw request URI contain path and query 

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -218,13 +218,12 @@ import scala.concurrent.{ExecutionContext, Future}
   }
 
   private def rawRequestUri(uri: Uri): String = {
-    val rawUri = uri.toString
+    val rawUri = uri.toHttpRequestTargetOriginForm.toString
     val rawPath = uri.path.toString()
 
     if (rawPath.contains("+")) {
       val fixedPath = rawPath.replaceAll("\\+", "%2B")
-
-      rawUri.replace(rawPath, fixedPath)
+      fixedPath + rawUri.drop(rawPath.length)
     } else {
       rawUri
     }

--- a/s3/src/test/resources/logback-test.xml
+++ b/s3/src/test/resources/logback-test.xml
@@ -7,6 +7,8 @@
         </encoder>
     </appender>
 
+    <logger name="org.eclipse.jetty.io" level="info"/>
+    <logger name="org.eclipse.jetty.util" level="info"/>
     <logger name="org.eclipse.jetty.servlet" level="warn"/>
 
     <root level="warn">

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/DiskBufferSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/DiskBufferSpec.scala
@@ -30,6 +30,8 @@ class DiskBufferSpec(_system: ActorSystem)
 
   implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system).withDebugLogging(true))
 
+  override protected def afterAll(): Unit = TestKit.shutdownActorSystem(system)
+
   "DiskBuffer" should
   "emit a chunk on its output containing the concatenation of all input values" in {
     val result = Source(Vector(ByteString(1, 2, 3, 4, 5), ByteString(6, 7, 8, 9, 10, 11, 12), ByteString(13, 14)))

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -15,7 +15,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.alpakka.s3.headers.{CannedAcl, ServerSideEncryption, StorageClass}
 import akka.stream.alpakka.s3.{ApiVersion, BufferType, MemoryBufferType, MetaHeaders, S3Headers, S3Settings}
 import akka.stream.scaladsl.Source
-import akka.testkit.{SocketUtil, TestProbe}
+import akka.testkit.{SocketUtil, TestKit, TestProbe}
 import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.regions.providers._
 import org.scalatest.concurrent.ScalaFutures
@@ -185,7 +185,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
     val req = HttpRequests.getDownloadRequest(location)
     req.uri.authority.host.toString shouldEqual "bucket.s3.amazonaws.com"
     req.uri.path.toString shouldEqual "/test%20folder/1%20+%202%20=%203"
-    req.headers should contain(`Raw-Request-URI`("https://bucket.s3.amazonaws.com/test%20folder/1%20%2B%202%20=%203"))
+    req.headers should contain(`Raw-Request-URI`("/test%20folder/1%20%2B%202%20=%203"))
   }
 
   it should "support download requests with keys containing spaces with path-style access in other regions" in {
@@ -378,7 +378,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
     probe.expectMsgType[HttpRequest]
 
     materializer.shutdown()
-    system.terminate()
+    TestKit.shutdownActorSystem(system)
   }
 
   it should "add two (source, range) headers to multipart upload (copy) request when byte range populated" in {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/MarshallingSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/MarshallingSpec.scala
@@ -12,16 +12,23 @@ import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.stream.alpakka.s3.ListBucketResultContents
 import akka.testkit.TestKit
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
 import scala.collection.immutable.Seq
 
-class MarshallingSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLike with Matchers with ScalaFutures {
+class MarshallingSpec(_system: ActorSystem)
+    extends TestKit(_system)
+    with FlatSpecLike
+    with Matchers
+    with ScalaFutures
+    with BeforeAndAfterAll {
 
   def this() = this(ActorSystem("MarshallingSpec"))
 
   implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system).withDebugLogging(true))
   implicit val ec = materializer.executionContext
+
+  override protected def afterAll(): Unit = TestKit.shutdownActorSystem(system)
 
   val xmlString = """<?xml version="1.0" encoding="UTF-8"?>
                     |<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/MemoryBufferSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/MemoryBufferSpec.scala
@@ -27,6 +27,8 @@ class MemoryBufferSpec(_system: ActorSystem)
 
   implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system).withDebugLogging(true))
 
+  override protected def afterAll(): Unit = TestKit.shutdownActorSystem(system)
+
   "MemoryBuffer" should "emit a chunk on its output containg the concatenation of all input values" in {
     val result = Source(Vector(ByteString(1, 2, 3, 4, 5), ByteString(6, 7, 8, 9, 10, 11, 12), ByteString(13, 14)))
       .via(new MemoryBuffer(200))

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
@@ -16,7 +16,7 @@ import akka.util.ByteString
 import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.regions.providers._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.{FlatSpecLike, Matchers, PrivateMethodTester}
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers, PrivateMethodTester}
 import software.amazon.awssdk.regions.Region
 
 import scala.concurrent.Future
@@ -25,6 +25,7 @@ class S3StreamSpec(_system: ActorSystem)
     extends TestKit(_system)
     with FlatSpecLike
     with Matchers
+    with BeforeAndAfterAll
     with PrivateMethodTester
     with ScalaFutures
     with IntegrationPatience {
@@ -33,6 +34,8 @@ class S3StreamSpec(_system: ActorSystem)
 
   def this() = this(ActorSystem("S3StreamSpec"))
   implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system).withDebugLogging(true))
+
+  override protected def afterAll(): Unit = TestKit.shutdownActorSystem(system)
 
   "Non-ranged downloads" should "have two (host and synthetic raw-request-uri) headers" in {
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/SplitAfterSizeSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/SplitAfterSizeSpec.scala
@@ -26,6 +26,8 @@ class SplitAfterSizeSpec(_system: ActorSystem)
 
   implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system).withDebugLogging(true))
 
+  override protected def afterAll(): Unit = TestKit.shutdownActorSystem(system)
+
   final val MaxChunkSize = 1024
   "SplitAfterSize" should "yield a single empty substream on no input" in assertAllStagesStopped {
     Source

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SignerSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SignerSpec.scala
@@ -13,7 +13,7 @@ import akka.stream.scaladsl.Sink
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.TestKit
 import software.amazon.awssdk.auth.credentials._
-import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.OptionValues._
 import org.scalatest.time.{Millis, Seconds, Span}
@@ -21,7 +21,12 @@ import software.amazon.awssdk.regions.Region
 
 import scala.compat.java8.OptionConverters._
 
-class SignerSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLike with Matchers with ScalaFutures {
+class SignerSpec(_system: ActorSystem)
+    extends TestKit(_system)
+    with FlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures {
   def this() = this(ActorSystem("SignerSpec"))
 
   implicit val defaultPatience =
@@ -32,6 +37,8 @@ class SignerSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLik
   val credentials = StaticCredentialsProvider.create(
     AwsBasicCredentials.create("AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
   )
+
+  override protected def afterAll(): Unit = TestKit.shutdownActorSystem(system)
 
   def signingKey(dateTime: ZonedDateTime) =
     SigningKey(dateTime, credentials, CredentialScope(dateTime.toLocalDate, Region.US_EAST_1, "iam"))

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/StreamUtilsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/StreamUtilsSpec.scala
@@ -31,6 +31,11 @@ class StreamUtilsSpec(_system: ActorSystem)
   implicit val defaultPatience =
     PatienceConfig(timeout = Span(5, Seconds), interval = Span(30, Millis))
 
+  override protected def afterAll(): Unit = {
+    fs.close()
+    TestKit.shutdownActorSystem(system)
+  }
+
   val fs = Jimfs.newFileSystem("FileSourceSpec", Configuration.unix())
 
   val TestText = {
@@ -78,7 +83,4 @@ class StreamUtilsSpec(_system: ActorSystem)
       result should contain theSameElementsInOrderAs dis.getMessageDigest.digest()
     }
   }
-
-  override def afterAll(): Unit = fs.close()
-
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ClientIntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ClientIntegrationSpec.scala
@@ -6,6 +6,7 @@ package akka.stream.alpakka.s3.scaladsl
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest._
 
@@ -19,4 +20,7 @@ trait S3ClientIntegrationSpec
 
   implicit val system: ActorSystem
   implicit val materializer = ActorMaterializer()
+
+  override protected def afterAll(): Unit = TestKit.shutdownActorSystem(system)
+
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -13,6 +13,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.alpakka.s3.BucketAccess.{AccessGranted, NotExists}
 import akka.stream.alpakka.s3._
 import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.testkit.TestKit
 import akka.util.ByteString
 import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.regions.providers._
@@ -47,6 +48,8 @@ trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
 
   val objectValue = "Some String"
   val metaHeaders: Map[String, String] = Map("location" -> "Africa", "datatype" -> "image")
+
+  override protected def afterAll(): Unit = TestKit.shutdownActorSystem(actorSystem)
 
   def config() = ConfigFactory.parseString("""
       |alpakka.s3.aws.region {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -21,7 +21,7 @@ import software.amazon.awssdk.regions.Region
 
 abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockServer) extends TestKit(_system) {
 
-  def this(mock: WireMockServer) =
+  private def this(mock: WireMockServer) =
     this(ActorSystem(getCallerName(getClass), config(mock.port()).withFallback(ConfigFactory.load())), mock)
   def this() = this(initServer())
 


### PR DESCRIPTION
## Purpose

Just pass the URI path and query as `Raw-Request-URI` so that Amazon S3 understands Alpakka's HTTP requests.

## References

Reported in #1919
https://github.com/akka/akka-http/issues/451
#1738 
#838 

## Changes

* Commit 1 solves the actual problem
* Commit 2 makes sure the tests shut down the ActorSystems they create

## Background Context

As Amazon S3's use of HTTP is non-standard the fix in #1738 introduced a new problem. Originally discussed in https://github.com/akka/akka-http/issues/451 the Raw Request URI needs to be without request scheme and authority.
