### PR TITLE
HDFS: upgrade Cats to 2.0.0 and enable Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -186,12 +186,7 @@ lazy val googleFcm = alpakkaProject(
 
 lazy val hbase = alpakkaProject("hbase", "hbase", Dependencies.HBase, fork in Test := true)
 
-lazy val hdfs = alpakkaProject("hdfs",
-                               "hdfs",
-                               Dependencies.Hdfs,
-                               parallelExecution in Test := false,
-                               crossScalaVersions -= Dependencies.Scala213 // Requires upgrade of cats-core
-)
+lazy val hdfs = alpakkaProject("hdfs", "hdfs", Dependencies.Hdfs, parallelExecution in Test := false)
 
 lazy val influxdb = alpakkaProject("influxdb",
                                    "influxdb",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -238,7 +238,7 @@ object Dependencies {
   val Hdfs = Seq(
     libraryDependencies ++= Seq(
         "org.apache.hadoop" % "hadoop-client" % HadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2
-        "org.typelevel" %% "cats-core" % "1.6.0", // MIT,
+        "org.typelevel" %% "cats-core" % "2.0.0", // MIT,
         "org.apache.hadoop" % "hadoop-hdfs" % HadoopVersion % Test classifier "tests" exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2
         "org.apache.hadoop" % "hadoop-common" % HadoopVersion % Test classifier "tests" exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2
         "org.apache.hadoop" % "hadoop-minicluster" % HadoopVersion % Test exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Make Alpakka HDFS build with Scala 2.13 by upgrading cats-core to the binary compatible 2.0.0 release.

## References

#1764
