### PR TITLE
IronMq: akka-http-circe 1.21 to 1.27 (Circe 0.9.3 to 0.11.1)

### DIFF
--- a/ironmq/src/main/scala/akka/stream/alpakka/ironmq/impl/Codec.scala
+++ b/ironmq/src/main/scala/akka/stream/alpakka/ironmq/impl/Codec.scala
@@ -18,16 +18,16 @@ import cats.syntax.either._
  *
  * @param name The name associated with this Queue.
  */
-private case class Queue(name: Queue.Name)
+private[ironmq] case class Queue(name: Queue.Name)
 
-private object Queue {
+private[ironmq] object Queue {
 
   case class Name(value: String) extends AnyVal {
     override def toString: String = value
   }
 }
 
-private trait Codec {
+private[ironmq] trait Codec {
 
   implicit val messageIdEncoder: Encoder[Message.Id] = Encoder.instance { id =>
     Json.fromString(id.value)
@@ -83,4 +83,4 @@ private trait Codec {
   }
 }
 
-private object Codec extends Codec
+private[ironmq] object Codec extends Codec

--- a/ironmq/src/main/scala/akka/stream/alpakka/ironmq/impl/IronMqClient.scala
+++ b/ironmq/src/main/scala/akka/stream/alpakka/ironmq/impl/IronMqClient.scala
@@ -90,10 +90,10 @@ private[ironmq] final class IronMqClient(settings: IronMqSettings)(implicit acto
             xs.map(extractName)
           }
         }
-        .as[Traversable[String]]
+        .as[scala.collection.immutable.Seq[String]]
     }
 
-    val query = List(prefix.map("prefix" -> _), from.map("previous" -> _.value))
+    val query = List(prefix.map("prefix" -> _), from.map("previous" -> _))
       .collect {
         case Some(x) => x
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -255,7 +255,7 @@ object Dependencies {
   val IronMq = Seq(
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-        "de.heikoseeberger" %% "akka-http-circe" % "1.21.0" // ApacheV2
+        "de.heikoseeberger" %% "akka-http-circe" % "1.27.0" // ApacheV2
       )
   )
 


### PR DESCRIPTION
## Purpose

Upgrade the akka-http-circe dependency from 1.21 to 1.27 (which means Circe goes from 0.9.3 to 0.11.1 and Cats from 1.0.1 to 1.5.0).

This does not reach Scala 2.13, yet.

## References

#1534
https://github.com/hseeberger/akka-http-json/releases
https://github.com/circe/circe/releases
