### PR TITLE
S3 docs: Fix typo

### DIFF
--- a/docs/src/main/paradox/s3.md
+++ b/docs/src/main/paradox/s3.md
@@ -106,7 +106,7 @@ Scala
 Java
 : @@snip [snip](/s3/src/test/java/docs/javadsl/S3Test.java) { #multipart-copy-with-source-version }
 
-Different options are available for server side encryption in the @scaladoc[ServerSideEncryption](akka.stream.alpakka.s3.headers.ServerSideEncryption$) fatory.
+Different options are available for server side encryption in the @scaladoc[ServerSideEncryption](akka.stream.alpakka.s3.headers.ServerSideEncryption$) factory.
 
 Scala
 : @@snip [snip](/s3/src/test/scala/docs/scaladsl/S3SinkSpec.scala) { #multipart-copy-sse }


### PR DESCRIPTION
## Purpose

Fixes a typo in the S3 documentation.

## References

https://doc.akka.io/docs/alpakka/current/s3.html
