### PR TITLE
GCS add versions support for listing, add generation support fo…

### DIFF
--- a/docs/src/main/paradox/google-cloud-storage.md
+++ b/docs/src/main/paradox/google-cloud-storage.md
@@ -45,6 +45,8 @@ Java
 A source for downloading a file can be created by calling @scala[@scaladoc[GCStorage.download](akka.stream.alpakka.googlecloud.storage.scaladsl.GCStorage$)]@java[@scaladoc[GCStorage.download](akka.stream.alpakka.googlecloud.storage.javadsl.GCStorage$)].
 It will emit an @scala[`Option`]@java[`Optional`] that will hold file's data or will be empty if no such file can be found.
 
+If you need to download the specific version of the object in a bucket where object versioning is enabled, you can specify the `generation`.
+
 Scala
 : @@snip [snip](/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSourceSpec.scala) { #download }
 
@@ -56,6 +58,8 @@ Java
 
 If you do not need object itself, you can query for only object metadata using a source from @scala[@scaladoc[GCStorage.getObject](akka.stream.alpakka.googlecloud.storage.scaladsl.GCStorage$)]@java[@scaladoc[GCStorage.getObject](akka.stream.alpakka.googlecloud.storage.javadsl.GCStorage$)].
 
+If you need the specific version of the object metadata in a bucket where object versioning is enabled, you can specify the `generation`. 
+
 Scala
 : @@snip [snip](/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSourceSpec.scala) { #objectMetadata }
 
@@ -66,6 +70,8 @@ Java
 
 To get a list of all objects in a bucket, use @scala[@scaladoc[GCStorage.listBucket](akka.stream.alpakka.googlecloud.storage.scaladsl.GCStorage$)]@java[@scaladoc[GCStorage.listBucket](akka.stream.alpakka.googlecloud.storage.javadsl.GCStorage$)].
 When run, this will give a stream of @scaladoc[StorageObject](akka.stream.alpakka.googlecloud.storage.StorageObject).
+
+To get a list of both live and archived versions of all objects in a bucket where object versioning is enabled, the `versions` has to be set to `true`
 
 Scala
 : @@snip [snip](/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSourceSpec.scala) { #list-bucket }

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStream.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStream.scala
@@ -12,17 +12,10 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.Uri.{Path, Query}
-import akka.http.scaladsl.model.headers.{OAuth2BearerToken, RawHeader, _}
+import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.{ActorMaterializer, Attributes, Materializer}
-import akka.stream.alpakka.googlecloud.storage.{
-  Bucket,
-  GCStorageExt,
-  GCStorageSettings,
-  GCStorageSettingsPath,
-  GCStorageSettingsValue,
-  _
-}
+import akka.stream.alpakka.googlecloud.storage._
 import akka.stream.alpakka.googlecloud.storage.impl.Formats._
 import akka.stream.scaladsl.{Flow, Keep, RunnableGraph, Sink, Source}
 import akka.util.ByteString
@@ -94,7 +87,7 @@ import scala.util.control.NonFatal
   def deleteBucket(bucketName: String)(implicit mat: Materializer, attr: Attributes): Future[Done] =
     deleteBucketSource(bucketName).withAttributes(attr).runWith(Sink.head)
 
-  def listBucket(bucket: String, prefix: Option[String]): Source[StorageObject, NotUsed] = {
+  def listBucket(bucket: String, prefix: Option[String], versions: Boolean = false): Source[StorageObject, NotUsed] = {
     sealed trait ListBucketState
     case object Starting extends ListBucketState
     case class Running(nextPageToken: String) extends ListBucketState
@@ -106,6 +99,7 @@ import scala.util.control.NonFatal
       import mat.executionContext
       val queryParams =
         Map(
+          "versions" -> s"$versions" ::
           pageToken.map(token => "pageToken" -> token).toList ++
           prefix.map(pref => "prefix" -> pref).toList: _*
         )

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/javadsl/GCStorage.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/javadsl/GCStorage.scala
@@ -111,7 +111,20 @@ object GCStorage {
    * @return a `Source` containing `StorageObject` if it exists
    */
   def getObject(bucket: String, objectName: String): Source[Optional[StorageObject], NotUsed] =
-    GCStorageStream.getObject(bucket, objectName).map(_.asJava).asJava
+    GCStorageStream.getObject(bucket, objectName, None).map(_.asJava).asJava
+
+  /**
+   * Get storage object
+   *
+   * @see https://cloud.google.com/storage/docs/json_api/v1/objects/get
+   *
+   * @param bucket the name of the bucket
+   * @param objectName the name of the object
+   * @param generation the generation of the object
+   * @return a `Source` containing `StorageObject` if it exists
+   */
+  def getObject(bucket: String, objectName: String, generation: Long): Source[Optional[StorageObject], NotUsed] =
+    GCStorageStream.getObject(bucket, objectName, Option(generation)).map(_.asJava).asJava
 
   /**
    * Deletes object in bucket
@@ -123,7 +136,20 @@ object GCStorage {
    * @return a `Source` of `Boolean` with `true` if object is deleted, `false` if object that we want to deleted doesn't exist
    */
   def deleteObject(bucketName: String, objectName: String): Source[java.lang.Boolean, NotUsed] =
-    GCStorageStream.deleteObjectSource(bucketName, objectName).map(boolean2Boolean).asJava
+    GCStorageStream.deleteObjectSource(bucketName, objectName, None).map(boolean2Boolean).asJava
+
+  /**
+   * Deletes object in bucket
+   *
+   * @see https://cloud.google.com/storage/docs/json_api/v1/objects/delete
+   *
+   * @param bucketName the name of the bucket
+   * @param objectName the name of the object
+   * @param generation the generation of the object
+   * @return a `Source` of `Boolean` with `true` if object is deleted, `false` if object that we want to deleted doesn't exist
+   */
+  def deleteObject(bucketName: String, objectName: String, generation: Long): Source[java.lang.Boolean, NotUsed] =
+    GCStorageStream.deleteObjectSource(bucketName, objectName, Option(generation)).map(boolean2Boolean).asJava
 
   /**
    * Lists the bucket contents
@@ -134,7 +160,7 @@ object GCStorage {
    * @return a `Source` of `StorageObject`
    */
   def listBucket(bucket: String): Source[StorageObject, NotUsed] =
-    GCStorageStream.listBucket(bucket, None).asJava
+    GCStorageStream.listBucket(bucket, None, versions = false).asJava
 
   /**
    * Lists the bucket contents
@@ -146,7 +172,20 @@ object GCStorage {
    * @return a `Source` of `StorageObject`
    */
   def listBucket(bucket: String, prefix: String): Source[StorageObject, NotUsed] =
-    GCStorageStream.listBucket(bucket, Option(prefix)).asJava
+    GCStorageStream.listBucket(bucket, Option(prefix), versions = false).asJava
+
+  /**
+   * Lists the bucket contents
+   *
+   * @see https://cloud.google.com/storage/docs/json_api/v1/objects/list
+   *
+   * @param bucket the bucket name
+   * @param prefix the bucket prefix
+   * @param versions if `true` list both live and archived bucket contents
+   * @return a `Source` of `StorageObject`
+   */
+  def listBucket(bucket: String, prefix: String, versions: Boolean): Source[StorageObject, NotUsed] =
+    GCStorageStream.listBucket(bucket, Option(prefix), versions).asJava
 
   /**
    * Downloads object from bucket.
@@ -159,7 +198,23 @@ object GCStorage {
    *         Otherwise [[scala.Option Option]] will contain a source of object's data.
    */
   def download(bucket: String, objectName: String): Source[Optional[Source[ByteString, NotUsed]], NotUsed] =
-    GCStorageStream.download(bucket, objectName).map(_.map(_.asJava).asJava).asJava
+    GCStorageStream.download(bucket, objectName, None).map(_.map(_.asJava).asJava).asJava
+
+  /**
+   * Downloads object from bucket.
+   *
+   * @see https://cloud.google.com/storage/docs/json_api/v1/objects/get
+   *
+   * @param bucket the bucket name
+   * @param objectName the bucket prefix
+   * @param generation the generation of the object
+   * @return  The source will emit an empty [[scala.Option Option]] if an object can not be found.
+   *         Otherwise [[scala.Option Option]] will contain a source of object's data.
+   */
+  def download(bucket: String,
+               objectName: String,
+               generation: Long): Source[Optional[Source[ByteString, NotUsed]], NotUsed] =
+    GCStorageStream.download(bucket, objectName, Option(generation)).map(_.map(_.asJava).asJava).asJava
 
   /**
    * Uploads object, use this for small files and `resumableUpload` for big ones

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/javadsl/GCStorage.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/javadsl/GCStorage.scala
@@ -111,7 +111,7 @@ object GCStorage {
    * @return a `Source` containing `StorageObject` if it exists
    */
   def getObject(bucket: String, objectName: String): Source[Optional[StorageObject], NotUsed] =
-    GCStorageStream.getObject(bucket, objectName, None).map(_.asJava).asJava
+    GCStorageStream.getObject(bucket, objectName).map(_.asJava).asJava
 
   /**
    * Get storage object
@@ -136,7 +136,7 @@ object GCStorage {
    * @return a `Source` of `Boolean` with `true` if object is deleted, `false` if object that we want to deleted doesn't exist
    */
   def deleteObject(bucketName: String, objectName: String): Source[java.lang.Boolean, NotUsed] =
-    GCStorageStream.deleteObjectSource(bucketName, objectName, None).map(boolean2Boolean).asJava
+    GCStorageStream.deleteObjectSource(bucketName, objectName).map(boolean2Boolean).asJava
 
   /**
    * Deletes object in bucket
@@ -160,7 +160,7 @@ object GCStorage {
    * @return a `Source` of `StorageObject`
    */
   def listBucket(bucket: String): Source[StorageObject, NotUsed] =
-    GCStorageStream.listBucket(bucket, None, versions = false).asJava
+    GCStorageStream.listBucket(bucket, None).asJava
 
   /**
    * Lists the bucket contents
@@ -172,7 +172,7 @@ object GCStorage {
    * @return a `Source` of `StorageObject`
    */
   def listBucket(bucket: String, prefix: String): Source[StorageObject, NotUsed] =
-    GCStorageStream.listBucket(bucket, Option(prefix), versions = false).asJava
+    GCStorageStream.listBucket(bucket, Option(prefix)).asJava
 
   /**
    * Lists the bucket contents
@@ -198,7 +198,7 @@ object GCStorage {
    *         Otherwise [[scala.Option Option]] will contain a source of object's data.
    */
   def download(bucket: String, objectName: String): Source[Optional[Source[ByteString, NotUsed]], NotUsed] =
-    GCStorageStream.download(bucket, objectName, None).map(_.map(_.asJava).asJava).asJava
+    GCStorageStream.download(bucket, objectName).map(_.map(_.asJava).asJava).asJava
 
   /**
    * Downloads object from bucket.

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/scaladsl/GCStorage.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/scaladsl/GCStorage.scala
@@ -96,13 +96,35 @@ object GCStorage {
    *
    * @param bucket the name of the bucket
    * @param objectName the name of the object
+   * @return a `Source` containing `StorageObject` if it exists
+   */
+  def getObject(bucket: String, objectName: String): Source[Option[StorageObject], NotUsed] =
+    GCStorageStream.getObject(bucket, objectName, generation = None)
+
+  /**
+   * Get storage object
+   *
+   * @see https://cloud.google.com/storage/docs/json_api/v1/objects/get
+   *
+   * @param bucket the name of the bucket
+   * @param objectName the name of the object
    * @param generation the generation of the object
    * @return a `Source` containing `StorageObject` if it exists
    */
-  def getObject(bucket: String,
-                objectName: String,
-                generation: Option[Long] = None): Source[Option[StorageObject], NotUsed] =
+  def getObject(bucket: String, objectName: String, generation: Option[Long]): Source[Option[StorageObject], NotUsed] =
     GCStorageStream.getObject(bucket, objectName, generation)
+
+  /**
+   * Deletes object in bucket
+   *
+   * @see https://cloud.google.com/storage/docs/json_api/v1/objects/delete
+   *
+   * @param bucketName the name of the bucket
+   * @param objectName the name of the object
+   * @return a `Source` of `Boolean` with `true` if object is deleted, `false` if object that we want to deleted doesn't exist
+   */
+  def deleteObject(bucketName: String, objectName: String): Source[Boolean, NotUsed] =
+    GCStorageStream.deleteObjectSource(bucketName, objectName, generation = None)
 
   /**
    * Deletes object in bucket
@@ -114,8 +136,20 @@ object GCStorage {
    * @param generation the generation of the object
    * @return a `Source` of `Boolean` with `true` if object is deleted, `false` if object that we want to deleted doesn't exist
    */
-  def deleteObject(bucketName: String, objectName: String, generation: Option[Long] = None): Source[Boolean, NotUsed] =
+  def deleteObject(bucketName: String, objectName: String, generation: Option[Long]): Source[Boolean, NotUsed] =
     GCStorageStream.deleteObjectSource(bucketName, objectName, generation)
+
+  /**
+   * Lists the bucket contents
+   *
+   * @see https://cloud.google.com/storage/docs/json_api/v1/objects/list
+   *
+   * @param bucket the bucket name
+   * @param prefix the bucket prefix
+   * @return a `Source` of `StorageObject`
+   */
+  def listBucket(bucket: String, prefix: Option[String]): Source[StorageObject, NotUsed] =
+    GCStorageStream.listBucket(bucket, prefix, versions = false)
 
   /**
    * Lists the bucket contents
@@ -127,8 +161,21 @@ object GCStorage {
    * @param versions `true` to list both live and archived bucket contents
    * @return a `Source` of `StorageObject`
    */
-  def listBucket(bucket: String, prefix: Option[String], versions: Boolean = false): Source[StorageObject, NotUsed] =
+  def listBucket(bucket: String, prefix: Option[String], versions: Boolean): Source[StorageObject, NotUsed] =
     GCStorageStream.listBucket(bucket, prefix, versions)
+
+  /**
+   * Downloads object from bucket.
+   *
+   * @see https://cloud.google.com/storage/docs/json_api/v1/objects/get
+   *
+   * @param bucket the bucket name
+   * @param objectName the bucket prefix
+   * @return  The source will emit an empty [[scala.Option Option]] if an object can not be found.
+   *         Otherwise [[scala.Option Option]] will contain a source of object's data.
+   */
+  def download(bucket: String, objectName: String): Source[Option[Source[ByteString, NotUsed]], NotUsed] =
+    GCStorageStream.download(bucket, objectName, generation = None)
 
   /**
    * Downloads object from bucket.
@@ -143,7 +190,7 @@ object GCStorage {
    */
   def download(bucket: String,
                objectName: String,
-               generation: Option[Long] = None): Source[Option[Source[ByteString, NotUsed]], NotUsed] =
+               generation: Option[Long]): Source[Option[Source[ByteString, NotUsed]], NotUsed] =
     GCStorageStream.download(bucket, objectName, generation)
 
   /**

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/scaladsl/GCStorage.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/scaladsl/GCStorage.scala
@@ -96,10 +96,13 @@ object GCStorage {
    *
    * @param bucket the name of the bucket
    * @param objectName the name of the object
+   * @param generation the generation of the object
    * @return a `Source` containing `StorageObject` if it exists
    */
-  def getObject(bucket: String, objectName: String): Source[Option[StorageObject], NotUsed] =
-    GCStorageStream.getObject(bucket, objectName)
+  def getObject(bucket: String,
+                objectName: String,
+                generation: Option[Long] = None): Source[Option[StorageObject], NotUsed] =
+    GCStorageStream.getObject(bucket, objectName, generation)
 
   /**
    * Deletes object in bucket
@@ -108,10 +111,11 @@ object GCStorage {
    *
    * @param bucketName the name of the bucket
    * @param objectName the name of the object
+   * @param generation the generation of the object
    * @return a `Source` of `Boolean` with `true` if object is deleted, `false` if object that we want to deleted doesn't exist
    */
-  def deleteObject(bucketName: String, objectName: String): Source[Boolean, NotUsed] =
-    GCStorageStream.deleteObjectSource(bucketName, objectName)
+  def deleteObject(bucketName: String, objectName: String, generation: Option[Long] = None): Source[Boolean, NotUsed] =
+    GCStorageStream.deleteObjectSource(bucketName, objectName, generation)
 
   /**
    * Lists the bucket contents
@@ -120,10 +124,11 @@ object GCStorage {
    *
    * @param bucket the bucket name
    * @param prefix the bucket prefix
+   * @param versions `true` to list both live and archived bucket contents
    * @return a `Source` of `StorageObject`
    */
-  def listBucket(bucket: String, prefix: Option[String]): Source[StorageObject, NotUsed] =
-    GCStorageStream.listBucket(bucket, prefix)
+  def listBucket(bucket: String, prefix: Option[String], versions: Boolean = false): Source[StorageObject, NotUsed] =
+    GCStorageStream.listBucket(bucket, prefix, versions)
 
   /**
    * Downloads object from bucket.
@@ -132,11 +137,14 @@ object GCStorage {
    *
    * @param bucket the bucket name
    * @param objectName the bucket prefix
+   * @param generation the generation of the object
    * @return  The source will emit an empty [[scala.Option Option]] if an object can not be found.
    *         Otherwise [[scala.Option Option]] will contain a source of object's data.
    */
-  def download(bucket: String, objectName: String): Source[Option[Source[ByteString, NotUsed]], NotUsed] =
-    GCStorageStream.download(bucket, objectName)
+  def download(bucket: String,
+               objectName: String,
+               generation: Option[Long] = None): Source[Option[Source[ByteString, NotUsed]], NotUsed] =
+    GCStorageStream.download(bucket, objectName, generation)
 
   /**
    * Uploads object, use this for small files and `resumableUpload` for big ones

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/scaladsl/GCStorage.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/scaladsl/GCStorage.scala
@@ -99,7 +99,7 @@ object GCStorage {
    * @return a `Source` containing `StorageObject` if it exists
    */
   def getObject(bucket: String, objectName: String): Source[Option[StorageObject], NotUsed] =
-    GCStorageStream.getObject(bucket, objectName, generation = None)
+    GCStorageStream.getObject(bucket, objectName)
 
   /**
    * Get storage object
@@ -124,7 +124,7 @@ object GCStorage {
    * @return a `Source` of `Boolean` with `true` if object is deleted, `false` if object that we want to deleted doesn't exist
    */
   def deleteObject(bucketName: String, objectName: String): Source[Boolean, NotUsed] =
-    GCStorageStream.deleteObjectSource(bucketName, objectName, generation = None)
+    GCStorageStream.deleteObjectSource(bucketName, objectName)
 
   /**
    * Deletes object in bucket
@@ -149,7 +149,7 @@ object GCStorage {
    * @return a `Source` of `StorageObject`
    */
   def listBucket(bucket: String, prefix: Option[String]): Source[StorageObject, NotUsed] =
-    GCStorageStream.listBucket(bucket, prefix, versions = false)
+    GCStorageStream.listBucket(bucket, prefix)
 
   /**
    * Lists the bucket contents
@@ -175,7 +175,7 @@ object GCStorage {
    *         Otherwise [[scala.Option Option]] will contain a source of object's data.
    */
   def download(bucket: String, objectName: String): Source[Option[Source[ByteString, NotUsed]], NotUsed] =
-    GCStorageStream.download(bucket, objectName, generation = None)
+    GCStorageStream.download(bucket, objectName)
 
   /**
    * Downloads object from bucket.

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
@@ -90,14 +90,14 @@ class GCStorageStreamIntegrationSpec
     "be able to list an empty bucket" ignore {
       // the bucket is no longer empty
       val objects = GCStorageStream
-        .listBucket(bucket, None, versions = false)
+        .listBucket(bucket, None)
         .runWith(Sink.seq)
       objects.futureValue shouldBe empty
     }
 
     "get an empty list when listing a non existing folder" ignore {
       val objects = GCStorageStream
-        .listBucket(bucket, Some("non-existent"), versions = false)
+        .listBucket(bucket, Some("non-existent"))
         .runWith(Sink.seq)
 
       objects.futureValue shouldBe empty
@@ -117,7 +117,7 @@ class GCStorageStreamIntegrationSpec
                      Source.single(ByteString("testa")),
                      ContentTypes.`text/plain(UTF-8)`)
           .runWith(Sink.head)
-        listing <- GCStorageStream.listBucket(bucket, Some(folderName), versions = false).runWith(Sink.seq)
+        listing <- GCStorageStream.listBucket(bucket, Some(folderName)).runWith(Sink.seq)
       } yield {
         listing
       }
@@ -132,7 +132,7 @@ class GCStorageStreamIntegrationSpec
         _ <- GCStorageStream
           .putObject(bucket, testFileName("metadata-file"), Source.single(content), ContentTypes.`text/plain(UTF-8)`)
           .runWith(Sink.head)
-        option <- GCStorageStream.getObject(bucket, testFileName("metadata-file"), None).runWith(Sink.head)
+        option <- GCStorageStream.getObject(bucket, testFileName("metadata-file")).runWith(Sink.head)
       } yield option
 
       val so = option.futureValue.get
@@ -142,7 +142,7 @@ class GCStorageStreamIntegrationSpec
     }
 
     "get none when asking metadata of non-existing file" ignore {
-      val option = GCStorageStream.getObject(bucket, testFileName("metadata-file"), None).runWith(Sink.head)
+      val option = GCStorageStream.getObject(bucket, testFileName("metadata-file")).runWith(Sink.head)
       option.futureValue shouldBe None
     }
 
@@ -157,7 +157,7 @@ class GCStorageStreamIntegrationSpec
             ContentTypes.`text/plain(UTF-8)`
           )
           .runWith(Sink.head)
-        listing <- GCStorageStream.listBucket(bucket, Some(folderName), versions = false).runWith(Sink.seq)
+        listing <- GCStorageStream.listBucket(bucket, Some(folderName)).runWith(Sink.seq)
       } yield (so, listing)
 
       val (so, listing) = res.futureValue
@@ -175,7 +175,7 @@ class GCStorageStreamIntegrationSpec
           .putObject(bucket, fileName, Source.single(content), ContentTypes.`text/plain(UTF-8)`)
           .runWith(Sink.head)
         bs <- GCStorageStream
-          .download(bucket, fileName, None)
+          .download(bucket, fileName)
           .runWith(Sink.head)
           .flatMap(
             _.map(_.runWith(Sink.fold(ByteString.empty) { _ ++ _ })).getOrElse(Future.successful(ByteString.empty))
@@ -187,7 +187,7 @@ class GCStorageStreamIntegrationSpec
     "get a None when downloading a non extisting file" ignore {
       val fileName = testFileName("non-existing-file")
       val download = GCStorageStream
-        .download(bucket, fileName, None)
+        .download(bucket, fileName)
         .runWith(Sink.head)
         .futureValue
 
@@ -201,7 +201,7 @@ class GCStorageStreamIntegrationSpec
           .putObject(bucket, fileName, Source.single(ByteString.empty), ContentTypes.`text/plain(UTF-8)`)
           .runWith(Sink.head)
         res <- GCStorageStream
-          .download(bucket, fileName, None)
+          .download(bucket, fileName)
           .runWith(Sink.head)
           .flatMap(
             _.map(_.runWith(Sink.fold(ByteString.empty) { _ ++ _ })).getOrElse(Future.successful(ByteString.empty))
@@ -218,14 +218,14 @@ class GCStorageStreamIntegrationSpec
                      Source.single(ByteString("File content")),
                      ContentTypes.`text/plain(UTF-8)`)
           .runWith(Sink.head)
-        result <- GCStorageStream.deleteObjectSource(bucket, testFileName("fileToDelete"), None).runWith(Sink.head)
+        result <- GCStorageStream.deleteObjectSource(bucket, testFileName("fileToDelete")).runWith(Sink.head)
       } yield result
       result.futureValue shouldBe true
     }
 
     "delete an unexisting file should not give an error" ignore {
       val result =
-        GCStorageStream.deleteObjectSource(bucket, testFileName("non-existing-file-to-delete"), None).runWith(Sink.head)
+        GCStorageStream.deleteObjectSource(bucket, testFileName("non-existing-file-to-delete")).runWith(Sink.head)
       result.futureValue shouldBe false
     }
 
@@ -270,10 +270,10 @@ class GCStorageStreamIntegrationSpec
 
       res.futureValue.name shouldBe fileName
       res.futureValue.bucket shouldBe rewriteBucket
-      GCStorageStream.getObject(rewriteBucket, fileName, None).runWith(Sink.head).futureValue.isDefined shouldBe true
+      GCStorageStream.getObject(rewriteBucket, fileName).runWith(Sink.head).futureValue.isDefined shouldBe true
 
-      GCStorageStream.deleteObjectSource(bucket, fileName, None).runWith(Sink.head).futureValue
-      GCStorageStream.deleteObjectSource(rewriteBucket, fileName, None).runWith(Sink.head).futureValue
+      GCStorageStream.deleteObjectSource(bucket, fileName).runWith(Sink.head).futureValue
+      GCStorageStream.deleteObjectSource(rewriteBucket, fileName).runWith(Sink.head).futureValue
     }
   }
 }


### PR DESCRIPTION
## Purpose

This PR adds support for listing both live and archived versions of objects in a bucket if versioning is enabled. It also adds support to select a generation of object to get, download or delete.

Fixes #1922 

## References

Using Object Versioning
https://cloud.google.com/storage/docs/using-object-versioning

## Changes

Added `Boolean` parameter `versions` with default value of false to `listBucket` method.
Added `Long` optional parameter `generation` to `getObject`, `deleteObject` and `download` methods.

The same applies to Java API, but using overloaded methods instead of default parameters.

## Background Context

It is currently unavailable to list both live and archived version of GCS bucket if versioning is enabled. And if you list archived versions as well, there is no way to interact with those.

Instead of wrapping google Java API to do that, using Alpakka for that purpose would be useful.