### PR TITLE
InfluxDB docs: fix artifact name for sbt, Maven and Gradle

### DIFF
--- a/docs/src/main/paradox/influxdb.md
+++ b/docs/src/main/paradox/influxdb.md
@@ -20,7 +20,7 @@ Furthermore, the major InfluxDB update to [version 2.0](https://www.influxdata.c
 
 @@dependency [sbt,Maven,Gradle] {
   group=com.lightbend.akka
-  artifact=akka-stream-alpakka-influxdb$scala.binary.version$
+  artifact=akka-stream-alpakka-influxdb_$scala.binary.version$
   version=$project.version$
 }
 


### PR DESCRIPTION
The documentation at https://doc.akka.io/docs/alpakka/current/influxdb.html renders the artifact name as `akka-stream-alpakka-influxdb2.12`. This should of course be `akka-stream-alpakka-influxdb_2.12` for Maven and Gradle, and just `akka-stream-alpakka-influxdb` for sbt.

I checked other Alpakka projects that do get it right, and the only difference appears to be the missing underscore.