### PR TITLE
Elasticsearch: refactor to make retrying more explicit

### DIFF
--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
@@ -92,7 +92,7 @@ private[elasticsearch] final class ElasticsearchFlowStage[T, C](
     private def handleResponse(args: (immutable.Seq[WriteMessage[T, C]], Response)): Unit = {
       val (messages, response) = args
       val jsonString = EntityUtils.toString(response.getEntity)
-      val messageResults = writeResults(messages, jsonString)
+      val messageResults = toWriteResults(messages, jsonString)
 
       val failedMsgs = messageResults.filterNot(_.error.isEmpty)
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchFlowStage.scala
@@ -131,7 +131,7 @@ private[elasticsearch] final class ElasticsearchFlowStage[T, C](
     }
 
     private def sendBulkUpdateRequest(messages: immutable.Seq[WriteMessage[T, C]]): Unit = {
-      val json: String = updateJson(messages)
+      val json: String = toJson(messages)
 
       log.debug("Posting data to Elasticsearch: {}", json)
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchJsonBase.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchJsonBase.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.elasticsearch.impl
+
+import akka.annotation.InternalApi
+import akka.stream.alpakka.elasticsearch.Operation.{Create, Delete, Index, Update, Upsert}
+import akka.stream.alpakka.elasticsearch.{MessageWriter, WriteMessage, WriteResult}
+import akka.stream.stage.StageLogging
+import spray.json._
+
+import scala.collection.immutable
+
+/**
+ * Internal API.
+ */
+@InternalApi
+trait ElasticsearchJsonBase[T, C] {
+
+  self: StageLogging =>
+
+  def indexName: String
+  def typeName: String
+  def versionType: Option[String]
+  def messageWriter: MessageWriter[T]
+
+  private lazy val typeNameTuple = "_type" -> JsString(typeName)
+  private lazy val versionTypeTuple: Option[(String, JsString)] = versionType.map { versionType =>
+    "version_type" -> JsString(versionType)
+  }
+
+  protected def updateJson(messages: immutable.Seq[WriteMessage[T, C]]): String =
+    messages
+      .map { message =>
+        val sharedFields: Seq[(String, JsString)] = Seq(
+            "_index" -> JsString(message.indexName.getOrElse(indexName)),
+            typeNameTuple
+          ) ++ message.customMetadata.map { case (field, value) => field -> JsString(value) }
+        val tuple: (String, JsObject) = message.operation match {
+          case Index =>
+            val fields = Seq(
+              message.version.map { version =>
+                "_version" -> JsNumber(version)
+              },
+              versionTypeTuple,
+              message.id.map { id =>
+                "_id" -> JsString(id)
+              }
+            ).flatten
+            "index" -> JsObject(
+              (sharedFields ++ fields): _*
+            )
+          case Create =>
+            val fields = Seq(
+              message.id.map { id =>
+                "_id" -> JsString(id)
+              }
+            ).flatten
+            "create" -> JsObject(
+              (sharedFields ++ fields): _*
+            )
+          case Update | Upsert =>
+            val fields = Seq(
+              message.version.map { version =>
+                "_version" -> JsNumber(version)
+              },
+              versionTypeTuple,
+              Option("_id" -> JsString(message.id.get))
+            ).flatten
+            "update" -> JsObject(
+              (sharedFields ++ fields): _*
+            )
+          case Delete =>
+            val fields = Seq(
+              message.version.map { version =>
+                "_version" -> JsNumber(version)
+              },
+              versionTypeTuple,
+              Option("_id" -> JsString(message.id.get))
+            ).flatten
+            "delete" -> JsObject(
+              (sharedFields ++ fields): _*
+            )
+        }
+        JsObject(tuple).compactPrint + messageToJsonString(message)
+      }
+      .mkString("", "\n", "\n")
+
+  private def messageToJsonString(message: WriteMessage[T, C]): String =
+    message.operation match {
+      case Index | Create =>
+        "\n" + messageWriter.convert(message.source.get)
+      case Upsert =>
+        "\n" + JsObject(
+          "doc" -> messageWriter.convert(message.source.get).parseJson,
+          "doc_as_upsert" -> JsTrue
+        ).toString
+      case Update =>
+        "\n" + JsObject(
+          "doc" -> messageWriter.convert(message.source.get).parseJson
+        ).toString
+      case Delete =>
+        ""
+    }
+
+  protected def writeResults(messages: immutable.Seq[WriteMessage[T, C]],
+                             jsonString: String): immutable.Seq[WriteResult[T, C]] = {
+    val responseJson = jsonString.parseJson
+    if (log.isDebugEnabled) log.debug("response {}", responseJson.prettyPrint)
+
+    // If some commands in bulk request failed, pass failed messages to follows.
+    val items = responseJson.asJsObject.fields("items").asInstanceOf[JsArray]
+    val messageResults: immutable.Seq[WriteResult[T, C]] = items.elements.zip(messages).map {
+      case (item, message) =>
+        val command = message.operation.command
+        val res = item.asJsObject.fields(command).asJsObject
+        val error: Option[String] = res.fields.get("error").map(_.toString())
+        new WriteResult(message, error)
+    }
+    messageResults
+  }
+
+}

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchJsonBase.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchJsonBase.scala
@@ -104,8 +104,8 @@ trait ElasticsearchJsonBase[T, C] {
         ""
     }
 
-  protected def writeResults(messages: immutable.Seq[WriteMessage[T, C]],
-                             jsonString: String): immutable.Seq[WriteResult[T, C]] = {
+  protected def toWriteResults(messages: immutable.Seq[WriteMessage[T, C]],
+                               jsonString: String): immutable.Seq[WriteResult[T, C]] = {
     val responseJson = jsonString.parseJson
     if (log.isDebugEnabled) log.debug("response {}", responseJson.prettyPrint)
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchJsonBase.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchJsonBase.scala
@@ -30,7 +30,7 @@ trait ElasticsearchJsonBase[T, C] {
     "version_type" -> JsString(versionType)
   }
 
-  protected def updateJson(messages: immutable.Seq[WriteMessage[T, C]]): String =
+  protected def toJson(messages: immutable.Seq[WriteMessage[T, C]]): String =
     messages
       .map { message =>
         val sharedFields: Seq[(String, JsString)] = Seq(
@@ -83,11 +83,11 @@ trait ElasticsearchJsonBase[T, C] {
               (sharedFields ++ fields): _*
             )
         }
-        JsObject(tuple).compactPrint + messageToJsonString(message)
+        JsObject(tuple).compactPrint + messageToJson(message)
       }
       .mkString("", "\n", "\n")
 
-  private def messageToJsonString(message: WriteMessage[T, C]): String =
+  private def messageToJson(message: WriteMessage[T, C]): String =
     message.operation match {
       case Index | Create =>
         "\n" + messageWriter.convert(message.source.get)

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.elasticsearch.impl
+
+import java.nio.charset.StandardCharsets
+
+import akka.annotation.InternalApi
+import akka.stream.alpakka.elasticsearch._
+import akka.stream.stage._
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import org.apache.http.entity.StringEntity
+import org.apache.http.message.BasicHeader
+import org.apache.http.util.EntityUtils
+import org.elasticsearch.client.{Response, ResponseListener, RestClient}
+
+import scala.collection.immutable
+import scala.util.{Failure, Success, Try}
+
+/**
+ * INTERNAL API.
+ *
+ * Updates Elasticsearch without any built-in retry logic.
+ */
+@InternalApi
+private[elasticsearch] final class ElasticsearchSimpleFlowStage[T, C](
+    _indexName: String,
+    _typeName: String,
+    client: RestClient,
+    settings: ElasticsearchWriteSettings,
+    writer: MessageWriter[T]
+) extends GraphStage[FlowShape[immutable.Seq[WriteMessage[T, C]], Try[immutable.Seq[WriteResult[T, C]]]]] {
+  require(_indexName != null, "You must define an index name")
+  require(_typeName != null, "You must define a type name")
+
+  private val in = Inlet[immutable.Seq[WriteMessage[T, C]]]("messages")
+  private val out = Outlet[Try[immutable.Seq[WriteResult[T, C]]]]("result")
+  override val shape = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new StageLogic()
+
+  private class StageLogic
+      extends GraphStageLogic(shape)
+      with ElasticsearchJsonBase[T, C]
+      with InHandler
+      with OutHandler
+      with StageLogging {
+
+    private var inflight = false
+
+    private val failureHandler = getAsyncCallback[Throwable](handleFailure)
+    private val responseHandler = getAsyncCallback[(immutable.Seq[WriteMessage[T, C]], Response)](handleResponse)
+
+    // ElasticsearchJsonBase parameters
+    override val indexName: String = _indexName
+    override val typeName: String = _typeName
+    override val versionType: Option[String] = settings.versionType
+    override val messageWriter: MessageWriter[T] = writer
+
+    setHandlers(in, out, this)
+
+    override def onPull(): Unit = tryPull()
+
+    override def onPush(): Unit = {
+      val messages = grab(in)
+      inflight = true
+      val json: String = updateJson(messages)
+
+      log.debug("Posting data to Elasticsearch: {}", json)
+
+      client.performRequestAsync(
+        "POST",
+        "/_bulk",
+        java.util.Collections.emptyMap[String, String](),
+        new StringEntity(json, StandardCharsets.UTF_8),
+        new ResponseListener() {
+          override def onFailure(exception: Exception): Unit = failureHandler.invoke(exception)
+          override def onSuccess(response: Response): Unit = responseHandler.invoke((messages, response))
+        },
+        new BasicHeader("Content-Type", "application/x-ndjson")
+      )
+    }
+
+    private def handleFailure(exception: Throwable): Unit = {
+      inflight = false
+      push(out, Failure(exception))
+      if (isClosed(in)) completeStage()
+      else tryPull()
+    }
+
+    private def handleResponse(args: (immutable.Seq[WriteMessage[T, C]], Response)): Unit = {
+      inflight = false
+      val (messages, response) = args
+      val jsonString = EntityUtils.toString(response.getEntity)
+      val messageResults = toWriteResults(messages, jsonString)
+      push(out, Success(messageResults))
+      if (isClosed(in)) completeStage()
+      else tryPull()
+    }
+
+    private def tryPull(): Unit =
+      if (!isClosed(in) && !hasBeenPulled(in)) {
+        pull(in)
+      }
+
+    override def onUpstreamFinish(): Unit =
+      if (!inflight) completeStage()
+  }
+}

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
@@ -65,7 +65,7 @@ private[elasticsearch] final class ElasticsearchSimpleFlowStage[T, C](
     override def onPush(): Unit = {
       val messages = grab(in)
       inflight = true
-      val json: String = updateJson(messages)
+      val json: String = toJson(messages)
 
       log.debug("Posting data to Elasticsearch: {}", json)
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

This PR introduces a simple flow stage implementation without retrying.

## References

See RetryFlow in https://github.com/akka/akka/pull/27742
DynamoDB retrying https://github.com/akka/alpakka/pull/1712

## Changes

* Introduce `ElasticsearchJsonBase`
* Add `ElasticsearchSimpleFlowStage`
* Rework the `javadsl` factory methods to use `scaladsl` implementations
* Rework the factory methods to choose stage depending on the retry settings

## Background Context

The Elasticsearch flow stage implementation is more involved than needed, as it contains retrying logic. I work on implementing generic retrying flows so that these concerns can be abstracted over in https://github.com/akka/akka/pull/27742
