### PR TITLE
Files: used in ArchiveTest.java are now read only once

### DIFF
--- a/file/src/test/java/docs/javadsl/ArchiveHelper.java
+++ b/file/src/test/java/docs/javadsl/ArchiveHelper.java
@@ -4,11 +4,14 @@
 
 package docs.javadsl;
 
+import akka.util.ByteString;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -29,6 +32,18 @@ public class ArchiveHelper {
         zout.write(bytes, 0, length);
       }
       fis.close();
+    }
+    zout.close();
+  }
+
+  public void createReferenceZipFileFromMemory(
+      Map<String, ByteString> inputFilePaths, String resultFileName) throws Exception {
+    FileOutputStream fout = new FileOutputStream(resultFileName);
+    ZipOutputStream zout = new ZipOutputStream(fout);
+    for (Map.Entry<String, ByteString> file : inputFilePaths.entrySet()) {
+      ZipEntry zipEntry = new ZipEntry(file.getKey());
+      zout.putNextEntry(zipEntry);
+      zout.write(file.getValue().toArray(), 0, file.getValue().toArray().length);
     }
     zout.close();
   }

--- a/file/src/test/java/docs/javadsl/ArchiveTest.java
+++ b/file/src/test/java/docs/javadsl/ArchiveTest.java
@@ -118,6 +118,6 @@ public class ArchiveTest {
   }
 
   private Source<ByteString, NotUsed> toSource(ByteString bs) {
-    return Source.from(scala.collection.JavaConverters.seqAsJavaList(bs.grouped(10).toList()));
+    return Source.single(bs);
   }
 }


### PR DESCRIPTION
## Purpose
Make stable "ArchiveTest.java" test.

## References
References #1909

## Changes
Instead of reading files multiple times in test. Now files are kept in memory. 

## Background Context
After checking the test I decided to give a try different solution than proposed in the issue.
I suspect, something was accessing files, while the tests were running and file metadata has changed before creating reference zip. After this change, files are read from disk only once and reused for both methods of creation ZIP.
