### PR TITLE
DynamoDB: make tryFlow a flowWithContext

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,8 @@ lazy val csvBench = internalProject("csv-bench")
   .dependsOn(csv)
   .enablePlugins(JmhPlugin)
 
-lazy val dynamodb = alpakkaProject("dynamodb", "aws.dynamodb", Dependencies.DynamoDB)
+lazy val dynamodb = alpakkaProject("dynamodb", "aws.dynamodb", Dependencies.DynamoDB,
+  Test / parallelExecution := false)
 
 lazy val elasticsearch = alpakkaProject(
   "elasticsearch",

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/javadsl/DynamoDb.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/javadsl/DynamoDb.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.CompletionStage
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.alpakka.dynamodb.{scaladsl, DynamoDbOp, DynamoDbPaginatedOp}
-import akka.stream.javadsl.{Flow, Sink, Source}
+import akka.stream.javadsl.{Flow, FlowWithContext, Sink, Source}
 import software.amazon.awssdk.core.async.SdkPublisher
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.{DynamoDbRequest, DynamoDbResponse}
@@ -32,32 +32,21 @@ object DynamoDb {
     scaladsl.DynamoDb.flow(parallelism)(client, operation).asJava
 
   /**
-   * Create a Flow that emits a response for every request to DynamoDB.
-   * A successful response is wrapped in [scala.util.Success] and a failed
-   * response is wrapped in [scala.util.Failure].
+   * Create a `FlowWithContext` that emits a response for every request to DynamoDB.
+   * A successful response is wrapped in [[scala.util.Success]] and a failed
+   * response is wrapped in [[scala.util.Failure]].
    *
-   * The returned flow is meant to compose easily with an Akka Stream RetryFlow
-   * which can retry requests, that have responses wrapped in [scala.util.Try].
+   * The context is merely passed through to the emitted element.
    *
    * @param parallelism maximum number of in-flight requests at any given time
-   *
-   * @tparam State the type of the pass-through value that is taken together with
-   *               requests and is emitted together with responses. Can be used,
-   *               for example:
-   *                 * to correlate a request with a response
-   *                 * to track number of retries
-   *                 * to store request to be issued in the case of retry
+   * @tparam Ctx context (or pass-through)
    */
-  def tryFlow[In <: DynamoDbRequest, Out <: DynamoDbResponse, State](
+  def flowWithContext[In <: DynamoDbRequest, Out <: DynamoDbResponse, Ctx](
       client: DynamoDbAsyncClient,
       operation: DynamoDbOp[In, Out],
       parallelism: Int
-  ): Flow[akka.japi.Pair[In, State], akka.japi.Pair[Try[Out], State], NotUsed] =
-    Flow
-      .create[akka.japi.Pair[In, State]]()
-      .map(func(p => (p.first, p.second)))
-      .via(scaladsl.DynamoDb.tryFlow(parallelism)(client, operation))
-      .map(func(t => akka.japi.Pair.create(t._1, t._2)))
+  ): FlowWithContext[In, Ctx, Try[Out], Ctx, NotUsed] =
+    scaladsl.DynamoDb.flowWithContext[In, Out, Ctx](parallelism)(client, operation).asJava
 
   /**
    * Create a Source that will emit potentially multiple responses for a given request.

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoDb.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/scaladsl/DynamoDb.scala
@@ -5,9 +5,10 @@
 package akka.stream.alpakka.dynamodb.scaladsl
 
 import akka.NotUsed
-import akka.stream.{FlowShape, Materializer}
+import akka.dispatch.ExecutionContexts
+import akka.stream.Materializer
 import akka.stream.alpakka.dynamodb.{DynamoDbOp, DynamoDbPaginatedOp}
-import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL, Sink, Source, ZipWith2}
+import akka.stream.scaladsl.{Flow, FlowWithContext, Sink, Source}
 import software.amazon.awssdk.core.async.SdkPublisher
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model._
@@ -31,48 +32,29 @@ object DynamoDb {
     Flow[In].mapAsync(parallelism)(operation.execute(_))
 
   /**
-   * Create a Flow that emits a response for every request to DynamoDB.
-   * A successful response is wrapped in [scala.util.Success] and a failed
-   * response is wrapped in [scala.util.Failure].
+   * Create a `FlowWithContext` that emits a response for every request to DynamoDB.
+   * A successful response is wrapped in [[scala.util.Success]] and a failed
+   * response is wrapped in [[scala.util.Failure]].
    *
-   * The returned flow is meant to compose easily with an Akka Stream RetryFlow
-   * which can retry requests, that have responses wrapped in [scala.util.Try].
+   * The context is merely passed through to the emitted element.
    *
    * @param parallelism maximum number of in-flight requests at any given time
-   *
-   * @tparam State the type of the pass-through value that is taken together with
-   *               requests and is emitted together with responses. Can be used,
-   *               for example:
-   *                 * to correlate a request with a response
-   *                 * to track number of retries
-   *                 * to store request to be issued in the case of retry
+   * @tparam Ctx context (or pass-through)
    */
-  def tryFlow[In <: DynamoDbRequest, Out <: DynamoDbResponse, State](
+  def flowWithContext[In <: DynamoDbRequest, Out <: DynamoDbResponse, Ctx](
       parallelism: Int
   )(implicit client: DynamoDbAsyncClient,
-    operation: DynamoDbOp[In, Out]): Flow[(In, State), (Try[Out], State), NotUsed] =
-    Flow
-      .setup { (mat, _) =>
-        implicit val ec = mat.system.dispatcher
-        val operationFlow = Flow[In].mapAsync(parallelism)(
-          // after 2.11 is dropped, replace this with operation.execute(_).transformWith(Future.successful)
-          operation.execute(_).map(Success.apply).recover { case t => Failure(t) }
-        )
-        Flow.fromGraph {
-          GraphDSL.create(operationFlow) { implicit b => flow =>
-            import GraphDSL.Implicits._
-            val broadcast = b.add(new Broadcast[(In, State)](outputPorts = 2, eagerCancel = true))
-            val zip = b.add(new ZipWith2[Try[Out], State, (Try[Out], State)]((out, state) => (out, state)))
-
-            broadcast.out(0).map(_._1) ~> flow ~> zip.in0
-            broadcast.out(1).map(_._2) ~> zip.in1
-
-            FlowShape(broadcast.in, zip.out)
-          }
+    operation: DynamoDbOp[In, Out]): FlowWithContext[In, Ctx, Try[Out], Ctx, NotUsed] =
+    FlowWithContext.fromTuples(
+      Flow[(In, Ctx)]
+        .mapAsync(parallelism) {
+          case (in, ctx) =>
+            operation
+              .execute(in)
+              .map[(Try[Out], Ctx)](res => (Success(res), ctx))(ExecutionContexts.sameThreadExecutionContext)
+              .recover { case t => (Failure(t), ctx) }(ExecutionContexts.sameThreadExecutionContext)
         }
-
-      }
-      .mapMaterializedValue(_ => NotUsed)
+    )
 
   /**
    * Create a Source that will emit potentially multiple responses for a given request.

--- a/dynamodb/src/test/java/docs/javadsl/RetryTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/RetryTest.java
@@ -108,8 +108,10 @@ public class RetryTest extends ItemSpecOps {
                 8,
                 Duration.ofMillis(10),
                 Duration.ofSeconds(5),
-                0,
-                DynamoDb.tryFlow(client, DynamoDbOp.batchGetItem(), 1),
+                0d,
+                DynamoDb.<BatchGetItemRequest, BatchGetItemResponse, NotUsed>flowWithContext(
+                        client, DynamoDbOp.batchGetItem(), 1)
+                    .asFlow(),
                 resp -> {
                   final Try<BatchGetItemResponse> response = resp.first();
                   if (response.isSuccess()) {
@@ -147,8 +149,10 @@ public class RetryTest extends ItemSpecOps {
                 8,
                 Duration.ofMillis(10),
                 Duration.ofSeconds(5),
-                0,
-                DynamoDb.tryFlow(client, DynamoDbOp.getItem(), 1),
+                0d,
+                DynamoDb.<GetItemRequest, GetItemResponse, Integer>flowWithContext(
+                        client, DynamoDbOp.getItem(), 1)
+                    .asFlow(),
                 resp -> {
                   final Try<GetItemResponse> response = resp.first();
                   final Integer retries = resp.second();

--- a/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala
+++ b/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala
@@ -74,8 +74,8 @@ class RetrySpec
         RetryFlow.withBackoff(8,
                               10.millis,
                               5.seconds,
-                              1,
-                              DynamoDb.tryFlow[BatchGetItemRequest, BatchGetItemResponse, NotUsed](1)) {
+                              1d,
+                              DynamoDb.flowWithContext[BatchGetItemRequest, BatchGetItemResponse, NotUsed](1).asFlow) {
           case (Success(resp), _) if resp.unprocessedKeys.size() > 0 =>
             Some(List((batchGetItemRequest(resp.unprocessedKeys), NotUsed)))
         }
@@ -92,7 +92,11 @@ class RetrySpec
     "retry failed requests" in {
       //#create-retry-flow
       val retryFlow =
-        RetryFlow.withBackoff(8, 10.millis, 5.seconds, 1, DynamoDb.tryFlow[GetItemRequest, GetItemResponse, Int](1)) {
+        RetryFlow.withBackoff(8,
+                              10.millis,
+                              5.seconds,
+                              1d,
+                              DynamoDb.flowWithContext[GetItemRequest, GetItemResponse, Int](1).asFlow) {
           case (Failure(_), retries) => Some(List((getItemRequest, retries + 1)))
         }
       //#create-retry-flow


### PR DESCRIPTION
## Purpose

Implements the `tryFlow` can be implemented much, much simpler and makes it a `FlowWithContext`.

## References

The `tryFlow` was added as part of #1896 

## Changes

* simpler implementation without Graph DSL
* rename `tryFlow` to `flowWithContext`
* change tests to run sequentially (see #1927, #1942)

## Background Context

I'm not happy with the current state of the `RetryFlow` and will update in Alpakka DynamoDb before this is released.
While working on that I found this nice simplification.

I'm not really happy with exposing Scala's `Try` in the Java API.
