### PR TITLE
Reference: add Stage to the names

### DIFF
--- a/reference/src/main/scala/akka/stream/alpakka/reference/impl/ReferenceFlowStage.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/impl/ReferenceFlowStage.scala
@@ -53,7 +53,7 @@ import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 /**
  * INTERNAL API
  */
-@InternalApi private[reference] final class ReferenceFlow()
+@InternalApi private[reference] final class ReferenceFlowStage()
     extends GraphStage[FlowShape[ReferenceWriteMessage, ReferenceWriteResult]] {
   val in: Inlet[ReferenceWriteMessage] = Inlet(Logging.simpleName(this) + ".in")
   val out: Outlet[ReferenceWriteResult] = Outlet(Logging.simpleName(this) + ".out")

--- a/reference/src/main/scala/akka/stream/alpakka/reference/impl/ReferenceSourceStage.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/impl/ReferenceSourceStage.scala
@@ -53,7 +53,7 @@ import scala.util.Success
 /**
  * INTERNAL API
  */
-@InternalApi private[reference] final class ReferenceSource(settings: SourceSettings)
+@InternalApi private[reference] final class ReferenceSourceStage(settings: SourceSettings)
     extends GraphStageWithMaterializedValue[SourceShape[ReferenceReadResult], Future[Done]] {
   val out: Outlet[ReferenceReadResult] = Outlet(Logging.simpleName(this) + ".out")
 

--- a/reference/src/main/scala/akka/stream/alpakka/reference/impl/ReferenceWithResourceFlowStage.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/impl/ReferenceWithResourceFlowStage.scala
@@ -55,7 +55,7 @@ import akka.util.ByteString
 /**
  * INTERNAL API
  */
-@InternalApi private[reference] final class ReferenceWithResourceFlow(resource: Resource)
+@InternalApi private[reference] final class ReferenceWithResourceFlowStage(resource: Resource)
     extends GraphStage[FlowShape[ReferenceWriteMessage, ReferenceWriteResult]] {
   val in: Inlet[ReferenceWriteMessage] = Inlet(Logging.simpleName(this) + ".in")
   val out: Outlet[ReferenceWriteResult] = Outlet(Logging.simpleName(this) + ".out")

--- a/reference/src/main/scala/akka/stream/alpakka/reference/scaladsl/Reference.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/scaladsl/Reference.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.reference.scaladsl
 import akka.actor.ActorSystem
 import akka.stream.Attributes
 import akka.{Done, NotUsed}
-import akka.stream.alpakka.reference.impl.{ReferenceFlow, ReferenceSource, ReferenceWithResourceFlow}
+import akka.stream.alpakka.reference.impl.{ReferenceFlowStage, ReferenceSourceStage, ReferenceWithResourceFlowStage}
 import akka.stream.alpakka.reference._
 import akka.stream.scaladsl.{Flow, Source}
 
@@ -21,14 +21,14 @@ object Reference {
    * Also describe the significance of the materialized value.
    */
   def source(settings: SourceSettings): Source[ReferenceReadResult, Future[Done]] =
-    Source.fromGraph(new ReferenceSource(settings))
+    Source.fromGraph(new ReferenceSourceStage(settings))
 
   /**
    * API doc should describe what will be done to the incoming messages to the flow,
    * and what messages will be emitted by the flow.
    */
   def flow(): Flow[ReferenceWriteMessage, ReferenceWriteResult, NotUsed] =
-    Flow.fromGraph(new ReferenceFlow())
+    Flow.fromGraph(new ReferenceFlowStage())
 
   /**
    * If the operator needs an ExecutionContext, take it as an implicit parameter.
@@ -42,7 +42,7 @@ object Reference {
   def flowWithResource(): Flow[ReferenceWriteMessage, ReferenceWriteResult, NotUsed] =
     Flow
       .setup { (mat, attr) =>
-        Flow.fromGraph(new ReferenceWithResourceFlow(resolveResource(mat.system, attr)))
+        Flow.fromGraph(new ReferenceWithResourceFlowStage(resolveResource(mat.system, attr)))
       }
       .mapMaterializedValue(_ => NotUsed)
 


### PR DESCRIPTION
## Purpose

Align the reference connector with the naming most connectors use.

## Background Context

As @kstrek pointed out in https://github.com/akka/alpakka/pull/1921#discussion_r328295990, the reference connector did not append `Stage` to the graph stage implementations in contrast to almost all other stages in Alpakka.