### PR TITLE
FileTailSource examples when file deleted or idle

### DIFF
--- a/docs/src/main/paradox/file.md
+++ b/docs/src/main/paradox/file.md
@@ -31,6 +31,10 @@ Use the `FileIO` class to create streams reading from or writing to files. It is
 The `FileTailSource` starts at a given offset in a file and emits chunks of bytes until reaching
 the end of the file, it will then poll the file for changes and emit new changes as they are written
  to the file (unless there is backpressure).
+ 
+When there are no new changes, a second timer is initiated to check if the file still exists. When
+the file no longer exists then the `FileTailSource` will complete. The file check timer uses the
+same interval as the timer to check for new changes in the file.
 
 A very common use case is combining reading bytes with parsing the bytes into lines, therefore
 `FileTailSource` contains a few factory methods to create a source that parses the bytes into

--- a/file/src/test/java/docs/javadsl/FileTailSourceTest.java
+++ b/file/src/test/java/docs/javadsl/FileTailSourceTest.java
@@ -22,7 +22,6 @@ import com.google.common.jimfs.Jimfs;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import scala.concurrent.duration.FiniteDuration;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
@@ -30,7 +29,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.APPEND;

--- a/file/src/test/resources/application.conf
+++ b/file/src/test/resources/application.conf
@@ -3,3 +3,5 @@ akka {
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   loglevel = "DEBUG"
 }
+
+akka.test.single-expect-default = 3s

--- a/file/src/test/resources/application.conf
+++ b/file/src/test/resources/application.conf
@@ -4,4 +4,4 @@ akka {
   loglevel = "DEBUG"
 }
 
-akka.test.single-expect-default = 3s
+akka.test.single-expect-default = 10s

--- a/file/src/test/scala/docs/scaladsl/FileTailSourceExtrasSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/FileTailSourceExtrasSpec.scala
@@ -1,0 +1,116 @@
+package docs.scaladsl
+
+import java.io.FileNotFoundException
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{Files, Path}
+import java.util.Collections
+
+import akka.actor.{ActorSystem, Cancellable}
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.file.scaladsl.FileTailSource
+import akka.stream.scaladsl.{Keep, Source}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.TestKit
+import com.google.common.jimfs.{Configuration, Jimfs}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration._
+
+class FileTailSourceExtrasSpec extends TestKit(ActorSystem("filetailsourceextrasspec"))
+  with WordSpecLike
+  with Matchers
+  with BeforeAndAfterAll
+  with ScalaFutures {
+
+  private val fs = Jimfs.newFileSystem(Configuration.forCurrentPlatform.toBuilder.build)
+  private implicit val mat = ActorMaterializer()
+
+  "The FileTailSource" should assertAllStagesStopped {
+    "demo stream shutdown when file deleted" in {
+      val path = fs.getPath("/file")
+      Files.write(path, "a\n".getBytes(UTF_8))
+
+      // #shutdown-on-delete
+
+      final case object Tick
+
+      /**
+       * Periodically checks if the file at `path` exists every `pollingInterval`. Shutdown the stream
+       * when the file is not found using an empty Source.
+       *
+       * @param pollingInterval Interval to check if file exists.
+       * @param path a file to check
+       */
+      def fileCheckSource(pollingInterval: FiniteDuration, path: Path): Source[String, Cancellable] =
+        Source
+          .tick(pollingInterval, pollingInterval, Tick)
+          .mapConcat { _ =>
+            if (Files.exists(path))
+              Collections.emptyList[String]
+            throw new FileNotFoundException
+          }
+          .recoverWithRetries(1, {
+            case _: FileNotFoundException => Source.empty
+          })
+
+      val checkInterval = 1.second
+
+      val stream = FileTailSource
+        .lines(path = path, maxLineSize = 8192, pollingInterval = 250.millis)
+        .merge(fileCheckSource(checkInterval, path), eagerComplete = true)
+
+      // #shutdown-on-delete
+
+      val probe = stream.toMat(TestSink.probe)(Keep.right).run()
+
+      val result = probe.requestNext()
+      result shouldEqual "a"
+
+      Files.delete(path)
+
+      probe.request(1)
+      probe.expectComplete()
+    }
+
+    "demo stream shutdown when with idle timeout" in {
+      val path = fs.getPath("/file")
+      Files.write(path, "a\n".getBytes(UTF_8))
+
+      // just for docs
+      // #shutdown-on-idle-timeout
+
+      val idleTimeout = 30.seconds
+
+      val stream = FileTailSource
+        .lines(path = path, maxLineSize = 8192, pollingInterval = 250.millis)
+        .idleTimeout(idleTimeout)
+        .recoverWithRetries(1, {
+          case _: TimeoutException => Source.empty
+        })
+
+      // #shutdown-on-idle-timeout
+
+      val idleTimeout2 = 1.seconds
+
+      val actualStream = FileTailSource
+        .lines(path = path, maxLineSize = 8192, pollingInterval = 250.millis)
+        .idleTimeout(idleTimeout2)
+        .recoverWithRetries(1, {
+          case _: TimeoutException => Source.empty
+        })
+
+      val probe = actualStream.toMat(TestSink.probe)(Keep.right).run()
+
+      val result = probe.requestNext()
+      result shouldEqual "a"
+
+      Thread.sleep(idleTimeout2.toMillis + 1000)
+
+      probe.expectComplete()
+    }
+
+  }
+}


### PR DESCRIPTION
## Purpose

When a file is deleted that is being tailed with `FileTailSource` the source will do nothing.  The underlying API used to stream files from the filesystem uses [`AsynchronousFileChannel`](https://docs.oracle.com/javase/8/docs/api/java/nio/channels/AsynchronousFileChannel.html).  The `FileTailSource` will issue an asynchronous read request to the channel which wil callback to the `CompletionHandler` successfully even if the file is deleted.  The handler will signal that no bytes were read with the `-1` special case that we use to trigger a new poll.  ~~Instead of repolling indefinitely, this PR checks if the file exists first.  If it does not exist, then we successfully complete the stage.~~

This PR adds examples to the docs to demonstrate how to shutdown the stream if the file is deleted or if it's been idle for an interval of time.

## References

* [`AsynchronousFileChannel.read`](https://docs.oracle.com/javase/8/docs/api/java/nio/channels/AsynchronousFileChannel.html#read-java.nio.ByteBuffer-long-)

## Changes

* Docs example to shutdown `FileTailSource` when file is deleted
* Docs example to shutdown `FileTailSource` when file has been idle for a period of time.
* New tests
