### PR TITLE
IronMq: akka-http-circe 1.21 to 1.29.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -200,9 +200,8 @@ lazy val ironmq = alpakkaProject(
   "ironmq",
   "ironmq",
   Dependencies.IronMq,
-  fork in Test := true,
-  crossScalaVersions -= Dependencies.Scala213, // https://github.com/hseeberger/akka-http-json/issues/253
-  fatalWarnings := false
+  Test / fork := true,
+  crossScalaVersions -= Dependencies.Scala211 // hseeberger/akka-http-json does not support Scala 2.11 anymore
 )
 
 lazy val jms =

--- a/ironmq/src/main/scala/akka/stream/alpakka/ironmq/impl/Codec.scala
+++ b/ironmq/src/main/scala/akka/stream/alpakka/ironmq/impl/Codec.scala
@@ -8,9 +8,6 @@ import akka.stream.alpakka.ironmq.Message
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, Json}
 
-// required on Scala 2.11
-import cats.syntax.either._
-
 /**
  * Internal API.
  *

--- a/ironmq/src/main/scala/akka/stream/alpakka/ironmq/impl/Codec.scala
+++ b/ironmq/src/main/scala/akka/stream/alpakka/ironmq/impl/Codec.scala
@@ -18,16 +18,16 @@ import cats.syntax.either._
  *
  * @param name The name associated with this Queue.
  */
-private case class Queue(name: Queue.Name)
+private[ironmq] case class Queue(name: Queue.Name)
 
-private object Queue {
+private[ironmq] object Queue {
 
   case class Name(value: String) extends AnyVal {
     override def toString: String = value
   }
 }
 
-private trait Codec {
+private[ironmq] trait Codec {
 
   implicit val messageIdEncoder: Encoder[Message.Id] = Encoder.instance { id =>
     Json.fromString(id.value)
@@ -83,4 +83,4 @@ private trait Codec {
   }
 }
 
-private object Codec extends Codec
+private[ironmq] object Codec extends Codec

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -255,7 +255,7 @@ object Dependencies {
   val IronMq = Seq(
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-        "de.heikoseeberger" %% "akka-http-circe" % "1.21.0" // ApacheV2
+        "de.heikoseeberger" %% "akka-http-circe" % "1.29.1" // ApacheV2
       )
   )
 


### PR DESCRIPTION
## Purpose

Upgrade the akka-http-circe dependency from 1.21 to 1.29.1 to reach scala 2.13
(This will not build with 2.11 bcs the lib was released only to 2.12 and 2.13)

Enable Scala 2.13 for IronMq, but disable 2.11.

## References

References #1926 #1534
Maven link: [akka-http-circe](https://mvnrepository.com/artifact/de.heikoseeberger/akka-http-circe)

## Changes

version up, fix broken code, add visibility modifications from #1926 