### PR TITLE
Idle timeout experiment

### DIFF
--- a/file/src/main/scala/akka/stream/alpakka/file/scaladsl/FileTailSource.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/scaladsl/FileTailSource.scala
@@ -6,10 +6,12 @@ package akka.stream.alpakka.file.scaladsl
 
 import java.nio.charset.{Charset, StandardCharsets}
 import java.nio.file.Path
+import java.time.temporal.TemporalUnit
+import java.util.concurrent.TimeUnit
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import akka.util.{ByteString, JavaDurationConverters}
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -29,14 +31,16 @@ object FileTailSource {
    * @param maxChunkSize     The max emitted size of the `ByteString`s
    * @param startingPosition Offset into the file to start reading
    * @param pollingInterval  When the end has been reached, look for new content with this interval
+   * @param idleTimeout      Shutdown the stream after this interval
    */
   def apply(path: Path,
             maxChunkSize: Int,
             startingPosition: Long,
-            pollingInterval: FiniteDuration): Source[ByteString, NotUsed] =
-    Source.fromGraph(
-      new akka.stream.alpakka.file.impl.FileTailSource(path, maxChunkSize, startingPosition, pollingInterval)
-    )
+            pollingInterval: FiniteDuration,
+            idleTimeout: FiniteDuration): Source[ByteString, NotUsed] =
+    akka.stream.alpakka.file.javadsl.FileTailSource.create(path, maxChunkSize, startingPosition,
+      java.time.Duration.ofMillis(pollingInterval.toMillis),
+      java.time.Duration.ofMillis(idleTimeout.toMillis)).asScala
 
   /**
    * Scala API: Read the entire contents of a file as text lines, and then when the end is reached, keep reading
@@ -49,15 +53,17 @@ object FileTailSource {
    * @param path            a file path to tail
    * @param maxLineSize     The max emitted size of the `ByteString`s
    * @param pollingInterval When the end has been reached, look for new content with this interval
+   * @param idleTimeout     Shutdown the stream after this interval
    * @param lf              The character or characters used as line separator, default is fetched from OS
    * @param charset         The charset of the file, defaults to UTF-8
    */
   def lines(path: Path,
             maxLineSize: Int,
             pollingInterval: FiniteDuration,
+            idleTimeout: FiniteDuration,
             lf: String = System.getProperty("line.separator"),
             charset: Charset = StandardCharsets.UTF_8): Source[String, NotUsed] =
-    apply(path, maxLineSize, 0, pollingInterval)
+    apply(path, maxLineSize, 0, pollingInterval, idleTimeout)
       .via(akka.stream.scaladsl.Framing.delimiter(ByteString.fromString(lf, charset.name), maxLineSize, false))
       .map(_.decodeString(charset))
 

--- a/file/src/test/java/docs/javadsl/FileTailSourceTest.java
+++ b/file/src/test/java/docs/javadsl/FileTailSourceTest.java
@@ -59,7 +59,8 @@ public class FileTailSourceTest {
             path,
             8192, // chunk size
             0, // starting position
-            Duration.ofMillis((250)));
+            Duration.ofMillis((250)),
+            Duration.ofDays(Long.MAX_VALUE));
 
     final TestSubscriber.Probe<ByteString> subscriber = TestSubscriber.probe(system);
 
@@ -86,6 +87,7 @@ public class FileTailSourceTest {
             path,
             8192, // chunk size
             Duration.ofMillis(250),
+            Duration.ofDays(Long.MAX_VALUE),
             "\n",
             StandardCharsets.UTF_8);
 

--- a/file/src/test/scala/docs/scaladsl/FileTailSourceSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/FileTailSourceSpec.scala
@@ -29,7 +29,8 @@ object FileTailSourceSpec {
     val lines: Source[String, NotUsed] = FileTailSource.lines(
       path = fs.getPath(path),
       maxLineSize = 8192,
-      pollingInterval = 250.millis
+      pollingInterval = 250.millis,
+      idleTimeout = 1000.minutes
     )
 
     lines.runForeach(line => System.out.println(line))


### PR DESCRIPTION
## Purpose

An experiment using the `idleTimeout` operator.  This is a WIP.  I think it's a good idea to add an option for the idle timeout, but I don't like how it requires us to add parameters across all the DSLs.  I think we should consider using configuration types as parameters to Alpakka DSLs to make it easier to add options in the future.

Or maybe I misunderstood what you wanted to do here.  Was this a feature you wanted to include, or just document?