### PR TITLE
[Backport #1889] File: Expect correct exception in 2.6

### DIFF
--- a/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
@@ -283,7 +283,16 @@ class LogRotatorSinkSpec
       probe.sendNext(ByteString("test"))
       probe.sendNext(ByteString("test"))
       probe.expectCancellation()
-      the[Exception] thrownBy Await.result(completion, 3.seconds) shouldBe a[NonWritableChannelException]
+
+      val exception = intercept[Exception] {
+        Await.result(completion, 3.seconds)
+      }
+
+      exactly(
+        1,
+        List(exception, // Akka 2.5 throws nio exception directly
+             exception.getCause) // Akka 2.6 wraps nio exception in a akka.stream.IOOperationIncompleteException
+      ) shouldBe a[java.nio.channels.NonWritableChannelException]
     }
 
   }


### PR DESCRIPTION
Backport of https://github.com/akka/alpakka/pull/1889 to make Alpakka 1.1 work with Akka 2.6