### PR TITLE
DynamoDB: flow with pagination

### DIFF
--- a/docs/src/main/paradox/dynamodb.md
+++ b/docs/src/main/paradox/dynamodb.md
@@ -52,8 +52,23 @@ Scala
 Java
 : @@snip [snip](/dynamodb/src/test/java/docs/javadsl/ExampleTest.java) { #flow }
 
-Some DynamoDB operations, such as ListTables, Query and Scan, are paginated by nature.
-This is how you can get a stream of all result pages:
+
+### Flow with context
+
+The `flowWithContext` allows to send an arbitrary value, such as commit handles for JMS or Kafka, past the DynamoDb operation.
+The responses are wrapped in a @scaladoc[Try](scala.util.Try)] to differentiate between successful operations and errors in-stream.
+
+Scala
+: @@snip [snip](/dynamodb/src/test/scala/docs/scaladsl/ExampleSpec.scala) { #withContext }
+
+Java
+: @@snip [snip](/dynamodb/src/test/java/docs/javadsl/ExampleTest.java) { #withContext }
+
+
+### Pagination
+
+The DynamoDB operations `BatchGetItem`, `ListTables`, `Query` and `Scan` allow paginating of results.
+The requests with paginated results can be used as source or in a flow with `flowPaginated`:
 
 Scala
 : @@snip [snip](/dynamodb/src/test/scala/docs/scaladsl/ExampleSpec.scala) { #paginated }

--- a/docs/src/main/paradox/dynamodb.md
+++ b/docs/src/main/paradox/dynamodb.md
@@ -56,7 +56,7 @@ Java
 ### Flow with context
 
 The `flowWithContext` allows to send an arbitrary value, such as commit handles for JMS or Kafka, past the DynamoDb operation.
-The responses are wrapped in a @scaladoc[Try](scala.util.Try)] to differentiate between successful operations and errors in-stream.
+The responses are wrapped in a @scaladoc[Try](scala.util.Try) to differentiate between successful operations and errors in-stream.
 
 Scala
 : @@snip [snip](/dynamodb/src/test/scala/docs/scaladsl/ExampleSpec.scala) { #withContext }

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/DynamoDbOp.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/DynamoDbOp.scala
@@ -10,13 +10,20 @@ import org.reactivestreams.Publisher
 import software.amazon.awssdk.core.async.SdkPublisher
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model._
-import software.amazon.awssdk.services.dynamodb.paginators.{ListTablesPublisher, QueryPublisher, ScanPublisher}
+import software.amazon.awssdk.services.dynamodb.paginators.{
+  BatchGetItemPublisher,
+  ListTablesPublisher,
+  QueryPublisher,
+  ScanPublisher
+}
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
 
 /**
- * Representation on an AWS dynamodb sdk operation
+ * Representation on an AWS dynamodb sdk operation.
+ *
+ * See https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/basics-async.html
  * @param sdkExecute function to be executed on the AWS client
  * @tparam In dynamodb request type
  * @tparam Out dynamodb response type
@@ -29,6 +36,8 @@ sealed class DynamoDbOp[In <: DynamoDbRequest, Out <: DynamoDbResponse](
 
 /**
  * Representation on an AWS dynamodb sdk paginated operation
+ *
+ * See https://docs.aws.amazon.com/en_pv/sdk-for-java/v2/developer-guide/examples-pagination.html
  * @param sdkExecute function to be executed on the AWS client
  * @param sdkPublisher publisher to be called on the AWS client
  * @tparam In dynamodb request type
@@ -45,7 +54,7 @@ object DynamoDbOp {
 
   // format: off
   // lower case names on purpose for nice Java API
-  implicit val batchGetItem :DynamoDbOp[BatchGetItemRequest, BatchGetItemResponse] = new DynamoDbOp[BatchGetItemRequest, BatchGetItemResponse](_.batchGetItem)
+  implicit val batchGetItem :DynamoDbPaginatedOp[BatchGetItemRequest, BatchGetItemResponse, BatchGetItemPublisher] = new DynamoDbPaginatedOp[BatchGetItemRequest, BatchGetItemResponse, BatchGetItemPublisher](_.batchGetItem, _.batchGetItemPaginator)
   implicit val batchWriteItem :DynamoDbOp[BatchWriteItemRequest, BatchWriteItemResponse] = new DynamoDbOp[BatchWriteItemRequest, BatchWriteItemResponse](_.batchWriteItem)
   implicit val createTable :DynamoDbOp[CreateTableRequest, CreateTableResponse] = new DynamoDbOp[CreateTableRequest, CreateTableResponse](_.createTable)
   implicit val deleteItem :DynamoDbOp[DeleteItemRequest, DeleteItemResponse] = new DynamoDbOp[DeleteItemRequest, DeleteItemResponse](_.deleteItem)

--- a/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/javadsl/DynamoDb.scala
+++ b/dynamodb/src/main/scala/akka/stream/alpakka/dynamodb/javadsl/DynamoDb.scala
@@ -60,6 +60,17 @@ object DynamoDb {
     scaladsl.DynamoDb.source(request)(client, operation).asJava
 
   /**
+   * Sends requests to DynamoDB and emits the paginated responses.
+   *
+   * Pagination is available for `BatchGetItem`, `ListTables`, `Query` and `Scan` requests.
+   */
+  def flowPaginated[In <: DynamoDbRequest, Out <: DynamoDbResponse](
+      client: DynamoDbAsyncClient,
+      operation: DynamoDbPaginatedOp[In, Out, _]
+  ): Flow[In, Out, NotUsed] =
+    scaladsl.DynamoDb.flowPaginated()(client, operation).asJava
+
+  /**
    * Create a CompletionStage that will be completed with a response to a given request.
    */
   def single[In <: DynamoDbRequest, Out <: DynamoDbResponse](client: DynamoDbAsyncClient,

--- a/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
@@ -7,14 +7,17 @@ package docs.javadsl;
 import akka.NotUsed;
 // #init-client
 import akka.actor.ActorSystem;
+import akka.japi.Pair;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 
 // #init-client
 import akka.stream.alpakka.dynamodb.DynamoDbOp;
 import akka.stream.alpakka.dynamodb.javadsl.DynamoDb;
+import akka.stream.javadsl.FlowWithContext;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
+import akka.stream.javadsl.SourceWithContext;
 import akka.stream.testkit.javadsl.StreamTestKit;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -22,6 +25,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 // #init-client
 import com.github.matsluni.akkahttpspi.AkkaHttpClient;
+import scala.util.Try;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -118,16 +122,71 @@ public class ExampleTest {
   }
 
   @Test
+  public void flowWithContext() throws Throwable {
+    class SomeContext {}
+
+    // #withContext
+    SourceWithContext<PutItemRequest, SomeContext, NotUsed> source = // ???
+        // #withContext
+        SourceWithContext.fromPairs(
+            Source.single(Pair.create(PutItemRequest.builder().build(), new SomeContext())));
+
+    // #withContext
+
+    FlowWithContext<PutItemRequest, SomeContext, Try<PutItemResponse>, SomeContext, NotUsed> flow =
+        DynamoDb.flowWithContext(client, DynamoDbOp.putItem(), 1);
+
+    SourceWithContext<PutItemResponse, SomeContext, NotUsed> writtenSource =
+        source
+            .via(flow)
+            .map(
+                result -> {
+                  if (result.isSuccess()) return result.get();
+                  else throw (Exception) result.failed().get();
+                });
+    // #withContext
+
+    CompletionStage<Pair<PutItemResponse, SomeContext>> streamCompletion =
+        writtenSource.runWith(Sink.head(), materializer);
+    try {
+      Pair<PutItemResponse, SomeContext> response =
+          streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS);
+      fail("expected missing schema");
+    } catch (ExecutionException expected) {
+      // expected
+    }
+  }
+
+  @Test
   public void paginated() throws Exception {
     // #paginated
+    ScanRequest scanRequest = ScanRequest.builder().tableName("testTable").build();
+
     Source<ScanResponse, NotUsed> scanPages =
-        DynamoDb.source(
-            client, DynamoDbOp.scan(), ScanRequest.builder().tableName("testTable").build());
+        DynamoDb.source(client, DynamoDbOp.scan(), scanRequest);
+
     // #paginated
     CompletionStage<List<ScanResponse>> streamCompletion =
         scanPages.runWith(Sink.seq(), materializer);
     try {
       List<ScanResponse> strings = streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS);
+      fail("expected missing schema");
+    } catch (ExecutionException expected) {
+      // expected
+    }
+  }
+
+  @Test
+  public void flowPaginated() throws Exception {
+    ScanRequest scanRequest = ScanRequest.builder().tableName("testTable").build();
+    // #paginated
+    Source<ScanResponse, NotUsed> scanPageInFlow =
+        Source.single(scanRequest).via(DynamoDb.flowPaginated(client, DynamoDbOp.scan()));
+    // #paginated
+    CompletionStage<List<ScanResponse>> streamCompletion2 =
+        scanPageInFlow.runWith(Sink.seq(), materializer);
+    try {
+      List<ScanResponse> strings = streamCompletion2.toCompletableFuture().get(1, TimeUnit.SECONDS);
       fail("expected missing schema");
     } catch (ExecutionException expected) {
       // expected

--- a/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
@@ -96,7 +96,7 @@ public class ExampleTest {
     assertNotNull(result.tableNames());
   }
 
-  @Test
+  @Test(expected = ExecutionException.class)
   public void allowMultipleRequests() throws Exception {
     // #flow
     Source<DescribeTableResponse, NotUsed> tableArnSource =
@@ -112,16 +112,11 @@ public class ExampleTest {
 
     CompletionStage<List<DescribeTableResponse>> streamCompletion =
         tableArnSource.runWith(Sink.seq(), materializer);
-    try {
-      List<DescribeTableResponse> responses =
-          streamCompletion.toCompletableFuture().get(5, TimeUnit.SECONDS);
-      fail("expected missing schema");
-    } catch (ExecutionException expected) {
-      // expected
-    }
+    // exception expected
+    streamCompletion.toCompletableFuture().get(5, TimeUnit.SECONDS);
   }
 
-  @Test
+  @Test(expected = ExecutionException.class)
   public void flowWithContext() throws Throwable {
     class SomeContext {}
 
@@ -148,16 +143,11 @@ public class ExampleTest {
 
     CompletionStage<Pair<PutItemResponse, SomeContext>> streamCompletion =
         writtenSource.runWith(Sink.head(), materializer);
-    try {
-      Pair<PutItemResponse, SomeContext> response =
-          streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS);
-      fail("expected missing schema");
-    } catch (ExecutionException expected) {
-      // expected
-    }
+    // exception expected
+    streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS);
   }
 
-  @Test
+  @Test(expected = ExecutionException.class)
   public void paginated() throws Exception {
     // #paginated
     ScanRequest scanRequest = ScanRequest.builder().tableName("testTable").build();
@@ -168,15 +158,11 @@ public class ExampleTest {
     // #paginated
     CompletionStage<List<ScanResponse>> streamCompletion =
         scanPages.runWith(Sink.seq(), materializer);
-    try {
-      List<ScanResponse> strings = streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS);
-      fail("expected missing schema");
-    } catch (ExecutionException expected) {
-      // expected
-    }
+    // exception expected
+    streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS);
   }
 
-  @Test
+  @Test(expected = ExecutionException.class)
   public void flowPaginated() throws Exception {
     ScanRequest scanRequest = ScanRequest.builder().tableName("testTable").build();
     // #paginated
@@ -185,11 +171,7 @@ public class ExampleTest {
     // #paginated
     CompletionStage<List<ScanResponse>> streamCompletion2 =
         scanPageInFlow.runWith(Sink.seq(), materializer);
-    try {
-      List<ScanResponse> strings = streamCompletion2.toCompletableFuture().get(1, TimeUnit.SECONDS);
-      fail("expected missing schema");
-    } catch (ExecutionException expected) {
-      // expected
-    }
+    // exception expected
+    streamCompletion2.toCompletableFuture().get(1, TimeUnit.SECONDS);
   }
 }

--- a/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
@@ -144,7 +144,7 @@ public class ExampleTest {
     CompletionStage<Pair<PutItemResponse, SomeContext>> streamCompletion =
         writtenSource.runWith(Sink.head(), materializer);
     // exception expected
-    streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS);
+    streamCompletion.toCompletableFuture().get(5, TimeUnit.SECONDS);
   }
 
   @Test(expected = ExecutionException.class)

--- a/dynamodb/src/test/scala/docs/scaladsl/ExampleSpec.scala
+++ b/dynamodb/src/test/scala/docs/scaladsl/ExampleSpec.scala
@@ -7,6 +7,9 @@ package docs.scaladsl
 import java.net.URI
 
 import akka.NotUsed
+import akka.stream.scaladsl.{FlowWithContext, SourceWithContext}
+
+import scala.util.{Failure, Success, Try}
 //#init-client
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
@@ -65,24 +68,50 @@ class ExampleSpec
 
     "provide a simple usage example" in {
 
-      //##simple-request
+      // #simple-request
       val listTablesResult: Future[ListTablesResponse] =
         DynamoDb.single(ListTablesRequest.builder().build())
-      //##simple-request
+      // #simple-request
 
       listTablesResult.futureValue
     }
 
     "allow multiple requests" in assertAllStagesStopped {
-      //##flow
+      // #flow
       val source: Source[DescribeTableResponse, NotUsed] = Source
         .single(CreateTableRequest.builder().tableName("testTable").build())
-        .via(DynamoDb.flow(1))
+        .via(DynamoDb.flow(parallelism = 1))
         .map(response => DescribeTableRequest.builder().tableName(response.tableDescription.tableName).build())
-        .via(DynamoDb.flow(1))
+        .via(DynamoDb.flow(parallelism = 1))
 
-      //##flow
+      // #flow
       source.runWith(Sink.ignore).failed.futureValue
+    }
+
+    "flow with context" in assertAllStagesStopped {
+      case class SomeContext()
+
+      // #withContext
+      val source: SourceWithContext[PutItemRequest, SomeContext, NotUsed] = // ???
+        // #withContext
+        SourceWithContext.fromTuples(
+          Source.single(PutItemRequest.builder().build() -> SomeContext())
+        )
+
+      // #withContext
+
+      val flow: FlowWithContext[PutItemRequest, SomeContext, Try[PutItemResponse], SomeContext, NotUsed] =
+        DynamoDb.flowWithContext(parallelism = 1)
+
+      val writtenSource: SourceWithContext[PutItemResponse, SomeContext, NotUsed] = source
+        .via(flow)
+        .map {
+          case Success(response) => response
+          case Failure(exception) => throw exception
+        }
+      // #withContext
+
+      writtenSource.runWith(Sink.ignore).failed.futureValue
     }
 
     "allow multiple requests - single source" in assertAllStagesStopped {
@@ -94,12 +123,26 @@ class ExampleSpec
       } yield describe.table.itemCount).failed.futureValue
     }
 
-    "provide a paginated requests example" in assertAllStagesStopped {
-      //##paginated
+    "provide a paginated requests source" in assertAllStagesStopped {
+      // #paginated
+      val scanRequest = ScanRequest.builder().tableName("testTable").build()
+
       val scanPages: Source[ScanResponse, NotUsed] =
-        DynamoDb.source(ScanRequest.builder().tableName("testTable").build())
-      //##paginated
+        DynamoDb.source(scanRequest)
+
+      // #paginated
       scanPages.runWith(Sink.ignore).failed.futureValue
+    }
+
+    "provide a paginated flow" in assertAllStagesStopped {
+      val scanRequest = ScanRequest.builder().tableName("testTable").build()
+      // #paginated
+      val scanPageInFlow: Source[ScanResponse, NotUsed] =
+        Source
+          .single(scanRequest)
+          .via(DynamoDb.flowPaginated())
+      // #paginated
+      scanPageInFlow.runWith(Sink.ignore).failed.futureValue
     }
   }
 }


### PR DESCRIPTION
## Purpose

Offer the paginating DynamoDB operations as a flow.

## Background Context

When @julianhowarth pointed out in https://github.com/akka/alpakka/issues/767#issuecomment-539102613 I discovered that the `GetBatchItem` operation wasn't prepared for use with pagination in Alpakka.
While at it I added a `flowPaginated` for use of paginated results in flows to complement the source and added some documentation for `flowWithContext`.

(The use of a `RetryFlow` is still pending, we might want to remove the `Try` from the Java API.)