### PR TITLE
Set path style access to true by default

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
@@ -431,7 +431,7 @@ object S3Settings {
     bufferType,
     credentialsProvider,
     s3RegionProvider,
-    false,
+    true,
     None,
     listBucketApiVersion,
     None


### PR DESCRIPTION
According to `reference.conf`, `path-style-access` is `true` by default:

https://github.com/akka/alpakka/blob/c143ee821feb650bc1c7b9902db3c535dad45f59/s3/src/main/resources/reference.conf#L80

(this has been in effect since https://github.com/akka/alpakka/pull/1308)

However, the non-deprecated version of `S3Settings.apply(...)` sets it to `false`. Following the motivation quoted in `reference.conf` above, I believe this should be `true` instead.

It appears this discrepancy was introduced as part of the polish that @2m applied to https://github.com/akka/alpakka/pull/1639 in https://github.com/akka/alpakka/pull/1639/commits/88217f57856f2e3ccc89fce7d1dfeba0b17525e2. I mention this only because he might have had a good reason for this that I'm unaware of.