### PR TITLE
Google Cloud Pub-Sub: Scala 2.13 is not supported in 1.1.x

### DIFF
--- a/docs/src/main/paradox/release-notes/1.1.x/google-cloud-pub-sub.md
+++ b/docs/src/main/paradox/release-notes/1.1.x/google-cloud-pub-sub.md
@@ -16,7 +16,7 @@ No changes.
 ## 1.1.0
 
 - 'messageId' and 'publishTime' should not be published [#1795](https://github.com/akka/alpakka/pull/1795) by [@LGLO](https://github.com/LGLO)
-- Versions for Scala 2.13.0 [#1755](https://github.com/akka/alpakka/issues/1755) by [@ennru](https://github.com/ennru)
+- Disable Scala 2.13 (part of Versions for Scala 2.13.0 [#1755](https://github.com/akka/alpakka/issues/1755) by [@ennru](https://github.com/ennru))
 
 [*closed in 1.1.0*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A1.1.0+label%3Ap%3Agoogle-cloud-pub-sub)
 


### PR DESCRIPTION
Improve the wording in the release notes.

See #1994