### PR TITLE
Slick: factory method SlickSession.forDbAndProfile

### DIFF
--- a/docs/src/main/paradox/slick.md
+++ b/docs/src/main/paradox/slick.md
@@ -84,6 +84,13 @@ SQL Server
 
 Of course these are just examples. Please visit the @extref[Slick documentation for `DatabaseConfig.fromConfig`](slick:api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader%29:Database) for the full list of things to configure.
 
+You also have the option to create a SlickSession from Slick Database and Profile objects.
+
+Scala
+:  @@snip [snip](/slick/src/test/scala/docs/scaladsl/SlickSpec.scala) { #init-session-from-db-and-profile }
+
+This can be useful if you need to share you configurations with code using Slick directly, or in cases where you first get the database information at runtime, as the Slicks Database class offer factory methods for that. This method is only available in the scaladsl, as Slick has no Java API and as such no easy way of creating a Database instance from Java.
+
 ## Closing a Database Session
 
 Slick requires you to eventually close your database session to free up connection pool resources. You would usually do this when terminating the `ActorSystem`, by registering a termination handler like this:

--- a/slick/src/main/mima-filters/1.1.x.backwards.excludes
+++ b/slick/src/main/mima-filters/1.1.x.backwards.excludes
@@ -1,0 +1,3 @@
+# New classes introduced for adding an extra factory method for SlickSession in #1509
+ProblemFilters.exclude[MissingClassProblem]("akka.stream.alpakka.slick.javadsl.SlickSession$SlickSessionImpl")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.slick.scaladsl.package.SlickSession")

--- a/slick/src/main/scala/akka/stream/alpakka/slick/javadsl/package.scala
+++ b/slick/src/main/scala/akka/stream/alpakka/slick/javadsl/package.scala
@@ -8,7 +8,6 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcBackend
 import slick.jdbc.JdbcProfile
 import slick.jdbc.PositionedResult
-
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
@@ -36,17 +35,23 @@ sealed abstract class SlickSession {
  * connection pools, etc.
  */
 object SlickSession {
-  private final class SlickSessionImpl(val slick: DatabaseConfig[JdbcProfile]) extends SlickSession {
+  private final class SlickSessionConfigBackedImpl(val slick: DatabaseConfig[JdbcProfile]) extends SlickSession {
     val db: JdbcBackend#Database = slick.db
     val profile: JdbcProfile = slick.profile
   }
+  private final class SlickSessionDbAndProfileBackedImpl(val db: JdbcBackend#Database, val profile: JdbcProfile)
+      extends SlickSession
 
   def forConfig(path: String): SlickSession = forConfig(path, ConfigFactory.load())
   def forConfig(config: Config): SlickSession = forConfig("", config)
   def forConfig(path: String, config: Config): SlickSession = forConfig(
     DatabaseConfig.forConfig[JdbcProfile](path, config)
   )
-  def forConfig(databaseConfig: DatabaseConfig[JdbcProfile]): SlickSession = new SlickSessionImpl(databaseConfig)
+  def forConfig(databaseConfig: DatabaseConfig[JdbcProfile]): SlickSession =
+    new SlickSessionConfigBackedImpl(databaseConfig)
+
+  def forDbAndProfile(db: JdbcBackend#Database, profile: JdbcProfile): SlickSession =
+    new SlickSessionDbAndProfileBackedImpl(db, profile)
 }
 
 /**

--- a/slick/src/main/scala/akka/stream/alpakka/slick/javadsl/package.scala
+++ b/slick/src/main/scala/akka/stream/alpakka/slick/javadsl/package.scala
@@ -27,19 +27,12 @@ sealed abstract class SlickSession {
   def close(): Unit = db.close()
 }
 
-/**
- * Java API: Methods for "opening" Slick databases for use.
- *
- * <b>NOTE</b>: databases created through these methods will need to be
- * closed after creation to avoid leaking database resources like active
- * connection pools, etc.
- */
-object SlickSession {
-  private final class SlickSessionConfigBackedImpl(val slick: DatabaseConfig[JdbcProfile]) extends SlickSession {
+private[slick] abstract class SlickSessionFactory {
+  protected final class SlickSessionConfigBackedImpl(val slick: DatabaseConfig[JdbcProfile]) extends SlickSession {
     val db: JdbcBackend#Database = slick.db
     val profile: JdbcProfile = slick.profile
   }
-  private final class SlickSessionDbAndProfileBackedImpl(val db: JdbcBackend#Database, val profile: JdbcProfile)
+  protected final class SlickSessionDbAndProfileBackedImpl(val db: JdbcBackend#Database, val profile: JdbcProfile)
       extends SlickSession
 
   def forConfig(path: String): SlickSession = forConfig(path, ConfigFactory.load())
@@ -49,10 +42,16 @@ object SlickSession {
   )
   def forConfig(databaseConfig: DatabaseConfig[JdbcProfile]): SlickSession =
     new SlickSessionConfigBackedImpl(databaseConfig)
-
-  def forDbAndProfile(db: JdbcBackend#Database, profile: JdbcProfile): SlickSession =
-    new SlickSessionDbAndProfileBackedImpl(db, profile)
 }
+
+/**
+ * Java API: Methods for "opening" Slick databases for use.
+ *
+ * <b>NOTE</b>: databases created through these methods will need to be
+ * closed after creation to avoid leaking database resources like active
+ * connection pools, etc.
+ */
+object SlickSession extends SlickSessionFactory
 
 /**
  * Java API: A class representing a slick resultset row, which is used

--- a/slick/src/main/scala/akka/stream/alpakka/slick/scaladsl/package.scala
+++ b/slick/src/main/scala/akka/stream/alpakka/slick/scaladsl/package.scala
@@ -4,6 +4,8 @@
 
 package akka.stream.alpakka.slick
 
+import slick.jdbc.{JdbcBackend, JdbcProfile}
+
 package object scaladsl {
 
   /**
@@ -21,5 +23,8 @@ package object scaladsl {
    * closed after creation to avoid leaking database resources like active
    * connection pools, etc.
    */
-  val SlickSession = javadsl.SlickSession
+  object SlickSession extends javadsl.SlickSessionFactory {
+    def forDbAndProfile(db: JdbcBackend#Database, profile: JdbcProfile): SlickSession =
+      new SlickSessionDbAndProfileBackedImpl(db, profile)
+  }
 }

--- a/slick/src/test/scala/docs/scaladsl/SlickSpec.scala
+++ b/slick/src/test/scala/docs/scaladsl/SlickSpec.scala
@@ -79,15 +79,21 @@ class SlickSpec extends WordSpec with ScalaFutures with BeforeAndAfterEach with 
 
   "SlickSession.forDbAndProfile" must {
     "create a slick session able to talk to the db" in {
+      //#init-session-from-db-and-profile
       val db = Database.forConfig("slick-h2.db")
       val profile = slick.jdbc.H2Profile
       val slickSessionCreatedForDbAndProfile: SlickSession = SlickSession.forDbAndProfile(db, profile)
-      val q = sql"select true".as[Boolean]
-      val result = Slick
-        .source(q)(slickSessionCreatedForDbAndProfile)
-        .runWith(Sink.head)
-        .futureValue
-      assert(result === true)
+      //#init-session-from-db-and-profile
+      try {
+        val q = sql"select true".as[Boolean]
+        val result = Slick
+          .source(q)(slickSessionCreatedForDbAndProfile)
+          .runWith(Sink.head)
+          .futureValue
+        assert(result === true)
+      } finally {
+        slickSessionCreatedForDbAndProfile.close()
+      }
     }
   }
 

--- a/slick/src/test/scala/docs/scaladsl/SlickSpec.scala
+++ b/slick/src/test/scala/docs/scaladsl/SlickSpec.scala
@@ -30,7 +30,7 @@ class SlickSpec extends WordSpec with ScalaFutures with BeforeAndAfterEach with 
   //#init-mat
 
   //#init-session
-  implicit val session = SlickSession.forConfig("slick-h2")
+  implicit val session: SlickSession = SlickSession.forConfig("slick-h2")
   //#init-session
 
   import session.profile.api._
@@ -75,6 +75,20 @@ class SlickSpec extends WordSpec with ScalaFutures with BeforeAndAfterEach with 
     //#close-session
 
     TestKit.shutdownActorSystem(system)
+  }
+
+  "SlickSession.forDbAndProfile" must {
+    "create a slick session able to talk to the db" in {
+      val db = Database.forConfig("slick-h2.db")
+      val profile = slick.jdbc.H2Profile
+      val slickSessionCreatedForDbAndProfile: SlickSession = SlickSession.forDbAndProfile(db, profile)
+      val q = sql"select true".as[Boolean]
+      val result = Slick
+        .source(q)(slickSessionCreatedForDbAndProfile)
+        .runWith(Sink.head)
+        .futureValue
+      assert(result === true)
+    }
   }
 
   "Slick.source(...)" must {


### PR DESCRIPTION
## Purpose

Introduces an extra factory method for creating a SlickSession out of Slick Database and Profile instances.

## References

References #1509

## Changes

* Created method forDbAndProfile(db: JdbcBackend#Database, profile: JdbcProfile): SlickSession in the scaladsl version.
* Before this changes, the scala version of SlickSession object was the same as the javadsl version. Now these two are different, as the above method, only makes sense from scala, due to Slicks missing Java API.
* To avoid duplicat code, all the shared logic of the two SlickSession objects, has been moved to a SlickSessionFactory abstract class, that they both extend.

## Background Context

It makes it possible to create a SlickSession, if you starting point is a Slick Database instance. This can be the case, when working with other libraries, that are based on Slick, but now nothing about Alpakka. In my case, it was a test library, that provides each test, with its own test database, provided as a Slick Database instance.
