### PR TITLE
AWS S3: discard entity on failed sign request

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -341,7 +341,7 @@ object Dependencies {
         "com.fasterxml.jackson.core" % "jackson-databind" % JacksonDatabindVersion,
         // in-memory filesystem for file related tests
         "com.google.jimfs" % "jimfs" % "1.1" % Test, // ApacheV2
-        "com.github.tomakehurst" % "wiremock" % "2.18.0" % Test // ApacheV2
+        "com.github.tomakehurst" % "wiremock" % "2.25.1" % Test // ApacheV2
       )
   )
 

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
@@ -420,8 +420,48 @@ object S3 {
    * @param bucket Which bucket that you list object metadata for
    * @param prefix Prefix of the keys you want to list under passed bucket
    * @return Source of object metadata
+   *
+   * @deprecated use version with `Optional` instead, since 2.0.0
    */
+  @Deprecated
   def listBucket(bucket: String, prefix: Option[String]): Source[ListBucketResultContents, NotUsed] =
+    listBucket(bucket, prefix.asJava, S3Headers.empty)
+
+  /**
+   * Will return a source of object metadata for a given bucket with optional prefix using version 2 of the List Bucket API.
+   * This will automatically page through all keys with the given parameters.
+   *
+   * The <code>akka.stream.alpakka.s3.list-bucket-api-version</code> can be set to 1 to use the older API version 1
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html  (version 1 API)
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html (version 1 API)
+   * @param bucket Which bucket that you list object metadata for
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @return Source of object metadata
+   *
+   * @deprecated use version with `Optional` instead, since 2.0.0
+   */
+  @Deprecated
+  def listBucket(bucket: String,
+                 prefix: Option[String],
+                 s3Headers: S3Headers): Source[ListBucketResultContents, NotUsed] =
+    S3Stream
+      .listBucket(bucket, prefix, s3Headers)
+      .asJava
+
+  /**
+   * Will return a source of object metadata for a given bucket with optional prefix using version 2 of the List Bucket API.
+   * This will automatically page through all keys with the given parameters.
+   *
+   * The <code>akka.stream.alpakka.s3.list-bucket-api-version</code> can be set to 1 to use the older API version 1
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html  (version 1 API)
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html (version 1 API)
+   * @param bucket Which bucket that you list object metadata for
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @return Source of object metadata
+   */
+  def listBucket(bucket: String, prefix: Optional[String]): Source[ListBucketResultContents, NotUsed] =
     listBucket(bucket, prefix, S3Headers.empty)
 
   /**
@@ -437,10 +477,10 @@ object S3 {
    * @return Source of object metadata
    */
   def listBucket(bucket: String,
-                 prefix: Option[String],
+                 prefix: Optional[String],
                  s3Headers: S3Headers): Source[ListBucketResultContents, NotUsed] =
     S3Stream
-      .listBucket(bucket, prefix, s3Headers)
+      .listBucket(bucket, prefix.asScala, s3Headers)
       .asJava
 
   /**

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -373,7 +373,7 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
     val req =
       HttpRequests.listBucket(location.bucket, Some("random/prefix"), Some("randomToken"))
 
-    Http().singleRequest(req)
+    Http().singleRequest(req).futureValue
 
     probe.expectMsgType[HttpRequest]
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -19,7 +19,7 @@ import com.github.tomakehurst.wiremock.stubbing.Scenario
 import com.typesafe.config.ConfigFactory
 import software.amazon.awssdk.regions.Region
 
-abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockServer) extends TestKit(_system) {
+abstract class S3WireMockBase(_system: ActorSystem, val _wireMockServer: WireMockServer) extends TestKit(_system) {
 
   private def this(mock: WireMockServer) =
     this(ActorSystem(getCallerName(getClass), config(mock.port()).withFallback(ConfigFactory.load())), mock)
@@ -295,7 +295,7 @@ abstract class S3WireMockBase(_system: ActorSystem, _wireMockServer: WireMockSer
 
     mock.register(
       put(urlEqualTo(s"/$bucketKey?partNumber=1&uploadId=$uploadId"))
-        .withRequestBody(matching(expectedBody))
+        .withRequestBody(if (expectedBody.isEmpty) absent() else matching(expectedBody))
         .willReturn(
           aResponse()
             .withStatus(200)


### PR DESCRIPTION
## Purpose

Ensure the HTTP response entity data is discarded when a signing response fails.

## Changes

* discard entity data in `signAndRequest`
* change Javadsl `listBucket` to use `Optional` instead of `scala.Option` (old methods deprecated)
* add shutdown of Actor System and WireMock in `S3Test`
* upgrade WireMock to 2.25.1 and adapt empty request mocking