### PR TITLE
Elasticsearch: Add charset

### DIFF
--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSourceStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSourceStage.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.elasticsearch.impl
 
 import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
 
 import akka.annotation.InternalApi
 import akka.stream.alpakka.elasticsearch.{ElasticsearchSourceSettings, ReadResult}
@@ -125,7 +126,7 @@ private[elasticsearch] final class ElasticsearchSourceLogic[T](indexName: String
           "POST",
           endpoint,
           Map("scroll" -> settings.scroll, "sort" -> "_doc").asJava,
-          new StringEntity(searchBody),
+          new StringEntity(searchBody, StandardCharsets.UTF_8),
           this,
           new BasicHeader("Content-Type", "application/json")
         )
@@ -136,7 +137,8 @@ private[elasticsearch] final class ElasticsearchSourceLogic[T](indexName: String
           "POST",
           s"/_search/scroll",
           Map[String, String]().asJava,
-          new StringEntity(Map("scroll" -> settings.scroll, "scroll_id" -> scrollId).toJson.toString),
+          new StringEntity(Map("scroll" -> settings.scroll, "scroll_id" -> scrollId).toJson.toString,
+                           StandardCharsets.UTF_8),
           this,
           new BasicHeader("Content-Type", "application/json")
         )


### PR DESCRIPTION
## Purpose

Queries sent from `ElasticsearchSource.typed` ignore non-ascii characters.
For example, the query created by the following code
```scala
ElasticsearchSource
  .typed[Document](
    "documents",
    "_doc",
    query = """{ "match": { "content": "先生" } }"""
  )
```
is recorded in `logs/elasticsearch_index_search_slowlog.log` as
```
source[{"size":10,"query":{"match":{"content":{"query":"??","operator":"OR","prefix_length":0,"max_expansions":50,"fuzzy_transpositions":true,"lenient":false,"zero_terms_query":"NONE","auto_generate_synonyms_phrase_query":true,"boost":1.0}}},"sort":[{"_doc":{"order":"asc"}}]}]
```
where "先生" is "??".

## Changes
- Add `StandardCharset.UTF_8` to `StringEntity` in `ElasticsearchSourceStage.scala` as in `ElasticsearchFlowStage.scala`
