### PR TITLE
Small docs fixes

### DIFF
--- a/build.sbt-2
+++ b/build.sbt-2
@@ -1,0 +1,424 @@
+import Whitesource.whitesourceGroup
+
+lazy val alpakka = project
+  .in(file("."))
+  .enablePlugins(ScalaUnidocPlugin)
+  .disablePlugins(MimaPlugin, SitePlugin)
+  .aggregate(
+    amqp,
+    avroparquet,
+    awslambda,
+    azureStorageQueue,
+    cassandra,
+    couchbase,
+    csv,
+    dynamodb,
+    elasticsearch,
+    files,
+    ftp,
+    geode,
+    googleCloudPubSub,
+    googleCloudPubSubGrpc,
+    googleCloudStorage,
+    googleFcm,
+    hbase,
+    hdfs,
+    influxdb,
+    ironmq,
+    jms,
+    jsonStreaming,
+    kinesis,
+    kudu,
+    mongodb,
+    mqtt,
+    mqttStreaming,
+    orientdb,
+    reference,
+    s3,
+    springWeb,
+    simpleCodecs,
+    slick,
+    sns,
+    solr,
+    sqs,
+    sse,
+    text,
+    udp,
+    unixdomainsocket,
+    xml
+  )
+  .aggregate(`doc-examples`)
+  .settings(
+    onLoadMessage :=
+      """
+        |** Welcome to the sbt build definition for Alpakka! **
+        |
+        |Useful sbt tasks:
+        |
+        |  docs/previewSite - builds Paradox and Scaladoc documentation,
+        |    starts a webserver and opens a new browser window
+        |
+        |  test - runs all the tests for all of the connectors.
+        |    Make sure to run `docker-compose up` first.
+        |
+        |  mqtt/testOnly *.MqttSourceSpec - runs a single test
+        |
+        |  mimaReportBinaryIssues - checks whether this current API
+        |    is binary compatible with the released version
+      """.stripMargin,
+    // unidoc combines sources and jars from all connectors and that
+    // might include some incompatible ones. Depending on the
+    // classpath order that might lead to scaladoc compilation errors.
+    // Therefore some versions are exlcuded here.
+    ScalaUnidoc / unidoc / fullClasspath := {
+      (ScalaUnidoc / unidoc / fullClasspath).value
+        .filterNot(_.data.getAbsolutePath.contains("protobuf-java-2.5.0.jar"))
+        .filterNot(_.data.getAbsolutePath.contains("guava-27.1-android.jar"))
+        .filterNot(_.data.getAbsolutePath.contains("commons-net-3.1.jar"))
+    },
+    ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(`doc-examples`,
+                                                                             csvBench,
+                                                                             mqttStreamingBench),
+    crossScalaVersions := List() // workaround for https://github.com/sbt/sbt/issues/3465
+  )
+
+lazy val amqp = alpakkaProject("amqp", "amqp", Dependencies.Amqp)
+
+lazy val avroparquet =
+  alpakkaProject("avroparquet", "avroparquet", Dependencies.AvroParquet, parallelExecution in Test := false)
+
+lazy val awslambda = alpakkaProject("awslambda",
+                                    "aws.lambda",
+                                    Dependencies.AwsLambda,
+                                    // For mockito https://github.com/akka/alpakka/issues/390
+                                    parallelExecution in Test := false)
+
+lazy val azureStorageQueue = alpakkaProject("azure-storage-queue", "azure.storagequeue", Dependencies.AzureStorageQueue)
+
+lazy val cassandra = alpakkaProject("cassandra", "cassandra", Dependencies.Cassandra)
+
+lazy val couchbase =
+  alpakkaProject("couchbase",
+                 "couchbase",
+                 Dependencies.Couchbase,
+                 parallelExecution in Test := false,
+                 whitesourceGroup := Whitesource.Group.Supported)
+
+lazy val csv = alpakkaProject("csv", "csv", whitesourceGroup := Whitesource.Group.Supported)
+
+lazy val csvBench = internalProject("csv-bench")
+  .dependsOn(csv)
+  .enablePlugins(JmhPlugin)
+
+lazy val dynamodb = alpakkaProject("dynamodb", "aws.dynamodb", Dependencies.DynamoDB, Test / parallelExecution := false)
+
+lazy val elasticsearch = alpakkaProject(
+  "elasticsearch",
+  "elasticsearch",
+  Dependencies.Elasticsearch,
+  // For elasticsearch-cluster-runner https://github.com/akka/alpakka/issues/479
+  parallelExecution in Test := false
+)
+
+// The name 'file' is taken by `sbt.file`, hence 'files'
+lazy val files = alpakkaProject("file", "file", Dependencies.File)
+
+lazy val ftp = alpakkaProject(
+  "ftp",
+  "ftp",
+  Dependencies.Ftp,
+  parallelExecution in Test := false,
+  fork in Test := true,
+  // To avoid potential blocking in machines with low entropy (default is `/dev/random`)
+  javaOptions in Test += "-Djava.security.egd=file:/dev/./urandom"
+)
+
+lazy val geode =
+  alpakkaProject(
+    "geode",
+    "geode",
+    Dependencies.Geode,
+    fork in Test := true,
+    parallelExecution in Test := false,
+    unmanagedSourceDirectories in Compile ++= {
+      val sourceDir = (sourceDirectory in Compile).value
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n >= 12 => Seq(sourceDir / "scala-2.12+")
+        case _ => Seq.empty
+      }
+    }
+  )
+
+lazy val googleCloudPubSub = alpakkaProject(
+  "google-cloud-pub-sub",
+  "google.cloud.pubsub",
+  Dependencies.GooglePubSub,
+  fork in Test := true,
+  envVars in Test := Map("PUBSUB_EMULATOR_HOST" -> "localhost:8538"),
+  // For mockito https://github.com/akka/alpakka/issues/390
+  parallelExecution in Test := false
+)
+
+lazy val googleCloudPubSubGrpc = alpakkaProject(
+  "google-cloud-pub-sub-grpc",
+  "google.cloud.pubsub.grpc",
+  Dependencies.GooglePubSubGrpc,
+  akkaGrpcCodeGeneratorSettings ~= { _.filterNot(_ == "flat_package") },
+  akkaGrpcGeneratedSources := Seq(AkkaGrpc.Client),
+  akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Scala, AkkaGrpc.Java),
+  javaAgents += Dependencies.GooglePubSubGrpcAlpnAgent % "test",
+  // for the ExampleApp in the tests
+  connectInput in run := true,
+  Compile / compile / scalacOptions += "-P:silencer:pathFilters=src_managed",
+  crossScalaVersions --= Seq(Dependencies.Scala211) // 2.11 is not supported since Akka gRPC 0.6
+).enablePlugins(AkkaGrpcPlugin, JavaAgent)
+
+lazy val googleCloudStorage =
+  alpakkaProject("google-cloud-storage",
+                 "google.cloud.storage",
+                 Dependencies.GoogleStorage,
+                 crossScalaVersions -= Dependencies.Scala211)
+
+lazy val googleFcm = alpakkaProject(
+  "google-fcm",
+  "google.firebase.fcm",
+  Dependencies.GoogleFcm,
+  fork in Test := true
+)
+
+lazy val hbase = alpakkaProject("hbase", "hbase", Dependencies.HBase, fork in Test := true)
+
+lazy val hdfs = alpakkaProject("hdfs", "hdfs", Dependencies.Hdfs, parallelExecution in Test := false)
+
+lazy val influxdb = alpakkaProject("influxdb",
+                                   "influxdb",
+                                   Dependencies.InfluxDB,
+                                   crossScalaVersions -= Dependencies.Scala211,
+                                   fatalWarnings := false)
+
+lazy val ironmq = alpakkaProject(
+  "ironmq",
+  "ironmq",
+  Dependencies.IronMq,
+  Test / fork := true,
+  crossScalaVersions -= Dependencies.Scala211 // hseeberger/akka-http-json does not support Scala 2.11 anymore
+)
+
+lazy val jms =
+  alpakkaProject("jms", "jms", Dependencies.Jms, parallelExecution in Test := false, fatalWarnings := false)
+
+lazy val jsonStreaming = alpakkaProject("json-streaming", "json.streaming", Dependencies.JsonStreaming)
+
+lazy val kinesis = alpakkaProject(
+  "kinesis",
+  "aws.kinesis",
+  Dependencies.Kinesis,
+  // For mockito https://github.com/akka/alpakka/issues/390
+  parallelExecution in Test := false,
+  fatalWarnings := false
+)
+
+lazy val kudu = alpakkaProject("kudu", "kudu", Dependencies.Kudu, fork in Test := false)
+
+lazy val mongodb =
+  alpakkaProject("mongodb", "mongodb", Dependencies.MongoDb)
+
+lazy val mqtt = alpakkaProject("mqtt", "mqtt", Dependencies.Mqtt)
+
+lazy val mqttStreaming = alpakkaProject("mqtt-streaming",
+                                        "mqttStreaming",
+                                        Dependencies.MqttStreaming,
+                                        crossScalaVersions -= Dependencies.Scala211)
+lazy val mqttStreamingBench = internalProject("mqtt-streaming-bench", crossScalaVersions -= Dependencies.Scala211)
+  .enablePlugins(JmhPlugin)
+  .dependsOn(mqtt, mqttStreaming)
+
+lazy val orientdb = alpakkaProject("orientdb",
+                                   "orientdb",
+                                   Dependencies.OrientDB,
+                                   fork in Test := true,
+                                   parallelExecution in Test := false,
+                                   fatalWarnings := false)
+
+lazy val reference = internalProject("reference", Dependencies.Reference)
+
+lazy val s3 = alpakkaProject("s3", "aws.s3", Dependencies.S3)
+
+lazy val springWeb = alpakkaProject("spring-web", "spring.web", Dependencies.SpringWeb)
+
+lazy val simpleCodecs = alpakkaProject("simple-codecs", "simplecodecs")
+
+lazy val slick = alpakkaProject("slick", "slick", Dependencies.Slick)
+
+lazy val sns = alpakkaProject(
+  "sns",
+  "aws.sns",
+  Dependencies.Sns,
+  // For mockito https://github.com/akka/alpakka/issues/390
+  parallelExecution in Test := false
+)
+
+lazy val solr = alpakkaProject("solr", "solr", Dependencies.Solr, parallelExecution in Test := false)
+
+lazy val sqs = alpakkaProject(
+  "sqs",
+  "aws.sqs",
+  Dependencies.Sqs,
+  // For mockito https://github.com/akka/alpakka/issues/390
+  parallelExecution in Test := false
+)
+
+lazy val sse = alpakkaProject("sse", "sse", Dependencies.Sse)
+
+lazy val text = alpakkaProject("text", "text")
+
+lazy val udp = alpakkaProject("udp", "udp")
+
+lazy val unixdomainsocket = alpakkaProject(
+  "unix-domain-socket",
+  "unixdomainsocket",
+  Dependencies.UnixDomainSocket
+)
+
+lazy val xml = alpakkaProject("xml", "xml", Dependencies.Xml)
+
+lazy val docs = project
+  .enablePlugins(AkkaParadoxPlugin, ParadoxSitePlugin, PreprocessPlugin, PublishRsyncPlugin)
+  .disablePlugins(BintrayPlugin, MimaPlugin)
+  .settings(
+    name := "Alpakka",
+    publish / skip := true,
+    whitesourceIgnore := true,
+    makeSite := makeSite.dependsOn(LocalRootProject / ScalaUnidoc / doc).value,
+    previewPath := (Paradox / siteSubdirName).value,
+    Preprocess / siteSubdirName := s"api/alpakka/${projectInfoVersion.value}",
+    Preprocess / sourceDirectory := (LocalRootProject / ScalaUnidoc / unidoc / target).value,
+    Paradox / siteSubdirName := s"docs/alpakka/${projectInfoVersion.value}",
+    paradoxProperties ++= Map(
+        // API links
+        "scaladoc.akka.stream.alpakka.base_url" -> s"/${(Preprocess / siteSubdirName).value}/",
+        "javadoc.akka.stream.alpakka.base_url" -> "",
+        // Scala
+        "scaladoc.scala.base_url" -> s"https://www.scala-lang.org/api/${scalaBinaryVersion.value}.x/",
+        // Akka
+        "akka.version" -> Dependencies.AkkaVersion,
+        "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.AkkaBinaryVersion}/%s",
+        "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.AkkaBinaryVersion}",
+        "javadoc.akka.base_url" -> s"https://doc.akka.io/japi/akka/${Dependencies.AkkaBinaryVersion}/",
+        "javadoc.akka.link_style" -> "frames",
+        // Akka HTTP
+        "akka-http.version" -> Dependencies.AkkaHttpVersion,
+        "extref.akka-http.base_url" -> s"https://doc.akka.io/docs/akka-http/${Dependencies.AkkaHttpBinaryVersion}/%s",
+        "scaladoc.akka.http.base_url" -> s"https://doc.akka.io/api/akka-http/${Dependencies.AkkaHttpBinaryVersion}/",
+        "javadoc.akka.http.base_url" -> s"https://doc.akka.io/japi/akka-http/${Dependencies.AkkaHttpBinaryVersion}/",
+        "javadoc.akka.http.link_style" -> "frames",
+        // AWS
+        "javadoc.com.amazonaws.base_url" -> "https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/",
+        "javadoc.com.amazonaws.link_style" -> "frames",
+        "javadoc.software.amazon.awssdk.base_url" -> "https://sdk.amazonaws.com/java/api/latest/",
+        "javadoc.software.amazon.awssdk.link_style" -> "frames",
+        // Couchbase
+        "couchbase.version" -> Dependencies.CouchbaseVersion,
+        "extref.couchbase.base_url" -> s"https://docs.couchbase.com/java-sdk/${Dependencies.CouchbaseVersionForDocs}/%s",
+        "javadoc.com.couchbase.base_url" -> s"https://docs.couchbase.com/sdk-api/couchbase-java-client-${Dependencies.CouchbaseVersion}/",
+        "javadoc.com.couchbase.link_style" -> "frames",
+        // Eclipse Paho client for MQTT
+        "extref.paho-api.base_url" -> "https://www.eclipse.org/paho/files/javadoc/index.html?%s.html",
+        "javadoc.org.eclipse.paho.client.mqttv3.base_url" -> "https://www.eclipse.org/paho/files/javadoc/",
+        "javadoc.org.eclipse.paho.client.mqttv3.link_style" -> "frames",
+        // Geode
+        "extref.geode.base_url" -> s"https://geode.apache.org/docs/guide/${Dependencies.GeodeVersionForDocs}/%s",
+        // Hadoop
+        "hadoop.version" -> Dependencies.HadoopVersion,
+        "javadoc.org.apache.hadoop.base_url" -> s"https://hadoop.apache.org/docs/r${Dependencies.HadoopVersion}/api/",
+        "javadoc.org.apache.hadoop.link_style" -> "frames",
+        // Java
+        "extref.java-api.base_url" -> "https://docs.oracle.com/javase/8/docs/api/index.html?%s.html",
+        "extref.javaee-api.base_url" -> "https://docs.oracle.com/javaee/7/api/index.html?%s.html",
+        "javadoc.base_url" -> "https://docs.oracle.com/javase/8/docs/api/",
+        "javadoc.link_style" -> "frames",
+        // JMS
+        "javadoc.javax.jms.base_url" -> "https://docs.oracle.com/javaee/7/api/",
+        "javadoc.javax.jms.link_style" -> "frames",
+        // Slick
+        "extref.slick.base_url" -> s"https://slick.lightbend.com/doc/${Dependencies.SlickVersion}/%s",
+        // Solr
+        "extref.solr.base_url" -> s"https://lucene.apache.org/solr/guide/${Dependencies.SolrVersionForDocs}/%s",
+        "javadoc.org.apache.solr.base_url" -> s"https://lucene.apache.org/solr/${Dependencies.SolrVersionForDocs}_0/solr-solrj/",
+        "javadoc.org.apache.solr.link_style" -> "direct",
+        // Kudu
+        "javadoc.org.apache.kudu.base_url" -> s"https://kudu.apache.org/releases/${Dependencies.KuduVersion}/apidocs/",
+        "javadoc.org.apache.kudu.link_style" -> "frames",
+        // MongoDB
+        "javadoc.org.bson.codecs.configuration.base_url" -> "https://mongodb.github.io/mongo-java-driver/3.7/javadoc/",
+        "javadoc.org.bson.codecs.configuration.link_style" -> "frames"
+      ),
+    paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
+    resolvers += Resolver.jcenterRepo,
+    publishRsyncArtifact := makeSite.value -> "www/",
+    publishRsyncHost := "akkarepo@gustav.akka.io",
+    apidocRootPackage := "akka"
+  )
+
+lazy val whitesourceSupported = project
+  .in(file("tmp"))
+  .settings(whitesourceGroup := Whitesource.Group.Supported)
+  .aggregate(
+    couchbase,
+    csv
+  )
+
+lazy val `doc-examples` = project
+  .enablePlugins(AutomateHeaderPlugin)
+  .disablePlugins(BintrayPlugin, MimaPlugin, SitePlugin)
+  .dependsOn(
+    files,
+    ftp,
+    mqtt
+  )
+  .settings(
+    name := s"akka-stream-alpakka-doc-examples",
+    publish / skip := true,
+    whitesourceIgnore := true,
+    // Google Cloud Pub/Sub gRPC is not available for Scala 2.11
+    crossScalaVersions -= Dependencies.Scala211,
+    // More projects are not available for Scala 2.13
+    crossScalaVersions -= Dependencies.Scala213,
+    Dependencies.`Doc-examples`
+  )
+
+def alpakkaProject(projectId: String, moduleName: String, additionalSettings: sbt.Def.SettingsDefinition*): Project = {
+  import com.typesafe.tools.mima.core.{Problem, ProblemFilters}
+  Project(id = projectId, base = file(projectId))
+    .enablePlugins(AutomateHeaderPlugin)
+    .disablePlugins(SitePlugin)
+    .settings(
+      name := s"akka-stream-alpakka-$projectId",
+      AutomaticModuleName.settings(s"akka.stream.alpakka.$moduleName"),
+      mimaPreviousArtifacts := Set(
+          organization.value %% name.value % previousStableVersion.value
+            .getOrElse(throw new Error("Unable to determine previous version"))
+        ),
+      mimaBinaryIssueFilters += ProblemFilters.exclude[Problem]("*.impl.*")
+    )
+    .settings(additionalSettings: _*)
+}
+
+def internalProject(projectId: String, additionalSettings: sbt.Def.SettingsDefinition*): Project =
+  Project(id = projectId, base = file(projectId))
+    .enablePlugins(AutomateHeaderPlugin)
+    .disablePlugins(SitePlugin, BintrayPlugin, MimaPlugin)
+    .settings(
+      name := s"akka-stream-alpakka-$projectId",
+      publish / skip := true
+    )
+    .settings(additionalSettings: _*)
+
+Global / onLoad := (Global / onLoad).value.andThen { s =>
+  val v = version.value
+  if (dynverGitDescribeOutput.value.hasNoTags)
+    throw new MessageOnlyException(
+      s"Failed to derive version from git tags. Maybe run `git fetch --unshallow`? Derived version: $v"
+    )
+  s
+}

--- a/docs/src/main/paradox/file.md
+++ b/docs/src/main/paradox/file.md
@@ -47,10 +47,10 @@ Java
 ### Shutdown stream when file is deleted
 
 The `FileTailSource` stream will not shutdown or throw an error when the file it is tailing is deleted from the filesystem. 
-If you would like to shutdown the stream, or throw an error, you can do so by merging in a @scala[@scaladoc[`DirectoryChangesSource`](akka.stream.alpakka.file.scaladsl.DirectoryChangesSource)]@java[@javadoc[`DirectoryChangesSource`](akka.stream.alpakka.file.javadsl.DirectoryChangesSource)] that listens to filesystem events in the directory that contains the file. 
+If you would like to shutdown the stream, or throw an error, you can do so by merging in a @scala[@scaladoc[DirectoryChangesSource](akka.stream.alpakka.file.scaladsl.DirectoryChangesSource)]@java[@javadoc[DirectoryChangesSource](akka.stream.alpakka.file.javadsl.DirectoryChangesSource)] that listens to filesystem events in the directory that contains the file.
 
 In the following example, a `DirectoryChangesSource` is used to watch for events in a directory. 
-If a file delete event is observed for the file we are tailing then we shutdown the stream gracefully by using a @scala[@scaladoc[`Flow.recoverWithRetries`](akka.stream.scaladsl.Flow$)]@java[@javadoc[`Flow.recoverWith`](akka.stream.javadsl.Flow$)] to switch to a @scala[@scaladoc[`Source.empty`](akka.stream.scaladsl.Source$)]@java[@javadoc[`Source.empty`](akka.stream.javadsl.Source$)], which with immediately send an `OnComplete` signal and shutdown the stream.
+If a file delete event is observed for the file we are tailing then we shutdown the stream gracefully by using a @scala[@scaladoc[Flow.recoverWithRetries](akka.stream.scaladsl.Flow$)]@java[@javadoc[Flow.recoverWith](akka.stream.javadsl.Flow$)] to switch to a @scala[@scaladoc[Source.empty](akka.stream.scaladsl.Source$)]@java[@javadoc[Source.empty](akka.stream.javadsl.Source$)], which with immediately send an `OnComplete` signal and shutdown the stream.
 
 Scala
 : @@snip [snip](/file/src/test/scala/docs/scaladsl/FileTailSourceExtrasSpec.scala) { #shutdown-on-delete }
@@ -68,7 +68,7 @@ If the file is detected as deleted and the stream is shutdown before the last el
 ### Shutdown stream after an idle timeout
 
 It may be useful to shutdown the stream when no new data has been added for awhile to a file being tailed by `FileTailSource`.
-In the following example, a @scala[@scaladoc[`Flow.idleTimeout`](akka.stream.scaladsl.Flow$)]@java[@javadoc[`Flow.idleTimeout`](akka.stream.javadsl.Flow$)] operator is used to trigger a `TimeoutException` that can be recovered with @scala[@scaladoc[`Flow.recoverWithRetries`](akka.stream.scaladsl.Flow$)]@java[@javadoc[`Flow.recoverWith`](akka.stream.javadsl.Flow$)] and a @scala[@scaladoc[`Source.empty`](akka.stream.scaladsl.Source$)]@java[@javadoc[`Source.empty`](akka.stream.javadsl.Source$)] to successfully shutdown the stream.
+In the following example, a @scala[@scaladoc[Flow.idleTimeout](akka.stream.scaladsl.Flow$)]@java[@javadoc[Flow.idleTimeout](akka.stream.javadsl.Flow$)] operator is used to trigger a `TimeoutException` that can be recovered with @scala[@scaladoc[Flow.recoverWithRetries](akka.stream.scaladsl.Flow$)]@java[@javadoc[Flow.recoverWith](akka.stream.javadsl.Flow$)] and a @scala[@scaladoc[Source.empty](akka.stream.scaladsl.Source$)]@java[@javadoc[Source.empty](akka.stream.javadsl.Source$)] to successfully shutdown the stream.
 
 Scala
 : @@snip [snip](/file/src/test/scala/docs/scaladsl/FileTailSourceExtrasSpec.scala) { #shutdown-on-idle-timeout }

--- a/docs/src/main/paradox/google-fcm.md
+++ b/docs/src/main/paradox/google-fcm.md
@@ -53,7 +53,7 @@ Java
 : @@snip [snip](/google-fcm/src/test/java/docs/javadsl/FcmExamples.java) { #imports #asFlow-send }
 
 With this type of send you can get responses from the server.
-These responses can be @scaladoc[`FcmSuccessResponse`](akka.stream.alpakka.google.firebase.fcm.FcmSuccessResponse) or @scaladoc[`FcmErrorResponse`](akka.stream.alpakka.google.firebase.fcm.FcmErrorResponse). 
+These responses can be @scaladoc[FcmSuccessResponse](akka.stream.alpakka.google.firebase.fcm.FcmSuccessResponse) or @scaladoc[FcmErrorResponse](akka.stream.alpakka.google.firebase.fcm.FcmErrorResponse). 
 You can choose what you want to do with this information, but keep in mind
 if you try to resend the failed messages you will need to use exponential backoff! (see [Akka docs `RestartFlow.onFailuresWithBackoff`](https://doc.akka.io/docs/akka/current/stream/operators/RestartFlow/onFailuresWithBackoff.html))
 

--- a/docs/src/main/paradox/jms/consumer.md
+++ b/docs/src/main/paradox/jms/consumer.md
@@ -14,7 +14,7 @@ The JMS message model supports several types of message bodies in (see @javadoc[
 
 @java[@scaladoc[JmsConsumer](akka.stream.alpakka.jms.javadsl.JmsConsumer$)]@scala[@scaladoc[JmsConsumer](akka.stream.alpakka.jms.scaladsl.JmsConsumer$)] offers factory methods to consume JMS messages in a number of ways.
 
-This examples shows how to listen to a JMS queue and emit @javadoc[`javax.jms.Message`](javax.jms.Message) elements into the stream.
+This examples shows how to listen to a JMS queue and emit @javadoc[javax.jms.Message](javax.jms.Message) elements into the stream.
 
 The materialized value `JmsConsumerControl` is used to shut down the consumer (it is a @scaladoc[Killswitch](akka.stream.KillSwitch)) and offers the possibility to inspect the connectivity state of the consumer. 
 

--- a/docs/src/main/paradox/kudu.md
+++ b/docs/src/main/paradox/kudu.md
@@ -23,10 +23,10 @@ The table below shows direct dependencies of this module and the second tab show
 
 To connect to Kudu you need:
 
-1. Describe the Kudu @javadoc[`Schema`](org.apache.kudu.Schema)
-1. Define a converter function to map your data type to a @javadoc[`PartialRow`](org.apache.kudu.client.PartialRow)
-1. Specify Kudu @javadoc[`CreateTableOptions`](org.apache.kudu.client.CreateTableOptions)
-1. Set up Alpakka's @scaladoc[`KuduTableSettings`](akka.stream.alpakka.kudu.KuduTableSettings)
+1. Describe the Kudu @javadoc[Schema](org.apache.kudu.Schema)
+1. Define a converter function to map your data type to a @javadoc[PartialRow](org.apache.kudu.client.PartialRow)
+1. Specify Kudu @javadoc[CreateTableOptions](org.apache.kudu.client.CreateTableOptions)
+1. Set up Alpakka's @scaladoc[KuduTableSettings](akka.stream.alpakka.kudu.KuduTableSettings)
 
 Scala
 :   @@snip [snip](/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala) { #configure }
@@ -34,9 +34,9 @@ Scala
 Java
 :   @@snip [snip](/kudu/src/test/java/docs/javadsl/KuduTableTest.java) { #configure }
 
-The @javadoc[`KuduClient`](org.apache.kudu.client.KuduClient) by default is automatically managed by the connector.
+The @javadoc[KuduClient](org.apache.kudu.client.KuduClient) by default is automatically managed by the connector.
 Settings for the client are read from the @github[reference.conf](/kudu/src/main/resources/reference.conf) file.
-A manually initialized client can be injected to the stream using @scaladoc[`KuduAttributes`](akka.stream.alpakka.kudu.KuduAttributes$)
+A manually initialized client can be injected to the stream using @scaladoc[KuduAttributes](akka.stream.alpakka.kudu.KuduAttributes$)
 
 Scala
 :   @@snip [snip](/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala) { #attributes }

--- a/docs/src/main/paradox/mongodb.md
+++ b/docs/src/main/paradox/mongodb.md
@@ -1,7 +1,7 @@
 # MongoDB
 
 The MongoDB connector allows you to read and save documents.
-You can query a stream of documents from @scala[@scaladoc[`MongoSource`](akka.stream.alpakka.mongodb.scaladsl.MongoSource$)]@java[@scaladoc[`MongoSource`](akka.stream.alpakka.mongodb.javadsl.MongoSource$)] or update documents in a collection with @scala[@scaladoc[`MongoSink`](akka.stream.alpakka.mongodb.scaladsl.MongoSink$)]@java[@scaladoc[`MongoSink`](akka.stream.alpakka.mongodb.javadsl.MongoSink$)].
+You can query a stream of documents from @scala[@scaladoc[MongoSource](akka.stream.alpakka.mongodb.scaladsl.MongoSource$)]@java[@scaladoc[MongoSource](akka.stream.alpakka.mongodb.javadsl.MongoSource$)] or update documents in a collection with @scala[@scaladoc[MongoSink](akka.stream.alpakka.mongodb.scaladsl.MongoSink$)]@java[@scaladoc[MongoSink](akka.stream.alpakka.mongodb.javadsl.MongoSink$)].
 
 This connector is based on the [Mongo Reactive Streams Driver](https://github.com/mongodb/mongo-java-driver-reactivestreams).
 
@@ -41,7 +41,7 @@ Scala
 Java
 : @@snip [snip](/mongodb/src/test/java/docs/javadsl/Number.java) { #pojo }
 
-For codec support, you first need to setup a @javadoc[`CodecRegistry`](org.bson.codecs.configuration.CodecRegistry).
+For codec support, you first need to setup a @javadoc[CodecRegistry](org.bson.codecs.configuration.CodecRegistry).
 
 Scala
 : @@snip [snip](/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala) { #codecs }
@@ -58,7 +58,7 @@ Scala
 Java
 : @@snip [snip](/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java) { #init-connection }
 
-We will also need an @scaladoc[`ActorSystem`](akka.actor.ActorSystem) and an @scaladoc[`ActorMaterializer`](akka.stream.ActorMaterializer).
+We will also need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and an @scaladoc[ActorMaterializer](akka.stream.ActorMaterializer).
 
 Scala
 : @@snip [snip](/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala) { #init-mat }
@@ -91,11 +91,11 @@ Feel free to edit the example code and build @extref:[more advanced stream topol
 
 ## Flow and Sink
 
-Each of these sink factory methods have a corresponding factory in @scala[@scaladoc[`MongoFlow`](akka.stream.alpakka.mongodb.scaladsl.MongoFlow$)]@java[@scaladoc[`MongoFlow`](akka.stream.alpakka.mongodb.javadsl.MongoFlow$)] which will emit the written document or result of the operation downstream.
+Each of these sink factory methods have a corresponding factory in @scala[@scaladoc[MongoFlow](akka.stream.alpakka.mongodb.scaladsl.MongoFlow$)]@java[@scaladoc[MongoFlow](akka.stream.alpakka.mongodb.javadsl.MongoFlow$)] which will emit the written document or result of the operation downstream.
 
 ### Insert
 
-We can use a Source of documents to save them to a mongo collection using @scala[@scaladoc[`MongoSink.insertOne`](akka.stream.alpakka.mongodb.scaladsl.MongoSink$)]@java[@scaladoc[`MongoSink.insertOne`](akka.stream.alpakka.mongodb.javadsl.MongoSink$)] or @scala[@scaladoc[`MongoSink.insertMany`](akka.stream.alpakka.mongodb.scaladsl.MongoSink$)]@java[@scaladoc[`MongoSink.insertMany`](akka.stream.alpakka.mongodb.javadsl.MongoSink$)].
+We can use a Source of documents to save them to a mongo collection using @scala[@scaladoc[MongoSink.insertOne](akka.stream.alpakka.mongodb.scaladsl.MongoSink$)]@java[@scaladoc[MongoSink.insertOne](akka.stream.alpakka.mongodb.javadsl.MongoSink$)] or @scala[@scaladoc[MongoSink.insertMany](akka.stream.alpakka.mongodb.scaladsl.MongoSink$)]@java[@scaladoc[MongoSink.insertMany](akka.stream.alpakka.mongodb.javadsl.MongoSink$)].
 
 Scala
 : @@snip [snip](/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala) { #insert-one }
@@ -115,8 +115,8 @@ Java
 
 ### Update
 
-We can update documents with a Source of @scaladoc[`DocumentUpdate`](akka.stream.alpakka.mongodb.DocumentUpdate) which is a filter and a update definition.
-Use either @scala[@scaladoc[`MongoSink.updateOne`](akka.stream.alpakka.mongodb.scaladsl.MongoSink$)]@java[@scaladoc[`MongoSink.updateOne`](akka.stream.alpakka.mongodb.javadsl.MongoSink$)] or @scala[@scaladoc[`MongoSink.updateMany`](akka.stream.alpakka.mongodb.scaladsl.MongoSink$)]@java[@scaladoc[`MongoSink.updateMany`](akka.stream.alpakka.mongodb.javadsl.MongoSink$)] if the filter should target one or many documents.
+We can update documents with a Source of @scaladoc[DocumentUpdate](akka.stream.alpakka.mongodb.DocumentUpdate) which is a filter and a update definition.
+Use either @scala[@scaladoc[MongoSink.updateOne](akka.stream.alpakka.mongodb.scaladsl.MongoSink$)]@java[@scaladoc[MongoSink.updateOne](akka.stream.alpakka.mongodb.javadsl.MongoSink$)] or @scala[@scaladoc[MongoSink.updateMany](akka.stream.alpakka.mongodb.scaladsl.MongoSink$)]@java[@scaladoc[MongoSink.updateMany](akka.stream.alpakka.mongodb.javadsl.MongoSink$)] if the filter should target one or many documents.
 
 Scala
 : @@snip [snip](/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala) { #update-one }
@@ -127,7 +127,7 @@ Java
 ### Delete
 
 We can delete documents with a Source of filters.
-Use either @scala[@scaladoc[`MongoSink.deleteOne`](akka.stream.alpakka.mongodb.scaladsl.MongoSink$)]@java[@scaladoc[`MongoSink.deleteOne`](akka.stream.alpakka.mongodb.javadsl.MongoSink$)] or @scala[@scaladoc[`MongoSink.deleteMany`](akka.stream.alpakka.mongodb.scaladsl.MongoSink$)]@java[@scaladoc[`MongoSink.deleteMany`](akka.stream.alpakka.mongodb.javadsl.MongoSink$)] if the filter should target one or many documents.
+Use either @scala[@scaladoc[MongoSink.deleteOne](akka.stream.alpakka.mongodb.scaladsl.MongoSink$)]@java[@scaladoc[MongoSink.deleteOne](akka.stream.alpakka.mongodb.javadsl.MongoSink$)] or @scala[@scaladoc[MongoSink.deleteMany](akka.stream.alpakka.mongodb.scaladsl.MongoSink$)]@java[@scaladoc[MongoSink.deleteMany](akka.stream.alpakka.mongodb.javadsl.MongoSink$)] if the filter should target one or many documents.
 
 Scala
 : @@snip [snip](/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala) { #delete-one }

--- a/docs/src/main/paradox/release-notes/2.0.x/amqp.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/amqp.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aamqp)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aamqp)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/amqp.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/avroparquet.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/avroparquet.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aavroparquet)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aavroparquet)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/avroparquet.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/awslambda.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/awslambda.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aaws-lambda)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aaws-lambda)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/awslambda.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/azure-storage-queue.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/azure-storage-queue.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aazure-storage-queue)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aazure-storage-queue)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/azure-storage-queue.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/cassandra.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/cassandra.md
@@ -5,6 +5,6 @@
 - Cassandra driver 3.7.1 (was 3.5.1) [#1917](https://github.com/akka/alpakka/pull/1917) by [@dotbg](https://github.com/dotbg)
 - Cassandra: check `isFullyFetched` before completion [#1935](https://github.com/akka/alpakka/issues/1935) by [@anzecesar](https://github.com/anzecesar)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Acassandra)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Acassandra)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/cassandra.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/couchbase.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/couchbase.md
@@ -4,6 +4,6 @@
 
 - Add bucket replace functionality [#1888](https://github.com/akka/alpakka/pull/1888) by [@maxrem](https://github.com/maxrem)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Acouchbase)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Acouchbase)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/couchbase.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/csv.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/csv.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Acsv)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Acsv)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/csv.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/dynamodb.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/dynamodb.md
@@ -7,6 +7,6 @@
 - DynamoDB: flow with pagination [#1985](https://github.com/akka/alpakka/issues/1985) by [@ennru](https://github.com/ennru)
 - DynamoDB: document retry configuration [#1986](https://github.com/akka/alpakka/issues/1986) by [@ennru](https://github.com/ennru)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Adynamodb)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Adynamodb)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/dynamodb.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/elasticsearch.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/elasticsearch.md
@@ -4,6 +4,6 @@
 
 - Elasticsearch: refactor to make retrying more explicit [#1941](https://github.com/akka/alpakka/pull/1941)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aelasticsearch)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aelasticsearch)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/elasticsearch.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/file.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/file.md
@@ -4,6 +4,6 @@
 
 - Added flow for creating file ZIP archive [#1890](https://github.com/akka/alpakka/pull/1890) by [@michalbogacz](https://github.com/michalbogacz)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Afile)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Afile)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/file.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/ftp.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/ftp.md
@@ -7,6 +7,6 @@
 - Akka 2.6/2.5 cross-compilation [#1988](https://github.com/akka/alpakka/issues/1988) by [@ennru](https://github.com/ennru)
 - FTP: enable Scala 2.13 and 2.12.9 compilation [#1779](https://github.com/akka/alpakka/pull/1779) by [@ennru](https://github.com/ennru)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aftp)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aftp)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/ftp.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/geode.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/geode.md
@@ -4,6 +4,6 @@
 
 - Geode 1.10.0 [#1950](https://github.com/akka/alpakka/pull/1950) by [@cheleb](https://github.com/cheleb)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Ageode)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Ageode)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/geode.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/google-cloud-pub-sub-grpc.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/google-cloud-pub-sub-grpc.md
@@ -7,6 +7,6 @@
 - Enable Scala 2.13 build for Google Cloud Pub/Sub gRPC connector [#1892](https://github.com/akka/alpakka/pull/1892) by [@2m](https://github.com/2m)
 
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Agoogle-cloud-pub-sub-grpc)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Agoogle-cloud-pub-sub-grpc)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/google-cloud-pub-sub-grpc.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/google-cloud-pub-sub.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/google-cloud-pub-sub.md
@@ -7,6 +7,6 @@
 - sync google modules jwt-core version [#1815](https://github.com/akka/alpakka/pull/1815) by [@francisdb](https://github.com/francisdb)
 
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Agoogle-cloud-pub-sub)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Agoogle-cloud-pub-sub)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/google-cloud-pub-sub.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/google-cloud-storage.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/google-cloud-storage.md
@@ -4,6 +4,6 @@
 
 - sync google modules jwt-core version [#1815](https://github.com/akka/alpakka/pull/1815) by [@francisdb](https://github.com/francisdb)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Agoogle-cloud-storage)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Agoogle-cloud-storage)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/google-cloud-storage.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/google-fcm.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/google-fcm.md
@@ -4,6 +4,6 @@
 
 - sync google modules jwt-core version [#1815](https://github.com/akka/alpakka/pull/1815) by [@francisdb](https://github.com/francisdb)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Agoogle-fcm)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Agoogle-fcm)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/google-fcm.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/hbase.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/hbase.md
@@ -4,6 +4,6 @@
 
 - HBase: version 1.4.9 [#1654](https://github.com/akka/alpakka/pull/1654) by [@shimamoto](https://github.com/shimamoto)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Ahbase)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Ahbase)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/hbase.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/hdfs.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/hdfs.md
@@ -4,6 +4,6 @@
 
 - HDFS: upgrade Cats to 2.0.0 and enable Scala 2.13 [#1925](https://github.com/akka/alpakka/pull/1925)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Ahdfs)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Ahdfs)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/hdfs.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/influxdb.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/influxdb.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Ainfluxdb)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Ainfluxdb)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/influxdb.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/ironmq.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/ironmq.md
@@ -4,6 +4,6 @@
 
 - IronMq: support Scala 2.13 (and drop 2.11) by akka-http-circe 1.21 to 1.29.1 [#1957](https://github.com/akka/alpakka/issues/1957) by [@tg44](https://github.com/tg44)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aironmq)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aironmq)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/ironmq.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/jms.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/jms.md
@@ -4,6 +4,6 @@
 
 - Added withHeader(s) withProperty(-ies) and withoutDestination methods… [#1830](https://github.com/akka/alpakka/pull/1830) by [@WellingR](https://github.com/WellingR)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Ajms)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Ajms)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/jms.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/json-streaming.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/json-streaming.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Ajson-streaming)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Ajson-streaming)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/json-streaming.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/kinesis.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/kinesis.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Akinesis)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Akinesis)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/kinesis.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/kudu.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/kudu.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Akudu)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Akudu)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/kudu.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/mongodb.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/mongodb.md
@@ -4,6 +4,6 @@
 
 - Update to Scala 2.13 supported MongoDb dependencies [#1891](https://github.com/akka/alpakka/pull/1891)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Amongodb)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Amongodb)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/mongodb.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/mqtt-streaming.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/mqtt-streaming.md
@@ -5,6 +5,6 @@
 - Automatically unregister packet ids and other resources [#1853](https://github.com/akka/alpakka/pull/1853) by [@huntc](https://github.com/huntc)
 - Akka 2.6/2.5 cross-compilation [#1988](https://github.com/akka/alpakka/issues/1988) by [@ennru](https://github.com/ennru)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Amqtt-streaming)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Amqtt-streaming)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/mqtt-streaming.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/mqtt.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/mqtt.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Amqtt)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Amqtt)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/mqtt.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/orientdb.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/orientdb.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aorientdb)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aorientdb)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/orientdb.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/s3.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/s3.md
@@ -7,6 +7,6 @@
 - AWS S3: Custom header injection [#1947](https://github.com/akka/alpakka/pull/1947) by [@vigoo](https://github.com/vigoo)
 - AWS S3: discard entity on failed sign request [#2001](https://github.com/akka/alpakka/pull/2001)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aaws-s3)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aaws-s3)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/s3.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/simple-codecs.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/simple-codecs.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Arecordio)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Arecordio)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/simple-codecs.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/slick.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/slick.md
@@ -4,6 +4,6 @@
 
 - Slick: factory method SlickSession.forDbAndProfile [#1996](https://github.com/akka/alpakka/issues/1996) by [@Kreinoee](https://github.com/Kreinoee)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aslick)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aslick)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/slick.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/sns.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/sns.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aaws-sns)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aaws-sns)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/sns.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/solr.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/solr.md
@@ -5,6 +5,6 @@
 - Solr: deprecate old write message factories [#1999](https://github.com/akka/alpakka/issues/1999) by [@ennru](https://github.com/ennru)
 - Solr: Upgrade to 7_7_2 [#1880](https://github.com/akka/alpakka/pull/1880) by [@Giena](https://github.com/giena)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Asolr)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Asolr)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/solr.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/spring-web.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/spring-web.md
@@ -4,7 +4,7 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aspring-web)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aspring-web)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/spring-web.md)
 

--- a/docs/src/main/paradox/release-notes/2.0.x/sqs.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/sqs.md
@@ -5,6 +5,6 @@
 - Akka 2.6/2.5 cross-compilation [#1988](https://github.com/akka/alpakka/issues/1988) by [@ennru](https://github.com/ennru)
 - Fix SqsSource attributes adoption from sqs source settings [#1839](https://github.com/akka/alpakka/pull/1839) by [@janjaali](https://github.com/janjaali)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aaws-sqs)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aaws-sqs)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/sqs.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/sse.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/sse.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Asse)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Asse)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/sse.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/udp.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/udp.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Audp)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Audp)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/udp.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/unix-domain-socket.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/unix-domain-socket.md
@@ -4,6 +4,6 @@
 
 No changes.
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aunix-domain-socket)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Aunix-domain-socket)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/unix-domain-socket.md)

--- a/docs/src/main/paradox/release-notes/2.0.x/xml.md
+++ b/docs/src/main/paradox/release-notes/2.0.x/xml.md
@@ -6,6 +6,6 @@
 - XML: add support for supplying XMLInputFactory configuration [#1982](https://github.com/akka/alpakka/issues/1982) by [@jphelp32](https://github.com/jphelp32)
 - XML: add ability to provide a specific XMLOutputFactory [#1945](https://github.com/akka/alpakka/pull/1945) by [@jphelp32](https://github.com/jphelp32)
 
-[*closed in 2.2.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Axml)
+[*closed in 2.0.0-M1*](https://github.com/akka/alpakka/issues?q=is%3Aclosed+milestone%3A2.0.0-M1+label%3Ap%3Axml)
 
 For earlier changes see @ref:[1.1.x versions](../1.1.x/xml.md)

--- a/docs/src/main/paradox/sns.md
+++ b/docs/src/main/paradox/sns.md
@@ -33,7 +33,7 @@ Java
 
 Alpakka SQS and SNS are set up to use @extref:[Akka HTTP](akka-http:) as default HTTP client via the thin adapter library [AWS Akka-Http SPI implementation](https://github.com/matsluni/aws-spi-akka-http). By setting the `httpClient` explicitly (as above) the Akka actor system is reused, if not set explicitly a separate actor system will be created internally.
 
-It is possible to configure the use of Netty instead, which is Amazon's default. Add an appropriate Netty version to the dependencies and configure @javadoc[`NettyNioAsyncHttpClient`](software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient).
+It is possible to configure the use of Netty instead, which is Amazon's default. Add an appropriate Netty version to the dependencies and configure @javadoc[NettyNioAsyncHttpClient](software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient).
 
 We will also need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and an @scaladoc[ActorMaterializer](akka.stream.ActorMaterializer).
 

--- a/docs/src/main/paradox/solr.md
+++ b/docs/src/main/paradox/solr.md
@@ -29,7 +29,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Set up a Solr client
 
-Sources, Flows and Sinks provided by this connector need a prepared @javadoc[`SolrClient`](org.apache.solr.client.solrj.SolrClient) (eg. @javadoc[`CloudSolrClient`](org.apache.solr.client.solrj.impl.CloudSolrClient)) to access to Solr.
+Sources, Flows and Sinks provided by this connector need a prepared @javadoc[SolrClient](org.apache.solr.client.solrj.SolrClient) (eg. @javadoc[CloudSolrClient](org.apache.solr.client.solrj.impl.CloudSolrClient)) to access to Solr.
 
 
 Scala
@@ -41,7 +41,7 @@ Java
 
 ## Reading from Solr
 
-Create a @javadoc[Solr `TupleStream`](org.apache.solr.client.solrj.io.stream.TupleStream) (eg. via @javadoc[`CloudSolrStream`](org.apache.solr.client.solrj.io.stream.CloudSolrStream)) and use `SolrSource.fromTupleStream` (@scala[@scaladoc[API](akka.stream.alpakka.solr.scaladsl.SolrSource$)]@java[@scaladoc[API](akka.stream.alpakka.solr.javadsl.SolrSource$)]) to create a source.
+Create a Solr @javadoc[TupleStream](org.apache.solr.client.solrj.io.stream.TupleStream) (eg. via @javadoc[CloudSolrStream](org.apache.solr.client.solrj.io.stream.CloudSolrStream)) and use `SolrSource.fromTupleStream` (@scala[@scaladoc[API](akka.stream.alpakka.solr.scaladsl.SolrSource$)]@java[@scaladoc[API](akka.stream.alpakka.solr.javadsl.SolrSource$)]) to create a source.
 
 Scala
 : @@snip [snip](/solr/src/test/scala/docs/scaladsl/SolrSpec.scala) { #tuple-stream }
@@ -56,9 +56,9 @@ Alpakka Solr batches updates to Solr by sending all updates of the same operatio
 
 Alpakka Solr offers three styles for writing to Apache Solr:
 
-1. Using @javadoc[`SolrInputDocument`](org.apache.solr.common.SolrInputDocument) (via `SolrSink.documents`, `SolrFlow.documents` and `SolrFlow.documentsWithPassThrough`)
-1. Annotated *Java Bean* classes supported by @javadoc[Solr's `DocumentObjectBinder`](org.apache.solr.client.solrj.beans.DocumentObjectBinder) (via `SolrSink.beans`, `SolrFlow.beans` and `SolrFlow.beansWithPassThrough`)
-1. Typed streams with document binders to translate to @javadoc[`SolrInputDocument`](org.apache.solr.common.SolrInputDocument) (via `SolrSink.typeds`, `SolrFlow.typeds` and `SolrFlow.typedsWithPassThrough`)
+1. Using @javadoc[SolrInputDocument](org.apache.solr.common.SolrInputDocument) (via `SolrSink.documents`, `SolrFlow.documents` and `SolrFlow.documentsWithPassThrough`)
+1. Annotated *Java Bean* classes supported by Solr's @javadoc[DocumentObjectBinder](org.apache.solr.client.solrj.beans.DocumentObjectBinder) (via `SolrSink.beans`, `SolrFlow.beans` and `SolrFlow.beansWithPassThrough`)
+1. Typed streams with document binders to translate to @javadoc[SolrInputDocument](org.apache.solr.common.SolrInputDocument) (via `SolrSink.typeds`, `SolrFlow.typeds` and `SolrFlow.typedsWithPassThrough`)
 
 In all variations the data is wrapped into `WriteMessage`s.
 

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -28,7 +28,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Setup
 
-Prepare an @scaladoc[`ActorSystem`](akka.actor.ActorSystem) and a @scaladoc[`Materializer`](akka.stream.Materializer).
+Prepare an @scaladoc[ActorSystem](akka.actor.ActorSystem) and a @scaladoc[Materializer](akka.stream.Materializer).
 
 Scala
 : @@snip [snip](/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala) { #init-mat }
@@ -37,7 +37,7 @@ Java
 : @@snip [snip](/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/BaseSqsTest.java) { #init-mat }
 
 
-This connector requires an implicit @javadoc[`SqsAsyncClient`](software.amazon.awssdk.services.sqs.SqsAsyncClient) instance to communicate with AWS SQS.
+This connector requires an implicit @javadoc[SqsAsyncClient](software.amazon.awssdk.services.sqs.SqsAsyncClient) instance to communicate with AWS SQS.
 
 It is your code's responsibility to call `close` to free any resources held by the client. In this example it will be called when the actor system is terminated.
 
@@ -51,7 +51,7 @@ Java
 
 Alpakka SQS and SNS are set up to use @extref:[Akka HTTP](akka-http:) as default HTTP client via the thin adapter library [AWS Akka-Http SPI implementation](https://github.com/matsluni/aws-spi-akka-http). By setting the `httpClient` explicitly (as above) the Akka actor system is reused, if not set explicitly a separate actor system will be created internally.
 
-It is possible to configure the use of Netty instead, which is Amazon's default. Add an appropriate Netty version to the dependencies and configure @javadoc[`NettyNioAsyncHttpClient`](software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient).
+It is possible to configure the use of Netty instead, which is Amazon's default. Add an appropriate Netty version to the dependencies and configure @javadoc[NettyNioAsyncHttpClient](software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient).
 
 Scala
 : @@snip [snip](/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala) { #init-custom-client }
@@ -131,7 +131,7 @@ Java
 : @@snip [snip](/sqs/src/test/java/docs/javadsl/SqsPublishTest.java) { #run-send-request }
 
 You can also build flow stages which publish messages to SQS queues, backpressure on queue response, and then forward 
-@scaladoc[`SqsPublishResult`](akka.stream.alpakka.sqs.SqsPublishResult) further down the stream.
+@scaladoc[SqsPublishResult](akka.stream.alpakka.sqs.SqsPublishResult) further down the stream.
 
 Scala
 : @@snip [snip](/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala) { #flow }
@@ -145,7 +145,7 @@ Java
 ### Group messages and publish batches to an SQS queue
 
 Create a sink, that forwards `String` to the SQS queue. However, the main difference from the previous use case, 
-it batches items and sends as a one request and forwards a @scaladoc[`SqsPublishResultEntry`](akka.stream.alpakka.sqs.SqsPublishResultEntry)
+it batches items and sends as a one request and forwards a @scaladoc[SqsPublishResultEntry](akka.stream.alpakka.sqs.SqsPublishResultEntry)
 further down the stream for each item processed.
 
 Note: There is also another option to send batch of messages to SQS which is using `AmazonSQSBufferedAsyncClient`.
@@ -219,7 +219,7 @@ Options:
 ## Updating message statuses
 
 `SqsAckSink` and `SqsAckFlow` provide the possibility to acknowledge (delete), ignore, or postpone messages on an SQS queue.
-They accept @scaladoc[`MessageAction`](akka.stream.alpakka.sqs.MessageAction) sub-classes to select the action to be taken.
+They accept @scaladoc[MessageAction](akka.stream.alpakka.sqs.MessageAction) sub-classes to select the action to be taken.
 
 For every message you may decide which action to take and push it together with message back to the queue:
 
@@ -259,7 +259,7 @@ Java
 
 ### Update message status in a flow
 
-The `SqsAckFlow` forwards a @scaladoc[`SqsAckResult`](akka.stream.alpakka.sqs.SqsAckResult) sub-class down the stream:
+The `SqsAckFlow` forwards a @scaladoc[SqsAckResult](akka.stream.alpakka.sqs.SqsAckResult) sub-class down the stream:
 
 - `DeleteResult` to acknowledge message deletion
 - `ChangeMessageVisibilityResult` to acknowledge message visibility change
@@ -289,7 +289,7 @@ Options:
 
 ### Updating message statuses in batches with grouping
 
-`SqsAckFlow.grouped` batches actions on their type and forwards a @scaladoc[`SqsAckResultEntry`](akka.stream.alpakka.sqs.SqsAckResultEntry) 
+`SqsAckFlow.grouped` batches actions on their type and forwards a @scaladoc[SqsAckResultEntry](akka.stream.alpakka.sqs.SqsAckResultEntry) 
 sub-class for each item processed:
 
 - `DeleteResultEntry` to acknowledge message deletion


### PR DESCRIPTION
## Purpose

Fix version number in AMQP release notes.
Remove the use of backticks in `@scaladoc` and `@javadoc` directives as the default formatting now is code-style.

## References

#2002 
https://github.com/lightbend/paradox/pull/378