### PR TITLE
Scalafmt: don't remove redundant braces

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -9,5 +9,5 @@ danglingParentheses        = true
 docstrings                 = JavaDoc
 indentOperator             = spray
 maxColumn                  = 120
-rewrite.rules              = [RedundantBraces, RedundantParens, SortImports]
+rewrite.rules              = [RedundantParens, SortImports]
 unindentTopLevelOperators  = true

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 2.0.1
+version = 2.1.0
 
 style = defaultWithAlign
 

--- a/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
@@ -117,8 +117,8 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       val parser = new CsvParser(',', '"', '\\', maximumLineLength)
       parser.offer(in)
       val exception = the[MalformedCsvException] thrownBy {
-          parser.poll(requireLineEnd = true)
-        }
+        parser.poll(requireLineEnd = true)
+      }
       exception.getMessage should be("wrong escaping at 1:3, quote is escaped as \"\"")
       exception.getLineNo should be(1)
       exception.getBytePos should be(3)
@@ -129,8 +129,8 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       val parser = new CsvParser(',', '"', '\\', maximumLineLength)
       parser.offer(in)
       val exception = the[MalformedCsvException] thrownBy {
-          parser.poll(requireLineEnd = false)
-        }
+        parser.poll(requireLineEnd = false)
+      }
       exception.getMessage should be("wrong escaping at 1:3, no character after escape")
     }
 
@@ -139,8 +139,8 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       val parser = new CsvParser(',', '"', '\\', maximumLineLength)
       parser.offer(in)
       val exception = the[MalformedCsvException] thrownBy {
-          parser.poll(requireLineEnd = false)
-        }
+        parser.poll(requireLineEnd = false)
+      }
       exception.getMessage should be("wrong escaping at 1:4, no character after escape")
     }
 
@@ -149,8 +149,8 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       val parser = new CsvParser(',', '"', '\\', maximumLineLength)
       parser.offer(in)
       val exception = the[MalformedCsvException] thrownBy {
-          parser.poll(requireLineEnd = false)
-        }
+        parser.poll(requireLineEnd = false)
+      }
       exception.getMessage should be("wrong escaping at 1:4, no character after escape")
     }
 
@@ -249,8 +249,8 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       parser.offer(ByteString("\",B"))
       parser.poll(requireLineEnd = true) should be('empty)
       val exception = the[MalformedCsvException] thrownBy {
-          parser.poll(requireLineEnd = false)
-        }
+        parser.poll(requireLineEnd = false)
+      }
       exception.getMessage should be("unclosed quote at end of input 1:6, no matching quote found")
     }
 
@@ -305,8 +305,8 @@ class CsvParserSpec extends WordSpec with Matchers with OptionValues {
       parser.offer(in)
       parser.poll(requireLineEnd = true)
       val exception = the[MalformedCsvException] thrownBy {
-          parser.poll(requireLineEnd = true)
-        }
+        parser.poll(requireLineEnd = true)
+      }
       exception.getMessage should be("no line end encountered within 11 bytes on line 2")
     }
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
@@ -53,11 +53,11 @@ class JmsAckConnectorsSpec extends JmsSpec {
           )
 
         val msgsIn = 1 to 100 map { n =>
-            JmsTextMessage(n.toString)
-              .withProperty("Number", n)
-              .withProperty("IsOdd", n % 2 == 1)
-              .withProperty("IsEven", n % 2 == 0)
-          }
+          JmsTextMessage(n.toString)
+            .withProperty("Number", n)
+            .withProperty("IsOdd", n % 2 == 1)
+            .withProperty("IsEven", n % 2 == 0)
+        }
 
         Source(msgsIn).runWith(jmsSink)
 
@@ -92,11 +92,11 @@ class JmsAckConnectorsSpec extends JmsSpec {
         )
 
         val msgsIn = 1 to 100 map { n =>
-            JmsTextMessage(n.toString)
-              .withProperty("Number", n)
-              .withProperty("IsOdd", n % 2 == 1)
-              .withProperty("IsEven", n % 2 == 0)
-          }
+          JmsTextMessage(n.toString)
+            .withProperty("Number", n)
+            .withProperty("IsOdd", n % 2 == 1)
+            .withProperty("IsEven", n % 2 == 0)
+        }
         Source(msgsIn).runWith(jmsSink)
 
         val jmsSource = JmsConsumer.ackSource(

--- a/jms/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
@@ -54,11 +54,11 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
         )
 
         val msgsIn = 1 to 100 map { n =>
-            JmsTextMessage(n.toString)
-              .withProperty("Number", n)
-              .withProperty("IsOdd", n % 2 == 1)
-              .withProperty("IsEven", n % 2 == 0)
-          }
+          JmsTextMessage(n.toString)
+            .withProperty("Number", n)
+            .withProperty("IsOdd", n % 2 == 1)
+            .withProperty("IsEven", n % 2 == 0)
+        }
 
         Source(msgsIn).runWith(jmsSink)
 
@@ -97,11 +97,11 @@ class JmsBufferedAckConnectorsSpec extends JmsSpec {
         )
 
         val msgsIn = 1 to 100 map { n =>
-            JmsTextMessage(n.toString)
-              .withProperty("Number", n)
-              .withProperty("IsOdd", n % 2 == 1)
-              .withProperty("IsEven", n % 2 == 0)
-          }
+          JmsTextMessage(n.toString)
+            .withProperty("Number", n)
+            .withProperty("IsOdd", n % 2 == 1)
+            .withProperty("IsEven", n % 2 == 0)
+        }
         Source(msgsIn).runWith(jmsSink)
 
         val jmsSource = JmsConsumer.ackSource(

--- a/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
@@ -53,11 +53,11 @@ class JmsTxConnectorsSpec extends JmsSpec {
         )
 
         val msgsIn = 1 to 100 map { n =>
-            JmsTextMessage(n.toString)
-              .withProperty("Number", n)
-              .withProperty("IsOdd", n % 2 == 1)
-              .withProperty("IsEven", n % 2 == 0)
-          }
+          JmsTextMessage(n.toString)
+            .withProperty("Number", n)
+            .withProperty("IsOdd", n % 2 == 1)
+            .withProperty("IsEven", n % 2 == 0)
+        }
 
         Source(msgsIn).runWith(jmsSink)
 
@@ -95,8 +95,8 @@ class JmsTxConnectorsSpec extends JmsSpec {
           JmsProducerSettings(producerConfig, connectionFactory).withQueue("numbers")
         )
         val msgsIn = 1 to 100 map { n =>
-            JmsTextMessage(n.toString).withProperty("Number", n)
-          }
+          JmsTextMessage(n.toString).withProperty("Number", n)
+        }
 
         Source(msgsIn).runWith(jmsSink)
 
@@ -132,11 +132,11 @@ class JmsTxConnectorsSpec extends JmsSpec {
         )
 
         val msgsIn = 1 to 100 map { n =>
-            JmsTextMessage(n.toString)
-              .withProperty("Number", n)
-              .withProperty("IsOdd", n % 2 == 1)
-              .withProperty("IsEven", n % 2 == 0)
-          }
+          JmsTextMessage(n.toString)
+            .withProperty("Number", n)
+            .withProperty("IsOdd", n % 2 == 1)
+            .withProperty("IsEven", n % 2 == 0)
+        }
         Source(msgsIn).runWith(jmsSink)
 
         val jmsSource = JmsConsumer.txSource(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.2")
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.26")


### PR DESCRIPTION
## Purpose

Don't let Scalafmt remove braces that are not strictly necessary (eg. around one-expression methods).

## Changes

* Use the latest sbt-plugin (that works with sbt 1.2.8)
* Up the version in the config to 2.1.0 (triggered a little reindentation)
* Remove `RedundantBraces` rewriting

## Background Context

The removing of braces has annoyed me for some time...