### PR TITLE
SQS: allow sub-types in the Java API; improve tests

### DIFF
--- a/sqs/src/main/mima-filters/2.0.0-M1.backwards.excludes/PR2032.excludes
+++ b/sqs/src/main/mima-filters/2.0.0-M1.backwards.excludes/PR2032.excludes
@@ -1,0 +1,4 @@
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.sqs.javadsl.SqsPublishFlow.batch")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.sqs.javadsl.SqsPublishFlow.batch")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.sqs.javadsl.SqsPublishSink.batch")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.sqs.javadsl.SqsPublishSink.batchedMessageSink")

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsPublishFlow.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsPublishFlow.scala
@@ -57,11 +57,11 @@ object SqsPublishFlow {
   /**
    * creates a [[akka.stream.javadsl.Flow Flow]] to publish messages in batches to a SQS queue using an [[software.amazon.awssdk.services.sqs.SqsAsyncClient AmazonSQSAsync]]
    */
-  def batch(
+  def batch[B <: java.lang.Iterable[SendMessageRequest]](
       queueUrl: String,
       settings: SqsPublishBatchSettings,
       sqsClient: SqsAsyncClient
-  ): Flow[java.lang.Iterable[SendMessageRequest], java.util.List[SqsPublishResultEntry], NotUsed] =
+  ): Flow[B, java.util.List[SqsPublishResultEntry], NotUsed] =
     SFlow[java.lang.Iterable[SendMessageRequest]]
       .map(_.asScala)
       .via(akka.stream.alpakka.sqs.scaladsl.SqsPublishFlow.batch(queueUrl, settings)(sqsClient))

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsPublishSink.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsPublishSink.scala
@@ -75,9 +75,9 @@ object SqsPublishSink {
    * creates a [[akka.stream.javadsl.Sink Sink]] that accepts an iterable of strings and publish them as messages in batches to a SQS queue using an [[software.amazon.awssdk.services.sqs.SqsAsyncClient SqsAsyncClient]]
    * @see https://doc.akka.io/docs/akka/current/stream/operators/Source-or-Flow/groupedWithin.html#groupedwithin
    */
-  def batch(queueUrl: String,
-            settings: SqsPublishBatchSettings,
-            sqsClient: SqsAsyncClient): Sink[java.lang.Iterable[String], CompletionStage[Done]] =
+  def batch[B <: java.lang.Iterable[String]](queueUrl: String,
+                                             settings: SqsPublishBatchSettings,
+                                             sqsClient: SqsAsyncClient): Sink[B, CompletionStage[Done]] =
     Flow[java.lang.Iterable[String]]
       .map(_.asScala)
       .toMat(scaladsl.SqsPublishSink.batch(queueUrl, settings)(sqsClient))(Keep.right)
@@ -87,11 +87,11 @@ object SqsPublishSink {
   /**
    * creates a [[akka.stream.javadsl.Sink Sink]] to publish messages in batches to a SQS queue using an [[software.amazon.awssdk.services.sqs.SqsAsyncClient SqsAsyncClient]]
    */
-  def batchedMessageSink(
+  def batchedMessageSink[B <: java.lang.Iterable[SendMessageRequest]](
       queueUrl: String,
       settings: SqsPublishBatchSettings,
       sqsClient: SqsAsyncClient
-  ): Sink[java.lang.Iterable[SendMessageRequest], CompletionStage[Done]] =
+  ): Sink[B, CompletionStage[Done]] =
     Flow[java.lang.Iterable[SendMessageRequest]]
       .map(_.asScala)
       .toMat(scaladsl.SqsPublishSink.batchedMessageSink(queueUrl, settings)(sqsClient))(Keep.right)

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/BaseSqsTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/BaseSqsTest.java
@@ -29,6 +29,7 @@ public abstract class BaseSqsTest {
 
   protected static ActorSystem system;
   protected static Materializer materializer;
+  private static SqsAsyncClient sqsClientForClose;
 
   private boolean initialized = false;
   protected String sqsEndpoint = "http://localhost:9324";
@@ -44,6 +45,9 @@ public abstract class BaseSqsTest {
 
   @AfterClass
   public static void teardown() {
+    if (sqsClientForClose != null) {
+      sqsClientForClose.close();
+    }
     TestKit.shutdownActorSystem(system);
   }
 
@@ -51,6 +55,7 @@ public abstract class BaseSqsTest {
   public void setupBefore() {
     if (!initialized) {
       sqsClient = createAsyncClient(sqsEndpoint);
+      sqsClientForClose = sqsClient;
       initialized = true;
     }
   }

--- a/sqs/src/test/java/docs/javadsl/SqsAckTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsAckTest.java
@@ -13,8 +13,6 @@ import akka.stream.alpakka.sqs.javadsl.SqsAckSink;
 import akka.stream.javadsl.Source;
 import akka.stream.javadsl.Sink;
 import org.junit.Test;
-import scala.Option;
-import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.*;
 

--- a/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
@@ -219,10 +219,9 @@ public class SqsPublishTest extends BaseSqsTest {
     for (int i = 0; i < 10; i++) {
       messagesToSend.add("Message - " + i);
     }
-    Iterable<String> it = messagesToSend;
 
     CompletionStage<Done> done =
-        Source.single(it)
+        Source.single(messagesToSend)
             .runWith(
                 SqsPublishSink.batch(queueUrl, SqsPublishBatchSettings.create(), sqsClient),
                 materializer);
@@ -249,10 +248,8 @@ public class SqsPublishTest extends BaseSqsTest {
       messagesToSend.add(SendMessageRequest.builder().messageBody("Message - " + i).build());
     }
 
-    Iterable<SendMessageRequest> it = messagesToSend;
-
     CompletionStage<Done> done =
-        Source.single(it)
+        Source.single(messagesToSend)
             .runWith(
                 SqsPublishSink.batchedMessageSink(
                     queueUrl, SqsPublishBatchSettings.create(), sqsClient),
@@ -312,10 +309,9 @@ public class SqsPublishTest extends BaseSqsTest {
     for (int i = 0; i < 10; i++) {
       messagesToSend.add(SendMessageRequest.builder().messageBody("Message - " + i).build());
     }
-    Iterable<SendMessageRequest> it = messagesToSend;
 
     CompletionStage<List<SqsPublishResultEntry>> stage =
-        Source.single(it)
+        Source.single(messagesToSend)
             .via(SqsPublishFlow.batch(queueUrl, SqsPublishBatchSettings.create(), sqsClient))
             .mapConcat(x -> x)
             .runWith(Sink.seq(), materializer);

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
@@ -61,6 +61,7 @@ trait DefaultTestContext extends Matchers with BeforeAndAfterAll with ScalaFutur
 
   override protected def afterAll(): Unit =
     try {
+      sqsClient.close()
       system.terminate().futureValue shouldBe a[Terminated]
     } finally {
       super.afterAll()


### PR DESCRIPTION
## Purpose

Change the type in the Java API of the batch operations to allow for sub-types of `Iterable` so it composes more nicely with eg. `grouped`.

## Changes

* Improved closing the SQS client in the tests
* Use Alpakka to publish to the topic in `SqsSourceTest` to avoid too many parallel HTTP connections when tests run on Travis