### PR TITLE
Testkit: introduce log capturing

### DIFF
--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectionProvidersTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectionProvidersTest.java
@@ -7,15 +7,19 @@ package akka.stream.alpakka.amqp.javadsl;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.*;
 
-import akka.japi.Pair;
 import akka.stream.alpakka.amqp.*;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.net.ConnectException;
 
 public class AmqpConnectionProvidersTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   @Test
   public void LocalAmqpConnectionCreatesNewConnection() throws Exception {
     AmqpConnectionProvider connectionProvider = AmqpLocalConnectionProvider.getInstance();

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
@@ -13,6 +13,7 @@ import akka.stream.KillSwitches;
 import akka.stream.Materializer;
 import akka.stream.UniqueKillSwitch;
 import akka.stream.alpakka.amqp.*;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
@@ -23,10 +24,7 @@ import akka.stream.testkit.javadsl.TestSink;
 import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
 import com.rabbitmq.client.AuthenticationFailureException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import scala.collection.JavaConverters;
 import scala.concurrent.duration.Duration;
 
@@ -44,6 +42,8 @@ import static org.junit.Assert.fail;
 
 /** Needs a local running AMQP server on the default port with no password. */
 public class AmqpConnectorsTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Materializer materializer;

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpFlowTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpFlowTest.java
@@ -10,7 +10,9 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import akka.Done;
@@ -34,6 +36,8 @@ import scala.collection.JavaConverters;
 
 /** Needs a local running AMQP server on the default port with no password. */
 public class AmqpFlowTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Materializer materializer;

--- a/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
+++ b/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
@@ -18,6 +18,7 @@ import akka.stream.alpakka.amqp.javadsl.AmqpRpcFlow;
 import akka.stream.alpakka.amqp.javadsl.AmqpSink;
 import akka.stream.alpakka.amqp.javadsl.AmqpSource;
 import akka.stream.alpakka.amqp.javadsl.CommittableReadResult;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
@@ -28,10 +29,7 @@ import akka.stream.testkit.javadsl.TestSink;
 import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.time.Duration;
 import java.util.*;
@@ -44,6 +42,8 @@ import static org.junit.Assert.assertEquals;
 
 /** Needs a local running AMQP server on the default port with no password. */
 public class AmqpDocsTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Materializer materializer;

--- a/amqp/src/test/resources/logback-test.xml
+++ b/amqp/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/amqp/src/test/resources/logback-test.xml
+++ b/amqp/src/test/resources/logback-test.xml
@@ -7,7 +7,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/AmqpSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/AmqpSpec.scala
@@ -7,12 +7,13 @@ package akka.stream.alpakka.amqp
 import akka.actor.ActorSystem
 import akka.dispatch.ExecutionContexts
 import akka.stream.ActorMaterializer
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-abstract class AmqpSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+abstract class AmqpSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with LogCapturing {
 
   implicit val system = ActorSystem(this.getClass.getSimpleName)
   implicit val materializer = ActorMaterializer()

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpGraphStageLogicConnectionShutdownSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpGraphStageLogicConnectionShutdownSpec.scala
@@ -17,6 +17,7 @@ import akka.stream.alpakka.amqp.{
   AmqpWriteSettings,
   QueueDeclaration
 }
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import com.rabbitmq.client.{AddressResolver, Connection, ConnectionFactory, ShutdownListener}
@@ -37,7 +38,8 @@ class AmqpGraphStageLogicConnectionShutdownSpec
     extends AnyWordSpec
     with Matchers
     with ScalaFutures
-    with BeforeAndAfterEach {
+    with BeforeAndAfterEach
+    with LogCapturing {
 
   override implicit val patienceConfig = PatienceConfig(10.seconds)
   private implicit val executionContext = ExecutionContexts.sameThreadExecutionContext

--- a/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java
+++ b/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java
@@ -9,6 +9,7 @@ import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.avroparquet.javadsl.AvroParquetSink;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.testkit.javadsl.StreamTestKit;
@@ -21,10 +22,10 @@ import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -33,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
 
 // #init-writer
 import org.apache.parquet.hadoop.ParquetWriter;
@@ -46,6 +46,8 @@ import org.apache.parquet.hadoop.util.HadoopInputFile;
 // #init-writer
 
 public class AvroParquetSinkTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private final Schema schema =
       new Schema.Parser()

--- a/avroparquet/src/test/resources/logback-test.xml
+++ b/avroparquet/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/avroparquet/src/test/resources/logback-test.xml
+++ b/avroparquet/src/test/resources/logback-test.xml
@@ -7,7 +7,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/awslambda/src/test/java/docs/javadsl/AwsLambdaFlowTest.java
+++ b/awslambda/src/test/java/docs/javadsl/AwsLambdaFlowTest.java
@@ -8,18 +8,16 @@ import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.alpakka.awslambda.javadsl.AwsLambdaFlow;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.testkit.javadsl.StreamTestKit;
 import akka.testkit.javadsl.TestKit;
+import org.junit.*;
 import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -27,12 +25,13 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class AwsLambdaFlowTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static ActorMaterializer materializer;

--- a/awslambda/src/test/resources/logback-test.xml
+++ b/awslambda/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/awslambda/src/test/resources/logback-test.xml
+++ b/awslambda/src/test/resources/logback-test.xml
@@ -7,7 +7,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/awslambda/src/test/scala/docs/scaladsl/AwsLambdaFlowSpec.scala
+++ b/awslambda/src/test/scala/docs/scaladsl/AwsLambdaFlowSpec.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletableFuture
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.awslambda.scaladsl.AwsLambdaFlow
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Keep, Sink}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSource
@@ -36,7 +37,8 @@ class AwsLambdaFlowSpec
     with BeforeAndAfterEach
     with ScalaFutures
     with Matchers
-    with MockitoSugar {
+    with MockitoSugar
+    with LogCapturing {
 
   implicit val mat = ActorMaterializer()
 

--- a/azure-storage-queue/src/test/java/docs/javadsl/JavaDslTest.java
+++ b/azure-storage-queue/src/test/java/docs/javadsl/JavaDslTest.java
@@ -10,6 +10,7 @@ import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.alpakka.azure.storagequeue.*;
 import akka.stream.alpakka.azure.storagequeue.javadsl.*;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.testkit.javadsl.StreamTestKit;
@@ -28,6 +29,8 @@ import java.util.function.Supplier;
 import org.junit.*;
 
 public class JavaDslTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static ActorSystem system;
   private static ActorMaterializer materializer;
   private static final String storageConnectionString = System.getenv("AZURE_CONNECTION_STRING");

--- a/azure-storage-queue/src/test/resources/logback-test.xml
+++ b/azure-storage-queue/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/azure-storage-queue/src/test/resources/logback-test.xml
+++ b/azure-storage-queue/src/test/resources/logback-test.xml
@@ -7,7 +7,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/build.sbt
+++ b/build.sbt
@@ -264,6 +264,7 @@ lazy val orientdb = alpakkaProject("orientdb",
                                    fatalWarnings := false)
 
 lazy val reference = internalProject("reference", Dependencies.Reference)
+  .dependsOn(testkit % Test)
 
 lazy val s3 = alpakkaProject("s3", "aws.s3", Dependencies.S3)
 
@@ -364,6 +365,8 @@ lazy val docs = project
     apidocRootPackage := "akka"
   )
 
+lazy val testkit = internalProject("testkit", Dependencies.testkit)
+
 lazy val whitesourceSupported = project
   .in(file("tmp"))
   .settings(whitesourceGroup := Whitesource.Group.Supported)
@@ -401,6 +404,7 @@ def alpakkaProject(projectId: String, moduleName: String, additionalSettings: sb
       mimaBinaryIssueFilters += ProblemFilters.exclude[Problem]("*.impl.*")
     )
     .settings(additionalSettings: _*)
+    .dependsOn(testkit % Test)
 }
 
 def internalProject(projectId: String, additionalSettings: sbt.Def.SettingsDefinition*): Project =

--- a/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
@@ -10,15 +10,13 @@ import akka.stream.alpakka.cassandra.CassandraBatchSettings;
 import akka.stream.alpakka.cassandra.javadsl.CassandraFlow;
 import akka.stream.alpakka.cassandra.javadsl.CassandraSink;
 import akka.stream.alpakka.cassandra.javadsl.CassandraSource;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Source;
 import akka.stream.testkit.javadsl.StreamTestKit;
 import akka.testkit.javadsl.TestKit;
 import com.datastax.driver.core.*;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import static org.junit.Assert.*;
 
@@ -38,6 +36,8 @@ import java.util.stream.IntStream;
 
 /** All the tests must be run with a local Cassandra running on default port 9042. */
 public class CassandraSourceTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   // #element-to-insert
   private class ToInsert {

--- a/cassandra/src/test/resources/logback-test.xml
+++ b/cassandra/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/cassandra/src/test/resources/logback-test.xml
+++ b/cassandra/src/test/resources/logback-test.xml
@@ -7,10 +7,25 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <logger name="com.datastax.driver" level="info" />
     <logger name="io.netty" level="info" />
 
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/cassandra/src/test/scala/docs/scaladsl/CassandraSourceSpec.scala
+++ b/cassandra/src/test/scala/docs/scaladsl/CassandraSourceSpec.scala
@@ -8,6 +8,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.cassandra.CassandraBatchSettings
 import akka.stream.alpakka.cassandra.scaladsl.{CassandraFlow, CassandraSink, CassandraSource}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import com.datastax.driver.core.{Cluster, PreparedStatement, SimpleStatement}
@@ -28,7 +29,8 @@ class CassandraSourceSpec
     with ScalaFutures
     with BeforeAndAfterEach
     with BeforeAndAfterAll
-    with Matchers {
+    with Matchers
+    with LogCapturing {
 
   //#element-to-insert
   case class ToInsert(id: Integer, cc: Integer)

--- a/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
+++ b/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
@@ -19,6 +19,7 @@ import akka.stream.alpakka.couchbase.javadsl.CouchbaseFlow;
 import akka.stream.alpakka.couchbase.javadsl.CouchbaseSource;
 import akka.stream.alpakka.couchbase.testing.CouchbaseSupportClass;
 import akka.stream.alpakka.couchbase.testing.TestObject;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.testkit.javadsl.StreamTestKit;
@@ -40,10 +41,7 @@ import com.couchbase.client.java.query.N1qlQuery;
 // #n1ql
 import com.couchbase.client.java.query.SimpleN1qlQuery;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -74,6 +72,8 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 public class CouchbaseExamplesTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final CouchbaseSupportClass support = new CouchbaseSupportClass();
   private static final CouchbaseSessionSettings sessionSettings = support.sessionSettings();

--- a/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
+++ b/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
@@ -13,11 +13,13 @@ import akka.stream.alpakka.couchbase.CouchbaseSessionSettings;
 import akka.stream.alpakka.couchbase.javadsl.DiscoverySupport;
 import akka.stream.alpakka.couchbase.javadsl.CouchbaseSession;
 // #registry
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.testkit.javadsl.TestKit;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.concurrent.CompletionStage;
@@ -28,6 +30,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class DiscoveryTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem actorSystem;
   private static Materializer materializer;

--- a/couchbase/src/test/resources/logback-test.xml
+++ b/couchbase/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/couchbase/src/test/resources/logback-test.xml
+++ b/couchbase/src/test/resources/logback-test.xml
@@ -7,12 +7,25 @@
         </encoder>
     </appender>
 
-    <logger name="akka" level="INFO"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="akka.http.impl" level="WARN"/>
     <logger name="akka.stream.alpakka" level="DEBUG"/>
     <logger name="com.couchbase" level="INFO"/>
 
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala
@@ -8,6 +8,7 @@ import akka.Done
 import akka.stream.alpakka.couchbase.{CouchbaseDeleteFailure, CouchbaseDeleteResult}
 import akka.stream.alpakka.couchbase.scaladsl.CouchbaseFlow
 import akka.stream.alpakka.couchbase.testing.{CouchbaseSupport, TestObject}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import com.couchbase.client.java.error.DocumentDoesNotExistException
 import org.scalatest.concurrent.ScalaFutures
@@ -40,7 +41,8 @@ class CouchbaseFlowSpec
     with CouchbaseSupport
     with Matchers
     with ScalaFutures
-    with Inspectors {
+    with Inspectors
+    with LogCapturing {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(10.seconds, 250.millis)
 

--- a/couchbase/src/test/scala/docs/scaladsl/CouchbaseSessionExamplesSpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/CouchbaseSessionExamplesSpec.scala
@@ -6,6 +6,7 @@ package docs.scaladsl
 
 import akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession
 import akka.stream.alpakka.couchbase.testing.CouchbaseSupport
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import com.couchbase.client.java.document.JsonDocument
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
@@ -20,7 +21,8 @@ class CouchbaseSessionExamplesSpec
     with CouchbaseSupport
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(10.seconds, 250.millis)
 

--- a/couchbase/src/test/scala/docs/scaladsl/CouchbaseSourceSpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/CouchbaseSourceSpec.scala
@@ -6,6 +6,7 @@ package docs.scaladsl
 
 import akka.stream.alpakka.couchbase.scaladsl.{CouchbaseSession, CouchbaseSource}
 import akka.stream.alpakka.couchbase.testing.CouchbaseSupport
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.Sink
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import com.couchbase.client.java.auth.PasswordAuthenticator
@@ -25,7 +26,8 @@ class CouchbaseSourceSpec
     with BeforeAndAfterAll
     with CouchbaseSupport
     with Matchers
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(10.seconds, 250.millis)
 

--- a/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala
@@ -5,6 +5,7 @@
 package docs.scaladsl
 
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.{ActorMaterializer, Materializer}
 import com.couchbase.client.java.document.JsonDocument
 import com.typesafe.config.{Config, ConfigFactory}
@@ -16,7 +17,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class DiscoverySpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+class DiscoverySpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with LogCapturing {
 
   val config: Config = ConfigFactory.parseResources("discovery.conf")
 

--- a/csv/src/test/java/docs/javadsl/CsvFormattingTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvFormattingTest.java
@@ -12,16 +12,14 @@ import akka.stream.alpakka.csv.javadsl.CsvFormatting;
 import akka.stream.alpakka.csv.javadsl.CsvQuotingStyle;
 
 // #import
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.testkit.javadsl.StreamTestKit;
 import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -34,6 +32,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 public class CsvFormattingTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static ActorSystem system;
   private static Materializer materializer;
 

--- a/csv/src/test/java/docs/javadsl/CsvParsingTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvParsingTest.java
@@ -9,16 +9,14 @@ import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.csv.MalformedCsvException;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.testkit.javadsl.StreamTestKit;
 import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 // #import
 import akka.stream.alpakka.csv.javadsl.CsvParsing;
@@ -38,6 +36,8 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 public class CsvParsingTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static ActorSystem system;
   private static Materializer materializer;
 

--- a/csv/src/test/java/docs/javadsl/CsvToMapTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvToMapTest.java
@@ -12,16 +12,14 @@ import akka.stream.alpakka.csv.javadsl.CsvParsing;
 import akka.stream.alpakka.csv.javadsl.CsvToMap;
 
 // #import
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.testkit.javadsl.StreamTestKit;
 import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -33,6 +31,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 public class CsvToMapTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static ActorSystem system;
   private static Materializer materializer;
 

--- a/csv/src/test/resources/logback-test.xml
+++ b/csv/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/csv/src/test/resources/logback-test.xml
+++ b/csv/src/test/resources/logback-test.xml
@@ -7,7 +7,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/csv/src/test/scala/akka/stream/alpakka/csv/CsvFormatterSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/CsvFormatterSpec.scala
@@ -8,10 +8,11 @@ import java.nio.charset.StandardCharsets
 
 import akka.stream.alpakka.csv.impl.CsvFormatter
 import akka.stream.alpakka.csv.scaladsl.CsvQuotingStyle
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class CsvFormatterSpec extends AnyWordSpec with Matchers {
+class CsvFormatterSpec extends AnyWordSpec with Matchers with LogCapturing {
 
   "CSV Formatter comma as delimiter" should {
     val formatter = new CsvFormatter(',', '\"', '\\', "\r\n", CsvQuotingStyle.Required)

--- a/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
@@ -8,12 +8,13 @@ import java.nio.charset.{StandardCharsets, UnsupportedCharsetException}
 
 import akka.stream.alpakka.csv.impl.CsvParser
 import akka.stream.alpakka.csv.scaladsl.ByteOrderMark
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.util.ByteString
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class CsvParserSpec extends AnyWordSpec with Matchers with OptionValues {
+class CsvParserSpec extends AnyWordSpec with Matchers with OptionValues with LogCapturing {
 
   val maximumLineLength = 10 * 1024
 

--- a/csv/src/test/scala/docs/scaladsl/CsvSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvSpec.scala
@@ -6,6 +6,7 @@ package docs.scaladsl
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
@@ -17,7 +18,8 @@ abstract class CsvSpec
     with Matchers
     with BeforeAndAfterAll
     with BeforeAndAfterEach
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
 
   implicit val system = ActorSystem(this.getClass.getSimpleName)
   implicit val materializer = ActorMaterializer()

--- a/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
@@ -14,16 +14,14 @@ import akka.stream.Materializer;
 // #init-client
 import akka.stream.alpakka.dynamodb.DynamoDbOp;
 import akka.stream.alpakka.dynamodb.javadsl.DynamoDb;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.FlowWithContext;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.javadsl.SourceWithContext;
 import akka.stream.testkit.javadsl.StreamTestKit;
 import akka.testkit.javadsl.TestKit;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 // #init-client
 import com.github.matsluni.akkahttpspi.AkkaHttpClient;
 import scala.util.Try;
@@ -44,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertNotNull;
 
 public class ExampleTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   static ActorSystem system;
   static Materializer materializer;

--- a/dynamodb/src/test/java/docs/javadsl/RetryTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/RetryTest.java
@@ -5,8 +5,10 @@
 package docs.javadsl;
 
 import akka.actor.ActorSystem;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.testkit.javadsl.TestKit;
 import com.github.matsluni.akkahttpspi.AkkaHttpClient;
+import org.junit.Rule;
 import org.junit.Test;
 // #clientRetryConfig
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -24,6 +26,7 @@ import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 // #awsRetryConfiguration
 
 public class RetryTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void setup() throws Exception {

--- a/dynamodb/src/test/resources/logback-test.xml
+++ b/dynamodb/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/dynamodb/src/test/resources/logback-test.xml
+++ b/dynamodb/src/test/resources/logback-test.xml
@@ -7,7 +7,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/dynamodb/src/test/scala/docs/scaladsl/ExampleSpec.scala
+++ b/dynamodb/src/test/scala/docs/scaladsl/ExampleSpec.scala
@@ -7,6 +7,7 @@ package docs.scaladsl
 import java.net.URI
 
 import akka.NotUsed
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{FlowWithContext, SourceWithContext}
 
 import scala.util.{Failure, Success, Try}
@@ -42,7 +43,8 @@ class ExampleSpec
     with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 100.millis)
   implicit val materializer: Materializer = ActorMaterializer()

--- a/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala
+++ b/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala
@@ -5,6 +5,7 @@
 package docs.scaladsl
 
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import com.github.matsluni.akkahttpspi.AkkaHttpClient
 import org.scalatest.BeforeAndAfterAll
@@ -21,7 +22,11 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import org.scalatest.wordspec.AnyWordSpecLike
 
-class RetrySpec extends TestKit(ActorSystem("RetrySpec")) with AnyWordSpecLike with BeforeAndAfterAll {
+class RetrySpec
+    extends TestKit(ActorSystem("RetrySpec"))
+    with AnyWordSpecLike
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   // #clientRetryConfig
   implicit val client: DynamoDbAsyncClient = DynamoDbAsyncClient

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTest.java
@@ -14,6 +14,7 @@ import akka.stream.alpakka.elasticsearch.*;
 import akka.stream.alpakka.elasticsearch.javadsl.*;
 
 // #init-client
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.testkit.javadsl.StreamTestKit;
@@ -26,10 +27,7 @@ import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.elasticsearch.client.RestClient;
 import org.apache.http.HttpHost;
 // #init-client
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -41,6 +39,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 
 public class ElasticsearchTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ElasticsearchClusterRunner runner;
   private static RestClient client;

--- a/elasticsearch/src/test/resources/logback-test.xml
+++ b/elasticsearch/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/elasticsearch/src/test/resources/logback-test.xml
+++ b/elasticsearch/src/test/resources/logback-test.xml
@@ -7,13 +7,26 @@
         </encoder>
     </appender>
 
-    <logger name="akka" level="info"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="akka.stream.alpakka" level="debug"/>
     <logger name="org.apache.http" level="info"/>
     <logger name="org.apache.http.impl" level="info"/>
     <logger name="org.elasticsearch.client" level="info"/>
 
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
@@ -12,6 +12,7 @@ import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.alpakka.elasticsearch.scaladsl._
 import akka.stream.alpakka.elasticsearch._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
@@ -28,7 +29,13 @@ import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class ElasticsearchSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with Inspectors {
+class ElasticsearchSpec
+    extends AnyWordSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with Inspectors
+    with LogCapturing {
 
   private implicit val patience = PatienceConfig(10.seconds)
 

--- a/file/src/test/java/docs/javadsl/ArchiveTest.java
+++ b/file/src/test/java/docs/javadsl/ArchiveTest.java
@@ -12,15 +12,14 @@ import akka.stream.IOResult;
 import akka.stream.Materializer;
 import akka.stream.alpakka.file.ArchiveMetadata;
 import akka.stream.alpakka.file.javadsl.Archive;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.FileIO;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.testkit.javadsl.StreamTestKit;
-import akka.testkit.TestKit;
+import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import scala.concurrent.duration.FiniteDuration;
 import static akka.util.ByteString.emptyByteString;
 import java.io.File;
@@ -35,14 +34,26 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 
 public class ArchiveTest {
-  private ActorSystem system;
-  private Materializer mat;
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
+  private static ActorSystem system;
+  private static Materializer mat;
+
+  @BeforeClass
+  public static void beforeAll() throws Exception {
+    system = ActorSystem.create();
+    mat = ActorMaterializer.create(system);
+  }
+
+  @AfterClass
+  public static void afterAll() throws Exception {
+    TestKit.shutdownActorSystem(system);
+  }
+
   private ArchiveHelper archiveHelper;
 
   @Before
   public void setup() throws Exception {
-    system = ActorSystem.create();
-    mat = ActorMaterializer.create(system);
     archiveHelper = new ArchiveHelper();
   }
 
@@ -100,7 +111,6 @@ public class ArchiveTest {
   @After
   public void tearDown() throws Exception {
     StreamTestKit.assertAllStagesStopped(mat);
-    TestKit.shutdownActorSystem(system, FiniteDuration.apply(3, TimeUnit.SECONDS), true);
   }
 
   private Path getFileFromResource(String fileName) {

--- a/file/src/test/java/docs/javadsl/DirectoryChangesSourceTest.java
+++ b/file/src/test/java/docs/javadsl/DirectoryChangesSourceTest.java
@@ -13,17 +13,16 @@ import akka.stream.alpakka.file.DirectoryChange;
 // #minimal-sample
 import akka.stream.alpakka.file.javadsl.DirectoryChangesSource;
 // #minimal-sample
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.testkit.TestSubscriber;
 import akka.stream.testkit.javadsl.StreamTestKit;
-import akka.testkit.TestKit;
+import akka.testkit.javadsl.TestKit;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.google.common.jimfs.WatchServiceConfiguration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.nio.file.FileSystem;
@@ -39,16 +38,27 @@ import static org.junit.Assert.assertEquals;
 
 public class DirectoryChangesSourceTest {
 
-  private ActorSystem system;
-  private Materializer materializer;
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private FileSystem fs;
   private Path testDir;
 
-  @Before
-  public void setup() throws Exception {
+  private static ActorSystem system;
+  private static Materializer materializer;
+
+  @BeforeClass
+  public static void beforeAll() throws Exception {
     system = ActorSystem.create();
     materializer = ActorMaterializer.create(system);
+  }
 
+  @AfterClass
+  public static void afterAll() throws Exception {
+    TestKit.shutdownActorSystem(system);
+  }
+
+  @Before
+  public void setup() throws Exception {
     fs =
         Jimfs.newFileSystem(
             Configuration.forCurrentPlatform()
@@ -130,7 +140,6 @@ public class DirectoryChangesSourceTest {
   @After
   public void tearDown() throws Exception {
     StreamTestKit.assertAllStagesStopped(materializer);
-    TestKit.shutdownActorSystem(system, FiniteDuration.apply(3, TimeUnit.SECONDS), true);
     fs.close();
   }
 

--- a/file/src/test/java/docs/javadsl/DirectoryTest.java
+++ b/file/src/test/java/docs/javadsl/DirectoryTest.java
@@ -15,18 +15,16 @@ import akka.stream.alpakka.file.javadsl.Directory;
 // #ls
 import java.nio.file.FileVisitOption;
 // #walk
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.FlowWithContext;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.testkit.javadsl.StreamTestKit;
-import akka.testkit.TestKit;
+import akka.testkit.javadsl.TestKit;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import scala.concurrent.duration.FiniteDuration;
+import org.junit.*;
 
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -41,15 +39,26 @@ import static org.junit.Assert.assertTrue;
 
 public class DirectoryTest {
 
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  private static ActorSystem system;
+  private static Materializer materializer;
+
+  @BeforeClass
+  public static void beforeAll() throws Exception {
+    system = ActorSystem.create();
+    materializer = ActorMaterializer.create(system);
+  }
+
+  @AfterClass
+  public static void afterAll() throws Exception {
+    TestKit.shutdownActorSystem(system);
+  }
+
   private FileSystem fs;
-  private ActorSystem system;
-  private Materializer materializer;
 
   @Before
   public void setup() {
     fs = Jimfs.newFileSystem(Configuration.unix());
-    system = ActorSystem.create();
-    materializer = ActorMaterializer.create(system);
   }
 
   @Test
@@ -164,9 +173,6 @@ public class DirectoryTest {
     fs.close();
     fs = null;
     StreamTestKit.assertAllStagesStopped(materializer);
-    TestKit.shutdownActorSystem(system, FiniteDuration.create(10, TimeUnit.SECONDS), true);
-    system = null;
-    materializer = null;
   }
 
   static class SomeContext {}

--- a/file/src/test/java/docs/javadsl/FileTailSourceTest.java
+++ b/file/src/test/java/docs/javadsl/FileTailSourceTest.java
@@ -12,6 +12,7 @@ import akka.stream.KillSwitches;
 import akka.stream.Materializer;
 import akka.stream.UniqueKillSwitch;
 import akka.stream.alpakka.file.DirectoryChange;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
@@ -21,9 +22,7 @@ import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 import java.io.FileNotFoundException;
 import java.nio.charset.StandardCharsets;
@@ -42,15 +41,27 @@ import static org.junit.Assert.assertEquals;
 
 public class FileTailSourceTest {
 
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
+  private static ActorSystem system;
+  private static Materializer materializer;
+
+  @BeforeClass
+  public static void beforeAll() throws Exception {
+    system = ActorSystem.create();
+    materializer = ActorMaterializer.create(system);
+  }
+
+  @AfterClass
+  public static void afterAll() throws Exception {
+    TestKit.shutdownActorSystem(system);
+  }
+
   private FileSystem fs;
-  private ActorSystem system;
-  private Materializer materializer;
 
   @Before
   public void setup() {
     fs = Jimfs.newFileSystem(Configuration.unix());
-    system = ActorSystem.create();
-    materializer = ActorMaterializer.create(system);
   }
 
   @Test
@@ -199,9 +210,6 @@ public class FileTailSourceTest {
     fs.close();
     fs = null;
     StreamTestKit.assertAllStagesStopped(materializer);
-    TestKit.shutdownActorSystem(system);
-    system = null;
-    materializer = null;
   }
 
   // small sample of usage, tails the first argument file path

--- a/file/src/test/java/docs/javadsl/LogRotatorSinkTest.java
+++ b/file/src/test/java/docs/javadsl/LogRotatorSinkTest.java
@@ -12,13 +12,12 @@ import akka.japi.function.Function;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.file.javadsl.LogRotatorSink;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.*;
 import akka.stream.testkit.javadsl.StreamTestKit;
 import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -34,11 +33,19 @@ import static org.junit.Assert.assertEquals;
 
 public class LogRotatorSinkTest {
 
-  private static final ActorSystem system = ActorSystem.create();
-  private static final Materializer materializer = ActorMaterializer.create(system);
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
+  private static ActorSystem system;
+  private static Materializer materializer;
+
+  @BeforeClass
+  public static void beforeAll() throws Exception {
+    system = ActorSystem.create();
+    materializer = ActorMaterializer.create(system);
+  }
 
   @AfterClass
-  public static void afterAll() {
+  public static void afterAll() throws Exception {
     TestKit.shutdownActorSystem(system);
   }
 

--- a/file/src/test/resources/logback-test.xml
+++ b/file/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/file/src/test/resources/logback-test.xml
+++ b/file/src/test/resources/logback-test.xml
@@ -7,7 +7,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/file/src/test/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlowTest.scala
+++ b/file/src/test/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlowTest.scala
@@ -6,6 +6,7 @@ package akka.stream.alpakka.file.impl.archive
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.Keep
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.testkit.TestKit
@@ -13,7 +14,11 @@ import akka.util.ByteString
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpecLike
 
-class ZipArchiveFlowTest extends TestKit(ActorSystem("ziparchive")) with AnyWordSpecLike with BeforeAndAfterAll {
+class ZipArchiveFlowTest
+    extends TestKit(ActorSystem("ziparchive"))
+    with AnyWordSpecLike
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   implicit val mat = ActorMaterializer()
 

--- a/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
@@ -5,10 +5,9 @@
 package docs.scaladsl
 
 import java.io._
-import java.nio.file.{OpenOption, Path, Paths, StandardOpenOption}
+import java.nio.file.{Path, Paths}
 import java.util.zip.ZipInputStream
 
-import akka.{Done, NotUsed}
 import akka.actor.ActorSystem
 import akka.stream.alpakka.file.ArchiveMetadata
 import akka.stream.alpakka.file.scaladsl.Archive
@@ -17,15 +16,15 @@ import akka.stream.scaladsl.{FileIO, Sink, Source}
 import akka.stream.{ActorMaterializer, IOResult, Materializer}
 import akka.testkit.TestKit
 import akka.util.ByteString
+import akka.{Done, NotUsed}
 import docs.javadsl.ArchiveHelper
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
-
-import scala.collection.JavaConverters._
-import scala.concurrent.Future
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
 import scala.util.Success
 
 class ArchiveSpec

--- a/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
@@ -12,6 +12,7 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.alpakka.file.ArchiveMetadata
 import akka.stream.alpakka.file.scaladsl.Archive
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{FileIO, Sink, Source}
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.testkit.TestKit
@@ -30,7 +31,8 @@ class ArchiveSpec
     with AnyWordSpecLike
     with Matchers
     with ScalaFutures
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   implicit val mat: Materializer = ActorMaterializer()
 

--- a/file/src/test/scala/docs/scaladsl/DirectorySpec.scala
+++ b/file/src/test/scala/docs/scaladsl/DirectorySpec.scala
@@ -9,6 +9,7 @@ import java.nio.file.{Files, Path}
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Flow, FlowWithContext, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
@@ -26,7 +27,8 @@ class DirectorySpec
     with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
 
   private val fs = Jimfs.newFileSystem(Configuration.forCurrentPlatform.toBuilder.build)
   private implicit val mat = ActorMaterializer()

--- a/file/src/test/scala/docs/scaladsl/FileTailSourceExtrasSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/FileTailSourceExtrasSpec.scala
@@ -12,6 +12,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.file.DirectoryChange
 import akka.stream.alpakka.file.scaladsl.{DirectoryChangesSource, FileTailSource}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Keep, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
@@ -30,7 +31,8 @@ class FileTailSourceExtrasSpec
     with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
 
   private val fs = Jimfs.newFileSystem(Configuration.forCurrentPlatform.toBuilder.build)
   private implicit val mat = ActorMaterializer()

--- a/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
@@ -11,6 +11,7 @@ import java.time.format.DateTimeFormatter
 import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.alpakka.file.scaladsl.LogRotatorSink
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Compression, FileIO, Flow, Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSource
@@ -33,7 +34,8 @@ class LogRotatorSinkSpec
     with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
 
   implicit val patience: PatienceConfig = PatienceConfig(5.seconds, 100.millis)
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/CommonFtpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/CommonFtpStageTest.java
@@ -41,7 +41,7 @@ interface CommonFtpStageTest extends BaseSupport, AkkaSupport {
   default IOResult await(CompletionStage<IOResult> result)
       throws InterruptedException, java.util.concurrent.ExecutionException,
           java.util.concurrent.TimeoutException {
-    return result.toCompletableFuture().get(5, TimeUnit.SECONDS);
+    return result.toCompletableFuture().get(10, TimeUnit.SECONDS);
   }
 
   default void listFiles() throws Exception {

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/CommonFtpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/CommonFtpStageTest.java
@@ -38,7 +38,9 @@ interface CommonFtpStageTest extends BaseSupport, AkkaSupport {
   Sink<FtpFile, CompletionStage<IOResult>> getMoveSink(Function<FtpFile, String> destinationPath)
       throws Exception;
 
-  default IOResult await(CompletionStage<IOResult> result) throws InterruptedException, java.util.concurrent.ExecutionException, java.util.concurrent.TimeoutException {
+  default IOResult await(CompletionStage<IOResult> result)
+      throws InterruptedException, java.util.concurrent.ExecutionException,
+          java.util.concurrent.TimeoutException {
     return result.toCompletableFuture().get(5, TimeUnit.SECONDS);
   }
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java
@@ -7,15 +7,20 @@ package akka.stream.alpakka.ftp;
 import akka.NotUsed;
 import akka.stream.IOResult;
 import akka.stream.alpakka.ftp.javadsl.Ftp;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
+import org.junit.Rule;
 import org.junit.Test;
 import java.net.InetAddress;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 public class FtpStageTest extends BaseFtpSupport implements CommonFtpStageTest {
+
+  @Rule
+  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java
@@ -19,8 +19,7 @@ import java.util.function.Function;
 
 public class FtpStageTest extends BaseFtpSupport implements CommonFtpStageTest {
 
-  @Rule
-  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpWithProxyStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpWithProxyStageTest.java
@@ -22,8 +22,7 @@ import java.util.function.Function;
 
 public class FtpWithProxyStageTest extends BaseFtpSupport implements CommonFtpStageTest {
 
-  @Rule
-  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private final Integer PROXYPORT = 3128;
   private final Proxy PROXY =

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpWithProxyStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpWithProxyStageTest.java
@@ -7,9 +7,11 @@ package akka.stream.alpakka.ftp;
 import akka.NotUsed;
 import akka.stream.IOResult;
 import akka.stream.alpakka.ftp.javadsl.Ftp;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -19,6 +21,9 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 public class FtpWithProxyStageTest extends BaseFtpSupport implements CommonFtpStageTest {
+
+  @Rule
+  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private final Integer PROXYPORT = 3128;
   private final Proxy PROXY =

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
@@ -20,8 +20,7 @@ import java.util.function.Function;
 
 public class FtpsStageTest extends BaseFtpSupport implements CommonFtpStageTest {
 
-  @Rule
-  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
@@ -7,15 +7,21 @@ package akka.stream.alpakka.ftp;
 import akka.NotUsed;
 import akka.stream.IOResult;
 import akka.stream.alpakka.ftp.javadsl.Ftps;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
+import org.junit.Rule;
 import org.junit.Test;
+
 import java.net.InetAddress;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 public class FtpsStageTest extends BaseFtpSupport implements CommonFtpStageTest {
+
+  @Rule
+  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsWithProxyStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsWithProxyStageTest.java
@@ -7,9 +7,11 @@ package akka.stream.alpakka.ftp;
 import akka.NotUsed;
 import akka.stream.IOResult;
 import akka.stream.alpakka.ftp.javadsl.Ftps;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -19,6 +21,9 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 public class FtpsWithProxyStageTest extends BaseFtpSupport implements CommonFtpStageTest {
+
+  @Rule
+  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private final Integer PROXYPORT = 3128;
   private final Proxy PROXY =

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsWithProxyStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsWithProxyStageTest.java
@@ -22,8 +22,7 @@ import java.util.function.Function;
 
 public class FtpsWithProxyStageTest extends BaseFtpSupport implements CommonFtpStageTest {
 
-  @Rule
-  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private final Integer PROXYPORT = 3128;
   private final Proxy PROXY =

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/KeyFileSftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/KeyFileSftpSourceTest.java
@@ -19,8 +19,7 @@ import java.util.function.Function;
 
 public class KeyFileSftpSourceTest extends BaseSftpSupport implements CommonFtpStageTest {
 
-  @Rule
-  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/KeyFileSftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/KeyFileSftpSourceTest.java
@@ -7,15 +7,20 @@ package akka.stream.alpakka.ftp;
 import akka.NotUsed;
 import akka.stream.IOResult;
 import akka.stream.alpakka.ftp.javadsl.Sftp;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
+import org.junit.Rule;
 import org.junit.Test;
 import java.net.InetAddress;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 public class KeyFileSftpSourceTest extends BaseSftpSupport implements CommonFtpStageTest {
+
+  @Rule
+  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/RawKeySftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/RawKeySftpSourceTest.java
@@ -21,8 +21,7 @@ import java.util.function.Function;
 
 public class RawKeySftpSourceTest extends BaseSftpSupport implements CommonFtpStageTest {
 
-  @Rule
-  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/RawKeySftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/RawKeySftpSourceTest.java
@@ -7,9 +7,11 @@ package akka.stream.alpakka.ftp;
 import akka.NotUsed;
 import akka.stream.IOResult;
 import akka.stream.alpakka.ftp.javadsl.Sftp;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
+import org.junit.Rule;
 import org.junit.Test;
 import java.net.InetAddress;
 import java.nio.file.Files;
@@ -18,6 +20,9 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 public class RawKeySftpSourceTest extends BaseSftpSupport implements CommonFtpStageTest {
+
+  @Rule
+  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/SftpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/SftpStageTest.java
@@ -7,9 +7,11 @@ package akka.stream.alpakka.ftp;
 import akka.NotUsed;
 import akka.stream.IOResult;
 import akka.stream.alpakka.ftp.javadsl.Sftp;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -17,6 +19,9 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 public class SftpStageTest extends BaseSftpSupport implements CommonFtpStageTest {
+
+  @Rule
+  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/SftpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/SftpStageTest.java
@@ -20,8 +20,7 @@ import java.util.function.Function;
 
 public class SftpStageTest extends BaseSftpSupport implements CommonFtpStageTest {
 
-  @Rule
-  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/SftpWithProxyStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/SftpWithProxyStageTest.java
@@ -7,9 +7,11 @@ package akka.stream.alpakka.ftp;
 import akka.NotUsed;
 import akka.stream.IOResult;
 import akka.stream.alpakka.ftp.javadsl.Sftp;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -19,6 +21,9 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 public class SftpWithProxyStageTest extends BaseSftpSupport implements CommonFtpStageTest {
+
+  @Rule
+  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private final Integer PROXYPORT = 3128;
   private final Proxy PROXY =

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/SftpWithProxyStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/SftpWithProxyStageTest.java
@@ -22,8 +22,7 @@ import java.util.function.Function;
 
 public class SftpWithProxyStageTest extends BaseSftpSupport implements CommonFtpStageTest {
 
-  @Rule
-  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private final Integer PROXYPORT = 3128;
   private final Proxy PROXY =

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/StrictHostCheckingSftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/StrictHostCheckingSftpSourceTest.java
@@ -7,9 +7,11 @@ package akka.stream.alpakka.ftp;
 import akka.NotUsed;
 import akka.stream.IOResult;
 import akka.stream.alpakka.ftp.javadsl.Sftp;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
+import org.junit.Rule;
 import org.junit.Test;
 import java.net.InetAddress;
 import java.util.concurrent.CompletionStage;
@@ -17,6 +19,9 @@ import java.util.function.Function;
 
 public class StrictHostCheckingSftpSourceTest extends BaseSftpSupport
     implements CommonFtpStageTest {
+
+  @Rule
+  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/StrictHostCheckingSftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/StrictHostCheckingSftpSourceTest.java
@@ -20,8 +20,7 @@ import java.util.function.Function;
 public class StrictHostCheckingSftpSourceTest extends BaseSftpSupport
     implements CommonFtpStageTest {
 
-  @Rule
-  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/docs/javadsl/FtpWritingTest.java
+++ b/ftp/src/test/java/docs/javadsl/FtpWritingTest.java
@@ -9,6 +9,7 @@ package docs.javadsl;
 import akka.stream.alpakka.ftp.javadsl.Ftp;
 // #create-settings
 import akka.stream.IOResult;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Compression;
 import akka.stream.testkit.javadsl.StreamTestKit;
 import akka.util.ByteString;
@@ -36,6 +37,9 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.CoreMatchers.is;
 
 public class FtpWritingTest extends BaseFtpSupport {
+
+  @Rule
+  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @After
   public void afterEach() {

--- a/ftp/src/test/java/docs/javadsl/FtpWritingTest.java
+++ b/ftp/src/test/java/docs/javadsl/FtpWritingTest.java
@@ -38,8 +38,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 public class FtpWritingTest extends BaseFtpSupport {
 
-  @Rule
-  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @After
   public void afterEach() {

--- a/ftp/src/test/resources/logback-test.xml
+++ b/ftp/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/ftp/src/test/resources/logback-test.xml
+++ b/ftp/src/test/resources/logback-test.xml
@@ -7,6 +7,19 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="net.schmizz.sshj.DefaultConfig" level="error"/>
     <logger name="net.schmizz" level="warn"/>
     <logger name="org.apache.ftpserver" level="info"/>
@@ -15,6 +28,7 @@
     <logger name="org.apache.sshd" level="warn"/>
 
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
@@ -6,6 +6,7 @@ package akka.stream.alpakka.ftp
 
 import akka.{Done, NotUsed}
 import akka.stream.IOResult
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -26,7 +27,8 @@ trait BaseSpec
     with IntegrationPatience
     with Inside
     with AkkaSupport
-    with BaseSupport { this: TestSuite =>
+    with BaseSupport
+    with LogCapturing { this: TestSuite =>
 
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed]
 

--- a/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala
+++ b/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala
@@ -8,6 +8,7 @@ import java.net.InetAddress
 
 import akka.stream.Materializer
 import akka.stream.alpakka.ftp.{BaseFtpSupport, FtpSettings}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
@@ -24,7 +25,8 @@ class FtpExamplesSpec
     with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
 
   implicit val materializer: Materializer = getMaterializer
 

--- a/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java
@@ -12,11 +12,13 @@ import akka.stream.alpakka.geode.GeodeSettings;
 import akka.stream.alpakka.geode.RegionSettings;
 import akka.stream.alpakka.geode.javadsl.Geode;
 import akka.stream.alpakka.geode.javadsl.GeodeWithPoolSubscription;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import org.junit.Rule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +26,7 @@ import java.util.Arrays;
 import java.util.Date;
 
 public class GeodeBaseTestCase {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   protected static final Logger LOGGER = LoggerFactory.getLogger(GeodeFlowTestCase.class);
 

--- a/geode/src/test/java/docs/javadsl/GeodeContinuousSourceTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeContinuousSourceTestCase.java
@@ -8,10 +8,12 @@ import akka.Done;
 import akka.NotUsed;
 import akka.japi.Pair;
 import akka.stream.alpakka.geode.javadsl.GeodeWithPoolSubscription;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -21,6 +23,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
 public class GeodeContinuousSourceTestCase extends GeodeBaseTestCase {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void continuousSourceTest() throws ExecutionException, InterruptedException {

--- a/geode/src/test/java/docs/javadsl/GeodeFiniteSourceTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeFiniteSourceTestCase.java
@@ -6,12 +6,15 @@ package docs.javadsl;
 
 import akka.Done;
 import akka.stream.alpakka.geode.javadsl.Geode;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
 public class GeodeFiniteSourceTestCase extends GeodeBaseTestCase {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void finiteSourceTest() throws ExecutionException, InterruptedException {

--- a/geode/src/test/java/docs/javadsl/GeodeFlowTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeFlowTestCase.java
@@ -6,10 +6,12 @@ package docs.javadsl;
 
 import akka.NotUsed;
 import akka.stream.alpakka.geode.javadsl.Geode;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.List;
@@ -17,6 +19,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
 public class GeodeFlowTestCase extends GeodeBaseTestCase {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void flow() throws ExecutionException, InterruptedException {

--- a/geode/src/test/java/docs/javadsl/GeodeSinkTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeSinkTestCase.java
@@ -7,16 +7,19 @@ package docs.javadsl;
 import akka.Done;
 import akka.NotUsed;
 import akka.stream.alpakka.geode.javadsl.Geode;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.RunnableGraph;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
 public class GeodeSinkTestCase extends GeodeBaseTestCase {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void sinkTest() throws ExecutionException, InterruptedException {

--- a/geode/src/test/resources/logback-test.xml
+++ b/geode/src/test/resources/logback-test.xml
@@ -8,7 +8,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/geode/src/test/resources/logback-test.xml
+++ b/geode/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/geode/src/test/scala/docs/scaladsl/GeodeBaseSpec.scala
+++ b/geode/src/test/scala/docs/scaladsl/GeodeBaseSpec.scala
@@ -9,6 +9,7 @@ import java.util.{Date, UUID}
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.geode.{GeodeSettings, RegionSettings}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.Source
 import org.scalatest.BeforeAndAfterAll
 
@@ -18,7 +19,7 @@ import scala.language.postfixOps
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class GeodeBaseSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+class GeodeBaseSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with LogCapturing {
 
   implicit val system = ActorSystem("test")
   implicit val materializer = ActorMaterializer()

--- a/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java
+++ b/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java
@@ -16,6 +16,7 @@ import akka.stream.alpakka.googlecloud.pubsub.grpc.PubSubSettings;
 import akka.stream.alpakka.googlecloud.pubsub.grpc.javadsl.GooglePubSub;
 import akka.stream.alpakka.googlecloud.pubsub.grpc.javadsl.GrpcPublisher;
 import akka.stream.alpakka.googlecloud.pubsub.grpc.javadsl.PubSubAttributes;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.*;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.*;
@@ -24,6 +25,7 @@ import com.google.pubsub.v1.*;
 
 import akka.stream.Materializer;
 import org.junit.AfterClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -38,6 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class IntegrationTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   static final ActorSystem system = ActorSystem.create("IntegrationTest");
   static final Materializer materializer = ActorMaterializer.create(system);

--- a/google-cloud-pub-sub-grpc/src/test/resources/application.conf
+++ b/google-cloud-pub-sub-grpc/src/test/resources/application.conf
@@ -1,3 +1,9 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  loglevel = "DEBUG"
+}
+
 alpakka.google.cloud.pubsub.grpc {
   host = "localhost"
   port = 8538

--- a/google-cloud-pub-sub-grpc/src/test/resources/logback-test.xml
+++ b/google-cloud-pub-sub-grpc/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/google-cloud-pub-sub-grpc/src/test/resources/logback-test.xml
+++ b/google-cloud-pub-sub-grpc/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <configuration>
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/google-cloud-pub-sub.log</file>
+        <file>target/google-cloud-pub-sub-grpc.log</file>
         <append>false</append>
         <encoder>
             <pattern>%d{ISO8601} %-5level [%thread] [%logger{36}]  %msg%n</pattern>

--- a/google-cloud-pub-sub-grpc/src/test/resources/logback-test.xml
+++ b/google-cloud-pub-sub-grpc/src/test/resources/logback-test.xml
@@ -1,11 +1,28 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/google-cloud-pub-sub.log</file>
+        <append>false</append>
         <encoder>
             <pattern>%d{ISO8601} %-5level [%thread] [%logger{36}]  %msg%n</pattern>
         </encoder>
     </appender>
 
-    <root level="info">
-        <appender-ref ref="STDOUT" />
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="CapturingAppender"/>
+        <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
+++ b/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
@@ -9,6 +9,7 @@ import akka.actor.{ActorSystem, Cancellable}
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.googlecloud.pubsub.grpc.PubSubSettings
 import akka.stream.alpakka.googlecloud.pubsub.grpc.scaladsl.{GrpcPublisher, PubSubAttributes}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import org.scalatest.OptionValues
 
 //#publish-single
@@ -34,7 +35,8 @@ class IntegrationSpec
     with Inside
     with BeforeAndAfterAll
     with ScalaFutures
-    with OptionValues {
+    with OptionValues
+    with LogCapturing {
 
   implicit val system = ActorSystem("IntegrationSpec")
   implicit val materializer = ActorMaterializer()

--- a/google-cloud-pub-sub/src/test/resources/logback-test.xml
+++ b/google-cloud-pub-sub/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/google-cloud-pub-sub/src/test/resources/logback-test.xml
+++ b/google-cloud-pub-sub/src/test/resources/logback-test.xml
@@ -7,9 +7,23 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="org.eclipse.jetty" level="info" />
 
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
@@ -11,6 +11,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.HttpExt
 import akka.stream.alpakka.googlecloud.pubsub.impl.{GoogleSession, PubSubApi, TestCredentials}
 import akka.stream.alpakka.googlecloud.pubsub.scaladsl.GooglePubSub
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Flow, FlowWithContext, Sink, Source}
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.{Done, NotUsed}
@@ -23,7 +24,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
-class GooglePubSubSpec extends AnyFlatSpec with MockitoSugar with ScalaFutures with Matchers {
+class GooglePubSubSpec extends AnyFlatSpec with MockitoSugar with ScalaFutures with Matchers with LogCapturing {
 
   implicit val defaultPatience =
     PatienceConfig(timeout = 5.seconds, interval = 100.millis)

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/ModelSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/ModelSpec.scala
@@ -9,7 +9,9 @@ import org.scalatest.matchers.should.Matchers
 import scala.collection.immutable.Seq
 import java.time.Instant
 
-class ModelSpec extends AnyFunSuite with Matchers {
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
+
+class ModelSpec extends AnyFunSuite with Matchers with LogCapturing {
 
   val publishMessage1 = PublishMessage("abcde", Map("k1" -> "v1", "k2" -> "v2"))
   val publishMessage2 = PublishMessage("abcde", Map("k1" -> "v1"))

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/GoogleSessionSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/GoogleSessionSpec.scala
@@ -7,6 +7,7 @@ package akka.stream.alpakka.googlecloud.pubsub.impl
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.googlecloud.pubsub.impl.GoogleTokenApi.AccessTokenExpiry
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import org.mockito.Mockito.{when, _}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
@@ -17,7 +18,13 @@ import org.scalatestplus.mockito.MockitoSugar
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class GoogleSessionSpec extends AnyFlatSpec with ScalaFutures with MockitoSugar with BeforeAndAfterAll with Matchers {
+class GoogleSessionSpec
+    extends AnyFlatSpec
+    with ScalaFutures
+    with MockitoSugar
+    with BeforeAndAfterAll
+    with Matchers
+    with LogCapturing {
 
   private trait Fixtures {
     val mockTokenApi = mock[GoogleTokenApi]

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/GoogleTokenApiSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/GoogleTokenApiSpec.scala
@@ -12,6 +12,7 @@ import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.http.scaladsl.{HttpExt, HttpsConnectionContext}
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.googlecloud.pubsub.impl.GoogleTokenApi.AccessTokenExpiry
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -21,8 +22,8 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
-
 import pdi.jwt.{Jwt, JwtAlgorithm}
+
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
@@ -32,7 +33,8 @@ class GoogleTokenApiSpec
     with Matchers
     with ScalaFutures
     with MockitoSugar
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   override def afterAll: Unit =
     TestKit.shutdownActorSystem(system)

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/PubSubApiSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/PubSubApiSpec.scala
@@ -13,6 +13,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.{ConnectionContext, Http}
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.googlecloud.pubsub._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
@@ -41,7 +42,7 @@ class NoopTrustManager extends X509TrustManager {
   }
 }
 
-class PubSubApiSpec extends AnyFlatSpec with BeforeAndAfterAll with ScalaFutures with Matchers {
+class PubSubApiSpec extends AnyFlatSpec with BeforeAndAfterAll with ScalaFutures with Matchers with LogCapturing {
 
   implicit val system = ActorSystem()
   implicit val mat = ActorMaterializer()

--- a/google-cloud-storage/src/test/java/docs/javadsl/GCStorageTest.java
+++ b/google-cloud-storage/src/test/java/docs/javadsl/GCStorageTest.java
@@ -14,22 +14,25 @@ import akka.stream.Materializer;
 import akka.stream.alpakka.googlecloud.storage.*;
 import akka.stream.alpakka.googlecloud.storage.javadsl.GCStorage;
 import akka.stream.alpakka.googlecloud.storage.scaladsl.GCStorageWiremockBase;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import com.google.common.collect.Lists;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
 public class GCStorageTest extends GCStorageWiremockBase {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private final Materializer materializer = ActorMaterializer.create(system());
   private final GCStorageSettings sampleSettings = GCStorageExt.get(system()).settings();
 

--- a/google-cloud-storage/src/test/resources/logback-test.xml
+++ b/google-cloud-storage/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/google-cloud-storage/src/test/resources/logback-test.xml
+++ b/google-cloud-storage/src/test/resources/logback-test.xml
@@ -7,9 +7,23 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="org.eclipse.jetty.servlet" level="warn"/>
 
-    <root level="warn">
+    <root level="DEBUG">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageExtSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageExtSpec.scala
@@ -5,13 +5,14 @@
 package akka.stream.alpakka.googlecloud.storage
 
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.collection.JavaConverters._
 
-class GCStorageExtSpec extends AnyFlatSpec with Matchers {
+class GCStorageExtSpec extends AnyFlatSpec with Matchers with LogCapturing {
   "GCStorageExt" should "reuse application config from actor system" in {
     val projectId = "projectId"
     val clientEmail = "clientEmail"

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageSettingsSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageSettingsSpec.scala
@@ -4,12 +4,14 @@
 
 package akka.stream.alpakka.googlecloud.storage
 
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
 import scala.collection.JavaConverters._
 
-class GCStorageSettingsSpec extends AnyFlatSpec with Matchers {
+class GCStorageSettingsSpec extends AnyFlatSpec with Matchers with LogCapturing {
   "GCStorageSettings" should "create settings from application config" in {
     val projectId = "projectId"
     val clientEmail = "clientEmail"

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/WithMaterializerGlobal.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/WithMaterializerGlobal.scala
@@ -25,7 +25,7 @@ trait WithMaterializerGlobal
   implicit val materializer = ActorMaterializer()
   implicit val ec = materializer.executionContext
 
-  override def afterAll(): Unit = {
+  override protected def afterAll(): Unit = {
     super.afterAll()
     Await.result(actorSystem.terminate(), 10.seconds)
   }

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/ChunkerSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/ChunkerSpec.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.googlecloud.storage.impl
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import org.scalatest.BeforeAndAfterAll
@@ -15,7 +16,7 @@ import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class ChunkerSpec extends AnyWordSpec with ScalaFutures with Matchers with BeforeAndAfterAll {
+class ChunkerSpec extends AnyWordSpec with ScalaFutures with Matchers with BeforeAndAfterAll with LogCapturing {
   implicit val system = ActorSystem("ChunkerSpec")
   implicit val mat = ActorMaterializer()
 

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
@@ -19,6 +19,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Random
 import akka.stream.alpakka.googlecloud.storage.GCStorageSettings
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
+
 import scala.concurrent.Future
 
 /**
@@ -38,7 +40,8 @@ class GCStorageStreamIntegrationSpec
     with WithMaterializerGlobal
     with BeforeAndAfter
     with Matchers
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
 
   private implicit val defaultPatience =
     PatienceConfig(timeout = 60.seconds, interval = 60.millis)

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GoogleTokenApiSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GoogleTokenApiSpec.scala
@@ -12,6 +12,7 @@ import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.http.scaladsl.{HttpExt, HttpsConnectionContext}
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.googlecloud.storage.impl.GoogleTokenApi.AccessTokenExpiry
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
@@ -25,7 +26,13 @@ import pdi.jwt.{Jwt, JwtAlgorithm}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-class GoogleTokenApiSpec extends AnyWordSpec with Matchers with ScalaFutures with MockitoSugar with BeforeAndAfterAll {
+class GoogleTokenApiSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaFutures
+    with MockitoSugar
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   implicit val defaultPatience =
     PatienceConfig(timeout = 2.seconds, interval = 50.millis)

--- a/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSinkSpec.scala
+++ b/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSinkSpec.scala
@@ -8,6 +8,7 @@ import akka.http.scaladsl.model.ContentTypes
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.googlecloud.storage.StorageObject
 import akka.stream.alpakka.googlecloud.storage.scaladsl.{GCStorage, GCStorageWiremockBase}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import org.scalatest.BeforeAndAfterAll
@@ -24,7 +25,8 @@ class GCStorageSinkSpec
     with BeforeAndAfterAll
     with ScalaFutures
     with IntegrationPatience
-    with Matchers {
+    with Matchers
+    with LogCapturing {
 
   implicit val materializer = ActorMaterializer()
 

--- a/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSourceSpec.scala
+++ b/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSourceSpec.scala
@@ -7,6 +7,7 @@ package docs.scaladsl
 import akka.http.scaladsl.model.ContentTypes
 import akka.stream.alpakka.googlecloud.storage.scaladsl.{GCStorage, GCStorageWiremockBase}
 import akka.stream.alpakka.googlecloud.storage.{Bucket, GCStorageAttributes, GCStorageExt, StorageObject}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.{ActorMaterializer, Attributes}
 import akka.util.ByteString
@@ -24,7 +25,8 @@ class GCStorageSourceSpec
     with BeforeAndAfterAll
     with ScalaFutures
     with IntegrationPatience
-    with Matchers {
+    with Matchers
+    with LogCapturing {
 
   implicit val materializer = ActorMaterializer()
   private val sampleSettings = GCStorageExt(system).settings

--- a/google-fcm/src/test/resources/application.conf
+++ b/google-fcm/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+akka {
+  loggers = ["akka.testkit.TestEventListener", "akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  loglevel = "INFO"
+}

--- a/google-fcm/src/test/resources/logback-test.xml
+++ b/google-fcm/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/google-fcm/src/test/resources/logback-test.xml
+++ b/google-fcm/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <configuration>
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/xml.log</file>
+        <file>target/google-fcm.log</file>
         <append>false</append>
         <encoder>
             <pattern>%d{ISO8601} %-5level [%thread] [%logger{36}]  %msg%n</pattern>
@@ -20,8 +20,9 @@
     </logger>
 
     <logger name="akka" level="DEBUG"/>
+    <logger name="org.eclipse.jetty.servlet" level="warn"/>
 
-    <root level="debug">
+    <root level="DEBUG">
         <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmSenderSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmSenderSpec.scala
@@ -13,6 +13,7 @@ import akka.http.scaladsl.{HttpExt, HttpsConnectionContext}
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.google.firebase.fcm.{FcmErrorResponse, FcmSuccessResponse}
 import akka.stream.alpakka.google.firebase.fcm.FcmNotification
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -32,7 +33,8 @@ class FcmSenderSpec
     with Matchers
     with ScalaFutures
     with MockitoSugar
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   import FcmJsonSupport._
 

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleTokenApiSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleTokenApiSpec.scala
@@ -12,6 +12,7 @@ import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.http.scaladsl.{HttpExt, HttpsConnectionContext}
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.alpakka.google.firebase.fcm.impl.GoogleTokenApi.AccessTokenExpiry
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -32,7 +33,8 @@ class GoogleTokenApiSpec
     with Matchers
     with ScalaFutures
     with MockitoSugar
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   override def afterAll: Unit =
     TestKit.shutdownActorSystem(system)

--- a/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
+++ b/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
@@ -12,6 +12,7 @@ import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.hbase.HTableSettings;
 import akka.stream.alpakka.hbase.javadsl.HTableStage;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
@@ -22,6 +23,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.*;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
@@ -37,6 +39,7 @@ import java.util.function.Function;
 import static org.junit.Assert.assertEquals;
 
 public class HBaseStageTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Materializer materializer;

--- a/hbase/src/test/resources/logback-test.xml
+++ b/hbase/src/test/resources/logback-test.xml
@@ -8,6 +8,19 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="akka.stream.alpakka.hbase" level="DEBUG"/>
 
     <logger name="akka.stream" level="DEBUG"/>
@@ -15,6 +28,7 @@
     <logger name="org.apache.hadoop.security" level="INFO"/>
 
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/hbase/src/test/resources/logback-test.xml
+++ b/hbase/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/hbase/src/test/scala/docs/scaladsl/HBaseStageSpec.scala
+++ b/hbase/src/test/scala/docs/scaladsl/HBaseStageSpec.scala
@@ -9,6 +9,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.hbase.HTableSettings
 import akka.stream.alpakka.hbase.scaladsl.HTableStage
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.testkit.TestKit
 import org.apache.hadoop.hbase.client._
@@ -28,7 +29,8 @@ class HBaseStageSpec
     with AnyWordSpecLike
     with Matchers
     with ScalaFutures
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   implicit val mat = ActorMaterializer()
 

--- a/hdfs/src/test/java/docs/javadsl/HdfsReaderTest.java
+++ b/hdfs/src/test/java/docs/javadsl/HdfsReaderTest.java
@@ -13,6 +13,7 @@ import akka.stream.alpakka.hdfs.*;
 import akka.stream.alpakka.hdfs.javadsl.HdfsFlow;
 import akka.stream.alpakka.hdfs.javadsl.HdfsSource;
 import akka.stream.alpakka.hdfs.util.JavaTestUtils;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
@@ -24,10 +25,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.compress.DefaultCodec;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,6 +36,8 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertArrayEquals;
 
 public class HdfsReaderTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static MiniDFSCluster hdfsCluster = null;
   private static ActorSystem system;
   private static ActorMaterializer materializer;

--- a/hdfs/src/test/java/docs/javadsl/HdfsWriterTest.java
+++ b/hdfs/src/test/java/docs/javadsl/HdfsWriterTest.java
@@ -12,6 +12,7 @@ import akka.stream.ActorMaterializer;
 import akka.stream.alpakka.hdfs.*;
 import akka.stream.alpakka.hdfs.javadsl.HdfsFlow;
 import akka.stream.alpakka.hdfs.util.JavaTestUtils;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
@@ -27,10 +28,7 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.compress.DefaultCodec;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import scala.concurrent.duration.Duration;
 
 import java.io.IOException;
@@ -47,6 +45,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class HdfsWriterTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static MiniDFSCluster hdfsCluster = null;
   private static ActorSystem system;
   private static ActorMaterializer materializer;

--- a/hdfs/src/test/resources/logback-test.xml
+++ b/hdfs/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/hdfs/src/test/resources/logback-test.xml
+++ b/hdfs/src/test/resources/logback-test.xml
@@ -7,10 +7,24 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="org.eclipse.jetty" level="info"/>
     <logger name="org.apache.hadoop" level="warn"/>
 
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/hdfs/src/test/scala/docs/scaladsl/HdfsReaderSpec.scala
+++ b/hdfs/src/test/scala/docs/scaladsl/HdfsReaderSpec.scala
@@ -9,6 +9,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.alpakka.hdfs._
 import akka.stream.alpakka.hdfs.scaladsl.{HdfsFlow, HdfsSource}
 import akka.stream.alpakka.hdfs.util.ScalaTestUtils._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -22,7 +23,12 @@ import scala.concurrent.{Await, ExecutionContextExecutor, Future}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-class HdfsReaderSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
+class HdfsReaderSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with LogCapturing {
 
   private var hdfsCluster: MiniDFSCluster = _
   private val destination = "/tmp/alpakka/"

--- a/hdfs/src/test/scala/docs/scaladsl/HdfsWriterSpec.scala
+++ b/hdfs/src/test/scala/docs/scaladsl/HdfsWriterSpec.scala
@@ -9,6 +9,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.alpakka.hdfs._
 import akka.stream.alpakka.hdfs.scaladsl.HdfsFlow
 import akka.stream.alpakka.hdfs.util.ScalaTestUtils._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.util.ByteString
 import org.apache.hadoop.fs.Path
@@ -24,7 +25,12 @@ import scala.concurrent.{Await, ExecutionContextExecutor}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-class HdfsWriterSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
+class HdfsWriterSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with LogCapturing {
 
   private var hdfsCluster: MiniDFSCluster = _
   private val destination = "/tmp/alpakka/"

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbSourceTest.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbSourceTest.java
@@ -7,15 +7,11 @@ package docs.javadsl;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import org.influxdb.InfluxDB;
 import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import akka.actor.ActorSystem;
 import akka.japi.Pair;
@@ -32,6 +28,7 @@ import static docs.javadsl.TestUtils.populateDatabase;
 import static docs.javadsl.TestUtils.setupConnection;
 
 public class InfluxDbSourceTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Materializer materializer;

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbTest.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbTest.java
@@ -17,16 +17,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import org.influxdb.InfluxDB;
 import org.influxdb.dto.Point;
 import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import akka.Done;
 import akka.NotUsed;
@@ -52,6 +48,7 @@ import static docs.javadsl.TestUtils.setupConnection;
 import static org.junit.Assert.assertEquals;
 
 public class InfluxDbTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Materializer materializer;

--- a/influxdb/src/test/resources/application.conf
+++ b/influxdb/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+akka.stream.akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  loglevel = "DEBUG"
+}

--- a/influxdb/src/test/resources/logback-test.xml
+++ b/influxdb/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/influxdb/src/test/resources/logback-test.xml
+++ b/influxdb/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <configuration>
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/xml.log</file>
+        <file>target/influxdb.log</file>
         <append>false</append>
         <encoder>
             <pattern>%d{ISO8601} %-5level [%thread] [%logger{36}]  %msg%n</pattern>

--- a/influxdb/src/test/scala/docs/scaladsl/FlowSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/FlowSpec.scala
@@ -12,6 +12,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.influxdb.{InfluxDbReadSettings, InfluxDbWriteMessage, InfluxDbWriteResult}
 import akka.stream.alpakka.influxdb.scaladsl.{InfluxDbFlow, InfluxDbSource}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.testkit.TestKit
 import org.influxdb.InfluxDB
@@ -25,7 +26,13 @@ import scala.concurrent.duration._
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class FlowSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach with BeforeAndAfterAll with ScalaFutures {
+class FlowSpec
+    extends AnyWordSpec
+    with Matchers
+    with BeforeAndAfterEach
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with LogCapturing {
 
   implicit val system = ActorSystem()
   implicit val mat = ActorMaterializer()

--- a/influxdb/src/test/scala/docs/scaladsl/InfluxDbSourceSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/InfluxDbSourceSpec.scala
@@ -6,8 +6,9 @@ package docs.scaladsl
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import akka.stream.alpakka.influxdb.{InfluxDbReadSettings}
+import akka.stream.alpakka.influxdb.InfluxDbReadSettings
 import akka.stream.alpakka.influxdb.scaladsl.InfluxDbSource
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.Sink
 import akka.testkit.TestKit
 import org.influxdb.{InfluxDB, InfluxDBException}
@@ -24,7 +25,8 @@ class InfluxDbSourceSpec
     with Matchers
     with BeforeAndAfterEach
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
 
   final val DatabaseName = "InfluxDbSourceSpec"
 

--- a/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpec.scala
@@ -14,17 +14,23 @@ import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.{Done, NotUsed}
 import akka.stream.alpakka.influxdb.{InfluxDbReadSettings, InfluxDbWriteMessage}
 import akka.stream.alpakka.influxdb.scaladsl.{InfluxDbSink, InfluxDbSource}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import docs.javadsl.TestUtils._
 import akka.stream.scaladsl.Sink
 
 import scala.collection.JavaConverters._
-
 import docs.javadsl.TestConstants.{INFLUXDB_URL, PASSWORD, USERNAME}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class InfluxDbSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach with BeforeAndAfterAll with ScalaFutures {
+class InfluxDbSpec
+    extends AnyWordSpec
+    with Matchers
+    with BeforeAndAfterEach
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with LogCapturing {
 
   implicit val system = ActorSystem()
   implicit val mat = ActorMaterializer()

--- a/ironmq/src/test/java/akka/stream/alpakka/ironmq/UnitTest.java
+++ b/ironmq/src/test/java/akka/stream/alpakka/ironmq/UnitTest.java
@@ -8,11 +8,13 @@ import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.ironmq.impl.IronMqClient;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.testkit.javadsl.TestKit;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 
 import java.util.List;
 import java.util.UUID;
@@ -23,6 +25,7 @@ import static scala.collection.JavaConverters.*;
 import static scala.compat.java8.FutureConverters.*;
 
 public abstract class UnitTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private ActorSystem system;
   private ActorMaterializer materializer;

--- a/ironmq/src/test/java/akka/stream/alpakka/ironmq/javadsl/IronMqConsumerTest.java
+++ b/ironmq/src/test/java/akka/stream/alpakka/ironmq/javadsl/IronMqConsumerTest.java
@@ -7,8 +7,10 @@ package akka.stream.alpakka.ironmq.javadsl;
 import akka.stream.alpakka.ironmq.IronMqSettings;
 import akka.stream.alpakka.ironmq.PushMessage;
 import akka.stream.alpakka.ironmq.UnitTest;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -17,6 +19,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class IronMqConsumerTest extends UnitTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void ironMqConsumerShouldBeNiceToMe() throws Exception {

--- a/ironmq/src/test/java/docs/javadsl/IronMqDocsTest.java
+++ b/ironmq/src/test/java/docs/javadsl/IronMqDocsTest.java
@@ -15,11 +15,13 @@ import akka.stream.alpakka.ironmq.javadsl.*;
 
 // #imports
 import akka.stream.alpakka.ironmq.impl.IronMqClientForJava;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
 import org.junit.AfterClass;
+import org.junit.Rule;
 import org.junit.Test;
 import scala.concurrent.Await;
 
@@ -32,6 +34,8 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 
 public class IronMqDocsTest extends IronMqClientForJava {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static final ActorSystem system = ActorSystem.create();
   private static final Materializer materializer = ActorMaterializer.create(system);
   private static final scala.concurrent.duration.Duration awaiting =

--- a/ironmq/src/test/resources/logback-test.xml
+++ b/ironmq/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/ironmq/src/test/resources/logback-test.xml
+++ b/ironmq/src/test/resources/logback-test.xml
@@ -8,9 +8,23 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="akka.http" level="info"/>
 
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/ironmq/src/test/scala/akka/stream/alpakka/ironmq/IronMqSpec.scala
+++ b/ironmq/src/test/scala/akka/stream/alpakka/ironmq/IronMqSpec.scala
@@ -8,6 +8,7 @@ import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.stream.alpakka.ironmq.impl.IronMqClient
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.{ActorMaterializer, Materializer}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.concurrent.ScalaFutures
@@ -19,7 +20,12 @@ import scala.util.hashing.MurmurHash3
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-abstract class IronMqSpec extends AnyWordSpec with Matchers with ScalaFutures with BeforeAndAfterEach {
+abstract class IronMqSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaFutures
+    with BeforeAndAfterEach
+    with LogCapturing {
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 15.seconds, interval = 1.second)
   val DefaultActorSystemTerminateTimeout: Duration = 10.seconds

--- a/ironmq/src/test/scala/docs/scaladsl/IronMqDocsSpec.scala
+++ b/ironmq/src/test/scala/docs/scaladsl/IronMqDocsSpec.scala
@@ -7,6 +7,7 @@ package docs.scaladsl
 import akka.stream.alpakka.ironmq.PushMessage
 import akka.stream.alpakka.ironmq.impl.IronMqClientForTests
 import akka.stream.alpakka.ironmq.scaladsl._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
@@ -25,7 +26,8 @@ class IronMqDocsSpec
     with IronMqClientForTests
     with Matchers
     with ScalaFutures
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 250.millis)
 

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsAckConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsAckConnectorsTest.java
@@ -10,6 +10,7 @@ import akka.japi.Pair;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.jms.*;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
@@ -17,6 +18,7 @@ import com.typesafe.config.Config;
 import org.apache.activemq.command.ActiveMQQueue;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import jmstestkit.JmsBroker;
 
@@ -34,6 +36,8 @@ import java.util.stream.Stream;
 import static org.junit.Assert.assertEquals;
 
 public class JmsAckConnectorsTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Materializer materializer;

--- a/jms/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
@@ -13,6 +13,7 @@ import akka.stream.alpakka.jms.*;
 import akka.stream.alpakka.jms.javadsl.JmsConsumer;
 import akka.stream.alpakka.jms.javadsl.JmsConsumerControl;
 import akka.stream.alpakka.jms.javadsl.JmsProducer;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
@@ -21,6 +22,7 @@ import com.typesafe.config.Config;
 import org.apache.activemq.command.ActiveMQQueue;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import javax.jms.ConnectionFactory;
@@ -37,6 +39,8 @@ import java.util.stream.Stream;
 import static org.junit.Assert.assertEquals;
 
 public class JmsBufferedAckConnectorsTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Materializer materializer;

--- a/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
@@ -16,6 +16,7 @@ import akka.stream.alpakka.jms.javadsl.JmsConsumer;
 import akka.stream.alpakka.jms.javadsl.JmsConsumerControl;
 import akka.stream.alpakka.jms.javadsl.JmsProducer;
 import akka.stream.alpakka.jms.javadsl.JmsProducerStatus;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
@@ -29,6 +30,7 @@ import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.command.ActiveMQTextMessage;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import scala.util.Failure;
 import scala.util.Success;
@@ -77,6 +79,8 @@ final class DummyJavaTests implements java.io.Serializable {
 }
 
 public class JmsConnectorsTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Materializer materializer;

--- a/jms/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
@@ -15,6 +15,7 @@ import akka.stream.alpakka.jms.TxEnvelope;
 import akka.stream.alpakka.jms.javadsl.JmsConsumer;
 import akka.stream.alpakka.jms.javadsl.JmsConsumerControl;
 import akka.stream.alpakka.jms.javadsl.JmsProducer;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
@@ -25,6 +26,7 @@ import com.ibm.mq.jms.MQTopicConnectionFactory;
 import com.ibm.msg.client.wmq.common.CommonConstants;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import javax.jms.Destination;
@@ -44,6 +46,8 @@ import java.util.function.Function;
 import static org.junit.Assert.assertEquals;
 
 public class JmsIbmmqConnectorsTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Materializer materializer;

--- a/jms/src/test/java/docs/javadsl/JmsSettingsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsSettingsTest.java
@@ -5,8 +5,10 @@
 package docs.javadsl;
 
 import akka.stream.alpakka.jms.*;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import com.typesafe.config.ConfigFactory;
 import org.apache.activemq.ActiveMQConnectionFactory;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -22,6 +24,8 @@ import scala.Option;
 // #retry-settings #send-retry-settings
 
 public class JmsSettingsTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void producerSettings() throws Exception {

--- a/jms/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
@@ -13,6 +13,7 @@ import akka.stream.alpakka.jms.*;
 import akka.stream.alpakka.jms.javadsl.JmsConsumer;
 import akka.stream.alpakka.jms.javadsl.JmsConsumerControl;
 import akka.stream.alpakka.jms.javadsl.JmsProducer;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
@@ -21,6 +22,7 @@ import com.typesafe.config.Config;
 import org.apache.activemq.command.ActiveMQQueue;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import javax.jms.ConnectionFactory;
@@ -38,6 +40,8 @@ import java.util.stream.Stream;
 import static org.junit.Assert.assertEquals;
 
 public class JmsTxConnectorsTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Materializer materializer;

--- a/jms/src/test/resources/logback-test.xml
+++ b/jms/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/jms/src/test/resources/logback-test.xml
+++ b/jms/src/test/resources/logback-test.xml
@@ -7,9 +7,23 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="org.apache.activemq" level="info" />
 
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsSpec.scala
@@ -6,6 +6,7 @@ package akka.stream.alpakka.jms
 
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Supervision}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import javax.jms._
 import jmstestkit.JmsBroker
@@ -24,7 +25,8 @@ abstract class JmsSpec
     with BeforeAndAfterEach
     with ScalaFutures
     with Eventually
-    with MockitoSugar {
+    with MockitoSugar
+    with LogCapturing {
 
   implicit val system = ActorSystem(this.getClass.getSimpleName)
 

--- a/json-streaming/src/test/java/docs/javadsl/JsonReaderUsageTest.java
+++ b/json-streaming/src/test/java/docs/javadsl/JsonReaderUsageTest.java
@@ -8,11 +8,13 @@ import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.json.javadsl.JsonReader;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.*;
 import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.List;
@@ -25,6 +27,8 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertThat;
 
 public class JsonReaderUsageTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static ActorSystem system;
   private static Materializer materializer;
 

--- a/json-streaming/src/test/resources/logback-test.xml
+++ b/json-streaming/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/json-streaming/src/test/resources/logback-test.xml
+++ b/json-streaming/src/test/resources/logback-test.xml
@@ -7,7 +7,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/json-streaming/src/test/scala/docs/scaladsl/JsonReaderTest.scala
+++ b/json-streaming/src/test/scala/docs/scaladsl/JsonReaderTest.scala
@@ -7,6 +7,7 @@ package docs.scaladsl
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.alpakka.json.scaladsl.JsonReader
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import org.jsfr.json.compiler.JsonPathCompiler
@@ -18,7 +19,7 @@ import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class JsonReaderTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+class JsonReaderTest extends AnyWordSpec with Matchers with BeforeAndAfterAll with LogCapturing {
   implicit val system: ActorSystem = ActorSystem("Test")
   implicit val mat: Materializer = ActorMaterializer()
 

--- a/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/KinesisTest.java
+++ b/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/KinesisTest.java
@@ -9,11 +9,13 @@ import akka.actor.ActorSystem;
 import akka.japi.Pair;
 import akka.stream.ActorMaterializer;
 import akka.stream.alpakka.kinesis.ShardSettings;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
@@ -27,6 +29,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class KinesisTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static ActorSystem system;
   private static ActorMaterializer materializer;
   private static ShardSettings settings;

--- a/kinesis/src/test/resources/logback-test.xml
+++ b/kinesis/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/kinesis/src/test/resources/logback-test.xml
+++ b/kinesis/src/test/resources/logback-test.xml
@@ -7,7 +7,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture
 
 import akka.stream.alpakka.kinesis.KinesisErrors.FailurePublishingRecords
 import akka.stream.alpakka.kinesis.scaladsl.KinesisFlow
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.Keep
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -23,7 +24,7 @@ import software.amazon.awssdk.services.kinesis.model._
 
 import scala.collection.JavaConverters._
 
-class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock {
+class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with LogCapturing {
 
   "KinesisFlow" must {
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSourceSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSourceSpec.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicReference
 
 import akka.stream.alpakka.kinesis.scaladsl.KinesisSource
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.testkit.scaladsl.TestSink
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.util.ByteString
@@ -23,7 +24,7 @@ import software.amazon.awssdk.services.kinesis.model._
 
 import scala.concurrent.duration._
 
-class KinesisSourceSpec extends AnyWordSpec with Matchers with KinesisMock {
+class KinesisSourceSpec extends AnyWordSpec with Matchers with KinesisMock with LogCapturing {
 
   implicit class recordToString(r: Record) {
     def utf8String: String = ByteString(r.data.asByteBuffer).utf8String

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/ShardSettingsSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/ShardSettingsSpec.scala
@@ -6,11 +6,12 @@ package akka.stream.alpakka.kinesis
 
 import java.time.Instant
 
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.must.Matchers
 import software.amazon.awssdk.services.kinesis.model.ShardIteratorType
 
-class ShardSettingsSpec extends AnyWordSpec with Matchers {
+class ShardSettingsSpec extends AnyWordSpec with Matchers with LogCapturing {
   val baseSettings = ShardSettings("name", "shardid")
   "ShardSettings" must {
     "require a timestamp for shard iterator type is AT_TIMESTAMP" in {

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSpec.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture
 
 import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseErrors.FailurePublishingRecords
 import akka.stream.alpakka.kinesisfirehose.scaladsl.KinesisFirehoseFlow
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.Keep
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
@@ -23,7 +24,7 @@ import software.amazon.awssdk.services.firehose.model._
 
 import scala.collection.JavaConverters._
 
-class KinesisFirehoseFlowSpec extends AnyWordSpec with Matchers with KinesisFirehoseMock {
+class KinesisFirehoseFlowSpec extends AnyWordSpec with Matchers with KinesisFirehoseMock with LogCapturing {
 
   "KinesisFirehoseFlow" must {
 

--- a/kudu/src/test/java/docs/javadsl/KuduTableTest.java
+++ b/kudu/src/test/java/docs/javadsl/KuduTableTest.java
@@ -12,6 +12,7 @@ import akka.stream.Materializer;
 import akka.stream.alpakka.kudu.KuduAttributes;
 import akka.stream.alpakka.kudu.KuduTableSettings;
 import akka.stream.alpakka.kudu.javadsl.KuduTable;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
@@ -26,6 +27,7 @@ import org.apache.kudu.client.KuduException;
 import org.apache.kudu.client.PartialRow;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -38,6 +40,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 public class KuduTableTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static ActorSystem system;
   private static Materializer materializer;
   private static Schema schema;

--- a/kudu/src/test/resources/logback-test.xml
+++ b/kudu/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/kudu/src/test/resources/logback-test.xml
+++ b/kudu/src/test/resources/logback-test.xml
@@ -8,12 +8,26 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="akka.stream.alpakka.kudu" level="DEBUG"/>
 
     <logger name="akka.stream" level="DEBUG"/>
 
 
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala
+++ b/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala
@@ -8,6 +8,7 @@ import akka.{Done, NotUsed}
 import akka.actor.ActorSystem
 import akka.stream.alpakka.kudu.{KuduAttributes, KuduTableSettings}
 import akka.stream.alpakka.kudu.scaladsl.KuduTable
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.testkit.TestKit
@@ -27,7 +28,8 @@ class KuduTableSpec
     with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
 
   implicit val materializer: Materializer = ActorMaterializer()
   implicit val defaultPatience: PatienceConfig =

--- a/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
@@ -12,6 +12,7 @@ import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.mongodb.DocumentUpdate;
 import akka.stream.alpakka.mongodb.javadsl.MongoSink;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.testkit.javadsl.StreamTestKit;
@@ -28,10 +29,7 @@ import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
 import org.bson.conversions.Bson;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -42,6 +40,7 @@ import java.util.stream.IntStream;
 import static org.junit.Assert.assertEquals;
 
 public class MongoSinkTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Materializer mat;

--- a/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java
@@ -9,6 +9,7 @@ import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.mongodb.javadsl.MongoSource;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Source;
 import akka.stream.javadsl.Sink;
 import akka.stream.testkit.javadsl.StreamTestKit;
@@ -18,10 +19,7 @@ import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -32,6 +30,7 @@ import java.util.stream.IntStream;
 import static org.junit.Assert.assertEquals;
 
 public class MongoSourceTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Materializer mat;

--- a/mongodb/src/test/resources/logback-test.xml
+++ b/mongodb/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/mongodb/src/test/resources/logback-test.xml
+++ b/mongodb/src/test/resources/logback-test.xml
@@ -7,7 +7,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
@@ -8,6 +8,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.mongodb.DocumentUpdate
 import akka.stream.alpakka.mongodb.scaladsl.MongoSink
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import com.mongodb.client.model.{Filters, InsertManyOptions, Updates}
@@ -24,7 +25,13 @@ import scala.concurrent.duration._
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class MongoSinkSpec extends AnyWordSpec with ScalaFutures with BeforeAndAfterEach with BeforeAndAfterAll with Matchers {
+class MongoSinkSpec
+    extends AnyWordSpec
+    with ScalaFutures
+    with BeforeAndAfterEach
+    with BeforeAndAfterAll
+    with Matchers
+    with LogCapturing {
 
   // case class and codec for mongodb macros
   case class Number(_id: Int)

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
@@ -8,6 +8,7 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.mongodb.scaladsl.MongoSource
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import com.mongodb.reactivestreams.client.MongoClients
@@ -27,7 +28,8 @@ class MongoSourceSpec
     with ScalaFutures
     with BeforeAndAfterEach
     with BeforeAndAfterAll
-    with Matchers {
+    with Matchers
+    with LogCapturing {
 
   // #init-mat
   implicit val system = ActorSystem()

--- a/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -34,6 +34,7 @@ import akka.stream.alpakka.mqtt.streaming.javadsl.ActorMqttServerSession;
 import akka.stream.alpakka.mqtt.streaming.javadsl.Mqtt;
 import akka.stream.alpakka.mqtt.streaming.javadsl.MqttClientSession;
 import akka.stream.alpakka.mqtt.streaming.javadsl.MqttServerSession;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
@@ -44,10 +45,7 @@ import akka.stream.javadsl.BroadcastHub;
 import akka.stream.testkit.javadsl.StreamTestKit;
 import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import scala.Tuple2;
 import scala.collection.JavaConverters;
 
@@ -64,6 +62,8 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 
 public class MqttFlowTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static int TIMEOUT_SECONDS = 5;
 

--- a/mqtt-streaming/src/test/resources/logback-test.xml
+++ b/mqtt-streaming/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/mqtt-streaming/src/test/resources/logback-test.xml
+++ b/mqtt-streaming/src/test/resources/logback-test.xml
@@ -7,12 +7,25 @@
         </encoder>
     </appender>
 
-    <logger name="akka" level="info" />
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="akka.stream" level="info" />
     <logger name="akka.stream.alpakka" level="debug" />
     <logger name="akka.stream.alpakka.mqtt.streaming.impl" level="info" />
 
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/MqttFrameStageSpec.scala
+++ b/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/MqttFrameStageSpec.scala
@@ -6,6 +6,7 @@ package akka.stream.alpakka.mqtt.streaming
 package impl
 
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Keep, Source}
 import akka.stream.testkit.javadsl.TestSink
 import akka.stream.testkit.scaladsl.TestSource
@@ -20,7 +21,8 @@ class MqttFrameStageSpec
     extends TestKit(ActorSystem("MqttFrameStageSpec"))
     with AnyWordSpecLike
     with Matchers
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   implicit val mat: Materializer = ActorMaterializer()
 

--- a/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/QueueOfferStateSpec.scala
+++ b/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/QueueOfferStateSpec.scala
@@ -10,8 +10,10 @@ import akka.actor.typed.ActorRef
 import akka.actor.typed.scaladsl.Behaviors
 import akka.stream.alpakka.mqtt.streaming.impl.QueueOfferState.QueueOfferCompleted
 import akka.stream.QueueOfferResult
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.scalatest.BeforeAndAfterAll
+
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers
@@ -21,7 +23,8 @@ class QueueOfferStateSpec
     extends TestKit(ActorSystem("QueueOfferStateSpec"))
     with AnyWordSpecLike
     with Matchers
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   sealed trait Msg
 

--- a/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/RequestStateSpec.scala
+++ b/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/RequestStateSpec.scala
@@ -6,6 +6,7 @@ package akka.stream.alpakka.mqtt.streaming
 package impl
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
@@ -15,7 +16,7 @@ import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class RequestStateSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+class RequestStateSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with LogCapturing {
 
   val testKit = ActorTestKit()
   override def afterAll(): Unit = testKit.shutdownTestKit()

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttCodecSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttCodecSpec.scala
@@ -6,13 +6,14 @@ package docs.scaladsl
 import java.nio.ByteOrder
 
 import akka.stream.alpakka.mqtt.streaming._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.util.{ByteString, ByteStringBuilder}
 
 import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class MqttCodecSpec extends AnyWordSpec with Matchers {
+class MqttCodecSpec extends AnyWordSpec with Matchers with LogCapturing {
 
   private implicit val byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN
   import MqttCodec._

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -13,6 +13,7 @@ import akka.stream.alpakka.mqtt.streaming.scaladsl.{ActorMqttClientSession, Acto
 import akka.stream.scaladsl.{BroadcastHub, Flow, Keep, Sink, Source, SourceQueueWithComplete, Tcp}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest._
@@ -34,7 +35,7 @@ class TypedMqttFlowSpec
 
 class ParametrizedTestKit(val clientId: String, val topic: String, system: ActorSystem) extends TestKit(system)
 
-trait MqttFlowSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures {
+trait MqttFlowSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures with LogCapturing {
   self: ParametrizedTestKit =>
 
   private implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = 5.seconds, interval = 100.millis)

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -14,6 +14,7 @@ import akka.stream.alpakka.mqtt.streaming.scaladsl.{
   Mqtt,
   MqttServerSession
 }
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{BroadcastHub, Flow, Keep, Sink, Source, SourceQueueWithComplete}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.{ActorMaterializer, Materializer, OverflowStrategy}
@@ -33,7 +34,8 @@ class MqttSessionSpec
     with AnyWordSpecLike
     with BeforeAndAfterAll
     with ScalaFutures
-    with Matchers {
+    with Matchers
+    with LogCapturing {
 
   implicit val mat: Materializer = ActorMaterializer()
   implicit val executionContext: ExecutionContext = system.dispatcher

--- a/mqtt/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -10,10 +10,14 @@ import akka.actor.ActorSystem;
 import akka.japi.Pair;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
-import akka.stream.alpakka.mqtt.*;
+import akka.stream.alpakka.mqtt.MqttConnectionSettings;
+import akka.stream.alpakka.mqtt.MqttMessage;
+import akka.stream.alpakka.mqtt.MqttQoS;
+import akka.stream.alpakka.mqtt.MqttSubscriptions;
 import akka.stream.alpakka.mqtt.javadsl.MqttFlow;
 import akka.stream.alpakka.mqtt.javadsl.MqttMessageWithAck;
 import akka.stream.alpakka.mqtt.javadsl.MqttMessageWithAckImpl;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
@@ -23,7 +27,10 @@ import akka.util.ByteString;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Optional;
@@ -33,6 +40,10 @@ import java.util.concurrent.CompletionStage;
 import static org.junit.Assert.assertFalse;
 
 public class MqttFlowTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
+  private static final Logger log = LoggerFactory.getLogger(MqttFlowTest.class);
 
   private static ActorSystem system;
   private static Materializer materializer;

--- a/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -16,6 +16,7 @@ import akka.stream.alpakka.mqtt.*;
 import akka.stream.alpakka.mqtt.javadsl.MqttMessageWithAck;
 import akka.stream.alpakka.mqtt.javadsl.MqttSink;
 import akka.stream.alpakka.mqtt.javadsl.MqttSource;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.*;
 import akka.stream.testkit.TestSubscriber;
 import akka.stream.testkit.javadsl.TestSink;
@@ -24,7 +25,10 @@ import akka.util.ByteString;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
 
@@ -43,6 +47,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class MqttSourceTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
+  private static final Logger log = LoggerFactory.getLogger(MqttSourceTest.class);
 
   private static ActorSystem system;
   private static Materializer materializer;

--- a/mqtt/src/test/resources/logback-test.xml
+++ b/mqtt/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/mqtt/src/test/resources/logback-test.xml
+++ b/mqtt/src/test/resources/logback-test.xml
@@ -7,10 +7,23 @@
         </encoder>
     </appender>
 
-    <logger name="akka" level="info"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="akka.stream.alpakka" level="debug"/>
 
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/mqtt/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -5,44 +5,16 @@
 package docs.scaladsl
 
 import akka.Done
-import akka.actor.ActorSystem
 import akka.stream.alpakka.mqtt._
 import akka.stream.alpakka.mqtt.scaladsl.{MqttFlow, MqttMessageWithAck}
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
-import akka.stream.{ActorMaterializer, Materializer}
-import akka.testkit.TestKit
 import akka.util.ByteString
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
-import org.scalatest._
-import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.time.{Seconds, Span}
 
-import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpecLike
 
-class MqttFlowSpec
-    extends TestKit(ActorSystem("MqttFlowSpec"))
-    with AnyWordSpecLike
-    with Matchers
-    with BeforeAndAfterAll
-    with ScalaFutures
-    with Eventually
-    with IntegrationPatience {
-
-  val timeout = 5.seconds
-  implicit val defaultPatience =
-    PatienceConfig(timeout = 5.seconds, interval = 100.millis)
-
-  implicit val mat: Materializer = ActorMaterializer()
-  val connectionSettings = MqttConnectionSettings(
-    "tcp://localhost:1883",
-    "test-client",
-    new MemoryPersistence
-  )
-
-  override def afterAll() = TestKit.shutdownActorSystem(system)
+class MqttFlowSpec extends MqttSpecBase("MqttFlowSpec") {
 
   "mqtt flow" should {
     "establish a bidirectional connection and subscribe to a topic" in {

--- a/mqtt/src/test/scala/docs/scaladsl/MqttSinkSpec.scala
+++ b/mqtt/src/test/scala/docs/scaladsl/MqttSinkSpec.scala
@@ -5,49 +5,23 @@
 package docs.scaladsl
 
 import akka.Done
-import akka.actor.ActorSystem
 import akka.stream.alpakka.mqtt
-import akka.stream.{ActorMaterializer, Materializer}
-import akka.stream.alpakka.mqtt.scaladsl.{MqttSink, MqttSource}
 import akka.stream.alpakka.mqtt._
+import akka.stream.alpakka.mqtt.scaladsl.{MqttSink, MqttSource}
 import akka.stream.scaladsl.{Keep, Sink, Source}
-import akka.testkit.TestKit
 import akka.util.ByteString
-import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
 import org.eclipse.paho.client.mqttv3.{MqttException, MqttSecurityException}
-import org.scalatest._
-import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpecLike
 
-class MqttSinkSpec
-    extends TestKit(ActorSystem("MqttSinkSpec"))
-    with AnyWordSpecLike
-    with Matchers
-    with BeforeAndAfterAll
-    with ScalaFutures {
-
-  val timeout = 5.seconds
-  implicit val defaultPatience =
-    PatienceConfig(timeout = 5.seconds, interval = 100.millis)
-
-  implicit val mat: Materializer = ActorMaterializer()
-  val connectionSettings = MqttConnectionSettings(
-    "tcp://localhost:1883",
-    "test-client",
-    new MemoryPersistence
-  )
+class MqttSinkSpec extends MqttSpecBase("MqttSinkSpec") {
 
   val topic = "sink-spec/topic1"
   val topic2 = "sink-spec/topic2"
   val secureTopic = "sink-spec/secure-topic1"
 
   val sinkSettings = connectionSettings.withClientId(clientId = "sink-spec/sink")
-
-  override def afterAll() = TestKit.shutdownActorSystem(system)
 
   "mqtt sink" should {
     "send one message to a topic" in {

--- a/mqtt/src/test/scala/docs/scaladsl/MqttSourceSpec.scala
+++ b/mqtt/src/test/scala/docs/scaladsl/MqttSourceSpec.scala
@@ -4,55 +4,30 @@
 
 package docs.scaladsl
 
-import akka.actor.ActorSystem
 import akka.stream._
 import akka.stream.alpakka.mqtt._
 import akka.stream.alpakka.mqtt.scaladsl.{MqttMessageWithAck, MqttSink, MqttSource}
 import akka.stream.scaladsl._
 import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.TestKit
 import akka.util.ByteString
 import akka.{Done, NotUsed}
 import javax.net.ssl.SSLContext
 import org.eclipse.paho.client.mqttv3.MqttException
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
-import org.scalatest._
-import org.scalatest.concurrent.ScalaFutures
 import org.slf4j.LoggerFactory
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpecLike
 
-class MqttSourceSpec
-    extends TestKit(ActorSystem("MqttSourceSpec"))
-    with AnyWordSpecLike
-    with Matchers
-    with BeforeAndAfterAll
-    with ScalaFutures {
+class MqttSourceSpec extends MqttSpecBase("MqttSourceSpec") {
 
   val log = LoggerFactory.getLogger(classOf[MqttSourceSpec])
-
-  val timeout = 5.seconds
-  implicit val defaultPatience =
-    PatienceConfig(timeout = 5.seconds, interval = 100.millis)
-
-  implicit val mat: Materializer = ActorMaterializer()
-
-  val connectionSettings = MqttConnectionSettings(
-    "tcp://localhost:1883", // (1)
-    "test-scala-client", // (2)
-    new MemoryPersistence // (3)
-  )
 
   val topic1 = "source-spec/topic1"
 
   val sourceSettings = connectionSettings.withClientId(clientId = "source-spec/source")
   val sinkSettings = connectionSettings.withClientId(clientId = "source-spec/sink")
-
-  override def afterAll() = TestKit.shutdownActorSystem(system)
 
   /** Wrap a source with restart logic and exposes an equivalent materialized value.
    * Could be simplified when https://github.com/akka/akka/issues/24771 is solved.

--- a/mqtt/src/test/scala/docs/scaladsl/MqttSpecBase.scala
+++ b/mqtt/src/test/scala/docs/scaladsl/MqttSpecBase.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.scaladsl
+
+import akka.actor.ActorSystem
+import akka.stream.alpakka.mqtt.MqttConnectionSettings
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.testkit.TestKit
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.concurrent.duration._
+
+abstract class MqttSpecBase(name: String)
+    extends TestKit(ActorSystem(name))
+    with AnyWordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with Eventually
+    with IntegrationPatience
+    with LogCapturing {
+  implicit val mat: Materializer = ActorMaterializer()
+  val connectionSettings = MqttConnectionSettings(
+    "tcp://localhost:1883",
+    "test-client",
+    new MemoryPersistence
+  )
+
+  val timeout = 5.seconds
+
+  override def afterAll() = TestKit.shutdownActorSystem(system)
+
+}

--- a/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
+++ b/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
@@ -14,6 +14,7 @@ import akka.stream.alpakka.orientdb.OrientDbWriteSettings;
 import akka.stream.alpakka.orientdb.javadsl.OrientDbFlow;
 import akka.stream.alpakka.orientdb.javadsl.OrientDbSink;
 import akka.stream.alpakka.orientdb.javadsl.OrientDbSource;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
@@ -27,6 +28,7 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -42,6 +44,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 
 public class OrientDbTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static OServerAdmin oServerAdmin;
   private static OPartitionedDatabasePool oDatabase;

--- a/orientdb/src/test/resources/logback-test.xml
+++ b/orientdb/src/test/resources/logback-test.xml
@@ -8,10 +8,23 @@
     </appender>
 
 
-    <logger name="akka" level="info"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="akka.stream.alpakka" level="debug"/>
 
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/orientdb/src/test/resources/logback-test.xml
+++ b/orientdb/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala
+++ b/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala
@@ -13,6 +13,7 @@ import akka.stream.alpakka.orientdb.{
   OrientDbWriteMessage,
   OrientDbWriteSettings
 }
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -35,7 +36,7 @@ import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class OrientDbSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+class OrientDbSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with LogCapturing {
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 100.millis)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,13 +44,22 @@ object Dependencies {
   val Common = Seq(
     // These libraries are added to all modules via the `Common` AutoPlugin
     libraryDependencies ++= Seq(
+        "com.typesafe.akka" %% "akka-stream" % AkkaVersion
+      )
+  )
+
+  val testkit = Seq(
+    libraryDependencies := Seq(
+        "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1",
         "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-        "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion % Test,
-        "ch.qos.logback" % "logback-classic" % "1.2.3" % Test, // Eclipse Public License 1.0
-        "org.scalatest" %% "scalatest" % "3.1.0" % Test, // ApacheV2
-        "com.novocode" % "junit-interface" % "0.11" % Test, // BSD-style
-        "junit" % "junit" % "4.12" % Test // Eclipse Public License 1.0
+        "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
+        "ch.qos.logback" % "logback-classic" % "1.2.3", // Eclipse Public License 1.0
+        "org.scalatest" %% "scalatest" % "3.1.0", // ApacheV2
+        "com.novocode" % "junit-interface" % "0.11", // BSD-style
+        "org.scalatest" %% "scalatest" % "3.0.8", // ApacheV2
+        "ch.qos.logback" % "logback-classic" % "1.2.3", // Eclipse Public License 1.0
+        "junit" % "junit" % "4.12" // Eclipse Public License 1.0
       )
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,7 +57,6 @@ object Dependencies {
         "ch.qos.logback" % "logback-classic" % "1.2.3", // Eclipse Public License 1.0
         "org.scalatest" %% "scalatest" % "3.1.0", // ApacheV2
         "com.novocode" % "junit-interface" % "0.11", // BSD-style
-        "org.scalatest" %% "scalatest" % "3.0.8", // ApacheV2
         "ch.qos.logback" % "logback-classic" % "1.2.3", // Eclipse Public License 1.0
         "junit" % "junit" % "4.12" // Eclipse Public License 1.0
       )
@@ -125,7 +124,10 @@ object Dependencies {
   val `Doc-examples` = Seq(
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-stream-kafka" % "1.1.0"
+        "com.typesafe.akka" %% "akka-stream-kafka" % "1.1.0",
+        "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
+        "junit" % "junit" % "4.12" % Test, // Eclipse Public License 1.0
+        "org.scalatest" %% "scalatest" % "3.1.0" % Test // ApacheV2
       )
   )
 

--- a/reference/src/test/java/docs/javadsl/ReferenceTest.java
+++ b/reference/src/test/java/docs/javadsl/ReferenceTest.java
@@ -15,6 +15,7 @@ import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.reference.*;
 import akka.stream.alpakka.reference.javadsl.Reference;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
@@ -31,6 +32,7 @@ import java.util.stream.Collectors;
 
 /** Append "Test" to every Java test suite. */
 public class ReferenceTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   static ActorSystem sys;
   static Materializer mat;

--- a/reference/src/test/resources/application.conf
+++ b/reference/src/test/resources/application.conf
@@ -1,0 +1,6 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  loglevel = "DEBUG"
+}
+

--- a/reference/src/test/resources/logback-test.xml
+++ b/reference/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/reference/src/test/resources/logback-test.xml
+++ b/reference/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <configuration>
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/xml.log</file>
+        <file>target/reference.log</file>
         <append>false</append>
         <encoder>
             <pattern>%d{ISO8601} %-5level [%thread] [%logger{36}]  %msg%n</pattern>
@@ -20,6 +20,7 @@
     </logger>
 
     <logger name="akka" level="DEBUG"/>
+    <logger name="akka.stream.alpakka" level="debug"/>
 
     <root level="debug">
         <appender-ref ref="CapturingAppender"/>

--- a/reference/src/test/scala/docs/scaladsl/ReferenceSpec.scala
+++ b/reference/src/test/scala/docs/scaladsl/ReferenceSpec.scala
@@ -9,6 +9,7 @@ import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.alpakka.reference.scaladsl.Reference
 import akka.stream.alpakka.reference._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.testkit.TestKit
 import akka.util.ByteString
@@ -23,7 +24,7 @@ import org.scalatest.wordspec.AnyWordSpec
 /**
  * Append "Spec" to every Scala test suite.
  */
-class ReferenceSpec extends AnyWordSpec with BeforeAndAfterAll with ScalaFutures with Matchers {
+class ReferenceSpec extends AnyWordSpec with BeforeAndAfterAll with ScalaFutures with Matchers with LogCapturing {
 
   implicit val sys = ActorSystem("ReferenceSpec")
   implicit val mat: Materializer = ActorMaterializer()

--- a/s3/src/test/java/docs/javadsl/S3Test.java
+++ b/s3/src/test/java/docs/javadsl/S3Test.java
@@ -22,6 +22,7 @@ import akka.stream.alpakka.s3.headers.CustomerKeys;
 import akka.stream.alpakka.s3.headers.ServerSideEncryption;
 import akka.stream.alpakka.s3.javadsl.S3;
 import akka.stream.alpakka.s3.scaladsl.S3WireMockBase;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
@@ -29,6 +30,7 @@ import akka.util.ByteString;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -41,6 +43,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class S3Test extends S3WireMockBase {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem actorSystemForShutdown;
   private static WireMockServer wireMockServerForShutdown;

--- a/s3/src/test/resources/logback-test.xml
+++ b/s3/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/s3/src/test/resources/logback-test.xml
+++ b/s3/src/test/resources/logback-test.xml
@@ -7,11 +7,25 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="org.eclipse.jetty.io" level="info"/>
     <logger name="org.eclipse.jetty.util" level="info"/>
     <logger name="org.eclipse.jetty.servlet" level="warn"/>
 
     <root level="warn">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/DiskBufferSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/DiskBufferSpec.scala
@@ -6,7 +6,9 @@ package akka.stream.alpakka.s3.impl
 
 import java.nio.BufferOverflowException
 import java.nio.file.Files
+
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.{EventFilter, TestKit}
@@ -23,7 +25,8 @@ class DiskBufferSpec(_system: ActorSystem)
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures
-    with Eventually {
+    with Eventually
+    with LogCapturing {
 
   def this() = this(ActorSystem("DiskBufferSpec"))
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -18,12 +18,12 @@ import akka.stream.scaladsl.Source
 import akka.testkit.{SocketUtil, TestKit, TestProbe}
 import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.regions.providers._
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import software.amazon.awssdk.regions.Region
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
+class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures with IntegrationPatience {
 
   // test fixtures
   def getSettings(

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -9,21 +9,22 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri.Query
-import akka.http.scaladsl.model.headers.{`Raw-Request-URI`, ByteRange, RawHeader}
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{`Raw-Request-URI`, ByteRange, RawHeader}
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.s3.headers.{CannedAcl, ServerSideEncryption, StorageClass}
-import akka.stream.alpakka.s3.{ApiVersion, BufferType, MemoryBufferType, MetaHeaders, S3Headers, S3Settings}
+import akka.stream.alpakka.s3._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.Source
 import akka.testkit.{SocketUtil, TestKit, TestProbe}
-import software.amazon.awssdk.auth.credentials._
-import software.amazon.awssdk.regions.providers._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import software.amazon.awssdk.regions.Region
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.auth.credentials._
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.regions.providers._
 
-class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures with IntegrationPatience {
+class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures with IntegrationPatience with LogCapturing {
 
   // test fixtures
   def getSettings(
@@ -397,28 +398,29 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures with 
     import system.dispatcher
     implicit val materializer: ActorMaterializer = ActorMaterializer()
 
-    val probe = TestProbe()
-    val address = SocketUtil.temporaryServerAddress()
+    try {
+      val probe = TestProbe()
+      val address = SocketUtil.temporaryServerAddress()
 
-    import akka.http.scaladsl.server.Directives._
+      import akka.http.scaladsl.server.Directives._
 
-    Http().bindAndHandle(extractRequestContext { ctx =>
-      probe.ref ! ctx.request
-      complete("MOCK")
-    }, address.getHostName, address.getPort)
+      Http().bindAndHandle(extractRequestContext { ctx =>
+        probe.ref ! ctx.request
+        complete("MOCK")
+      }, address.getHostName, address.getPort)
 
-    implicit val setting: S3Settings =
-      getSettings().withEndpointUrl(s"http://${address.getHostName}:${address.getPort}/")
+      implicit val setting: S3Settings =
+        getSettings().withEndpointUrl(s"http://${address.getHostName}:${address.getPort}/")
 
-    val req =
-      HttpRequests.listBucket(location.bucket, Some("random/prefix"), Some("randomToken"))
+      val req =
+        HttpRequests.listBucket(location.bucket, Some("random/prefix"), Some("randomToken"))
 
-    Http().singleRequest(req).futureValue
+      Http().singleRequest(req).futureValue shouldBe a[HttpResponse]
 
-    probe.expectMsgType[HttpRequest]
-
-    materializer.shutdown()
-    TestKit.shutdownActorSystem(system)
+      probe.expectMsgType[HttpRequest]
+    } finally {
+      TestKit.shutdownActorSystem(system)
+    }
   }
 
   it should "add two (source, range) headers to multipart upload (copy) request when byte range populated" in {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/MarshallingSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/MarshallingSpec.scala
@@ -10,6 +10,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{MediaTypes, _}
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.stream.alpakka.s3.{ListBucketResultCommonPrefixes, ListBucketResultContents}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
@@ -23,7 +24,8 @@ class MarshallingSpec(_system: ActorSystem)
     with AnyFlatSpecLike
     with Matchers
     with ScalaFutures
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   def this() = this(ActorSystem("MarshallingSpec"))
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/MemoryBufferSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/MemoryBufferSpec.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.s3.impl
 
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.testkit.TestKit
@@ -20,7 +21,8 @@ class MemoryBufferSpec(_system: ActorSystem)
     with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
 
   def this() = this(ActorSystem("MemoryBufferSpec"))
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
 import akka.http.scaladsl.model.headers.ByteRange
 import akka.stream.alpakka.s3.BucketAccess.{AccessDenied, AccessGranted, NotExists}
 import akka.stream.alpakka.s3.{ApiVersion, BucketAccess, MemoryBufferType, S3Settings}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.TestKit
@@ -30,7 +31,8 @@ class S3StreamSpec(_system: ActorSystem)
     with BeforeAndAfterAll
     with PrivateMethodTester
     with ScalaFutures
-    with IntegrationPatience {
+    with IntegrationPatience
+    with LogCapturing {
 
   import HttpRequests._
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/SplitAfterSizeSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/SplitAfterSizeSpec.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.s3.impl
 
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -12,6 +13,7 @@ import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
+
 import scala.concurrent.duration._
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -21,7 +23,8 @@ class SplitAfterSizeSpec(_system: ActorSystem)
     with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
 
   def this() = this(ActorSystem("SplitAfterSizeSpec"))
   implicit val defaultPatience: PatienceConfig = PatienceConfig(1.seconds, 5.millis)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SignerSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SignerSpec.scala
@@ -9,6 +9,7 @@ import java.time.{LocalDateTime, ZoneOffset, ZonedDateTime}
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpMethods, HttpRequest}
 import akka.http.scaladsl.model.headers.{`Raw-Request-URI`, Host, RawHeader}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.Sink
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.TestKit
@@ -28,7 +29,8 @@ class SignerSpec(_system: ActorSystem)
     with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
   def this() = this(ActorSystem("SignerSpec"))
 
   implicit val defaultPatience =

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/StreamUtilsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/StreamUtilsSpec.scala
@@ -9,6 +9,7 @@ import java.nio.file.{Files, Path}
 import java.security.{DigestInputStream, MessageDigest}
 
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.stream.scaladsl.{Sink, Source, StreamConverters}
 import akka.testkit.TestKit
@@ -25,7 +26,8 @@ class StreamUtilsSpec(_system: ActorSystem)
     with AnyFlatSpecLike
     with Matchers
     with ScalaFutures
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with LogCapturing {
   def this() = this(ActorSystem("StreamUtilsSpec"))
 
   implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system).withDebugLogging(true))

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ClientIntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ClientIntegrationSpec.scala
@@ -6,6 +6,7 @@ package akka.stream.alpakka.s3.scaladsl
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest._
@@ -18,7 +19,8 @@ trait S3ClientIntegrationSpec
     with BeforeAndAfterEach
     with Matchers
     with ScalaFutures
-    with IntegrationPatience {
+    with IntegrationPatience
+    with LogCapturing {
 
   implicit val system: ActorSystem
   implicit val materializer = ActorMaterializer()

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ExtSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ExtSpec.scala
@@ -12,9 +12,6 @@ import scala.collection.JavaConverters._
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
- */
 class S3ExtSpec extends AnyFlatSpecLike with Matchers {
   it should "reuse application config from actor system" in {
     val config = ConfigFactory.parseMap(

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -12,6 +12,7 @@ import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.s3.BucketAccess.{AccessGranted, NotExists}
 import akka.stream.alpakka.s3._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.testkit.TestKit
 import akka.util.ByteString
@@ -32,7 +33,8 @@ trait S3IntegrationSpec
     with BeforeAndAfterAll
     with Matchers
     with ScalaFutures
-    with OptionValues {
+    with OptionValues
+    with LogCapturing {
 
   implicit val actorSystem: ActorSystem = ActorSystem(
     "S3IntegrationSpec",

--- a/simple-codecs/src/test/java/docs/javadsl/RecordIOFramingTest.java
+++ b/simple-codecs/src/test/java/docs/javadsl/RecordIOFramingTest.java
@@ -8,11 +8,13 @@ import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.alpakka.recordio.javadsl.RecordIOFraming;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
 import org.junit.AfterClass;
+import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
@@ -24,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 public class RecordIOFramingTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final ActorSystem system = ActorSystem.create();
   private static final ActorMaterializer materializer = ActorMaterializer.create(system);

--- a/simple-codecs/src/test/resources/application.conf
+++ b/simple-codecs/src/test/resources/application.conf
@@ -1,0 +1,6 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  loglevel = "DEBUG"
+}
+

--- a/simple-codecs/src/test/resources/logback-test.xml
+++ b/simple-codecs/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/simple-codecs/src/test/resources/logback-test.xml
+++ b/simple-codecs/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <configuration>
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/xml.log</file>
+        <file>target/record-io.log</file>
         <append>false</append>
         <encoder>
             <pattern>%d{ISO8601} %-5level [%thread] [%logger{36}]  %msg%n</pattern>
@@ -20,6 +20,7 @@
     </logger>
 
     <logger name="akka" level="DEBUG"/>
+    <logger name="akka.stream.alpakka" level="debug"/>
 
     <root level="debug">
         <appender-ref ref="CapturingAppender"/>

--- a/simple-codecs/src/test/scala/docs/scaladsl/RecordIOFramingSpec.scala
+++ b/simple-codecs/src/test/scala/docs/scaladsl/RecordIOFramingSpec.scala
@@ -6,6 +6,7 @@ package docs.scaladsl
 
 import akka.NotUsed
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.{ActorMaterializer, Materializer}
 //#run-via-scanner
 import akka.stream.alpakka.recordio.scaladsl.RecordIOFraming
@@ -27,7 +28,8 @@ class RecordIOFramingSpec(_system: ActorSystem)
     with AnyFlatSpecLike
     with Matchers
     with ScalaFutures
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with LogCapturing {
   def this() = this(ActorSystem("RecordIOFramingSpec"))
 
   override protected def afterAll(): Unit = shutdown()

--- a/slick/src/test/java/docs/javadsl/SlickTest.java
+++ b/slick/src/test/java/docs/javadsl/SlickTest.java
@@ -12,14 +12,12 @@ import akka.stream.Materializer;
 import akka.stream.alpakka.slick.javadsl.Slick;
 import akka.stream.alpakka.slick.javadsl.SlickRow;
 import akka.stream.alpakka.slick.javadsl.SlickSession;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -37,6 +35,8 @@ import static org.junit.Assert.assertEquals;
  * storage.
  */
 public class SlickTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static ActorSystem system;
   private static Materializer materializer;
 

--- a/slick/src/test/resources/logback-test.xml
+++ b/slick/src/test/resources/logback-test.xml
@@ -7,10 +7,24 @@
     </encoder>
   </appender>
 
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+  <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
+  <logger name="akka" level="DEBUG"/>
   <logger name="slick.basic" level="info" />
   <logger name="slick.jdbc" level="info" />
 
   <root level="debug">
+    <appender-ref ref="CapturingAppender"/>
     <appender-ref ref="FILE" />
   </root>
 </configuration>

--- a/slick/src/test/resources/logback-test.xml
+++ b/slick/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
   <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-  <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+  <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/slick/src/test/scala/docs/scaladsl/SlickSpec.scala
+++ b/slick/src/test/scala/docs/scaladsl/SlickSpec.scala
@@ -8,6 +8,7 @@ import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.slick.scaladsl.{Slick, SlickSession}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl._
 import akka.testkit.TestKit
 import org.scalatest._
@@ -25,7 +26,13 @@ import org.scalatest.wordspec.AnyWordSpec
  * This unit test is run using a local H2 database using
  * `/tmp/alpakka-slick-h2-test` for temporary storage.
  */
-class SlickSpec extends AnyWordSpec with ScalaFutures with BeforeAndAfterEach with BeforeAndAfterAll with Matchers {
+class SlickSpec
+    extends AnyWordSpec
+    with ScalaFutures
+    with BeforeAndAfterEach
+    with BeforeAndAfterAll
+    with Matchers
+    with LogCapturing {
   //#init-mat
   implicit val system = ActorSystem()
   implicit val mat = ActorMaterializer()

--- a/sns/src/test/java/docs/javadsl/SnsPublisherTest.java
+++ b/sns/src/test/java/docs/javadsl/SnsPublisherTest.java
@@ -9,6 +9,7 @@ import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.sns.javadsl.SnsPublisher;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
@@ -16,6 +17,7 @@ import akka.testkit.javadsl.TestKit;
 // #init-client
 import java.net.URI;
 import com.github.matsluni.akkahttpspi.AkkaHttpClient;
+import org.junit.Rule;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -36,6 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 public class SnsPublisherTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   static ActorSystem system;
   static Materializer materializer;

--- a/sns/src/test/resources/logback-test.xml
+++ b/sns/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
   <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-  <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+  <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/sns/src/test/resources/logback-test.xml
+++ b/sns/src/test/resources/logback-test.xml
@@ -7,8 +7,21 @@
     </encoder>
   </appender>
 
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+  <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
   <logger name="akka" level="DEBUG"/>
   <root level="debug">
+    <appender-ref ref="CapturingAppender"/>
     <appender-ref ref="FILE" />
   </root>
 </configuration>

--- a/sns/src/test/scala/akka/stream/alpakka/sns/SnsPublishMockingSpec.scala
+++ b/sns/src/test/scala/akka/stream/alpakka/sns/SnsPublishMockingSpec.scala
@@ -7,6 +7,7 @@ package akka.stream.alpakka.sns
 import java.util.concurrent.CompletableFuture
 
 import akka.stream.alpakka.sns.scaladsl.SnsPublisher
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Keep, Sink}
 import akka.stream.testkit.scaladsl.TestSource
 import org.mockito.ArgumentMatchers.{any, eq => meq}
@@ -18,7 +19,7 @@ import software.amazon.awssdk.services.sns.model.{PublishRequest, PublishRespons
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class SnsPublishMockingSpec extends AnyFlatSpec with DefaultTestContext with Matchers {
+class SnsPublishMockingSpec extends AnyFlatSpec with DefaultTestContext with Matchers with LogCapturing {
 
   it should "publish a single PublishRequest message to sns" in {
     val publishRequest = PublishRequest.builder().topicArn("topic-arn").message("sns-message").build()

--- a/sns/src/test/scala/docs/scaladsl/SnsPublisherSpec.scala
+++ b/sns/src/test/scala/docs/scaladsl/SnsPublisherSpec.scala
@@ -7,6 +7,7 @@ package docs.scaladsl
 import akka.Done
 import akka.stream.alpakka.sns.IntegrationTestContext
 import akka.stream.alpakka.sns.scaladsl.SnsPublisher
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
@@ -16,7 +17,12 @@ import software.amazon.awssdk.services.sns.model.PublishRequest
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class SnsPublisherSpec extends AnyFlatSpec with Matchers with ScalaFutures with IntegrationTestContext {
+class SnsPublisherSpec
+    extends AnyFlatSpec
+    with Matchers
+    with ScalaFutures
+    with IntegrationTestContext
+    with LogCapturing {
 
   implicit val defaultPatience =
     PatienceConfig(timeout = 15.seconds, interval = 100.millis)

--- a/solr/src/test/java/docs/javadsl/SolrTest.java
+++ b/solr/src/test/java/docs/javadsl/SolrTest.java
@@ -15,6 +15,7 @@ import akka.stream.alpakka.solr.WriteMessage;
 import akka.stream.alpakka.solr.javadsl.SolrFlow;
 import akka.stream.alpakka.solr.javadsl.SolrSink;
 import akka.stream.alpakka.solr.javadsl.SolrSource;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
@@ -40,6 +41,7 @@ import org.apache.solr.cloud.ZkTestServer;
 import org.apache.solr.common.SolrInputDocument;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
@@ -57,6 +59,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class SolrTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static MiniSolrCloudCluster cluster;
   private static SolrClient solrClient;
   private static SolrClient cl;

--- a/solr/src/test/resources/logback-test.xml
+++ b/solr/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/solr/src/test/resources/logback-test.xml
+++ b/solr/src/test/resources/logback-test.xml
@@ -7,12 +7,26 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="org.apache.solr" level="warn"/>
     <logger name="org.apache.zookeeper" level="warn"/>
     <logger name="org.eclipse.jetty" level="warn"/>
     <logger name="org.apache.http" level="warn"/>
 
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
+++ b/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
@@ -12,6 +12,7 @@ import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.alpakka.solr._
 import akka.stream.alpakka.solr.scaladsl.{SolrFlow, SolrSink, SolrSource}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.testkit.TestKit
@@ -33,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class SolrSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+class SolrSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with LogCapturing {
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds)
 

--- a/spring-web/src/test/java/docs/javadsl/SampleController.java
+++ b/spring-web/src/test/java/docs/javadsl/SampleController.java
@@ -10,7 +10,6 @@ import javax.annotation.PostConstruct;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.event.LoggingAdapter;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Source;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;

--- a/spring-web/src/test/resources/logback-test.xml
+++ b/spring-web/src/test/resources/logback-test.xml
@@ -7,7 +7,22 @@
     </encoder>
   </appender>
 
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+  <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
+  <logger name="akka" level="DEBUG"/>
+
   <root level="debug">
+    <appender-ref ref="CapturingAppender"/>
     <appender-ref ref="FILE" />
   </root>
 </configuration>

--- a/spring-web/src/test/resources/logback-test.xml
+++ b/spring-web/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
   <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-  <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+  <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/BaseSqsTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/BaseSqsTest.java
@@ -7,9 +7,11 @@ package akka.stream.alpakka.sqs.javadsl;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.testkit.javadsl.TestKit;
 // #init-client
 import com.github.matsluni.akkahttpspi.AkkaHttpClient;
+import org.junit.Rule;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -26,6 +28,8 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 public abstract class BaseSqsTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   protected static ActorSystem system;
   protected static Materializer materializer;

--- a/sqs/src/test/resources/logback-test.xml
+++ b/sqs/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/sqs/src/test/resources/logback-test.xml
+++ b/sqs/src/test/resources/logback-test.xml
@@ -7,7 +7,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/SqsModelSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/SqsModelSpec.scala
@@ -6,12 +6,13 @@ package akka.stream.alpakka.sqs
 
 import akka.stream.alpakka.sqs.SqsAckResult._
 import akka.stream.alpakka.sqs.SqsAckResultEntry._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.awscore.DefaultAwsResponseMetadata
 import software.amazon.awssdk.services.sqs.model._
 
-class SqsModelSpec extends AnyFlatSpec with Matchers {
+class SqsModelSpec extends AnyFlatSpec with Matchers with LogCapturing {
 
   val msg = Message.builder().build()
   val otherMsg = Message.builder().body("other-body").build()

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/MessageAttributeNameSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/MessageAttributeNameSpec.scala
@@ -5,10 +5,11 @@
 package akka.stream.alpakka.sqs.scaladsl
 
 import akka.stream.alpakka.sqs.MessageAttributeName
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class MessageAttributeNameSpec extends AnyFlatSpec with Matchers {
+class MessageAttributeNameSpec extends AnyFlatSpec with Matchers with LogCapturing {
 
   it should "not allow names which have periods at the beginning" in {
     a[IllegalArgumentException] should be thrownBy {

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
@@ -10,6 +10,7 @@ import java.util.function.Supplier
 
 import akka.Done
 import akka.stream.alpakka.sqs._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.Keep
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSource
@@ -24,7 +25,7 @@ import software.amazon.awssdk.services.sqs.model._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestContext {
+class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestContext with LogCapturing {
 
   "SqsPublishSink" should "send a message" in assertAllStagesStopped {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceMockSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceMockSpec.scala
@@ -7,6 +7,7 @@ package akka.stream.alpakka.sqs.scaladsl
 import java.util.concurrent.CompletableFuture
 
 import akka.stream.alpakka.sqs.SqsSourceSettings
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
 import org.mockito.ArgumentMatchers._
@@ -23,11 +24,10 @@ import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class SqsSourceMockSpec extends AnyFlatSpec with Matchers with DefaultTestContext {
+class SqsSourceMockSpec extends AnyFlatSpec with Matchers with DefaultTestContext with LogCapturing {
 
   override def createAsyncClient(sqsEndpoint: String): SqsAsyncClient = ???
   override def closeSqsClient(): Unit = ()
-
   val defaultMessages = (1 to 10).map { i =>
     Message.builder().body(s"message $i").build()
   }

--- a/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
@@ -12,6 +12,7 @@ import akka.stream.alpakka.sqs.scaladsl._
 import akka.stream.alpakka.sqs._
 import akka.stream.alpakka.sqs.SqsAckResult._
 import akka.stream.alpakka.sqs.SqsAckResultEntry._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.mockito.ArgumentMatchers.any
@@ -25,7 +26,7 @@ import software.amazon.awssdk.services.sqs.model._
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
-class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext {
+class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with LogCapturing {
 
   trait IntegrationFixture {
     val queueUrl: String = randomQueueUrl()

--- a/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit
 import akka.Done
 import akka.stream.alpakka.sqs._
 import akka.stream.alpakka.sqs.scaladsl._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.scalatest.flatspec.AnyFlatSpec
@@ -19,7 +20,7 @@ import software.amazon.awssdk.services.sqs.model.{Message, ReceiveMessageRequest
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
-class SqsPublishSpec extends AnyFlatSpec with Matchers with DefaultTestContext {
+class SqsPublishSpec extends AnyFlatSpec with Matchers with DefaultTestContext with LogCapturing {
 
   abstract class IntegrationFixture(fifo: Boolean = false) {
     val queueUrl: String = if (fifo) randomFifoQueueUrl() else randomQueueUrl()

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -11,6 +11,7 @@ import akka.Done
 import akka.stream.KillSwitches
 import akka.stream.alpakka.sqs._
 import akka.stream.alpakka.sqs.scaladsl.{DefaultTestContext, SqsSource}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Keep, Sink}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import com.github.matsluni.akkahttpspi.AkkaHttpClient
@@ -34,7 +35,7 @@ import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class SqsSourceSpec extends AnyFlatSpec with ScalaFutures with Matchers with DefaultTestContext {
+class SqsSourceSpec extends AnyFlatSpec with ScalaFutures with Matchers with DefaultTestContext with LogCapturing {
 
   import SqsSourceSpec._
 

--- a/sse/src/test/resources/logback-test.xml
+++ b/sse/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/sse/src/test/resources/logback-test.xml
+++ b/sse/src/test/resources/logback-test.xml
@@ -7,7 +7,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/testkit/src/main/scala/akka.stream.alpakka.testkit/CapturingAppender.scala
+++ b/testkit/src/main/scala/akka.stream.alpakka.testkit/CapturingAppender.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.testkit
+
+import akka.annotation.InternalApi
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+
+/**
+ * See https://doc.akka.io/docs/akka/current/typed/testing-async.html#silence-logging-output-from-tests
+ *
+ * INTERNAL API
+ */
+@InternalApi private[akka] object CapturingAppender {
+  import LogbackUtil._
+
+  private val CapturingAppenderName = "CapturingAppender"
+
+  def get(loggerName: String): CapturingAppender = {
+    val logbackLogger = getLogbackLogger(loggerName)
+    logbackLogger.getAppender(CapturingAppenderName) match {
+      case null =>
+        throw new IllegalStateException(
+          s"$CapturingAppenderName not defined for [${loggerNameOrRoot(loggerName)}] in logback-test.xml"
+        )
+      case appender: CapturingAppender => appender
+      case other =>
+        throw new IllegalStateException(s"Unexpected $CapturingAppender: $other")
+    }
+  }
+
+}
+
+/**
+ * See https://doc.akka.io/docs/akka/current/typed/testing-async.html#silence-logging-output-from-tests
+ *
+ * INTERNAL API
+ *
+ * Logging from tests can be silenced by this appender. When there is a test failure
+ * the captured logging events are flushed to the appenders defined for the
+ * akka.actor.testkit.typed.internal.CapturingAppenderDelegate logger.
+ *
+ * The flushing on test failure is handled by [[akka.actor.testkit.typed.scaladsl.LogCapturing]]
+ * for ScalaTest and [[akka.actor.testkit.typed.javadsl.LogCapturing]] for JUnit.
+ *
+ * Use configuration like the following the logback-test.xml:
+ *
+ * {{{
+ *     <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+ *
+ *     <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+ *       <appender-ref ref="STDOUT"/>
+ *     </logger>
+ *
+ *     <root level="DEBUG">
+ *         <appender-ref ref="CapturingAppender"/>
+ *     </root>
+ * }}}
+ */
+@InternalApi private[akka] class CapturingAppender extends AppenderBase[ILoggingEvent] {
+  import LogbackUtil._
+
+  private var buffer: Vector[ILoggingEvent] = Vector.empty
+
+  // invocations are synchronized via doAppend in AppenderBase
+  override def append(event: ILoggingEvent): Unit = {
+    event.prepareForDeferredProcessing()
+    buffer :+= event
+  }
+
+  /**
+   * Flush buffered logging events to the output appenders
+   * Also clears the buffer..
+   */
+  def flush(): Unit = synchronized {
+    import scala.jdk.CollectionConverters._
+    val logbackLogger = getLogbackLogger(classOf[CapturingAppender].getName + "Delegate")
+    val appenders = logbackLogger.iteratorForAppenders().asScala.filterNot(_ == this).toList
+    for (event <- buffer; appender <- appenders) {
+      appender.doAppend(event)
+    }
+    clear()
+  }
+
+  /**
+   * Discards the buffered logging events without output.
+   */
+  def clear(): Unit = synchronized {
+    buffer = Vector.empty
+  }
+
+}

--- a/testkit/src/main/scala/akka.stream.alpakka.testkit/CapturingAppender.scala
+++ b/testkit/src/main/scala/akka.stream.alpakka.testkit/CapturingAppender.scala
@@ -7,6 +7,7 @@ package akka.stream.alpakka.testkit
 import akka.annotation.InternalApi
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.AppenderBase
+import org.slf4j.LoggerFactory
 
 /**
  * See https://doc.akka.io/docs/akka/current/typed/testing-async.html#silence-logging-output-from-tests
@@ -16,7 +17,11 @@ import ch.qos.logback.core.AppenderBase
 @InternalApi private[akka] object CapturingAppender {
   import LogbackUtil._
 
+  // make sure logging is booted
+  private val dummy = LoggerFactory.getLogger("logcapture")
   private val CapturingAppenderName = "CapturingAppender"
+
+  dummy.debug("enabling CapturingAppender")
 
   def get(loggerName: String): CapturingAppender = {
     val logbackLogger = getLogbackLogger(loggerName)

--- a/testkit/src/main/scala/akka.stream.alpakka.testkit/LogbackUtil.scala
+++ b/testkit/src/main/scala/akka.stream.alpakka.testkit/LogbackUtil.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.testkit
+
+import akka.annotation.InternalApi
+import ch.qos.logback.classic.Level
+import org.slf4j.LoggerFactory
+
+/**
+ * See https://doc.akka.io/docs/akka/current/typed/testing-async.html#silence-logging-output-from-tests
+ *
+ * INTERNAL API
+ */
+@InternalApi private[akka] object LogbackUtil {
+  def loggerNameOrRoot(loggerName: String): String =
+    if (loggerName == "") org.slf4j.Logger.ROOT_LOGGER_NAME else loggerName
+
+  def getLogbackLogger(loggerName: String): ch.qos.logback.classic.Logger = {
+    LoggerFactory.getLogger(loggerNameOrRoot(loggerName)) match {
+      case logger: ch.qos.logback.classic.Logger => logger
+      case null =>
+        throw new IllegalArgumentException(s"Couldn't find logger for [$loggerName].")
+      case other =>
+        throw new IllegalArgumentException(
+          s"Requires Logback logger for [$loggerName], it was a [${other.getClass.getName}]"
+        )
+    }
+  }
+
+  def convertLevel(level: ch.qos.logback.classic.Level): Level = {
+    level.levelInt match {
+      case ch.qos.logback.classic.Level.TRACE_INT => Level.TRACE
+      case ch.qos.logback.classic.Level.DEBUG_INT => Level.DEBUG
+      case ch.qos.logback.classic.Level.INFO_INT => Level.INFO
+      case ch.qos.logback.classic.Level.WARN_INT => Level.WARN
+      case ch.qos.logback.classic.Level.ERROR_INT => Level.ERROR
+      case _ =>
+        throw new IllegalArgumentException("Level " + level.levelStr + ", " + level.levelInt + " is unknown.")
+    }
+  }
+}

--- a/testkit/src/main/scala/akka.stream.alpakka.testkit/javadsl/LogCapturingJunit4.scala
+++ b/testkit/src/main/scala/akka.stream.alpakka.testkit/javadsl/LogCapturingJunit4.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.testkit.javadsl
+
+import akka.stream.alpakka.testkit.CapturingAppender
+
+import scala.util.control.NonFatal
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import org.slf4j.LoggerFactory
+
+/**
+ * See https://doc.akka.io/docs/akka/current/typed/testing-async.html#silence-logging-output-from-tests
+ *
+ * JUnit `TestRule` to make log lines appear only when the test failed.
+ *
+ * Use this in test by adding a public field annotated with `@TestRule`:
+ * {{{
+ *   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+ * }}}
+ *
+ * Requires Logback and configuration like the following the logback-test.xml:
+ *
+ * {{{
+ *     <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+ *
+ *     <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+ *       <appender-ref ref="STDOUT"/>
+ *     </logger>
+ *
+ *     <root level="DEBUG">
+ *         <appender-ref ref="CapturingAppender"/>
+ *     </root>
+ * }}}
+ */
+final class LogCapturingJunit4 extends TestRule {
+  // eager access of CapturingAppender to fail fast if misconfigured
+  private val capturingAppender = CapturingAppender.get("")
+
+  private val myLogger = LoggerFactory.getLogger(classOf[LogCapturingJunit4])
+
+  override def apply(base: Statement, description: Description): Statement = {
+    new Statement {
+      override def evaluate(): Unit = {
+        try {
+          myLogger.info(s"Logging started for test [${description.getClassName}: ${description.getMethodName}]")
+          base.evaluate()
+          myLogger.info(
+            s"Logging finished for test [${description.getClassName}: ${description.getMethodName}] that was successful"
+          )
+        } catch {
+          case NonFatal(e) =>
+            println(
+              s"--> [${Console.BLUE}${description.getClassName}: ${description.getMethodName}${Console.RESET}] " +
+              s"Start of log messages of test that failed with ${e.getMessage}"
+            )
+            capturingAppender.flush()
+            println(
+              s"<-- [${Console.BLUE}${description.getClassName}: ${description.getMethodName}${Console.RESET}] " +
+              s"End of log messages of test that failed with ${e.getMessage}"
+            )
+            throw e
+        } finally {
+          capturingAppender.clear()
+        }
+      }
+    }
+  }
+}

--- a/testkit/src/main/scala/akka.stream.alpakka.testkit/javadsl/LogCapturingJunit4.scala
+++ b/testkit/src/main/scala/akka.stream.alpakka.testkit/javadsl/LogCapturingJunit4.scala
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory
  *
  * JUnit `TestRule` to make log lines appear only when the test failed.
  *
- * Use this in test by adding a public field annotated with `@TestRule`:
+ * Use this in test by adding a public field annotated with `@Rule`:
  * {{{
  *   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
  * }}}

--- a/testkit/src/main/scala/akka.stream.alpakka.testkit/scaladsl/LogCapturing.scala
+++ b/testkit/src/main/scala/akka.stream.alpakka.testkit/scaladsl/LogCapturing.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.testkit.scaladsl
+
+import akka.stream.alpakka.testkit.CapturingAppender
+
+import scala.util.control.NonFatal
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.Outcome
+import org.scalatest.TestSuite
+import org.slf4j.LoggerFactory
+
+/**
+ * See https://doc.akka.io/docs/akka/current/typed/testing-async.html#silence-logging-output-from-tests
+ *
+ * Mixin this trait to a ScalaTest test to make log lines appear only when the test failed.
+ *
+ * Requires Logback and configuration like the following the logback-test.xml:
+ *
+ * {{{
+ *     <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+ *
+ *     <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+ *       <appender-ref ref="STDOUT"/>
+ *     </logger>
+ *
+ *     <root level="DEBUG">
+ *         <appender-ref ref="CapturingAppender"/>
+ *     </root>
+ * }}}
+ */
+trait LogCapturing extends BeforeAndAfterAll { self: TestSuite =>
+
+  // eager access of CapturingAppender to fail fast if misconfigured
+  private val capturingAppender = CapturingAppender.get("")
+
+  private val myLogger = LoggerFactory.getLogger(classOf[LogCapturing])
+
+  override protected def afterAll(): Unit = {
+    try {
+      super.afterAll()
+    } catch {
+      case NonFatal(e) =>
+        myLogger.error("Exception from afterAll", e)
+        capturingAppender.flush()
+    } finally {
+      capturingAppender.clear()
+    }
+  }
+
+  abstract override def withFixture(test: NoArgTest): Outcome = {
+    myLogger.info(s"Logging started for test [${self.getClass.getName}: ${test.name}]")
+    val res = test()
+    myLogger.info(s"Logging finished for test [${self.getClass.getName}: ${test.name}] that [$res]")
+
+    if (!(res.isSucceeded || res.isPending)) {
+      println(
+        s"--> [${Console.BLUE}${self.getClass.getName}: ${test.name}${Console.RESET}] Start of log messages of test that [$res]"
+      )
+      capturingAppender.flush()
+      println(
+        s"<-- [${Console.BLUE}${self.getClass.getName}: ${test.name}${Console.RESET}] End of log messages of test that [$res]"
+      )
+    }
+
+    res
+  }
+}

--- a/text/src/test/java/docs/javadsl/CharsetCodingFlowsDoc.java
+++ b/text/src/test/java/docs/javadsl/CharsetCodingFlowsDoc.java
@@ -9,6 +9,7 @@ import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 
 // #encoding
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.alpakka.text.javadsl.TextFlow;
 import akka.stream.IOResult;
 import akka.stream.javadsl.FileIO;
@@ -21,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 // #encoding
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.nio.file.Path;
@@ -35,6 +37,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.*;
 
 public class CharsetCodingFlowsDoc {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final ActorSystem system = ActorSystem.create();
   private static final Materializer materializer = ActorMaterializer.create(system);

--- a/text/src/test/resources/application.conf
+++ b/text/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  loglevel = "DEBUG"
+}

--- a/text/src/test/resources/logback-test.xml
+++ b/text/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/text/src/test/resources/logback-test.xml
+++ b/text/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <configuration>
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/xml.log</file>
+        <file>target/text.log</file>
         <append>false</append>
         <encoder>
             <pattern>%d{ISO8601} %-5level [%thread] [%logger{36}]  %msg%n</pattern>

--- a/text/src/test/scala/akka/stream/alpakka/text/scaladsl/CharsetCodingFlowsSpec.scala
+++ b/text/src/test/scala/akka/stream/alpakka/text/scaladsl/CharsetCodingFlowsSpec.scala
@@ -9,6 +9,7 @@ import java.nio.file.Paths
 
 import akka.Done
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.stream.{ActorMaterializer, IOResult, Materializer}
@@ -30,7 +31,8 @@ class CharsetCodingFlowsSpec
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures
-    with RecoverMethods {
+    with RecoverMethods
+    with LogCapturing {
 
   private implicit val mat: Materializer = ActorMaterializer()
   private implicit val executionContext: ExecutionContextExecutor = system.dispatcher

--- a/text/src/test/scala/docs/scaladsl/CharsetCodingFlowsDoc.scala
+++ b/text/src/test/scala/docs/scaladsl/CharsetCodingFlowsDoc.scala
@@ -8,6 +8,7 @@ import java.nio.file.Paths
 
 import akka.Done
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.{ActorMaterializer, IOResult, Materializer}
 import akka.testkit.TestKit
@@ -27,7 +28,8 @@ class CharsetCodingFlowsDoc
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures
-    with RecoverMethods {
+    with RecoverMethods
+    with LogCapturing {
 
   private implicit val mat: Materializer = ActorMaterializer()
 

--- a/udp/src/test/java/docs/javadsl/UdpTest.java
+++ b/udp/src/test/java/docs/javadsl/UdpTest.java
@@ -8,6 +8,7 @@ import akka.actor.ActorSystem;
 import akka.japi.Pair;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.alpakka.udp.Datagram;
 import akka.stream.alpakka.udp.javadsl.Udp;
 import akka.stream.javadsl.Flow;
@@ -21,12 +22,15 @@ import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.CompletionStage;
 
 public class UdpTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static ActorSystem system;
   private static Materializer materializer;
 

--- a/udp/src/test/resources/application.conf
+++ b/udp/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  loglevel = "DEBUG"
+}

--- a/udp/src/test/resources/logback-test.xml
+++ b/udp/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/udp/src/test/resources/logback-test.xml
+++ b/udp/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <configuration>
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/xml.log</file>
+        <file>target/udp.log</file>
         <append>false</append>
         <encoder>
             <pattern>%d{ISO8601} %-5level [%thread] [%logger{36}]  %msg%n</pattern>

--- a/udp/src/test/scala/docs/scaladsl/UdpSpec.scala
+++ b/udp/src/test/scala/docs/scaladsl/UdpSpec.scala
@@ -8,6 +8,7 @@ import java.net.InetSocketAddress
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.alpakka.udp.Datagram
 import akka.stream.alpakka.udp.scaladsl.Udp
 import akka.stream.scaladsl.{Flow, Keep, Source}
@@ -27,7 +28,8 @@ class UdpSpec
     with AnyWordSpecLike
     with Matchers
     with ScalaFutures
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   implicit val mat = ActorMaterializer()
   implicit val pat = PatienceConfig(3.seconds, 50.millis)

--- a/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
+++ b/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
@@ -4,16 +4,16 @@
 
 package docs.javadsl;
 
+import akka.Done;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
+import akka.stream.KillSwitch;
+import akka.stream.KillSwitches;
 import akka.stream.Materializer;
 import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.alpakka.unixdomainsocket.javadsl.UnixDomainSocket;
-import akka.stream.javadsl.Flow;
-import akka.stream.javadsl.Framing;
-import akka.stream.javadsl.FramingTruncation;
-import akka.stream.javadsl.Source;
+import akka.stream.javadsl.*;
 import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
 import org.junit.AfterClass;
@@ -25,15 +25,18 @@ import akka.japi.Pair;
 
 import java.nio.file.Files;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 import akka.stream.alpakka.unixdomainsocket.javadsl.UnixDomainSocket.IncomingConnection;
 import akka.stream.alpakka.unixdomainsocket.javadsl.UnixDomainSocket.ServerBinding;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UnixDomainSocketTest {
 
-  @Rule
-  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
+  private static final Logger log = LoggerFactory.getLogger(UnixDomainSocketTest.class);
   private static ActorSystem system;
   private static Materializer materializer;
 
@@ -69,22 +72,31 @@ public class UnixDomainSocketTest {
     // #binding
 
     // #outgoingConnection
-    connections.runForeach(
-        connection -> {
-          System.out.println("New connection from: " + connection.remoteAddress());
+    CompletionStage<ServerBinding> streamCompletion =
+        connections
+            .map(
+                connection -> {
+                  System.out.println("New connection from: " + connection.remoteAddress());
 
-          final Flow<ByteString, ByteString, NotUsed> echo =
-              Flow.of(ByteString.class)
-                  .via(
-                      Framing.delimiter(
-                          ByteString.fromString("\n"), 256, FramingTruncation.DISALLOW))
-                  .map(ByteString::utf8String)
-                  .map(s -> s + "!!!\n")
-                  .map(ByteString::fromString);
+                  final Flow<ByteString, ByteString, NotUsed> echo =
+                      Flow.of(ByteString.class)
+                          .via(
+                              Framing.delimiter(
+                                  ByteString.fromString("\n"), 256, FramingTruncation.DISALLOW))
+                          .map(ByteString::utf8String)
+                          .map(s -> s + "!!!\n")
+                          .map(ByteString::fromString);
 
-          connection.handleWith(echo, materializer);
-        },
-        materializer);
+                  return connection.handleWith(echo, materializer);
+                })
+            .toMat(Sink.ignore(), Keep.left())
+            .run(materializer);
     // #outgoingConnection
+    streamCompletion
+        .toCompletableFuture()
+        .get(2, TimeUnit.SECONDS)
+        .unbind()
+        .toCompletableFuture()
+        .get(5, TimeUnit.SECONDS);
   }
 }

--- a/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
+++ b/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
@@ -76,7 +76,7 @@ public class UnixDomainSocketTest {
         connections
             .map(
                 connection -> {
-                  System.out.println("New connection from: " + connection.remoteAddress());
+                  log.info("New connection from: {}", connection.remoteAddress());
 
                   final Flow<ByteString, ByteString, NotUsed> echo =
                       Flow.of(ByteString.class)

--- a/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
+++ b/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
@@ -8,6 +8,7 @@ import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.alpakka.unixdomainsocket.javadsl.UnixDomainSocket;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Framing;
@@ -17,6 +18,7 @@ import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import akka.japi.Pair;
@@ -28,6 +30,9 @@ import akka.stream.alpakka.unixdomainsocket.javadsl.UnixDomainSocket.IncomingCon
 import akka.stream.alpakka.unixdomainsocket.javadsl.UnixDomainSocket.ServerBinding;
 
 public class UnixDomainSocketTest {
+
+  @Rule
+  public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Materializer materializer;

--- a/unix-domain-socket/src/test/resources/logback-test.xml
+++ b/unix-domain-socket/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/unix-domain-socket/src/test/resources/logback-test.xml
+++ b/unix-domain-socket/src/test/resources/logback-test.xml
@@ -7,7 +7,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
+
     <root level="debug">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala
+++ b/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit
 
 import akka.Done
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.alpakka.unixdomainsocket.UnixSocketAddress
 import akka.stream.{ActorMaterializer, OverflowStrategy}
 import akka.stream.alpakka.unixdomainsocket.scaladsl.UnixDomainSocket
@@ -30,7 +31,8 @@ class UnixDomainSocketSpec
     with Matchers
     with ScalaFutures
     with BeforeAndAfterAll
-    with IntegrationPatience {
+    with IntegrationPatience
+    with LogCapturing {
 
   override def afterAll: Unit =
     TestKit.shutdownActorSystem(system)

--- a/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala
+++ b/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala
@@ -17,22 +17,26 @@ import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.testkit._
 import akka.util.ByteString
 import org.scalatest._
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpecLike
 
 class UnixDomainSocketSpec
     extends TestKit(ActorSystem("UnixDomainSocketSpec"))
-    with AsyncWordSpecLike
+    with WordSpecLike
     with Matchers
-    with BeforeAndAfterAll {
+    with ScalaFutures
+    with BeforeAndAfterAll
+    with IntegrationPatience {
 
   override def afterAll: Unit =
     TestKit.shutdownActorSystem(system)
 
   implicit val ma: ActorMaterializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
 
   private val dir = Files.createTempDirectory("UnixDomainSocketSpec")
 
@@ -54,17 +58,16 @@ class UnixDomainSocketSpec
       //#binding
 
       //#outgoingConnection
+      val sendBytes = ByteString("Hello")
       binding.flatMap { _ => // connection
-        val sendBytes = ByteString("Hello")
         Source
           .single(sendBytes)
           .via(UnixDomainSocket().outgoingConnection(path))
           .runWith(Sink.ignore)
-        //#outgoingConnection
-        received.future.map(receiveBytes => assert(receiveBytes == sendBytes))
-        //#outgoingConnection
       }
       //#outgoingConnection
+      received.future.futureValue shouldBe sendBytes
+      binding.futureValue.unbind().futureValue should be(())
     }
 
     "send and receive more ten times the size of a buffer" ignore {
@@ -75,20 +78,17 @@ class UnixDomainSocketSpec
       val binding: Future[UnixDomainSocket.ServerBinding] =
         UnixDomainSocket().bindAndHandle(Flow.fromFunction(identity), path, halfClose = true)
 
-      binding.flatMap { connection =>
-        val sendBytes = ByteString(Array.ofDim[Byte](BufferSizeBytes * 10))
-        val result: Future[ByteString] =
+      val sendBytes = ByteString(Array.ofDim[Byte](BufferSizeBytes * 10))
+      val result: Future[ByteString] =
+        binding.flatMap { connection =>
           Source
             .single(sendBytes)
             .via(UnixDomainSocket().outgoingConnection(path))
             .runWith(Sink.fold(ByteString.empty) { case (acc, b) => acc ++ b })
-        result
-          .map(receiveBytes => assert(receiveBytes == sendBytes))
-          .flatMap {
-            case `succeed` => connection.unbind().map(_ => succeed)
-            case failedAssertion => failedAssertion
-          }
-      }
+
+        }
+      result.futureValue shouldBe sendBytes
+      binding.futureValue.unbind().futureValue should be(())
     }
 
     "allow the client to close the connection" in {
@@ -99,15 +99,14 @@ class UnixDomainSocketSpec
       val binding =
         UnixDomainSocket().bindAndHandle(Flow[ByteString].delay(5.seconds), path)
 
-      binding.flatMap { connection =>
+      val result = binding.flatMap { connection =>
         Source
           .single(sendBytes)
           .via(UnixDomainSocket().outgoingConnection(UnixSocketAddress(path), halfClose = false))
           .runWith(Sink.headOption)
-          .flatMap {
-            case e if e.isEmpty => connection.unbind().map(_ => succeed)
-          }
       }
+      result.futureValue shouldBe Symbol("empty")
+      binding.futureValue.unbind().futureValue should be(())
     }
 
     "close the server once the client is also closed" in {
@@ -123,16 +122,15 @@ class UnixDomainSocketSpec
           halfClose = true
         )
 
-      binding.flatMap { connection =>
+      val result = binding.flatMap { connection =>
         Source
           .tick(0.seconds, 1.second, sendBytes)
           .takeWhile(_ => !receiving.isCompleted)
           .via(UnixDomainSocket().outgoingConnection(path))
           .runWith(Sink.headOption)
-          .flatMap {
-            case e if e.nonEmpty => connection.unbind().map(_ => succeed)
-          }
       }
+      result.futureValue shouldNot be(Symbol("empty"))
+      binding.futureValue.unbind().futureValue should be(())
     }
 
     "be able to materialize outgoing connection flow more than once" in {
@@ -155,17 +153,13 @@ class UnixDomainSocketSpec
       materialize(connection)
 
       receivedLatch.await(5, TimeUnit.SECONDS)
-
-      succeed
     }
 
     "not be able to bind to a non-existent file" in {
       val binding =
         UnixDomainSocket().bindAndHandle(Flow.fromFunction(identity), Paths.get("/thisshouldnotexist"))
 
-      binding.failed.map {
-        case _: IOException => succeed
-      }
+      binding.failed.futureValue shouldBe an[IOException]
     }
 
     "not be able to connect to a non-existent file" in {
@@ -175,9 +169,7 @@ class UnixDomainSocketSpec
           .via(UnixDomainSocket().outgoingConnection(Paths.get("/thisshouldnotexist")))
           .runWith(Sink.head)
 
-      connection.failed.map {
-        case _: IOException => succeed
-      }
+      connection.failed.futureValue shouldBe an[IOException]
     }
 
   }

--- a/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala
+++ b/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala
@@ -22,11 +22,11 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AsyncWordSpecLike
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class UnixDomainSocketSpec
     extends TestKit(ActorSystem("UnixDomainSocketSpec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with ScalaFutures
     with BeforeAndAfterAll

--- a/xml/src/test/java/docs/javadsl/XmlParsingTest.java
+++ b/xml/src/test/java/docs/javadsl/XmlParsingTest.java
@@ -7,6 +7,7 @@ package docs.javadsl;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.alpakka.xml.Characters;
 import akka.stream.alpakka.xml.EndDocument;
 import akka.stream.alpakka.xml.EndElement;
@@ -21,6 +22,7 @@ import akka.util.ByteString;
 import com.fasterxml.aalto.AsyncXMLInputFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.w3c.dom.Element;
 
@@ -39,6 +41,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class XmlParsingTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static ActorSystem system;
   private static Materializer materializer;
 

--- a/xml/src/test/java/docs/javadsl/XmlWritingTest.java
+++ b/xml/src/test/java/docs/javadsl/XmlWritingTest.java
@@ -7,6 +7,7 @@ package docs.javadsl;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.alpakka.xml.*;
 import akka.stream.alpakka.xml.javadsl.XmlWriting;
 import akka.stream.javadsl.Flow;
@@ -17,6 +18,7 @@ import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -33,6 +35,8 @@ import javax.xml.stream.XMLOutputFactory;
 import static org.junit.Assert.assertEquals;
 
 public class XmlWritingTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static ActorSystem system;
   private static Materializer materializer;
 

--- a/xml/src/test/resources/logback-test.xml
+++ b/xml/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
 
     <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
 
-    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+    <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/xml/src/test/scala/docs/scaladsl/XmlCoalesceSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlCoalesceSpec.scala
@@ -5,6 +5,7 @@
 package docs.scaladsl
 
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.alpakka.xml._
 import akka.stream.alpakka.xml.scaladsl.XmlParsing
@@ -17,7 +18,7 @@ import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class XmlCoalesceSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+class XmlCoalesceSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with LogCapturing {
   implicit val system: ActorSystem = ActorSystem("Test")
   implicit val mat: Materializer = ActorMaterializer()
 

--- a/xml/src/test/scala/docs/scaladsl/XmlProcessingSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlProcessingSpec.scala
@@ -5,6 +5,7 @@
 package docs.scaladsl
 
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.alpakka.xml._
 import akka.stream.alpakka.xml.scaladsl.XmlParsing
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
@@ -19,7 +20,7 @@ import scala.concurrent.{Await, Future}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class XmlProcessingSpec extends AnyWordSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
+class XmlProcessingSpec extends AnyWordSpec with Matchers with ScalaFutures with BeforeAndAfterAll with LogCapturing {
   implicit val system: ActorSystem = ActorSystem("Test")
   implicit val mat: Materializer = ActorMaterializer()
   implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = 2.seconds, interval = 50.millis)

--- a/xml/src/test/scala/docs/scaladsl/XmlSubsliceSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlSubsliceSpec.scala
@@ -5,6 +5,7 @@
 package docs.scaladsl
 
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.alpakka.xml._
 import akka.stream.alpakka.xml.scaladsl.XmlParsing
@@ -17,7 +18,7 @@ import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class XmlSubsliceSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+class XmlSubsliceSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with LogCapturing {
   implicit val system: ActorSystem = ActorSystem("Test")
   implicit val mat: Materializer = ActorMaterializer()
 

--- a/xml/src/test/scala/docs/scaladsl/XmlSubtreeSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlSubtreeSpec.scala
@@ -5,6 +5,7 @@
 package docs.scaladsl
 
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.alpakka.xml.scaladsl.XmlParsing
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
@@ -17,7 +18,7 @@ import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class XmlSubtreeSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+class XmlSubtreeSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with LogCapturing {
   implicit val system: ActorSystem = ActorSystem("Test")
   implicit val mat: Materializer = ActorMaterializer()
 

--- a/xml/src/test/scala/docs/scaladsl/XmlWritingSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlWritingSpec.scala
@@ -5,6 +5,7 @@
 package docs.scaladsl
 
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.alpakka.xml._
 import akka.stream.alpakka.xml.scaladsl.XmlWriting
@@ -19,7 +20,7 @@ import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class XmlWritingSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+class XmlWritingSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with LogCapturing {
   implicit val system: ActorSystem = ActorSystem("Test")
   implicit val mat: Materializer = ActorMaterializer()
 


### PR DESCRIPTION
## Purpose

Introduce log capturing the with an Alpakka testkit which lends code from akka-actor-typed-testkit.

## References

https://doc.akka.io/docs/akka/current/typed/testing-async.html#silence-logging-output-from-tests
