### PR TITLE
AWS SQS: assert stage stopping

### DIFF
--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
@@ -61,11 +61,13 @@ trait DefaultTestContext extends Matchers with BeforeAndAfterAll with ScalaFutur
 
   override protected def afterAll(): Unit =
     try {
-      sqsClient.close()
+      closeSqsClient()
       system.terminate().futureValue shouldBe a[Terminated]
     } finally {
       super.afterAll()
     }
+
+  protected def closeSqsClient(): Unit = sqsClient.close()
 
   def createAsyncClient(sqsEndpoint: String): SqsAsyncClient = {
     //#init-client

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
@@ -11,6 +11,7 @@ import java.util.function.Supplier
 import akka.Done
 import akka.stream.alpakka.sqs._
 import akka.stream.scaladsl.Keep
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSource
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
@@ -24,7 +25,7 @@ import scala.concurrent.duration._
 
 class SqsPublishSinkSpec extends FlatSpec with Matchers with DefaultTestContext {
 
-  "SqsPublishSink" should "send a message" in {
+  "SqsPublishSink" should "send a message" in assertAllStagesStopped {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
     when(sqsClient.sendMessage(any[SendMessageRequest]))
       .thenReturn(CompletableFuture.completedFuture(SendMessageResponse.builder().build()))
@@ -37,7 +38,7 @@ class SqsPublishSinkSpec extends FlatSpec with Matchers with DefaultTestContext 
       .sendMessage(any[SendMessageRequest]())
   }
 
-  it should "fail stage on client failure and fail the promise" in {
+  it should "fail stage on client failure and fail the promise" in assertAllStagesStopped {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
 
     when(sqsClient.sendMessage(any[SendMessageRequest]()))
@@ -58,7 +59,7 @@ class SqsPublishSinkSpec extends FlatSpec with Matchers with DefaultTestContext 
       .sendMessage(any[SendMessageRequest]())
   }
 
-  it should "pull a message and publish it to another queue" taggedAs Integration in {
+  it should "pull a message and publish it to another queue" taggedAs Integration in assertAllStagesStopped {
     val queue1 = randomQueueUrl()
     val queue2 = randomQueueUrl()
     implicit val awsSqsClient = sqsClient
@@ -84,7 +85,7 @@ class SqsPublishSinkSpec extends FlatSpec with Matchers with DefaultTestContext 
     result.messages().get(0).body() shouldBe "alpakka"
   }
 
-  it should "failure the promise on upstream failure" in {
+  it should "failure the promise on upstream failure" in assertAllStagesStopped {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
     val (probe, future) = TestSource.probe[String].toMat(SqsPublishSink("notused"))(Keep.both).run()
 
@@ -95,7 +96,7 @@ class SqsPublishSinkSpec extends FlatSpec with Matchers with DefaultTestContext 
     }
   }
 
-  it should "complete promise after all messages have been sent" in {
+  it should "complete promise after all messages have been sent" in assertAllStagesStopped {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
 
     when(sqsClient.sendMessage(any[SendMessageRequest]))
@@ -115,7 +116,7 @@ class SqsPublishSinkSpec extends FlatSpec with Matchers with DefaultTestContext 
       .sendMessage(any[SendMessageRequest]())
   }
 
-  it should "send batch of messages" in {
+  it should "send batch of messages" in assertAllStagesStopped {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
 
     when(sqsClient.sendMessageBatch(any[SendMessageBatchRequest]))
@@ -139,7 +140,7 @@ class SqsPublishSinkSpec extends FlatSpec with Matchers with DefaultTestContext 
     )
   }
 
-  it should "send all messages in batches of given size" in {
+  it should "send all messages in batches of given size" in assertAllStagesStopped {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
 
     when(sqsClient.sendMessageBatch(any[SendMessageBatchRequest]))
@@ -181,7 +182,7 @@ class SqsPublishSinkSpec extends FlatSpec with Matchers with DefaultTestContext 
     )
   }
 
-  it should "fail if any of the messages in batch failed" in {
+  it should "fail if any of the messages in batch failed" in assertAllStagesStopped {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
 
     when(sqsClient.sendMessageBatch(any[SendMessageBatchRequest]))
@@ -218,7 +219,7 @@ class SqsPublishSinkSpec extends FlatSpec with Matchers with DefaultTestContext 
     )
   }
 
-  it should "fail if whole batch is failed" in {
+  it should "fail if whole batch is failed" in assertAllStagesStopped {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
     when(
       sqsClient.sendMessageBatch(any[SendMessageBatchRequest]())
@@ -247,7 +248,7 @@ class SqsPublishSinkSpec extends FlatSpec with Matchers with DefaultTestContext 
     )
   }
 
-  it should "send all batches of messages" in {
+  it should "send all batches of messages" in assertAllStagesStopped {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
 
     when(sqsClient.sendMessageBatch(any[SendMessageBatchRequest]))

--- a/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
@@ -10,6 +10,7 @@ import akka.Done
 import akka.stream.alpakka.sqs._
 import akka.stream.alpakka.sqs.scaladsl._
 import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.scalatest.{FlatSpec, Matchers}
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.{Message, ReceiveMessageRequest, SendMessageRequest}
@@ -85,120 +86,136 @@ class SqsPublishSpec extends FlatSpec with Matchers with DefaultTestContext {
     batchSettings.concurrentRequests shouldBe 1
   }
 
-  "PublishSink" should "publish and pull a message" taggedAs Integration in new IntegrationFixture {
-    val future =
+  "PublishSink" should "publish and pull a message" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      val future =
+        //#run-string
+        Source
+          .single("alpakka")
+          .runWith(SqsPublishSink(queueUrl))
       //#run-string
-      Source
-        .single("alpakka")
-        .runWith(SqsPublishSink(queueUrl))
-    //#run-string
-    future.futureValue shouldBe Done
+      future.futureValue shouldBe Done
 
-    receiveMessage().body() shouldBe "alpakka"
+      receiveMessage().body() shouldBe "alpakka"
+    }
   }
 
-  it should "publish and pull a message provided as a SendMessageRequest" taggedAs Integration in new IntegrationFixture {
-    val future =
+  it should "publish and pull a message provided as a SendMessageRequest" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      val future =
+        //#run-send-request
+        // for fix SQS queue
+        Source
+          .single(SendMessageRequest.builder().messageBody("alpakka").build())
+          .runWith(SqsPublishSink.messageSink(queueUrl))
+
       //#run-send-request
-      // for fix SQS queue
-      Source
-        .single(SendMessageRequest.builder().messageBody("alpakka").build())
-        .runWith(SqsPublishSink.messageSink(queueUrl))
 
-    //#run-send-request
+      future.futureValue shouldBe Done
 
-    future.futureValue shouldBe Done
-
-    receiveMessage().body() shouldBe "alpakka"
+      receiveMessage().body() shouldBe "alpakka"
+    }
   }
 
-  it should "publish and pull a message provided as a SendMessageRequest with dynamic queue" taggedAs Integration in new IntegrationFixture {
-    val future =
+  it should "publish and pull a message provided as a SendMessageRequest with dynamic queue" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      val future =
+        //#run-send-request
+        // for dynamic SQS queues
+        Source
+          .single(SendMessageRequest.builder().messageBody("alpakka").queueUrl(queueUrl).build())
+          .runWith(SqsPublishSink.messageSink())
       //#run-send-request
-      // for dynamic SQS queues
-      Source
-        .single(SendMessageRequest.builder().messageBody("alpakka").queueUrl(queueUrl).build())
-        .runWith(SqsPublishSink.messageSink())
-    //#run-send-request
 
-    future.futureValue shouldBe Done
+      future.futureValue shouldBe Done
 
-    receiveMessage().body() shouldBe "alpakka"
+      receiveMessage().body() shouldBe "alpakka"
+    }
   }
 
-  it should "publish messages by grouping and pull them" taggedAs Integration in new IntegrationFixture {
-    //#group
-    val messages = for (i <- 0 until 10) yield s"Message - $i"
+  it should "publish messages by grouping and pull them" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      //#group
+      val messages = for (i <- 0 until 10) yield s"Message - $i"
 
-    val future = Source(messages)
-      .runWith(SqsPublishSink.grouped(queueUrl, SqsPublishGroupedSettings.Defaults.withMaxBatchSize(2)))
-    //#group
+      val future = Source(messages)
+        .runWith(SqsPublishSink.grouped(queueUrl, SqsPublishGroupedSettings.Defaults.withMaxBatchSize(2)))
+      //#group
 
-    future.futureValue shouldBe Done
+      future.futureValue shouldBe Done
 
-    receiveMessages(10) should have size 10
+      receiveMessages(10) should have size 10
+    }
   }
 
-  it should "publish batch of messages and pull them" taggedAs Integration in new IntegrationFixture {
-    //#batch-string
-    val messages = for (i <- 0 until 10) yield s"Message - $i"
+  it should "publish batch of messages and pull them" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      //#batch-string
+      val messages = for (i <- 0 until 10) yield s"Message - $i"
 
-    val future = Source
-      .single(messages)
-      .runWith(SqsPublishSink.batch(queueUrl))
-    //#batch-string
+      val future = Source
+        .single(messages)
+        .runWith(SqsPublishSink.batch(queueUrl))
+      //#batch-string
 
-    future.futureValue shouldBe Done
+      future.futureValue shouldBe Done
 
-    receiveMessages(10) should have size 10
+      receiveMessages(10) should have size 10
+    }
   }
 
-  it should "publish batch of SendMessageRequests and pull them" taggedAs Integration in new IntegrationFixture {
-    //#batch-send-request
-    val messages = for (i <- 0 until 10) yield SendMessageRequest.builder().messageBody(s"Message - $i").build()
+  it should "publish batch of SendMessageRequests and pull them" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      //#batch-send-request
+      val messages = for (i <- 0 until 10) yield SendMessageRequest.builder().messageBody(s"Message - $i").build()
 
-    val future = Source
-      .single(messages)
-      .runWith(SqsPublishSink.batchedMessageSink(queueUrl))
-    //#batch-send-request
+      val future = Source
+        .single(messages)
+        .runWith(SqsPublishSink.batchedMessageSink(queueUrl))
+      //#batch-send-request
 
-    future.futureValue shouldBe Done
+      future.futureValue shouldBe Done
 
-    receiveMessages(10) should have size 10
+      receiveMessages(10) should have size 10
+    }
   }
 
-  "PublishFlow" should "put message in a flow, then pass the result further" taggedAs Integration in new IntegrationFixture {
-    val future =
+  "PublishFlow" should "put message in a flow, then pass the result further" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      val future =
+        //#flow
+        // for fix SQS queue
+        Source
+          .single(SendMessageRequest.builder().messageBody("alpakka").build())
+          .via(SqsPublishFlow(queueUrl))
+          .runWith(Sink.head)
+
       //#flow
-      // for fix SQS queue
-      Source
-        .single(SendMessageRequest.builder().messageBody("alpakka").build())
-        .via(SqsPublishFlow(queueUrl))
-        .runWith(Sink.head)
 
-    //#flow
+      val result = future.futureValue
+      result.result
+      result.result.md5OfMessageBody() shouldBe md5HashString("alpakka")
 
-    val result = future.futureValue
-    result.result
-    result.result.md5OfMessageBody() shouldBe md5HashString("alpakka")
-
-    receiveMessage().body() shouldBe "alpakka"
+      receiveMessage().body() shouldBe "alpakka"
+    }
   }
 
-  it should "put message in a flow, then pass the result further with dynamic queue" taggedAs Integration in new IntegrationFixture {
-    val future =
+  it should "put message in a flow, then pass the result further with dynamic queue" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      val future =
+        //#flow
+        // for dynamic SQS queues
+        Source
+          .single(SendMessageRequest.builder().messageBody("alpakka").queueUrl(queueUrl).build())
+          .via(SqsPublishFlow())
+          .runWith(Sink.head)
       //#flow
-      // for dynamic SQS queues
-      Source
-        .single(SendMessageRequest.builder().messageBody("alpakka").queueUrl(queueUrl).build())
-        .via(SqsPublishFlow())
-        .runWith(Sink.head)
-    //#flow
 
-    val result = future.futureValue
-    result.result.md5OfMessageBody() shouldBe md5HashString("alpakka")
+      val result = future.futureValue
+      result.result.md5OfMessageBody() shouldBe md5HashString("alpakka")
 
-    receiveMessage().body() shouldBe "alpakka"
+      receiveMessage().body() shouldBe "alpakka"
+    }
   }
 
   ignore should "put message in a flow, then pass the result further with fifo queues" taggedAs Integration in new IntegrationFixture(

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -8,9 +8,11 @@ import java.net.URI
 import java.util.concurrent.TimeUnit
 
 import akka.Done
+import akka.stream.KillSwitches
 import akka.stream.alpakka.sqs._
 import akka.stream.alpakka.sqs.scaladsl.{DefaultTestContext, SqsSource}
-import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.{Keep, Sink}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import com.github.matsluni.akkahttpspi.AkkaHttpClient
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FlatSpec, Matchers}
@@ -58,21 +60,28 @@ class SqsSourceSpec extends FlatSpec with ScalaFutures with Matchers with Defaul
     future.futureValue.body() shouldBe "alpakka"
   }
 
-  it should "continue streaming if receives an empty response" taggedAs Integration in new IntegrationFixture {
-    val future = SqsSource(queueUrl, SqsSourceSettings().withWaitTimeSeconds(0))
-      .runWith(Sink.ignore)
+  it should "continue streaming if receives an empty response" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      val (switch, source) = SqsSource(queueUrl, SqsSourceSettings().withWaitTimeSeconds(0))
+        .viaMat(KillSwitches.single)(Keep.right)
+        .toMat(Sink.ignore)(Keep.both)
+        .run
 
-    // make sure the source polled sqs once for an empty response
-    Thread.sleep(1.second.toMillis)
+      // make sure the source polled sqs once for an empty response
+      Thread.sleep(1.second.toMillis)
 
-    future.isCompleted shouldBe false
+      source shouldNot be(Symbol("completed"))
+      switch.shutdown()
+    }
   }
 
-  it should "terminate on an empty response if requested" taggedAs Integration in new IntegrationFixture {
-    val future = SqsSource(queueUrl, sqsSourceSettings.withCloseOnEmptyReceive(true))
-      .runWith(Sink.ignore)
+  it should "terminate on an empty response if requested" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      val future = SqsSource(queueUrl, sqsSourceSettings.withCloseOnEmptyReceive(true))
+        .runWith(Sink.ignore)
 
-    future.futureValue shouldBe Done
+      future.futureValue shouldBe Done
+    }
   }
 
   it should "finish immediately if the queue does not exist" taggedAs Integration in new IntegrationFixture {
@@ -83,28 +92,9 @@ class SqsSourceSpec extends FlatSpec with ScalaFutures with Matchers with Defaul
     future.failed.futureValue.getCause shouldBe a[QueueDoesNotExistException]
   }
 
-  "SqsSource" should "ask for 'All' attributes set in the settings" taggedAs Integration in new IntegrationFixture {
-    val attribute = All
-    val settings = sqsSourceSettings.withAttribute(attribute)
-
-    val sendMessageRequest =
-      SendMessageRequest
-        .builder()
-        .queueUrl(queueUrl)
-        .messageBody("alpakka")
-        .build()
-
-    sqsClient.sendMessage(sendMessageRequest).get(2, TimeUnit.SECONDS)
-
-    val future = SqsSource(queueUrl, settings).runWith(Sink.head)
-
-    private val message: Message = future.futureValue
-    message.attributes().keySet.asScala should contain theSameElementsAs allAvailableAttributes
-      .map(attr => MessageSystemAttributeName.fromValue(attr.name))
-  }
-
-  allAvailableAttributes foreach { attribute =>
-    it should s"ask for '${attribute.name}' set in the settings" taggedAs Integration in new IntegrationFixture {
+  "SqsSource" should "ask for 'All' attributes set in the settings" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      val attribute = All
       val settings = sqsSourceSettings.withAttribute(attribute)
 
       val sendMessageRequest =
@@ -119,53 +109,80 @@ class SqsSourceSpec extends FlatSpec with ScalaFutures with Matchers with Defaul
       val future = SqsSource(queueUrl, settings).runWith(Sink.head)
 
       private val message: Message = future.futureValue
-      message.attributes().keySet.asScala should contain only MessageSystemAttributeName.fromValue(attribute.name)
+      message.attributes().keySet.asScala should contain theSameElementsAs allAvailableAttributes
+        .map(attr => MessageSystemAttributeName.fromValue(attr.name))
     }
   }
 
-  it should "ask for multiple attributes set in the settings" taggedAs Integration in new IntegrationFixture {
-    val attributes = allAvailableAttributes.filterNot(_ == All)
-    val settings = sqsSourceSettings.withAttributes(attributes)
+  allAvailableAttributes foreach { attribute =>
+    it should s"ask for '${attribute.name}' set in the settings" taggedAs Integration in assertAllStagesStopped {
+      new IntegrationFixture {
+        val settings = sqsSourceSettings.withAttribute(attribute)
 
-    val sendMessageRequest =
-      SendMessageRequest
-        .builder()
-        .queueUrl(queueUrl)
-        .messageBody("alpakka")
-        .build()
+        val sendMessageRequest =
+          SendMessageRequest
+            .builder()
+            .queueUrl(queueUrl)
+            .messageBody("alpakka")
+            .build()
 
-    sqsClient.sendMessage(sendMessageRequest).get(2, TimeUnit.SECONDS)
+        sqsClient.sendMessage(sendMessageRequest).get(2, TimeUnit.SECONDS)
 
-    val future = SqsSource(queueUrl, settings).runWith(Sink.head)
+        val future = SqsSource(queueUrl, settings).runWith(Sink.head)
 
-    private val message: Message = future.futureValue
-    message.attributes().keySet.asScala should contain theSameElementsAs attributes
-      .map(_.name)
-      .map(MessageSystemAttributeName.fromValue)
+        private val message: Message = future.futureValue
+        message.attributes().keySet.asScala should contain only MessageSystemAttributeName.fromValue(attribute.name)
+      }
+    }
   }
 
-  it should "ask for all the message attributes set in the settings" taggedAs Integration in new IntegrationFixture {
-    val messageAttributes = Map(
-      "attribute-1" -> MessageAttributeValue.builder().stringValue("v1").dataType("String").build(),
-      "attribute-2" -> MessageAttributeValue.builder().stringValue("v2").dataType("String").build()
-    )
-    val settings =
-      sqsSourceSettings.withMessageAttributes(messageAttributes.keys.toList.map(MessageAttributeName.apply))
+  it should "ask for multiple attributes set in the settings" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      val attributes = allAvailableAttributes.filterNot(_ == All)
+      val settings = sqsSourceSettings.withAttributes(attributes)
 
-    val sendMessageRequest =
-      SendMessageRequest
-        .builder()
-        .queueUrl(queueUrl)
-        .messageBody("alpakka")
-        .messageAttributes(messageAttributes.asJava)
-        .build()
+      val sendMessageRequest =
+        SendMessageRequest
+          .builder()
+          .queueUrl(queueUrl)
+          .messageBody("alpakka")
+          .build()
 
-    sqsClient.sendMessage(sendMessageRequest).get(2, TimeUnit.SECONDS)
+      sqsClient.sendMessage(sendMessageRequest).get(2, TimeUnit.SECONDS)
 
-    val future = SqsSource(queueUrl, settings)
-      .runWith(Sink.head)
+      val future = SqsSource(queueUrl, settings).runWith(Sink.head)
 
-    future.futureValue.messageAttributes().asScala shouldBe messageAttributes
+      private val message: Message = future.futureValue
+      message.attributes().keySet.asScala should contain theSameElementsAs attributes
+        .map(_.name)
+        .map(MessageSystemAttributeName.fromValue)
+    }
+  }
+
+  it should "ask for all the message attributes set in the settings" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      val messageAttributes = Map(
+        "attribute-1" -> MessageAttributeValue.builder().stringValue("v1").dataType("String").build(),
+        "attribute-2" -> MessageAttributeValue.builder().stringValue("v2").dataType("String").build()
+      )
+      val settings =
+        sqsSourceSettings.withMessageAttributes(messageAttributes.keys.toList.map(MessageAttributeName.apply))
+
+      val sendMessageRequest =
+        SendMessageRequest
+          .builder()
+          .queueUrl(queueUrl)
+          .messageBody("alpakka")
+          .messageAttributes(messageAttributes.asJava)
+          .build()
+
+      sqsClient.sendMessage(sendMessageRequest).get(2, TimeUnit.SECONDS)
+
+      val future = SqsSource(queueUrl, settings)
+        .runWith(Sink.head)
+
+      future.futureValue.messageAttributes().asScala shouldBe messageAttributes
+    }
   }
 
   "SqsSourceSettings" should "be constructed" in {
@@ -218,99 +235,106 @@ class SqsSourceSpec extends FlatSpec with ScalaFutures with Matchers with Defaul
     }
   }
 
-  "SqsSource" should "stream a single batch from the queue with custom client" taggedAs Integration in new IntegrationFixture {
-    /*
+  "SqsSource" should "stream a single batch from the queue with custom client" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      /*
     // #init-custom-client
     import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
     val customClient: SdkAsyncHttpClient = NettyNioAsyncHttpClient.builder().maxConcurrency(100).build()
     // #init-custom-client
-     */
-    val customClient: SdkAsyncHttpClient = AkkaHttpClient.builder().withActorSystem(system).build()
+       */
+      val customClient: SdkAsyncHttpClient = AkkaHttpClient.builder().withActorSystem(system).build()
 
-    //#init-custom-client
-    implicit val customSqsClient = SqsAsyncClient
-      .builder()
-      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
       //#init-custom-client
-      .endpointOverride(URI.create(sqsEndpoint))
-      //#init-custom-client
-      .region(Region.EU_CENTRAL_1)
-      .httpClient(customClient)
-      .build()
-
-    //#init-custom-client
-
-    val sendMessageRequest =
-      SendMessageRequest
+      implicit val customSqsClient = SqsAsyncClient
         .builder()
-        .queueUrl(queueUrl)
-        .messageBody("alpakka")
+        .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
+        //#init-custom-client
+        .endpointOverride(URI.create(sqsEndpoint))
+        //#init-custom-client
+        .region(Region.EU_CENTRAL_1)
+        .httpClient(customClient)
         .build()
 
-    customSqsClient.sendMessage(sendMessageRequest).get(2, TimeUnit.SECONDS)
+      //#init-custom-client
 
-    val future = SqsSource(queueUrl, sqsSourceSettings)(customSqsClient)
-      .runWith(Sink.head)
-
-    future.futureValue.body() shouldBe "alpakka"
-  }
-
-  it should "stream multiple batches from the queue" taggedAs Integration in new IntegrationFixture {
-    val input =
-      for (i <- 1 to 100)
-        yield SendMessageRequest
+      val sendMessageRequest =
+        SendMessageRequest
           .builder()
           .queueUrl(queueUrl)
-          .messageBody(s"alpakka-$i")
+          .messageBody("alpakka")
           .build()
 
-    input.foreach(m => sqsClient.sendMessage(m).get(2, TimeUnit.SECONDS))
+      customSqsClient.sendMessage(sendMessageRequest).get(2, TimeUnit.SECONDS)
 
-    //#run
-    val messages: Future[immutable.Seq[Message]] =
-      SqsSource(
-        queueUrl,
-        SqsSourceSettings().withCloseOnEmptyReceive(true).withWaitTime(10.millis)
-      ).runWith(Sink.seq)
-    //#run
+      val future = SqsSource(queueUrl, sqsSourceSettings)(customSqsClient)
+        .runWith(Sink.head)
 
-    messages.futureValue should have size 100
+      future.futureValue.body() shouldBe "alpakka"
+    }
   }
 
-  it should "stream single message at least twice from the queue when visibility timeout passed" taggedAs Integration in new IntegrationFixture {
-    val sendMessageRequest =
-      SendMessageRequest
-        .builder()
-        .queueUrl(queueUrl)
-        .messageBody("alpakka")
-        .build()
+  it should "stream multiple batches from the queue" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      val input =
+        for (i <- 1 to 100)
+          yield SendMessageRequest
+            .builder()
+            .queueUrl(queueUrl)
+            .messageBody(s"alpakka-$i")
+            .build()
 
-    sqsClient.sendMessage(sendMessageRequest).get(2, TimeUnit.SECONDS)
+      input.foreach(m => sqsClient.sendMessage(m).get(2, TimeUnit.SECONDS))
 
-    val future = SqsSource(queueUrl, sqsSourceSettings.withVisibilityTimeout(1.second))
-      .takeWithin(1200.milliseconds)
-      .runWith(Sink.seq)
+      //#run
+      val messages: Future[immutable.Seq[Message]] =
+        SqsSource(
+          queueUrl,
+          SqsSourceSettings().withCloseOnEmptyReceive(true).withWaitTime(10.millis)
+        ).runWith(Sink.seq)
+      //#run
 
-    future.futureValue.size should be > 1
+      messages.futureValue should have size 100
+    }
   }
 
-  it should "stream single message once from the queue when visibility timeout did not pass" taggedAs Integration in new IntegrationFixture {
-    val sendMessageRequest =
-      SendMessageRequest
-        .builder()
-        .queueUrl(queueUrl)
-        .messageBody("alpakka")
-        .build()
+  it should "stream single message at least twice from the queue when visibility timeout passed" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      val sendMessageRequest =
+        SendMessageRequest
+          .builder()
+          .queueUrl(queueUrl)
+          .messageBody("alpakka")
+          .build()
 
-    sqsClient.sendMessage(sendMessageRequest).get(2, TimeUnit.SECONDS)
+      sqsClient.sendMessage(sendMessageRequest).get(2, TimeUnit.SECONDS)
 
-    val future = SqsSource(queueUrl, sqsSourceSettings.withVisibilityTimeout(10.seconds))
-      .takeWithin(500.milliseconds)
-      .runWith(Sink.seq)
+      val future = SqsSource(queueUrl, sqsSourceSettings.withVisibilityTimeout(1.second))
+        .takeWithin(1200.milliseconds)
+        .runWith(Sink.seq)
 
-    future.futureValue should have size 1
+      future.futureValue.size should be > 1
+    }
   }
 
+  it should "stream single message once from the queue when visibility timeout did not pass" taggedAs Integration in assertAllStagesStopped {
+    new IntegrationFixture {
+      val sendMessageRequest =
+        SendMessageRequest
+          .builder()
+          .queueUrl(queueUrl)
+          .messageBody("alpakka")
+          .build()
+
+      sqsClient.sendMessage(sendMessageRequest).get(2, TimeUnit.SECONDS)
+
+      val future = SqsSource(queueUrl, sqsSourceSettings.withVisibilityTimeout(10.seconds))
+        .takeWithin(500.milliseconds)
+        .runWith(Sink.seq)
+
+      future.futureValue should have size 1
+    }
+  }
 }
 
 object SqsSourceSpec {


### PR DESCRIPTION
## Purpose

Make sure SQS tests shut down their streams properly.

## Background Context

Some SQS tests did not shut down the created sources, this makes sure everything is cleaned up.