### PR TITLE
Google Cloud Pub/Sub: remove ActorSystem and Materializer

### DIFF
--- a/google-cloud-pub-sub/src/main/mima-filters/2.0.0-M1.backwards.excludes/issue-2017-remove-implicits.excludes
+++ b/google-cloud-pub-sub/src/main/mima-filters/2.0.0-M1.backwards.excludes/issue-2017-remove-implicits.excludes
@@ -1,0 +1,5 @@
+# Remove ActorSystem and Materializer from factory methods
+ProblemFilters.exclude[MissingMethodProblem]("akka.stream.alpakka.googlecloud.pubsub.javadsl.GooglePubSub.acknowledge")
+ProblemFilters.exclude[MissingMethodProblem]("akka.stream.alpakka.googlecloud.pubsub.javadsl.GooglePubSub.publish")
+ProblemFilters.exclude[MissingMethodProblem]("akka.stream.alpakka.googlecloud.pubsub.scaladsl.GooglePubSub.acknowledge")
+ProblemFilters.exclude[MissingMethodProblem]("akka.stream.alpakka.googlecloud.pubsub.scaladsl.GooglePubSub.publish")

--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/javadsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/javadsl/GooglePubSub.scala
@@ -6,8 +6,7 @@ package akka.stream.alpakka.googlecloud.pubsub.javadsl
 
 import java.util.concurrent.CompletionStage
 
-import akka.actor.{ActorSystem, Cancellable}
-import akka.stream.Materializer
+import akka.actor.Cancellable
 import akka.stream.alpakka.googlecloud.pubsub.scaladsl.{GooglePubSub => GPubSub}
 import akka.stream.alpakka.googlecloud.pubsub.{AcknowledgeRequest, PubSubConfig, PublishRequest, ReceivedMessage}
 import akka.stream.javadsl.{Flow, FlowWithContext, Sink, Source}
@@ -20,48 +19,34 @@ object GooglePubSub {
 
   def publish(topic: String,
               config: PubSubConfig,
-              parallelism: Int,
-              actorSystem: ActorSystem,
-              materializer: Materializer): Flow[PublishRequest, java.util.List[String], NotUsed] =
+              parallelism: Int): Flow[PublishRequest, java.util.List[String], NotUsed] =
     GPubSub
-      .publish(topic = topic, config = config, parallelism = parallelism)(actorSystem, materializer)
+      .publish(topic = topic, config = config, parallelism = parallelism)
       .map(response => response.asJava)
       .asJava
 
-  def publishWithContext[C](
-      topic: String,
-      config: PubSubConfig,
-      parallelism: Int,
-      actorSystem: ActorSystem,
-      materializer: Materializer
-  ): FlowWithContext[PublishRequest, C, java.util.List[String], C, NotUsed] =
+  def publishWithContext[C](topic: String,
+                            config: PubSubConfig,
+                            parallelism: Int): FlowWithContext[PublishRequest, C, java.util.List[String], C, NotUsed] =
     GPubSub
-      .publishWithContext[C](topic = topic, config = config, parallelism = parallelism)(actorSystem, materializer)
+      .publishWithContext[C](topic = topic, config = config, parallelism = parallelism)
       .map(response => response.asJava)
       .asJava
 
-  def subscribe(subscription: String,
-                config: PubSubConfig,
-                actorSystem: ActorSystem,
-                materializer: Materializer): Source[ReceivedMessage, Cancellable] =
+  def subscribe(subscription: String, config: PubSubConfig): Source[ReceivedMessage, Cancellable] =
     GPubSub
-      .subscribe(subscription = subscription, config = config)(actorSystem, materializer)
+      .subscribe(subscription = subscription, config = config)
       .asJava
 
   @deprecated("Use `acknowledge` without `parallelism` param", since = "2.0.0")
   def acknowledge(subscription: String,
                   config: PubSubConfig,
-                  parallelism: Int,
-                  actorSystem: ActorSystem,
-                  materializer: Materializer): Sink[AcknowledgeRequest, CompletionStage[Done]] =
-    acknowledge(subscription, config, actorSystem, materializer)
+                  parallelism: Int): Sink[AcknowledgeRequest, CompletionStage[Done]] =
+    acknowledge(subscription, config)
 
-  def acknowledge(subscription: String,
-                  config: PubSubConfig,
-                  actorSystem: ActorSystem,
-                  materializer: Materializer): Sink[AcknowledgeRequest, CompletionStage[Done]] =
+  def acknowledge(subscription: String, config: PubSubConfig): Sink[AcknowledgeRequest, CompletionStage[Done]] =
     GPubSub
-      .acknowledge(subscription = subscription, config = config)(actorSystem, materializer)
+      .acknowledge(subscription = subscription, config = config)
       .mapMaterializedValue(_.toJava)
       .asJava
 }

--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/scaladsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/scaladsl/GooglePubSub.scala
@@ -23,12 +23,11 @@ protected[pubsub] trait GooglePubSub {
   private[pubsub] def httpApi: PubSubApi
 
   /**
-   * Creates a flow to that publish messages to a topic and emits the message ids
+   * Creates a flow to that publishes messages to a topic and emits the message ids.
    */
-  def publish(topic: String, config: PubSubConfig, parallelism: Int = 1)(
-      implicit actorSystem: ActorSystem,
-      materializer: Materializer
-  ): Flow[PublishRequest, immutable.Seq[String], NotUsed] =
+  def publish(topic: String,
+              config: PubSubConfig,
+              parallelism: Int = 1): Flow[PublishRequest, immutable.Seq[String], NotUsed] =
     Flow[PublishRequest]
       .map((_, ()))
       .via(
@@ -36,52 +35,83 @@ protected[pubsub] trait GooglePubSub {
       )
       .map(_._1)
 
-  def publishWithContext[C](topic: String, config: PubSubConfig, parallelism: Int = 1)(
-      implicit actorSystem: ActorSystem,
-      materializer: Materializer
-  ): FlowWithContext[PublishRequest, C, immutable.Seq[String], C, NotUsed] =
-    httpApi
-      .accessTokenWithContext[PublishRequest, C](config)
-      .via(
-        httpApi.publish[C](config.projectId, topic, parallelism)
-      )
+  /**
+   * Creates a flow to that publishes messages to a topic and emits the message ids and carries a context
+   * through.
+   */
+  def publishWithContext[C](
+      topic: String,
+      config: PubSubConfig,
+      parallelism: Int = 1
+  ): FlowWithContext[PublishRequest, C, immutable.Seq[String], C, NotUsed] = {
+    // some wrapping back and forth as FlowWithContext doesn't offer `setup`
+    // https://github.com/akka/akka/issues/27883
+    FlowWithContext.fromTuples {
+      Flow
+        .setup { (mat, _) =>
+          implicit val system: ActorSystem = mat.system
+          implicit val materializer: Materializer = mat
+          httpApi
+            .accessTokenWithContext[PublishRequest, C](config)
+            .via(
+              httpApi.publish[C](config.projectId, topic, parallelism)
+            )
+            .asFlow
+        }
+        .mapMaterializedValue(_ => NotUsed)
+    }
+  }
 
   /**
    * Creates a source pulling messages from subscription
    */
-  def subscribe(subscription: String, config: PubSubConfig)(
-      implicit actorSystem: ActorSystem,
-      materializer: Materializer
-  ): Source[ReceivedMessage, Cancellable] =
+  def subscribe(subscription: String, config: PubSubConfig): Source[ReceivedMessage, Cancellable] = {
+    val flow =
+      Flow
+        .setup { (mat, _) =>
+          implicit val system: ActorSystem = mat.system
+          implicit val materializer: Materializer = mat
+          Flow[Done]
+            .via(httpApi.accessToken[Done](config))
+            .via(
+              httpApi
+                .pull(config.projectId,
+                      subscription,
+                      config.pullReturnImmediately,
+                      config.pullMaxMessagesPerInternalBatch)
+            )
+            .mapConcat(_.receivedMessages.getOrElse(Seq.empty[ReceivedMessage]).toIndexedSeq)
+        }
+
     Source
       .tick(0.seconds, 1.second, Done)
-      .via(httpApi.accessToken[Done](config))
-      .via(
-        httpApi
-          .pull(config.projectId, subscription, config.pullReturnImmediately, config.pullMaxMessagesPerInternalBatch)
-      )
-      .mapConcat(_.receivedMessages.getOrElse(Seq.empty[ReceivedMessage]).toIndexedSeq)
+      .via(flow)
+  }
 
   /**
    * Creates a sink for acknowledging messages on subscription
    */
   @deprecated("Use `acknowledge` without `parallelism` param", since = "2.0.0")
-  def acknowledge(subscription: String, config: PubSubConfig, parallelism: Int = 1)(
-      implicit actorSystem: ActorSystem,
-      materializer: Materializer
-  ): Sink[AcknowledgeRequest, Future[Done]] =
+  def acknowledge(subscription: String,
+                  config: PubSubConfig,
+                  parallelism: Int = 1): Sink[AcknowledgeRequest, Future[Done]] =
     acknowledge(subscription, config)
 
   /**
    * Creates a sink for acknowledging messages on subscription
    */
-  def acknowledge(subscription: String, config: PubSubConfig)(
-      implicit actorSystem: ActorSystem,
-      materializer: Materializer
-  ): Sink[AcknowledgeRequest, Future[Done]] =
-    Flow[AcknowledgeRequest]
-      .via(httpApi.accessToken[AcknowledgeRequest](config))
-      .via(httpApi.acknowledge(config.projectId, subscription))
+  def acknowledge(subscription: String, config: PubSubConfig): Sink[AcknowledgeRequest, Future[Done]] = {
+    val flow =
+      Flow
+        .setup { (mat, _) =>
+          implicit val system: ActorSystem = mat.system
+          implicit val materializer: Materializer = mat
+          Flow[AcknowledgeRequest]
+            .via(httpApi.accessToken[AcknowledgeRequest](config))
+            .via(httpApi.acknowledge(config.projectId, subscription))
+        }
+    flow
       .toMat(Sink.ignore)(Keep.right)
+  }
 
 }

--- a/google-cloud-pub-sub/src/test/java/docs/javadsl/ExampleUsageJava.java
+++ b/google-cloud-pub-sub/src/test/java/docs/javadsl/ExampleUsageJava.java
@@ -61,7 +61,7 @@ public class ExampleUsageJava {
     Source<PublishRequest, NotUsed> source = Source.single(publishRequest);
 
     Flow<PublishRequest, List<String>, NotUsed> publishFlow =
-        GooglePubSub.publish(topic, config, 1, system, materializer);
+        GooglePubSub.publish(topic, config, 1);
 
     CompletionStage<List<List<String>>> publishedMessageIds =
         source.via(publishFlow).runWith(Sink.seq(), materializer);
@@ -78,7 +78,7 @@ public class ExampleUsageJava {
         Source.single(Pair.apply(publishRequestWithContext, context));
 
     FlowWithContext<PublishRequest, String, List<String>, String, NotUsed> publishFlowWithContext =
-        GooglePubSub.publishWithContext(topic, config, 1, system, materializer);
+        GooglePubSub.publishWithContext(topic, config, 1);
 
     CompletionStage<List<Pair<List<String>, String>>> publishedMessageIdsWithContext =
         sourceWithContext.via(publishFlowWithContext).runWith(Sink.seq(), materializer);
@@ -95,10 +95,10 @@ public class ExampleUsageJava {
 
     // #subscribe
     Source<ReceivedMessage, Cancellable> subscriptionSource =
-        GooglePubSub.subscribe(subscription, config, system, materializer);
+        GooglePubSub.subscribe(subscription, config);
 
     Sink<AcknowledgeRequest, CompletionStage<Done>> ackSink =
-        GooglePubSub.acknowledge(subscription, config, system, materializer);
+        GooglePubSub.acknowledge(subscription, config);
 
     subscriptionSource
         .map(


### PR DESCRIPTION
## Purpose

Use `Flow.setup` to get access to the `ActorSystem` and `Materializer` on materialization so that those don't need to be passed as (implicit) parameters.

## References

#2017 

## Background Context

The APIs were changed by #1983 which introduced the need to access the materializer.