### PR TITLE
JMS: close sessions in postStop

### DIFF
--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsConnector.scala
@@ -67,6 +67,7 @@ private[jms] trait JmsConnector[S <: JmsSession] {
       case current => current
     }
 
+    closeSessions()
     val previous = updateStateWith(update)
     connection(previous).foreach(_.close())
     connectionStateQueue.complete()

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsProducerStage.scala
@@ -122,7 +122,7 @@ private[jms] final class JmsProducerStage[E <: JmsEnvelope[PassThrough], PassThr
           override def onUpstreamFinish(): Unit = if (inFlightMessages.isEmpty) publishAndCompleteStage()
 
           override def onUpstreamFailure(ex: Throwable): Unit = {
-            jmsSessions.foreach(s => Try(s.closeSession()))
+            closeSessions()
             publishAndFailStage(ex)
           }
 
@@ -149,7 +149,7 @@ private[jms] final class JmsProducerStage[E <: JmsEnvelope[PassThrough], PassThr
 
       private def publishAndCompleteStage(): Unit = {
         val previous = updateState(InternalConnectionState.JmsConnectorStopping(Success(Done)))
-        jmsSessions.foreach(_.closeSession())
+        closeSessions()
         JmsConnector.connection(previous).foreach(_.close())
         completeStage()
       }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsProducerStage.scala
@@ -122,7 +122,6 @@ private[jms] final class JmsProducerStage[E <: JmsEnvelope[PassThrough], PassThr
           override def onUpstreamFinish(): Unit = if (inFlightMessages.isEmpty) publishAndCompleteStage()
 
           override def onUpstreamFailure(ex: Throwable): Unit = {
-            closeSessions()
             publishAndFailStage(ex)
           }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/Sessions.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/Sessions.scala
@@ -22,11 +22,7 @@ private[jms] sealed trait JmsSession {
 
   def session: jms.Session
 
-  private[jms] def closeSessionAsync()(implicit ec: ExecutionContext): Future[Unit] = Future { closeSession() }
-
   private[jms] def closeSession(): Unit = session.close()
-
-  private[jms] def abortSessionAsync()(implicit ec: ExecutionContext): Future[Unit] = Future { abortSession() }
 
   private[jms] def abortSession(): Unit = closeSession()
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/SourceStageLogic.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/SourceStageLogic.scala
@@ -114,8 +114,7 @@ private abstract class SourceStageLogic[T](shape: SourceShape[T],
       val status = updateState(JmsConnectorStopping(Success(Done)))
       val connectionFuture = JmsConnector.connection(status)
 
-      Future
-        .sequence(closeSessionsAsync())
+      closeSessionsAsync()
         .onComplete { _ =>
           connectionFuture
             .map { connection =>
@@ -140,8 +139,7 @@ private abstract class SourceStageLogic[T](shape: SourceShape[T],
       if (log.isDebugEnabled) log.debug("aborting sessions ({})", ex.toString)
       val status = updateState(JmsConnectorStopping(Failure(ex)))
       val connectionFuture = JmsConnector.connection(status)
-      Future
-        .sequence(abortSessionsAsync())
+      abortSessionsAsync()
         .onComplete { _ =>
           connectionFuture
             .map { connection =>

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/SourceStageLogic.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/SourceStageLogic.scala
@@ -15,7 +15,6 @@ import akka.stream.{Attributes, Outlet, SourceShape}
 import akka.{Done, NotUsed}
 
 import scala.collection.mutable
-import scala.concurrent.Future
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
@@ -67,7 +66,7 @@ private abstract class SourceStageLogic[T](shape: SourceShape[T],
 
   protected val handleError = getAsyncCallback[Throwable] { e =>
     updateState(JmsConnectorStopping(Failure(e)))
-    fail(out, e)
+    failStage(e)
   }
 
   override def preStart(): Unit = {

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsSharedServerSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsSharedServerSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.jms
+
+import javax.jms._
+import jmstestkit.JmsBroker
+
+import scala.util.Random
+
+/**
+ * Creates a single server and connection factory which is shared for all tests.
+ */
+abstract class JmsSharedServerSpec extends JmsSpec {
+  private var jmsBroker: JmsBroker = _
+  private var connectionFactory: ConnectionFactory = _
+
+  override def beforeAll(): Unit = {
+    jmsBroker = JmsBroker()
+    connectionFactory = jmsBroker.createConnectionFactory
+    Thread.sleep(500)
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    if (jmsBroker != null && jmsBroker.isStarted) {
+      jmsBroker.stop()
+    }
+  }
+
+  override def withConnectionFactory()(test: ConnectionFactory => Unit): Unit = {
+    test(connectionFactory)
+  }
+
+  def createName(prefix: String) = prefix + Random.nextInt().toString
+
+}

--- a/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
@@ -632,7 +632,7 @@ class JmsTxConnectorsSpec extends JmsSharedServerSpec {
     }
 
     // Illustrates https://github.com/akka/alpakka/issues/2039
-    "close the JMS session" ignore withConnectionFactory() { connectionFactory =>
+    "close the JMS session" in withConnectionFactory() { connectionFactory =>
       val queueName = createName("test")
       val jmsSink: Sink[String, Future[Done]] = JmsProducer.textSink(
         JmsProducerSettings(producerConfig, connectionFactory).withQueue(queueName)

--- a/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
@@ -20,21 +20,22 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
-class JmsTxConnectorsSpec extends JmsSpec {
+class JmsTxConnectorsSpec extends JmsSharedServerSpec {
 
   override implicit val patienceConfig = PatienceConfig(2.minutes)
 
   "The JMS Transactional Connectors" should {
     "publish and consume strings through a queue" in withConnectionFactory() { connectionFactory =>
+      val queueName = createName("test")
       val jmsSink: Sink[String, Future[Done]] = JmsProducer.textSink(
-        JmsProducerSettings(producerConfig, connectionFactory).withQueue("test")
+        JmsProducerSettings(producerConfig, connectionFactory).withQueue(queueName)
       )
 
       val in = 0 to 25 map (i => ('a' + i).asInstanceOf[Char].toString)
       Source(in).runWith(jmsSink)
 
       val jmsSource: Source[TxEnvelope, JmsConsumerControl] = JmsConsumer.txSource(
-        JmsConsumerSettings(consumerConfig, connectionFactory).withSessionCount(5).withQueue("test")
+        JmsConsumerSettings(consumerConfig, connectionFactory).withSessionCount(5).withQueue(queueName)
       )
 
       val result = jmsSource
@@ -47,9 +48,10 @@ class JmsTxConnectorsSpec extends JmsSpec {
     }
 
     "publish and consume JMS text messages with properties through a queue" in withConnectionFactory() {
+      val queueName = createName("numbers")
       connectionFactory =>
         val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer.sink(
-          JmsProducerSettings(producerConfig, connectionFactory).withQueue("numbers")
+          JmsProducerSettings(producerConfig, connectionFactory).withQueue(queueName)
         )
 
         val msgsIn = 1 to 100 map { n =>
@@ -66,7 +68,7 @@ class JmsTxConnectorsSpec extends JmsSpec {
           JmsConsumerSettings(consumerConfig, connectionFactory)
             .withSessionCount(5)
             .withAckTimeout(1.second)
-            .withQueue("numbers")
+            .withQueue(queueName)
         )
 
         val result: Future[immutable.Seq[javax.jms.Message]] =
@@ -91,8 +93,9 @@ class JmsTxConnectorsSpec extends JmsSpec {
 
     "ensure re-delivery when rollback JMS text messages through a queue" in withConnectionFactory() {
       connectionFactory =>
+        val queueName = createName("numbers")
         val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer.sink(
-          JmsProducerSettings(producerConfig, connectionFactory).withQueue("numbers")
+          JmsProducerSettings(producerConfig, connectionFactory).withQueue(queueName)
         )
         val msgsIn = 1 to 100 map { n =>
           JmsTextMessage(n.toString).withProperty("Number", n)
@@ -101,7 +104,7 @@ class JmsTxConnectorsSpec extends JmsSpec {
         Source(msgsIn).runWith(jmsSink)
 
         val jmsSource: Source[TxEnvelope, JmsConsumerControl] = JmsConsumer.txSource(
-          JmsConsumerSettings(consumerConfig, connectionFactory).withSessionCount(5).withQueue("numbers")
+          JmsConsumerSettings(consumerConfig, connectionFactory).withSessionCount(5).withQueue(queueName)
         )
 
         val expectedElements = (1 to 100) ++ (2 to 100 by 2) map (_.toString)
@@ -127,8 +130,9 @@ class JmsTxConnectorsSpec extends JmsSpec {
 
     "publish JMS text messages with properties through a queue and consume them with a selector" in withConnectionFactory() {
       connectionFactory =>
+        val queueName = createName("numbers")
         val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer.sink(
-          JmsProducerSettings(producerConfig, connectionFactory).withQueue("numbers")
+          JmsProducerSettings(producerConfig, connectionFactory).withQueue(queueName)
         )
 
         val msgsIn = 1 to 100 map { n =>
@@ -142,7 +146,7 @@ class JmsTxConnectorsSpec extends JmsSpec {
         val jmsSource = JmsConsumer.txSource(
           JmsConsumerSettings(consumerConfig, connectionFactory)
             .withSessionCount(5)
-            .withQueue("numbers")
+            .withQueue(queueName)
             .withSelector("IsOdd = TRUE")
         )
 
@@ -170,12 +174,13 @@ class JmsTxConnectorsSpec extends JmsSpec {
     "applying backpressure when the consumer is slower than the producer" in withConnectionFactory() {
       connectionFactory =>
         val in = 0 to 25 map (i => ('a' + i).asInstanceOf[Char].toString)
+        val queueName = createName("test")
         Source(in).runWith(
-          JmsProducer.textSink(JmsProducerSettings(producerConfig, connectionFactory).withQueue("test"))
+          JmsProducer.textSink(JmsProducerSettings(producerConfig, connectionFactory).withQueue(queueName))
         )
 
         val jmsSource: Source[TxEnvelope, JmsConsumerControl] = JmsConsumer.txSource(
-          JmsConsumerSettings(consumerConfig, connectionFactory).withSessionCount(5).withQueue("test")
+          JmsConsumerSettings(consumerConfig, connectionFactory).withSessionCount(5).withQueue(queueName)
         )
 
         val result = jmsSource
@@ -189,11 +194,12 @@ class JmsTxConnectorsSpec extends JmsSpec {
     }
 
     "disconnection should fail the stage after exhausting retries" in withServer() { server =>
+      val queueName = createName("test")
       val connectionFactory = server.createConnectionFactory
       val result = JmsConsumer
         .txSource(
           JmsConsumerSettings(consumerConfig, connectionFactory)
-            .withQueue("test")
+            .withQueue(queueName)
             .withConnectionRetrySettings(ConnectionRetrySettings(system).withMaxRetries(3))
         )
         .runWith(Sink.seq)
@@ -206,22 +212,23 @@ class JmsTxConnectorsSpec extends JmsSpec {
 
     "publish and consume elements through a topic " in withConnectionFactory() { connectionFactory =>
       import system.dispatcher
+      val topic = createName("topic")
 
       val jmsTopicSink: Sink[String, Future[Done]] = JmsProducer.textSink(
-        JmsProducerSettings(producerConfig, connectionFactory).withTopic("topic")
+        JmsProducerSettings(producerConfig, connectionFactory).withTopic(topic)
       )
       val jmsTopicSink2: Sink[String, Future[Done]] = JmsProducer.textSink(
-        JmsProducerSettings(producerConfig, connectionFactory).withTopic("topic")
+        JmsProducerSettings(producerConfig, connectionFactory).withTopic(topic)
       )
 
       val in = List("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")
       val inNumbers = (1 to 10).map(_.toString)
 
       val jmsTopicSource: Source[TxEnvelope, JmsConsumerControl] = JmsConsumer.txSource(
-        JmsConsumerSettings(consumerConfig, connectionFactory).withSessionCount(1).withTopic("topic")
+        JmsConsumerSettings(consumerConfig, connectionFactory).withSessionCount(1).withTopic(topic)
       )
       val jmsSource2: Source[TxEnvelope, JmsConsumerControl] = JmsConsumer.txSource(
-        JmsConsumerSettings(consumerConfig, connectionFactory).withSessionCount(1).withTopic("topic")
+        JmsConsumerSettings(consumerConfig, connectionFactory).withSessionCount(1).withTopic(topic)
       )
 
       val expectedSize = in.size + inNumbers.size
@@ -250,8 +257,9 @@ class JmsTxConnectorsSpec extends JmsSpec {
     }
 
     "ensure no message loss when stopping a stream" in withConnectionFactory() { connectionFactory =>
+      val queueName = createName("numbers")
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer.sink(
-        JmsProducerSettings(producerConfig, connectionFactory).withQueue("numbers")
+        JmsProducerSettings(producerConfig, connectionFactory).withQueue(queueName)
       )
 
       val (publishKillSwitch, publishedData) = Source
@@ -263,7 +271,7 @@ class JmsTxConnectorsSpec extends JmsSpec {
         .run()
 
       val jmsSource: Source[TxEnvelope, JmsConsumerControl] = JmsConsumer.txSource(
-        JmsConsumerSettings(consumerConfig, connectionFactory).withSessionCount(5).withQueue("numbers")
+        JmsConsumerSettings(consumerConfig, connectionFactory).withSessionCount(5).withQueue(queueName)
       )
 
       val resultQueue = new LinkedBlockingQueue[String]()
@@ -323,8 +331,9 @@ class JmsTxConnectorsSpec extends JmsSpec {
     }
 
     "ensure no message loss when aborting a stream" in withConnectionFactory() { connectionFactory =>
+      val queueName = createName("numbers")
       val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer.sink(
-        JmsProducerSettings(producerConfig, connectionFactory).withQueue("numbers")
+        JmsProducerSettings(producerConfig, connectionFactory).withQueue(queueName)
       )
 
       val (publishKillSwitch, publishedData) = Source
@@ -336,7 +345,7 @@ class JmsTxConnectorsSpec extends JmsSpec {
         .run()
 
       val jmsSource: Source[TxEnvelope, JmsConsumerControl] = JmsConsumer.txSource(
-        JmsConsumerSettings(consumerConfig, connectionFactory).withSessionCount(5).withQueue("numbers")
+        JmsConsumerSettings(consumerConfig, connectionFactory).withSessionCount(5).withQueue(queueName)
       )
 
       val resultQueue = new LinkedBlockingQueue[String]()
@@ -400,8 +409,9 @@ class JmsTxConnectorsSpec extends JmsSpec {
 
     "ensure no message loss or starvation when exceptions occur in a stream missing commits" in withConnectionFactory() {
       connectionFactory =>
+        val queueName = createName("numbers")
         val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer.sink(
-          JmsProducerSettings(producerConfig, connectionFactory).withQueue("numbers")
+          JmsProducerSettings(producerConfig, connectionFactory).withQueue(queueName)
         )
 
         val (publishKillSwitch, publishedData) = Source
@@ -415,7 +425,7 @@ class JmsTxConnectorsSpec extends JmsSpec {
         val jmsSource: Source[TxEnvelope, JmsConsumerControl] = JmsConsumer.txSource(
           JmsConsumerSettings(consumerConfig, connectionFactory)
             .withSessionCount(5)
-            .withQueue("numbers")
+            .withQueue(queueName)
             .withAckTimeout(10.millis)
         )
 
@@ -490,8 +500,9 @@ class JmsTxConnectorsSpec extends JmsSpec {
 
     "ensure no message loss or starvation when timeouts occur in a stream processing" in withConnectionFactory() {
       connectionFactory =>
+        val queueName = createName("numbers")
         val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer.sink(
-          JmsProducerSettings(producerConfig, connectionFactory).withQueue("numbers")
+          JmsProducerSettings(producerConfig, connectionFactory).withQueue(queueName)
         )
 
         val (publishKillSwitch, publishedData) = Source
@@ -505,7 +516,7 @@ class JmsTxConnectorsSpec extends JmsSpec {
         val jmsSource: Source[TxEnvelope, JmsConsumerControl] = JmsConsumer.txSource(
           JmsConsumerSettings(consumerConfig, connectionFactory)
             .withSessionCount(5)
-            .withQueue("numbers")
+            .withQueue(queueName)
             .withAckTimeout(10.millis)
         )
 
@@ -574,8 +585,9 @@ class JmsTxConnectorsSpec extends JmsSpec {
 
     "fail the stream when ack-timeout causes a rollback (and fail-stream-on-ack-timeout is true)" in {
       withConnectionFactory() { connectionFactory =>
+        val queueName = createName("numbers")
         val jmsSink: Sink[JmsTextMessage, Future[Done]] = JmsProducer.sink(
-          JmsProducerSettings(producerConfig, connectionFactory).withQueue("numbers")
+          JmsProducerSettings(producerConfig, connectionFactory).withQueue(queueName)
         )
 
         val publishKillSwitch = Source
@@ -589,7 +601,7 @@ class JmsTxConnectorsSpec extends JmsSpec {
         val jmsSource: Source[TxEnvelope, JmsConsumerControl] = JmsConsumer.txSource(
           JmsConsumerSettings(consumerConfig, connectionFactory)
             .withSessionCount(5)
-            .withQueue("numbers")
+            .withQueue(queueName)
             .withAckTimeout(10.millis)
             .withFailStreamOnAckTimeout(true)
         )
@@ -621,7 +633,7 @@ class JmsTxConnectorsSpec extends JmsSpec {
 
     // Illustrates https://github.com/akka/alpakka/issues/2039
     "close the JMS session" ignore withConnectionFactory() { connectionFactory =>
-      val queueName = "test"
+      val queueName = createName("test")
       val jmsSink: Sink[String, Future[Done]] = JmsProducer.textSink(
         JmsProducerSettings(producerConfig, connectionFactory).withQueue(queueName)
       )


### PR DESCRIPTION
## Purpose

Close JMS sessions on stage stop.

## Changes

(See commits)
* Isolate the access to `sessions` within `JmsConnector`.
* Switch some tests to use a shared JMS broker with by using random queue names
* Close sessions in `finishStop` which is called from `postStop`

## Background Context

While exploring possible solutions to #2039 I noticed the JMS sessions are not properly closed in more scenarios.