### PR TITLE
Google Cloud Pub/Sub gRPC: latest versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -171,7 +171,10 @@ lazy val googleCloudPubSubGrpc = alpakkaProject(
   connectInput in run := true,
   scalacOptions += "-P:silencer:pathFilters=src_managed",
   crossScalaVersions --= Seq(Dependencies.Scala211) // 2.11 is not supported since Akka gRPC 0.6
-).enablePlugins(AkkaGrpcPlugin, JavaAgent)
+)
+// #grpc-plugins
+  .enablePlugins(AkkaGrpcPlugin, JavaAgent)
+// #grpc-plugins
 
 lazy val googleCloudStorage =
   alpakkaProject("google-cloud-storage",
@@ -305,6 +308,7 @@ lazy val docs = project
         "extref.akka-http.base_url" -> s"https://doc.akka.io/docs/akka-http/${Dependencies.AkkaHttpBinaryVersion}/%s",
         "scaladoc.akka.http.base_url" -> s"https://doc.akka.io/api/akka-http/${Dependencies.AkkaHttpBinaryVersion}/",
         "javadoc.akka.http.base_url" -> s"https://doc.akka.io/japi/akka-http/${Dependencies.AkkaHttpBinaryVersion}/",
+        "extref.akka-grpc.base_url" -> s"https://doc.akka.io/docs/akka-grpc/current/%s",
         "extref.couchbase.base_url" -> s"https://docs.couchbase.com/java-sdk/${Dependencies.CouchbaseVersionForDocs}/%s",
         "extref.java-api.base_url" -> "https://docs.oracle.com/javase/8/docs/api/index.html?%s.html",
         "extref.geode.base_url" -> s"https://geode.apache.org/docs/guide/${Dependencies.GeodeVersionForDocs}/%s",

--- a/build.sbt
+++ b/build.sbt
@@ -69,11 +69,11 @@ lazy val alpakka = project
     // unidoc combines sources and jars from all connectors and that
     // might include some incompatible ones. Depending on the
     // classpath order that might lead to scaladoc compilation errors.
-    // Therefore some versions are exlcuded here.
+    // Therefore some versions are excluded here.
     ScalaUnidoc / unidoc / fullClasspath := {
       (ScalaUnidoc / unidoc / fullClasspath).value
         .filterNot(_.data.getAbsolutePath.contains("protobuf-java-2.5.0.jar"))
-        .filterNot(_.data.getAbsolutePath.contains("guava-27.1-android.jar"))
+        .filterNot(_.data.getAbsolutePath.contains("guava-28.1-android.jar"))
         .filterNot(_.data.getAbsolutePath.contains("commons-net-3.1.jar"))
     },
     ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(`doc-examples`,

--- a/build.sbt
+++ b/build.sbt
@@ -166,10 +166,10 @@ lazy val googleCloudPubSubGrpc = alpakkaProject(
   akkaGrpcCodeGeneratorSettings ~= { _.filterNot(_ == "flat_package") },
   akkaGrpcGeneratedSources := Seq(AkkaGrpc.Client),
   akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Scala, AkkaGrpc.Java),
-  javaAgents += Dependencies.GooglePubSubGrpcAlpnAgent % "test",
+  javaAgents += Dependencies.GooglePubSubGrpcAlpnAgent % Test,
   // for the ExampleApp in the tests
   connectInput in run := true,
-  Compile / compile / scalacOptions += "-P:silencer:pathFilters=src_managed",
+  scalacOptions += "-P:silencer:pathFilters=src_managed",
   crossScalaVersions --= Seq(Dependencies.Scala211) // 2.11 is not supported since Akka gRPC 0.6
 ).enablePlugins(AkkaGrpcPlugin, JavaAgent)
 

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/impl/GuavaFutures.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/impl/GuavaFutures.scala
@@ -29,6 +29,7 @@ private[cassandra] object GuavaFutures {
         override def onSuccess(a: A): Unit = p.success(a)
         override def onFailure(err: Throwable): Unit = p.failure(err)
       }
+      // Alpakka build: if this fails during `unidoc` check the filters in build.sbt
       Futures.addCallback(guavaFut, callback)
       p.future
     }

--- a/docs/src/main/paradox/google-cloud-pub-sub-grpc.md
+++ b/docs/src/main/paradox/google-cloud-pub-sub-grpc.md
@@ -29,6 +29,40 @@ The table below shows direct dependencies of this module and the second tab show
 
 @@dependencies { projectId="google-cloud-pub-sub-grpc" }
 
+## Build setup
+
+The Alpakka Google Cloud Pub/Sub gRPC library contains the classes generated from [Google's protobuf specification](https://github.com/googleapis/java-pubsub/tree/master/proto-google-cloud-pubsub-v1/).
+
+To call the API via gRPC, the ALPN Java agent is required to be set up correctly.
+
+### Maven
+
+Configure your project to use the Java agent for ALPN and add `-javaagent:...` to your startup scripts as described in the @extref:[Akka gRPC documentation](akka-grpc:/buildtools/maven.html#starting-your-akka-grpc-server-from-maven).
+
+### sbt
+
+Configure your project to use the Java agent for ALPN and add `-javaagent:...` to your startup scripts.
+
+Pull in the [`sbt-javaagent`](https://github.com/sbt/sbt-javaagent) plugin.
+
+project/plugins.sbt
+: @@snip (/project/plugins.sbt) { #grpc-agent }
+
+Enable the Akka gRPC and JavaAgent plugins on the sbt project.
+
+build.sbt
+: @@snip (/build.sbt) { #grpc-plugins }
+
+Add the Java agent to the runtime configuration.
+
+build.sbt
+:   ```scala
+    javaAgents += "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.9"
+    ```
+
+### Gradle
+
+Configure your project to use the Java agent for ALPN and add `-javaagent:...` to your startup scripts as described in the @extref:[Akka gRPC documentation](akka-grpc:/buildtools/gradle.html#starting-your-akka-grpc-server-from-gradle).
 
 ## Configuration
 

--- a/docs/src/main/paradox/google-cloud-pub-sub-grpc.md
+++ b/docs/src/main/paradox/google-cloud-pub-sub-grpc.md
@@ -33,15 +33,19 @@ The table below shows direct dependencies of this module and the second tab show
 
 The Alpakka Google Cloud Pub/Sub gRPC library contains the classes generated from [Google's protobuf specification](https://github.com/googleapis/java-pubsub/tree/master/proto-google-cloud-pubsub-v1/).
 
-To call the API via gRPC, the ALPN Java agent is required to be set up correctly.
+@@@note { title="ALPN on JDK 8" }
+
+For use on JDK 8 the ALPN Java agent needs to be set up explicitly.
+
+@@@
 
 ### Maven
 
-Configure your project to use the Java agent for ALPN and add `-javaagent:...` to your startup scripts as described in the @extref:[Akka gRPC documentation](akka-grpc:/buildtools/maven.html#starting-your-akka-grpc-server-from-maven).
+When using JDK 8: configure your project to use the Java agent for ALPN and add `-javaagent:...` to your startup scripts as described in the @extref:[Akka gRPC documentation](akka-grpc:/buildtools/maven.html#starting-your-akka-grpc-server-from-maven).
 
 ### sbt
 
-Configure your project to use the Java agent for ALPN and add `-javaagent:...` to your startup scripts.
+When using JDK 8: Configure your project to use the Java agent for ALPN and add `-javaagent:...` to your startup scripts.
 
 Pull in the [`sbt-javaagent`](https://github.com/sbt/sbt-javaagent) plugin.
 
@@ -62,7 +66,7 @@ build.sbt
 
 ### Gradle
 
-Configure your project to use the Java agent for ALPN and add `-javaagent:...` to your startup scripts as described in the @extref:[Akka gRPC documentation](akka-grpc:/buildtools/gradle.html#starting-your-akka-grpc-server-from-gradle).
+When using JDK 8: Configure your project to use the Java agent for ALPN and add `-javaagent:...` to your startup scripts as described in the @extref:[Akka gRPC documentation](akka-grpc:/buildtools/gradle.html#starting-your-akka-grpc-server-from-gradle).
 
 ## Configuration
 

--- a/google-cloud-pub-sub-grpc/src/main/mima-filters/2.0.0-M2.backwards.excludes/PR2050-version-upgrades.excludes
+++ b/google-cloud-pub-sub-grpc/src/main/mima-filters/2.0.0-M2.backwards.excludes/PR2050-version-upgrades.excludes
@@ -1,0 +1,3 @@
+ProblemFilters.exclude[Problem]("com.google.pubsub.v1.*")
+ProblemFilters.exclude[Problem]("com.google.api.*")
+ProblemFilters.exclude[Problem]("com.google.iam.*")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -189,6 +189,7 @@ object Dependencies {
   val GooglePubSubGrpc = Seq(
     // see Akka gRPC version in plugins.sbt
     libraryDependencies ++= Seq(
+        // https://github.com/googleapis/java-pubsub/tree/master/proto-google-cloud-pubsub-v1/
         "com.google.api.grpc" % "grpc-google-cloud-pubsub-v1" % "1.84.0" % "protobuf", // ApacheV2
         "io.grpc" % "grpc-auth" % "1.25.0", // ApacheV2
         "com.google.auth" % "google-auth-library-oauth2-http" % "0.19.0", // BSD 3-clause

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -187,10 +187,11 @@ object Dependencies {
   )
 
   val GooglePubSubGrpc = Seq(
+    // see Akka gRPC version in plugins.sbt
     libraryDependencies ++= Seq(
-        "com.google.api.grpc" % "grpc-google-cloud-pubsub-v1" % "1.68.0" % "protobuf", // ApacheV2
-        "io.grpc" % "grpc-auth" % "1.22.1", // ApacheV2
-        "com.google.auth" % "google-auth-library-oauth2-http" % "0.16.2", // BSD 3-clause
+        "com.google.api.grpc" % "grpc-google-cloud-pubsub-v1" % "1.84.0" % "protobuf", // ApacheV2
+        "io.grpc" % "grpc-auth" % "1.25.0", // ApacheV2
+        "com.google.auth" % "google-auth-library-oauth2-http" % "0.19.0", // BSD 3-clause
         // pull in Akka Discovery for our Akka version
         "com.typesafe.akka" %% "akka-discovery" % AkkaVersion
       ) ++ Silencer

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,9 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.7.3")
+// #grpc-agent
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")
+// #grpc-agent
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
 // depend directly on the patched version see https://github.com/akka/alpakka/issues/1388
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2+10-148ba0ff")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.18")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.7.2")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.7.3")
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
 // depend directly on the patched version see https://github.com/akka/alpakka/issues/1388


### PR DESCRIPTION
## Purpose

Use the current versions of Akka gRPC and other dependencies.

## References

https://github.com/akka/akka-grpc/releases/tag/v0.7.3
