### PR TITLE
AWS S3: disallow sub-dir selection with bucket names

### DIFF
--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -92,6 +92,23 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
     )
   }
 
+  it should "throw an error when using `..` with path-style access" in {
+    implicit val settings = getSettings(s3Region = Region.EU_WEST_1).withPathStyleAccess(true)
+
+    assertThrows[IllegalUriException](
+      HttpRequests.getDownloadRequest(S3Location("invalid/../bucket_name", "image-1024@2x"))
+    )
+    assertThrows[IllegalUriException](
+      HttpRequests.getDownloadRequest(S3Location("../bucket_name", "image-1024@2x"))
+    )
+    assertThrows[IllegalUriException](
+      HttpRequests.getDownloadRequest(S3Location("bucket_name/..", "image-1024@2x"))
+    )
+    assertThrows[IllegalUriException](
+      HttpRequests.getDownloadRequest(S3Location("..", "image-1024@2x"))
+    )
+  }
+
   it should "initiate multipart upload with path-style access in region us-east-1" in {
     implicit val settings = getSettings(s3Region = Region.US_EAST_1).withPathStyleAccess(true)
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -26,7 +26,7 @@ abstract class S3WireMockBase(_system: ActorSystem, val _wireMockServer: WireMoc
 
   def this() = {
     this(initServer())
-    system.registerOnTermination(mock.shutdown())
+    system.registerOnTermination(stopWireMockServer())
   }
 
   val mock = new WireMock("localhost", _wireMockServer.port())

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -23,7 +23,11 @@ abstract class S3WireMockBase(_system: ActorSystem, val _wireMockServer: WireMoc
 
   private def this(mock: WireMockServer) =
     this(ActorSystem(getCallerName(getClass), config(mock.port()).withFallback(ConfigFactory.load())), mock)
-  def this() = this(initServer())
+
+  def this() = {
+    this(initServer())
+    system.registerOnTermination(mock.shutdown())
+  }
 
   val mock = new WireMock("localhost", _wireMockServer.port())
   val port = _wireMockServer.port()


### PR DESCRIPTION
## Purpose

Validate the bucket name even when using path-style access so that using `..` doesn't give access to other S3 buckets levels.

## References

#1679

## Changes

* validate bucket names for path-style access
* shut down WireMock in tests
* avoid nesting `Source.setup` in `request`

## Background Context

When using path-style access, the S3 bucket name becomes a part of the URLs and opens up to select sub-directories on S3.
Path-style access is being discontinued by AWS from September 2020 see #1679 