### PR TITLE
IDE: Rename docs project so that IntelliJ imports it

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -286,7 +286,7 @@ lazy val docs = project
   .enablePlugins(AkkaParadoxPlugin, ParadoxSitePlugin, PreprocessPlugin, PublishRsyncPlugin)
   .disablePlugins(BintrayPlugin, MimaPlugin)
   .settings(
-    name := "Alpakka",
+    Compile / paradox / name := "Alpakka",
     publish / skip := true,
     whitesourceIgnore := true,
     makeSite := makeSite.dependsOn(LocalRootProject / ScalaUnidoc / doc).value,


### PR DESCRIPTION
## Purpose

Make the IntelliJ import work.

## References

Fixes #2028

## Background Context

The IntelliJ sbt import seems to get lost when the `docs` project has a "similar" name as the root project.