### PR TITLE
Elasticsearch - #1566 - ElasticsearchFlowStage retry logic improvement

### DIFF
--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
@@ -473,9 +473,7 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll wi
         )
         .runWith(Sink.seq)
 
-      val start = System.currentTimeMillis()
       val writeResults = createBooks.futureValue
-      val end = System.currentTimeMillis()
 
       writeResults should have size writeMsgs.size
 

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
@@ -441,21 +441,26 @@ class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll wi
       val indexName = "sink5_1"
 
       val bookNr = 100
-      val writeMsgs = Iterator.from(0)
+      val writeMsgs = Iterator
+        .from(0)
         .take(bookNr)
         .grouped(5)
         .zipWithIndex
-        .flatMap { case (numBlock, index) =>
-          val writeMsgBlock = numBlock.map { n =>
-            WriteMessage.createCreateMessage(n.toString, Map("title" -> s"Book ${n}"))
-              .withPassThrough(n)
-          }
+        .flatMap {
+          case (numBlock, index) =>
+            val writeMsgBlock = numBlock.map { n =>
+              WriteMessage
+                .createCreateMessage(n.toString, Map("title" -> s"Book ${n}"))
+                .withPassThrough(n)
+            }
 
-          val writeMsgFailed = WriteMessage.createCreateMessage("0", Map("title" -> s"Failed"))
-            .withPassThrough(bookNr + index)
+            val writeMsgFailed = WriteMessage
+              .createCreateMessage("0", Map("title" -> s"Failed"))
+              .withPassThrough(bookNr + index)
 
-          (writeMsgBlock ++ Iterator(writeMsgFailed)).toList
-        }.toList
+            (writeMsgBlock ++ Iterator(writeMsgFailed)).toList
+        }
+        .toList
 
       val createBooks = Source(writeMsgs)
         .via(


### PR DESCRIPTION
- failed messages are treated independently to avoid loosing track of previously failed ones
- retry counts are kept per message so to guarantee correct number of retries and intervals
- added test case proving fix correctness

Apart for the added test, this pull request has also been tested on a live system which kept failing with the 1.1.2 release.

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Purpose

This pull request corrects ElasticsearchFlowStage retry logic implementation making sure that old failed messages are not lost due to new failures.

## References

References #1566

## Changes

Only the internal implementation of ElasticsearchFlowStage has been changed to keep track of retry counts on a per message basis.
