### PR TITLE
JMS: Fix memory leak in connection status

### DIFF
--- a/docs/src/main/paradox/jms/browse.md
+++ b/docs/src/main/paradox/jms/browse.md
@@ -55,6 +55,7 @@ connectionFactory       | Factory to use for creating JMS connections           
 destination             | The queue to browse                                                  | Must be set in code |
 credentials             | JMS broker credentials                                               | Empty               |
 connectionRetrySettings | Retry characteristics if the connection failed to be established or is taking a long time. | See @ref[Connection Retries](producer.md#connection-retries) 
+connectionStatusSubscriptionTimeout | 5 seconds | Time to wait for subscriber of connection status events before starting to discard them |
 
 reference.conf
 : @@snip [snip](/jms/src/main/resources/reference.conf) { #browse }

--- a/docs/src/main/paradox/jms/consumer.md
+++ b/docs/src/main/paradox/jms/consumer.md
@@ -59,6 +59,7 @@ sessionCount            | Number of parallel sessions to use for receiving JMS m
 bufferSize              | Maximum number of messages to prefetch before applying backpressure. | 100                 |
 ackTimeout              | For use with JMS transactions, only: maximum time given to a message to be committed or rolled back. | 1 second  |
 selector                | JMS selector expression (see [below](#using-jms-selectors))          | Empty               |
+connectionStatusSubscriptionTimeout | 5 seconds | Time to wait for subscriber of connection status events before starting to discard them |
 
 reference.conf
 : @@snip [snip](/jms/src/main/resources/reference.conf) { #consumer }

--- a/docs/src/main/paradox/jms/producer.md
+++ b/docs/src/main/paradox/jms/producer.md
@@ -189,14 +189,15 @@ The producer can be configured with the following settings. On the second tab, t
 
 Table
 : Setting                 | Defaults    |   Description                                           | 
-------------------------|-------------|---------------------------------------------------------|
-connectionFactory       | mandatory   | Factory to use for creating JMS connections             |
-destination             | mandatory   | Destination (queue or topic) to send JMS messages to    |
-credentials             | optional    | JMS broker credentials                                  |
-connectionRetrySettings | default settings | Retry characteristics if the connection failed to be established or taking a long time. Please see default values under [Connection Retries](#connection-retries) |
-sendRetrySettings       | default settings | Retry characteristics if message sending failed. Please see default values under [Send Retries](#send-retries) |
-sessionCount            | defaults to `1` | Number of parallel sessions to use for sending JMS messages. Increasing the number of parallel sessions increases throughput at the cost of message ordering. While the messages may arrive out of order on the JMS broker, the producer flow outputs messages in the order they are received |
-timeToLive              | optional    | Time messages should be kept on the Jms broker. This setting can be overridden on individual messages. If not set, messages will never expire |
+--------------------------|-------------|---------------------------------------------------------|
+connectionFactory         | mandatory   | Factory to use for creating JMS connections             |
+destination               | mandatory   | Destination (queue or topic) to send JMS messages to    |
+credentials               | optional    | JMS broker credentials                                  |
+connectionRetrySettings   | default settings | Retry characteristics if the connection failed to be established or taking a long time. Please see default values under [Connection Retries](#connection-retries) |
+sendRetrySettings         | default settings | Retry characteristics if message sending failed. Please see default values under [Send Retries](#send-retries) |
+sessionCount              | defaults to `1` | Number of parallel sessions to use for sending JMS messages. Increasing the number of parallel sessions increases throughput at the cost of message ordering. While the messages may arrive out of order on the JMS broker, the producer flow outputs messages in the order they are received |
+timeToLive                | optional    | Time messages should be kept on the Jms broker. This setting can be overridden on individual messages. If not set, messages will never expire |
+connectionStatusSubscriptionTimeout | 5 seconds | Time to wait for subscriber of connection status events before starting to discard them |
 
 reference.conf
 : @@snip [snip](/jms/src/main/resources/reference.conf) { #producer }

--- a/jms/src/main/mima-filters/2.0.0-M2.backwards.excludes/PR2067.excludes
+++ b/jms/src/main/mima-filters/2.0.0-M2.backwards.excludes/PR2067.excludes
@@ -1,0 +1,6 @@
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.alpakka.jms.JmsSettings.connectionStatusSubscriptionTimeout")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.jms.JmsConsumerSettings.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.jms.JmsProducerSettings.this")
+
+ProblemFilters.exclude[MissingTypesProblem]("akka.stream.alpakka.jms.JmsBrowseSettings")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.jms.JmsBrowseSettings.sessionCount")

--- a/jms/src/main/resources/reference.conf
+++ b/jms/src/main/resources/reference.conf
@@ -53,6 +53,8 @@ alpakka.jms {
     # For use with transactions, if true the stream fails if Alpakka rolls back the transaction
     # when `ack-timeout` is hit.
     fail-stream-on-ack-timeout = false
+    # How long the stage should preserve connection status events for the first subscriber before discarding them
+    connection-status-subscription-timeout = 5 seconds
   }
   #consumer
 
@@ -96,6 +98,8 @@ alpakka.jms {
     # This setting can be overridden on individual messages.
     # "off" to not let messages expire.
     time-to-live = off
+    # How long the stage should preserve connection status events for the first subscriber before discarding them
+    connection-status-subscription-timeout = 5 seconds
   }
   # #producer
 
@@ -120,6 +124,8 @@ alpakka.jms {
     # See eg. javax.jms.Session.AUTO_ACKNOWLEDGE
     # Allowed values: "auto", "client", "duplicates-ok", "session", integer value
     acknowledge-mode = auto
+    # How long the stage should preserve connection status events for the first subscriber before discarding them
+    connection-status-subscription-timeout = 5 seconds
   }
   #browse
 }

--- a/jms/src/main/resources/reference.conf
+++ b/jms/src/main/resources/reference.conf
@@ -124,8 +124,6 @@ alpakka.jms {
     # See eg. javax.jms.Session.AUTO_ACKNOWLEDGE
     # Allowed values: "auto", "client", "duplicates-ok", "session", integer value
     acknowledge-mode = auto
-    # How long the stage should preserve connection status events for the first subscriber before discarding them
-    connection-status-subscription-timeout = 5 seconds
   }
   #browse
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsBrowseSettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsBrowseSettings.scala
@@ -5,7 +5,6 @@
 package akka.stream.alpakka.jms
 
 import akka.actor.ActorSystem
-import akka.util.JavaDurationConverters._
 import com.typesafe.config.{Config, ConfigValueType}
 
 /**
@@ -17,10 +16,8 @@ final class JmsBrowseSettings private (
     val destination: Option[Destination],
     val credentials: Option[Credentials],
     val selector: Option[String],
-    val acknowledgeMode: AcknowledgeMode,
-    val connectionStatusSubscriptionTimeout: scala.concurrent.duration.FiniteDuration
-) extends akka.stream.alpakka.jms.JmsSettings {
-  override val sessionCount = 1
+    val acknowledgeMode: AcknowledgeMode
+) {
 
   /** Factory to use for creating JMS connections. */
   def withConnectionFactory(value: javax.jms.ConnectionFactory): JmsBrowseSettings = copy(connectionFactory = value)
@@ -48,27 +45,20 @@ final class JmsBrowseSettings private (
   /** Set an explicit acknowledge mode. (Consumers have specific defaults.) */
   def withAcknowledgeMode(value: AcknowledgeMode): JmsBrowseSettings = copy(acknowledgeMode = value)
 
-  /** Java API: Timeout for connection status subscriber */
-  def withConnectionStatusSubscriptionTimeout(value: java.time.Duration): JmsBrowseSettings =
-    copy(connectionStatusSubscriptionTimeout = value.asScala)
-
   private def copy(
       connectionFactory: javax.jms.ConnectionFactory = connectionFactory,
       connectionRetrySettings: ConnectionRetrySettings = connectionRetrySettings,
       destination: Option[Destination] = destination,
       credentials: Option[Credentials] = credentials,
       selector: Option[String] = selector,
-      acknowledgeMode: AcknowledgeMode = acknowledgeMode,
-      connectionStatusSubscriptionTimeout: scala.concurrent.duration.FiniteDuration =
-        connectionStatusSubscriptionTimeout
+      acknowledgeMode: AcknowledgeMode = acknowledgeMode
   ): JmsBrowseSettings = new JmsBrowseSettings(
     connectionFactory = connectionFactory,
     connectionRetrySettings = connectionRetrySettings,
     destination = destination,
     credentials = credentials,
     selector = selector,
-    acknowledgeMode = acknowledgeMode,
-    connectionStatusSubscriptionTimeout = connectionStatusSubscriptionTimeout
+    acknowledgeMode = acknowledgeMode
   )
 
   override def toString =
@@ -78,8 +68,7 @@ final class JmsBrowseSettings private (
     s"destination=$destination," +
     s"credentials=$credentials," +
     s"selector=$selector," +
-    s"acknowledgeMode=${AcknowledgeMode.asString(acknowledgeMode)}," +
-    s"connectionStatusSubscriptionTimeout=${connectionStatusSubscriptionTimeout.toCoarsest}" +
+    s"acknowledgeMode=${AcknowledgeMode.asString(acknowledgeMode)}" +
     ")"
 }
 
@@ -106,15 +95,13 @@ object JmsBrowseSettings {
     val credentials = getOption("credentials", c => Credentials(c.getConfig("credentials")))
     val selector = getStringOption("selector")
     val acknowledgeMode = AcknowledgeMode.from(c.getString("acknowledge-mode"))
-    val connectionStatusSubscriptionTimeout = c.getDuration("connection-status-subscription-timeout").asScala
     new JmsBrowseSettings(
       connectionFactory,
       connectionRetrySettings,
       destination,
       credentials,
       selector,
-      acknowledgeMode,
-      connectionStatusSubscriptionTimeout
+      acknowledgeMode
     )
   }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
@@ -21,7 +21,8 @@ final class JmsConsumerSettings private (
     val selector: Option[String],
     val acknowledgeMode: Option[AcknowledgeMode],
     val ackTimeout: scala.concurrent.duration.Duration,
-    val failStreamOnAckTimeout: Boolean
+    val failStreamOnAckTimeout: Boolean,
+    val connectionStatusSubscriptionTimeout: scala.concurrent.duration.FiniteDuration
 ) extends akka.stream.alpakka.jms.JmsSettings {
 
   /** Factory to use for creating JMS connections. */
@@ -77,6 +78,10 @@ final class JmsConsumerSettings private (
   def withFailStreamOnAckTimeout(value: Boolean): JmsConsumerSettings =
     if (failStreamOnAckTimeout == value) this else copy(failStreamOnAckTimeout = value)
 
+  /** Java API: Timeout for connection status subscriber */
+  def withConnectionStatusSubscriptionTimeout(value: java.time.Duration): JmsConsumerSettings =
+    copy(connectionStatusSubscriptionTimeout = value.asScala)
+
   private def copy(
       connectionFactory: javax.jms.ConnectionFactory = connectionFactory,
       connectionRetrySettings: ConnectionRetrySettings = connectionRetrySettings,
@@ -87,7 +92,9 @@ final class JmsConsumerSettings private (
       selector: Option[String] = selector,
       acknowledgeMode: Option[AcknowledgeMode] = acknowledgeMode,
       ackTimeout: scala.concurrent.duration.Duration = ackTimeout,
-      failStreamOnAckTimeout: Boolean = failStreamOnAckTimeout
+      failStreamOnAckTimeout: Boolean = failStreamOnAckTimeout,
+      connectionStatusSubscriptionTimeout: scala.concurrent.duration.FiniteDuration =
+        connectionStatusSubscriptionTimeout
   ): JmsConsumerSettings = new JmsConsumerSettings(
     connectionFactory = connectionFactory,
     connectionRetrySettings = connectionRetrySettings,
@@ -98,7 +105,8 @@ final class JmsConsumerSettings private (
     selector = selector,
     acknowledgeMode = acknowledgeMode,
     ackTimeout = ackTimeout,
-    failStreamOnAckTimeout = failStreamOnAckTimeout
+    failStreamOnAckTimeout = failStreamOnAckTimeout,
+    connectionStatusSubscriptionTimeout = connectionStatusSubscriptionTimeout
   )
 
   override def toString =
@@ -112,7 +120,8 @@ final class JmsConsumerSettings private (
     s"selector=$selector," +
     s"acknowledgeMode=${acknowledgeMode.map(m => AcknowledgeMode.asString(m))}," +
     s"ackTimeout=${ackTimeout.toCoarsest}," +
-    s"failStreamOnAckTimeout=$failStreamOnAckTimeout" +
+    s"failStreamOnAckTimeout=$failStreamOnAckTimeout," +
+    s"connectionStatusSubscriptionTimeout=${connectionStatusSubscriptionTimeout.toCoarsest}" +
     ")"
 }
 
@@ -144,6 +153,7 @@ object JmsConsumerSettings {
       getOption("acknowledge-mode", c => AcknowledgeMode.from(c.getString("acknowledge-mode")))
     val ackTimeout = c.getDuration("ack-timeout").asScala
     val failStreamOnAckTimeout = c.getBoolean("fail-stream-on-ack-timeout")
+    val connectionStatusSubscriptionTimeout = c.getDuration("connection-status-subscription-timeout").asScala
     new JmsConsumerSettings(
       connectionFactory,
       connectionRetrySettings,
@@ -154,7 +164,8 @@ object JmsConsumerSettings {
       selector,
       acknowledgeMode,
       ackTimeout,
-      failStreamOnAckTimeout
+      failStreamOnAckTimeout,
+      connectionStatusSubscriptionTimeout
     )
   }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
@@ -8,6 +8,8 @@ import akka.actor.ActorSystem
 import akka.util.JavaDurationConverters._
 import com.typesafe.config.{Config, ConfigValueType}
 
+import scala.concurrent.duration.FiniteDuration
+
 /**
  * Settings for [[akka.stream.alpakka.jms.scaladsl.JmsConsumer]] and [[akka.stream.alpakka.jms.javadsl.JmsConsumer]].
  */
@@ -77,6 +79,10 @@ final class JmsConsumerSettings private (
    */
   def withFailStreamOnAckTimeout(value: Boolean): JmsConsumerSettings =
     if (failStreamOnAckTimeout == value) this else copy(failStreamOnAckTimeout = value)
+
+  /**  Timeout for connection status subscriber */
+  def withConnectionStatusSubscriptionTimeout(value: FiniteDuration): JmsConsumerSettings =
+    copy(connectionStatusSubscriptionTimeout = value)
 
   /** Java API: Timeout for connection status subscriber */
   def withConnectionStatusSubscriptionTimeout(value: java.time.Duration): JmsConsumerSettings =

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerSettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerSettings.scala
@@ -18,7 +18,8 @@ final class JmsProducerSettings private (
     val destination: Option[Destination],
     val credentials: Option[Credentials],
     val sessionCount: Int,
-    val timeToLive: Option[scala.concurrent.duration.Duration]
+    val timeToLive: Option[scala.concurrent.duration.Duration],
+    val connectionStatusSubscriptionTimeout: scala.concurrent.duration.FiniteDuration
 ) extends akka.stream.alpakka.jms.JmsSettings {
 
   /** Factory to use for creating JMS connections. */
@@ -63,6 +64,10 @@ final class JmsProducerSettings private (
    */
   def withTimeToLive(value: java.time.Duration): JmsProducerSettings = copy(timeToLive = Option(value).map(_.asScala))
 
+  /** Java API: Timeout for connection status subscriber */
+  def withConnectionStatusSubscriptionTimeout(value: java.time.Duration): JmsProducerSettings =
+    copy(connectionStatusSubscriptionTimeout = value.asScala)
+
   private def copy(
       connectionFactory: javax.jms.ConnectionFactory = connectionFactory,
       connectionRetrySettings: ConnectionRetrySettings = connectionRetrySettings,
@@ -70,7 +75,9 @@ final class JmsProducerSettings private (
       destination: Option[Destination] = destination,
       credentials: Option[Credentials] = credentials,
       sessionCount: Int = sessionCount,
-      timeToLive: Option[scala.concurrent.duration.Duration] = timeToLive
+      timeToLive: Option[scala.concurrent.duration.Duration] = timeToLive,
+      connectionStatusSubscriptionTimeout: scala.concurrent.duration.FiniteDuration =
+        connectionStatusSubscriptionTimeout
   ): JmsProducerSettings = new JmsProducerSettings(
     connectionFactory = connectionFactory,
     connectionRetrySettings = connectionRetrySettings,
@@ -78,7 +85,8 @@ final class JmsProducerSettings private (
     destination = destination,
     credentials = credentials,
     sessionCount = sessionCount,
-    timeToLive = timeToLive
+    timeToLive = timeToLive,
+    connectionStatusSubscriptionTimeout = connectionStatusSubscriptionTimeout
   )
 
   override def toString =
@@ -89,7 +97,8 @@ final class JmsProducerSettings private (
     s"destination=$destination," +
     s"credentials=$credentials," +
     s"sessionCount=$sessionCount," +
-    s"timeToLive=${timeToLive.map(_.toCoarsest)}" +
+    s"timeToLive=${timeToLive.map(_.toCoarsest)}," +
+    s"connectionStatusSubscriptionTimeout=${connectionStatusSubscriptionTimeout.toCoarsest}" +
     ")"
 }
 
@@ -114,6 +123,7 @@ object JmsProducerSettings {
     val credentials = getOption("credentials", c => Credentials(c.getConfig("credentials")))
     val sessionCount = c.getInt("session-count")
     val timeToLive = getOption("time-to-live", _.getDuration("time-to-live").asScala)
+    val connectionStatusSubscriptionTimeout = c.getDuration("connection-status-subscription-timeout").asScala
     new JmsProducerSettings(
       connectionFactory,
       connectionRetrySettings,
@@ -121,7 +131,8 @@ object JmsProducerSettings {
       destination = None,
       credentials,
       sessionCount,
-      timeToLive
+      timeToLive,
+      connectionStatusSubscriptionTimeout
     )
   }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerSettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerSettings.scala
@@ -8,6 +8,8 @@ import akka.actor.ActorSystem
 import akka.util.JavaDurationConverters._
 import com.typesafe.config.{Config, ConfigValueType}
 
+import scala.concurrent.duration.FiniteDuration
+
 /**
  * Settings for [[akka.stream.alpakka.jms.scaladsl.JmsProducer]] and [[akka.stream.alpakka.jms.javadsl.JmsProducer]].
  */
@@ -63,6 +65,10 @@ final class JmsProducerSettings private (
    * individual messages. If not set, messages will never expire.
    */
   def withTimeToLive(value: java.time.Duration): JmsProducerSettings = copy(timeToLive = Option(value).map(_.asScala))
+
+  /**  Timeout for connection status subscriber */
+  def withConnectionStatusSubscriptionTimeout(value: FiniteDuration): JmsProducerSettings =
+    copy(connectionStatusSubscriptionTimeout = value)
 
   /** Java API: Timeout for connection status subscriber */
   def withConnectionStatusSubscriptionTimeout(value: java.time.Duration): JmsProducerSettings =

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsSettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsSettings.scala
@@ -18,4 +18,5 @@ trait JmsSettings {
   def destination: Option[Destination]
   def credentials: Option[Credentials]
   def sessionCount: Int
+  def connectionStatusSubscriptionTimeout: scala.concurrent.duration.FiniteDuration
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsConnector.scala
@@ -78,7 +78,7 @@ private[jms] trait JmsConnector[S <: JmsSession] {
       case stopped: JmsConnectorStopped => stopped
       case current =>
         JmsConnectorStopped(
-          Failure(new IllegalStateException(s"BUG: completing stage stop in unexpected state ${current.getClass}"))
+          Failure(new IllegalStateException(s"Completing stage stop in unexpected state ${current.getClass}"))
         )
     }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsConnector.scala
@@ -68,7 +68,7 @@ private[jms] trait JmsConnector[S <: JmsSession] {
     // add subscription to purge queued connection status events after the configured timeout.
     val system: ActorSystem = ActorMaterializerHelper.downcast(materializer).system
     after(jmsSettings.connectionStatusSubscriptionTimeout, system.scheduler) {
-      Future(source.runWith(Sink.ignore)(this.materializer))
+      source.runWith(Sink.ignore)(this.materializer)
     }
   }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsProducerStage.scala
@@ -149,7 +149,7 @@ private[jms] final class JmsProducerStage[E <: JmsEnvelope[PassThrough], PassThr
       private def publishAndCompleteStage(): Unit = {
         val previous = updateState(InternalConnectionState.JmsConnectorStopping(Success(Done)))
         closeSessions()
-        JmsConnector.connection(previous).foreach(_.close())
+        closeConnectionAsync(JmsConnector.connection(previous))
         completeStage()
       }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsProducerStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsProducerStage.scala
@@ -90,8 +90,8 @@ private[jms] final class JmsProducerStage[E <: JmsEnvelope[PassThrough], PassThr
       protected val jmsSettings: JmsProducerSettings = settings
 
       override def preStart(): Unit = {
-        super.preStart()
         ec = executionContext(inheritedAttributes)
+        super.preStart()
         initSessionAsync()
       }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/SourceStageLogic.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/SourceStageLogic.scala
@@ -15,7 +15,6 @@ import akka.stream.{Attributes, Outlet, SourceShape}
 import akka.{Done, NotUsed}
 
 import scala.collection.mutable
-import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
 import javax.jms
@@ -70,8 +69,8 @@ private abstract class SourceStageLogic[T](shape: SourceShape[T],
   }
 
   override def preStart(): Unit = {
-    super.preStart()
     ec = executionContext(inheritedAttributes)
+    super.preStart()
     initSessionAsync()
   }
 


### PR DESCRIPTION
Fixes #2066

This change aims to make sure that references to Jms connection are cleared in both main logic and connection status publishing. Also, it clears the reference to the graph stage logic via the exception listener when the connection gets closed.

This is achieved by:

- Evicting non-consumed connection status events after a specific timeout. This uses a broadcast hub and subscribes a single discarding consumer after a configurable timeout I preliminary called `connection-status-subscription-timeout` and gave it a default of 5 seconds. There would be other ways to fix the leak, but I think this is the simplest and safest way (i.e. safe against accidental misuse).
- Making sure that the reference of the graph stage logic to its Jms connection  is cleared on stop. The code in `finishStop` didn't necessarily catch all corner cases that might exist or be introduced in the future.
- Clearing the Jms connection exception listener before closing the connection. This removes the reference from the Jms client to the Akka consumer/producer stage that can prevent it from being GCed. This for example happens when using the in-JVM ActiveMQ broker. Its buffered messages hold a reference to the connection they were received from (even if this connection is closed), and through this transitively to the Akka producer stage. While doing this, this also cleans up the stopping code of SourceStageLogic at the cost of one additional logging statement on closing Jms connections normally.

