### PR TITLE
GCS: Remove Unexpected Download Limit

### DIFF
--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStream.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStream.scala
@@ -268,7 +268,7 @@ import scala.util.control.NonFatal
             Uri(settings.baseUrl)
               .withPath(Path(settings.basePath) ++ sourcePath / "rewriteTo" ++ destinationPath)
               .withQuery(Query(queryParams))
-        )
+        ).map(response => response.withEntity(response.entity.withoutSizeLimit))
       ).runWith(Sink.head)
         .flatMap(entityForSuccess)
         .flatMap(responseEntityTo[RewriteResponse])


### PR DESCRIPTION
## Purpose

Allowing file download from GCS without having to override `akka.http.client.parsing.max-content-length`

## References

Relevant issue #303 
Relative PR #1036
Possible workout explained [here](https://github.com/akka/alpakka/issues/1176#issuecomment-422230025)

## Background Context

While investigating an issue with file downloads in GCS I came across #303, I thought the fix would be very similar for GCS as well.
