### PR TITLE
Bump akka-http to 10.1.11

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val AwsSdkVersion = "1.11.476"
   val AwsSdk2Version = "2.10.34"
   val AwsSpiAkkaHttpVersion = "0.0.7"
-  val AkkaHttpVersion = "10.1.10"
+  val AkkaHttpVersion = "10.1.11"
   val AkkaHttpBinaryVersion = "10.1"
   val mockitoVersion = "3.1.0"
 


### PR DESCRIPTION
## Purpose

Upgrade akka-http patch release.

## References

* Refs #2064

## Background Context

The version of akka-http includes a fix to make transient connection error exception messages more clear. akka/akka-http@d46130d
