### PR TITLE
Do not use silencer scalac params when running doc task

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,7 +169,9 @@ lazy val googleCloudPubSubGrpc = alpakkaProject(
   javaAgents += Dependencies.GooglePubSubGrpcAlpnAgent % Test,
   // for the ExampleApp in the tests
   connectInput in run := true,
-  Compile / compile / scalacOptions += "-P:silencer:pathFilters=src_managed",
+  scalacOptions += "-P:silencer:pathFilters=src_managed",
+  // compiler plugin not enabled for doc task. see https://github.com/ghik/silencer/issues/40
+  Compile / doc / scalacOptions := scalacOptions.value.filterNot(_.startsWith("-P:silencer")),
   crossScalaVersions --= Seq(Dependencies.Scala211) // 2.11 is not supported since Akka gRPC 0.6
 )
 // #grpc-plugins

--- a/build.sbt
+++ b/build.sbt
@@ -169,7 +169,7 @@ lazy val googleCloudPubSubGrpc = alpakkaProject(
   javaAgents += Dependencies.GooglePubSubGrpcAlpnAgent % Test,
   // for the ExampleApp in the tests
   connectInput in run := true,
-  scalacOptions in (Compile, compile) += "-P:silencer:pathFilters=src_managed",
+  Compile / compile / scalacOptions += "-P:silencer:pathFilters=src_managed",
   crossScalaVersions --= Seq(Dependencies.Scala211) // 2.11 is not supported since Akka gRPC 0.6
 )
 // #grpc-plugins

--- a/build.sbt
+++ b/build.sbt
@@ -169,7 +169,7 @@ lazy val googleCloudPubSubGrpc = alpakkaProject(
   javaAgents += Dependencies.GooglePubSubGrpcAlpnAgent % Test,
   // for the ExampleApp in the tests
   connectInput in run := true,
-  scalacOptions += "-P:silencer:pathFilters=src_managed",
+  scalacOptions in (Compile, compile) += "-P:silencer:pathFilters=src_managed",
   crossScalaVersions --= Seq(Dependencies.Scala211) // 2.11 is not supported since Akka gRPC 0.6
 )
 // #grpc-plugins


### PR DESCRIPTION
## Purpose

The travis build fails when publishing artifacts for google-cloud-pub-sub because the `doc` task doesn't have the silencer plugin in scope.  For some reason this is only an issue in the 2.12 and 2.13 cross builds.

Ex)

```
[error] (google-cloud-pub-sub-grpc / Compile / doc) Scaladoc generation failed
```

https://travis-ci.com/akka/alpakka/jobs/273152362#L1611
https://travis-ci.com/akka/alpakka/jobs/273152363#L2199


## References

* Issue created in #2050
* Ref: https://github.com/ghik/silencer/issues/40

## Changes

* Only apply silencer `scalac` parameters in `Compile, compile` targets.