### PR TITLE
Use silencer plugin params only in Compile configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,9 +169,7 @@ lazy val googleCloudPubSubGrpc = alpakkaProject(
   javaAgents += Dependencies.GooglePubSubGrpcAlpnAgent % Test,
   // for the ExampleApp in the tests
   connectInput in run := true,
-  scalacOptions += "-P:silencer:pathFilters=src_managed",
-  // compiler plugin not enabled for doc task. see https://github.com/ghik/silencer/issues/40
-  Compile / doc / scalacOptions := scalacOptions.value.filterNot(_.startsWith("-P:silencer")),
+  Compile / scalacOptions += "-P:silencer:pathFilters=src_managed",
   crossScalaVersions --= Seq(Dependencies.Scala211) // 2.11 is not supported since Akka gRPC 0.6
 )
 // #grpc-plugins


### PR DESCRIPTION
## Purpose

The fix in #2077 was able to progress the Alpakka master publishing a step further, but then fails again when the silencer exemption is not available for during the `publish` task itself.  After consulting with @eed3si9n I found a cleaner universal fix that should resolve this issue once and for all.

## References

* Ref #2077 
* https://github.com/ghik/silencer/issues/40#issuecomment-572208376
* Previous master build failure on snapshot publishing https://travis-ci.com/akka/alpakka/jobs/273614859#L1325

## Changes

Use silencer parameters in all `Compile` configurations only.  Omit `intask` in scoping so it applies to all tasks and remove previous workaround to filter out parameters for the `doc` task specifically.
