### PR TITLE
Google Cloud Storage: remove download limit (2084)

### DIFF
--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStream.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStream.scala
@@ -231,7 +231,7 @@ import scala.util.control.NonFatal
           )
         ).mapAsync(parallelism)(entityForSuccessOption)
           .map {
-            _.map(_.dataBytes.mapMaterializedValue(_ => NotUsed))
+            _.map(_.withoutSizeLimit.dataBytes.mapMaterializedValue(_ => NotUsed))
           }
 
       }

--- a/google-cloud-storage/src/test/resources/application.conf
+++ b/google-cloud-storage/src/test/resources/application.conf
@@ -4,6 +4,9 @@ akka {
   loglevel = "INFO"
 }
 
+// Extra small client parsing limit to allow testing for payloads that are over this limit
+akka.http.client.parsing.max-content-length = 10000
+
 //#settings
 
 privateKey ="""-----BEGIN PRIVATE KEY-----

--- a/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSourceSpec.scala
+++ b/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSourceSpec.scala
@@ -285,7 +285,8 @@ class GCStorageSourceSpec
     }
 
     "download file when file exists" in {
-      val fileContent = "Google storage file content"
+      // Ensure file content is above the size limit set by akka.http.client.parsing.max-content-length
+      val fileContent = "Google storage file content" + ("x" * 10000)
       val fileContentGeneration = "Google storage file content (archived)"
 
       mockFileDownload(fileContent)


### PR DESCRIPTION
Remove 8MB download limit on GCS files.

<!--
# Pull Request Checklist

* [ x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [x ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #2084 

## Changes

* Removes 8MB download limit for GCS

