### PR TITLE
File: Used emit instead of push in onUpstreamFinish

### DIFF
--- a/file/src/main/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlow.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlow.scala
@@ -68,7 +68,7 @@ import akka.util.{ByteString, ByteStringBuilder}
       override def onUpstreamFinish(): Unit = {
         if (!emptyStream) {
           zip.close()
-          push(out, builder.result)
+          emit(out, builder.result)
           builder.clear()
         }
         super.onUpstreamFinish()

--- a/file/src/test/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlowTest.scala
+++ b/file/src/test/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlowTest.scala
@@ -10,9 +10,10 @@ import akka.stream.scaladsl.Keep
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.testkit.TestKit
 import akka.util.ByteString
-import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class ZipArchiveFlowTest extends TestKit(ActorSystem("ziparchive")) with WordSpecLike with BeforeAndAfterAll {
+class ZipArchiveFlowTest extends TestKit(ActorSystem("ziparchive")) with AnyWordSpecLike with BeforeAndAfterAll {
 
   implicit val mat = ActorMaterializer()
 

--- a/file/src/test/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlowTest.scala
+++ b/file/src/test/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlowTest.scala
@@ -10,10 +10,9 @@ import akka.stream.scaladsl.Keep
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.testkit.TestKit
 import akka.util.ByteString
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
 
-class ZipArchiveFlowTest extends TestKit(ActorSystem("ziparchive")) with WordSpecLike with Matchers with ScalaFutures {
+class ZipArchiveFlowTest extends TestKit(ActorSystem("ziparchive")) with WordSpecLike with BeforeAndAfterAll {
 
   implicit val mat = ActorMaterializer()
 
@@ -39,5 +38,10 @@ class ZipArchiveFlowTest extends TestKit(ActorSystem("ziparchive")) with WordSpe
         downstream.expectComplete()
       }
     }
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    TestKit.shutdownActorSystem(system)
   }
 }

--- a/file/src/test/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlowTest.scala
+++ b/file/src/test/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlowTest.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.file.impl.archive
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Keep
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
+import akka.testkit.TestKit
+import akka.util.ByteString
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{Matchers, WordSpecLike}
+
+class ZipArchiveFlowTest extends TestKit(ActorSystem("ziparchive")) with WordSpecLike with Matchers with ScalaFutures {
+
+  implicit val mat = ActorMaterializer()
+
+  "ZipArchiveFlowStage" when {
+    "steam ends" should {
+      "emit element only when downstream requests" in {
+        val (upstream, downstream) =
+          TestSource
+            .probe[ByteString]
+            .via(new ZipArchiveFlow())
+            .toMat(TestSink.probe)(Keep.both)
+            .run()
+
+        upstream.sendNext(FileByteStringSeparators.createStartingByteString("test"))
+        upstream.sendNext(ByteString(1))
+        upstream.sendNext(FileByteStringSeparators.createEndingByteString())
+        upstream.sendComplete()
+
+        downstream.request(2)
+        downstream.expectNextN(2)
+        downstream.request(1)
+        downstream.expectNextN(1)
+        downstream.expectComplete()
+      }
+    }
+  }
+}

--- a/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
@@ -14,17 +14,22 @@ import akka.stream.alpakka.file.ArchiveMetadata
 import akka.stream.alpakka.file.scaladsl.Archive
 import akka.stream.scaladsl.{FileIO, Sink, Source}
 import akka.stream.{ActorMaterializer, Materializer}
+import akka.testkit.TestKit
 import akka.util.ByteString
 import docs.javadsl.ArchiveHelper
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 
-class ArchiveSpec extends WordSpec with Matchers with ScalaFutures {
+class ArchiveSpec
+    extends TestKit(ActorSystem("ArchiveSpec"))
+    with WordSpecLike
+    with Matchers
+    with ScalaFutures
+    with BeforeAndAfterAll {
 
-  implicit val sys = ActorSystem("ArchiveSpec")
   implicit val mat: Materializer = ActorMaterializer()
 
   private val archiveHelper = new ArchiveHelper()
@@ -146,5 +151,10 @@ class ArchiveSpec extends WordSpec with Matchers with ScalaFutures {
       zis.close()
     }
     result
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    TestKit.shutdownActorSystem(system)
   }
 }

--- a/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
@@ -23,11 +23,11 @@ import org.scalatest.BeforeAndAfterAll
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class ArchiveSpec
     extends TestKit(ActorSystem("ArchiveSpec"))
-    with AnyWordSpec
+    with AnyWordSpecLike
     with Matchers
     with ScalaFutures
     with BeforeAndAfterAll {


### PR DESCRIPTION
##  Purpose

Fix for possible error "Cannot push port ZipArchiveFlow.out twice"

## References

References #2010

## Changes

`emit` is used instead of `push` in `onUpstreamFinish()`

