### PR TITLE
Scalatest 3.1.0

### DIFF
--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/AmqpSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/AmqpSpec.scala
@@ -8,9 +8,11 @@ import akka.actor.ActorSystem
 import akka.dispatch.ExecutionContexts
 import akka.stream.ActorMaterializer
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-abstract class AmqpSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+abstract class AmqpSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
 
   implicit val system = ActorSystem(this.getClass.getSimpleName)
   implicit val materializer = ActorMaterializer()

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpGraphStageLogicConnectionShutdownSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpGraphStageLogicConnectionShutdownSpec.scala
@@ -21,18 +21,20 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import com.rabbitmq.client.{AddressResolver, Connection, ConnectionFactory, ShutdownListener}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterEach
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 /**
  * see [[https://github.com/akka/alpakka/issues/883]] and
  * [[https://github.com/akka/alpakka/pull/887]]
  */
 class AmqpGraphStageLogicConnectionShutdownSpec
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with ScalaFutures
     with BeforeAndAfterEach {

--- a/awslambda/src/test/scala/docs/scaladsl/AwsLambdaFlowSpec.scala
+++ b/awslambda/src/test/scala/docs/scaladsl/AwsLambdaFlowSpec.scala
@@ -10,26 +10,28 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.awslambda.scaladsl.AwsLambdaFlow
 import akka.stream.scaladsl.{Keep, Sink}
-import akka.stream.testkit.scaladsl.TestSource
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import akka.stream.testkit.scaladsl.TestSource
 import akka.testkit.TestKit
-import software.amazon.awssdk.services.lambda.LambdaAsyncClient
-import software.amazon.awssdk.services.lambda.model.{InvokeRequest, InvokeResponse}
-import software.amazon.awssdk.core.SdkBytes
 import org.mockito.ArgumentMatchers.{any => mockitoAny, eq => mockitoEq}
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest._
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.mockito.MockitoSugar
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient
+import software.amazon.awssdk.services.lambda.model.{InvokeRequest, InvokeResponse}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class AwsLambdaFlowSpec
     extends TestKit(ActorSystem("AwsLambdaFlowSpec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with BeforeAndAfterAll
     with BeforeAndAfterEach
     with ScalaFutures

--- a/azure-storage-queue/src/test/scala/docs/scaladsl/AzureQueueSpec.scala
+++ b/azure-storage-queue/src/test/scala/docs/scaladsl/AzureQueueSpec.scala
@@ -20,6 +20,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.util.Properties
+import org.scalatest.flatspec.AsyncFlatSpecLike
 
 // These tests are all live since the Azure Storage Emulator
 // does not run on Linux/Docker yet

--- a/cassandra/src/test/scala/docs/scaladsl/CassandraSourceSpec.scala
+++ b/cassandra/src/test/scala/docs/scaladsl/CassandraSourceSpec.scala
@@ -17,16 +17,18 @@ import org.scalatest.concurrent.ScalaFutures
 import scala.collection.JavaConverters._
 import scala.concurrent._
 import scala.concurrent.duration._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 /**
  * All the tests must be run with a local Cassandra running on default port 9042.
  */
 class CassandraSourceSpec
-    extends WordSpec
+    extends AnyWordSpec
     with ScalaFutures
     with BeforeAndAfterEach
     with BeforeAndAfterAll
-    with MustMatchers {
+    with Matchers {
 
   //#element-to-insert
   case class ToInsert(id: Integer, cc: Integer)

--- a/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala
@@ -28,11 +28,13 @@ import scala.concurrent.Future
 
 //#init-sourceBulk
 import com.couchbase.client.java.document.JsonDocument
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 //#init-sourceBulk
 
 class CouchbaseFlowSpec
-    extends WordSpec
+    extends AnyWordSpec
     with BeforeAndAfterAll
     with BeforeAndAfterEach
     with CouchbaseSupport

--- a/couchbase/src/test/scala/docs/scaladsl/CouchbaseSessionExamplesSpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/CouchbaseSessionExamplesSpec.scala
@@ -8,13 +8,15 @@ import akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession
 import akka.stream.alpakka.couchbase.testing.CouchbaseSupport
 import com.couchbase.client.java.document.JsonDocument
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class CouchbaseSessionExamplesSpec
-    extends WordSpec
+    extends AnyWordSpec
     with CouchbaseSupport
     with Matchers
     with BeforeAndAfterAll

--- a/couchbase/src/test/scala/docs/scaladsl/CouchbaseSourceSpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/CouchbaseSourceSpec.scala
@@ -12,14 +12,16 @@ import com.couchbase.client.java.auth.PasswordAuthenticator
 import com.couchbase.client.java.{Bucket, CouchbaseCluster}
 import com.couchbase.client.java.document.json.JsonObject
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.concurrent.Future
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class CouchbaseSourceSpec
-    extends WordSpec
+    extends AnyWordSpec
     with BeforeAndAfterAll
     with CouchbaseSupport
     with Matchers

--- a/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala
@@ -9,12 +9,14 @@ import akka.stream.{ActorMaterializer, Materializer}
 import com.couchbase.client.java.document.JsonDocument
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DiscoverySpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+class DiscoverySpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
 
   val config: Config = ConfigFactory.parseResources("discovery.conf")
 

--- a/csv/src/test/scala/akka/stream/alpakka/csv/CsvFormatterSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/CsvFormatterSpec.scala
@@ -8,9 +8,10 @@ import java.nio.charset.StandardCharsets
 
 import akka.stream.alpakka.csv.impl.CsvFormatter
 import akka.stream.alpakka.csv.scaladsl.CsvQuotingStyle
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CsvFormatterSpec extends WordSpec with Matchers {
+class CsvFormatterSpec extends AnyWordSpec with Matchers {
 
   "CSV Formatter comma as delimiter" should {
     val formatter = new CsvFormatter(',', '\"', '\\', "\r\n", CsvQuotingStyle.Required)

--- a/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
@@ -9,9 +9,11 @@ import java.nio.charset.{StandardCharsets, UnsupportedCharsetException}
 import akka.stream.alpakka.csv.impl.CsvParser
 import akka.stream.alpakka.csv.scaladsl.ByteOrderMark
 import akka.util.ByteString
-import org.scalatest.{Matchers, OptionValues, WordSpec}
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CsvParserSpec extends WordSpec with Matchers with OptionValues {
+class CsvParserSpec extends AnyWordSpec with Matchers with OptionValues {
 
   val maximumLineLength = 10 * 1024
 

--- a/csv/src/test/scala/docs/scaladsl/CsvSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvSpec.scala
@@ -8,9 +8,16 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-abstract class CsvSpec extends WordSpec with Matchers with BeforeAndAfterAll with BeforeAndAfterEach with ScalaFutures {
+abstract class CsvSpec
+    extends AnyWordSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with ScalaFutures {
 
   implicit val system = ActorSystem(this.getClass.getSimpleName)
   implicit val materializer = ActorMaterializer()

--- a/doc-examples/src/test/scala/akka/stream/alpakka/eip/scaladsl/PassThroughExamples.scala
+++ b/doc-examples/src/test/scala/akka/stream/alpakka/eip/scaladsl/PassThroughExamples.scala
@@ -13,9 +13,11 @@ import akka.stream.{ActorMaterializer, FlowShape, Graph}
 import akka.stream.scaladsl._
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, StringDeserializer}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class PassThroughExamples extends WordSpec with BeforeAndAfterAll with Matchers with ScalaFutures {
+class PassThroughExamples extends AnyWordSpec with BeforeAndAfterAll with Matchers with ScalaFutures {
 
   implicit val system = ActorSystem("Test")
   implicit val mat = ActorMaterializer()

--- a/doc-examples/src/test/scala/akka/stream/alpakka/eip/scaladsl/SplitterExamples.scala
+++ b/doc-examples/src/test/scala/akka/stream/alpakka/eip/scaladsl/SplitterExamples.scala
@@ -9,9 +9,11 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SplitterExamples extends WordSpec with BeforeAndAfterAll with Matchers with ScalaFutures {
+class SplitterExamples extends AnyWordSpec with BeforeAndAfterAll with Matchers with ScalaFutures {
 
   implicit val system = ActorSystem("Test")
   implicit val mat = ActorMaterializer()

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ItemSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ItemSpec.scala
@@ -21,6 +21,8 @@ import software.amazon.awssdk.services.dynamodb.model.TableStatus
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpecLike
 
 class ItemSpec extends TestKit(ActorSystem("ItemSpec")) with AsyncWordSpecLike with Matchers with BeforeAndAfterAll {
 

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TableSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TableSpec.scala
@@ -12,12 +12,14 @@ import akka.stream.alpakka.dynamodb.scaladsl.DynamoDb
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import com.github.matsluni.akkahttpspi.AkkaHttpClient
-import org.scalatest.{AsyncWordSpecLike, BeforeAndAfterAll, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 
 import scala.collection.JavaConverters._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpecLike
 
 class TableSpec extends TestKit(ActorSystem("TableSpec")) with AsyncWordSpecLike with Matchers with BeforeAndAfterAll {
 

--- a/dynamodb/src/test/scala/docs/scaladsl/ExampleSpec.scala
+++ b/dynamodb/src/test/scala/docs/scaladsl/ExampleSpec.scala
@@ -21,7 +21,7 @@ import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
 //#init-client
 import com.github.matsluni.akkahttpspi.AkkaHttpClient
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
@@ -34,10 +34,12 @@ import software.amazon.awssdk.services.dynamodb.model._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class ExampleSpec
     extends TestKit(ActorSystem("ExampleSpec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures {

--- a/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala
+++ b/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala
@@ -7,7 +7,7 @@ package docs.scaladsl
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import com.github.matsluni.akkahttpspi.AkkaHttpClient
-import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
 // #awsRetryConfiguration
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
@@ -19,8 +19,9 @@ import software.amazon.awssdk.core.retry.conditions.RetryCondition
 // #awsRetryConfiguration
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class RetrySpec extends TestKit(ActorSystem("RetrySpec")) with WordSpecLike with BeforeAndAfterAll {
+class RetrySpec extends TestKit(ActorSystem("RetrySpec")) with AnyWordSpecLike with BeforeAndAfterAll {
 
   // #clientRetryConfig
   implicit val client: DynamoDbAsyncClient = DynamoDbAsyncClient

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
@@ -19,14 +19,16 @@ import org.apache.http.entity.StringEntity
 import org.apache.http.message.BasicHeader
 import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Inspectors, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, Inspectors}
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ElasticsearchSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with Inspectors {
+class ElasticsearchSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with Inspectors {
 
   private implicit val patience = PatienceConfig(10.seconds)
 

--- a/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
@@ -17,12 +17,13 @@ import akka.stream.{ActorMaterializer, Materializer}
 import akka.util.ByteString
 import docs.javadsl.ArchiveHelper
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ArchiveSpec extends WordSpec with Matchers with ScalaFutures {
+class ArchiveSpec extends AnyWordSpec with Matchers with ScalaFutures {
 
   implicit val sys = ActorSystem("ArchiveSpec")
   implicit val mat: Materializer = ActorMaterializer()

--- a/file/src/test/scala/docs/scaladsl/DirectorySpec.scala
+++ b/file/src/test/scala/docs/scaladsl/DirectorySpec.scala
@@ -14,14 +14,16 @@ import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import com.google.common.jimfs.{Configuration, Jimfs}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable
 import scala.concurrent.Future
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class DirectorySpec
     extends TestKit(ActorSystem("directoryspec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures {

--- a/file/src/test/scala/docs/scaladsl/FileTailSourceExtrasSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/FileTailSourceExtrasSpec.scala
@@ -18,14 +18,16 @@ import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.TestKit
 import com.google.common.jimfs.{Configuration, Jimfs}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class FileTailSourceExtrasSpec
     extends TestKit(ActorSystem("filetailsourceextrasspec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures {

--- a/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
@@ -19,16 +19,18 @@ import akka.testkit.TestKit
 import akka.util.ByteString
 import com.google.common.jimfs.{Configuration, Jimfs}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class LogRotatorSinkSpec
     extends TestKit(ActorSystem("LogRotatorSinkSpec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures {

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
@@ -9,24 +9,16 @@ import akka.stream.IOResult
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.{
-  Args,
-  BeforeAndAfter,
-  BeforeAndAfterAll,
-  Inside,
-  Matchers,
-  Status,
-  TestSuite,
-  TestSuiteMixin,
-  WordSpecLike
-}
+import org.scalatest.{Args, BeforeAndAfter, BeforeAndAfterAll, Inside, Status, TestSuite, TestSuiteMixin}
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 trait BaseSpec
     extends TestSuiteMixin
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfter
     with BeforeAndAfterAll

--- a/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala
+++ b/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala
@@ -15,9 +15,16 @@ import org.apache.commons.net.PrintCommandListener
 import org.apache.commons.net.ftp.FTPClient
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class FtpExamplesSpec extends BaseFtpSupport with WordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures {
+class FtpExamplesSpec
+    extends BaseFtpSupport
+    with AnyWordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures {
 
   implicit val materializer: Materializer = getMaterializer
 

--- a/geode/src/test/scala/akka/stream/alpakka/geode/impl/pdx/PDXDecoderSpec.scala
+++ b/geode/src/test/scala/akka/stream/alpakka/geode/impl/pdx/PDXDecoderSpec.scala
@@ -6,9 +6,10 @@ package akka.stream.alpakka.geode.impl.pdx
 
 import java.util.{Date, UUID}
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class PDXDecoderSpec extends WordSpec with Matchers {
+class PDXDecoderSpec extends AnyWordSpec with Matchers {
 
   "PDX decoder" should {
     "decode primitive type" in {

--- a/geode/src/test/scala/akka/stream/alpakka/geode/impl/pdx/PDXEncodeSpec.scala
+++ b/geode/src/test/scala/akka/stream/alpakka/geode/impl/pdx/PDXEncodeSpec.scala
@@ -6,9 +6,10 @@ package akka.stream.alpakka.geode.impl.pdx
 
 import java.util.{Date, UUID}
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class PDXEncodeSpec extends WordSpec with Matchers {
+class PDXEncodeSpec extends AnyWordSpec with Matchers {
 
   "PDXEncoder" should {
 

--- a/geode/src/test/scala/docs/scaladsl/GeodeBaseSpec.scala
+++ b/geode/src/test/scala/docs/scaladsl/GeodeBaseSpec.scala
@@ -10,13 +10,15 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.geode.{GeodeSettings, RegionSettings}
 import akka.stream.scaladsl.Source
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class GeodeBaseSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+class GeodeBaseSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   implicit val system = ActorSystem("test")
   implicit val materializer = ActorMaterializer()

--- a/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
+++ b/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
@@ -21,13 +21,15 @@ import com.google.pubsub.v1.pubsub._
 import akka.NotUsed
 import com.google.protobuf.ByteString
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Inside, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, Inside}
 
 import scala.concurrent.duration._
 import scala.concurrent.Future
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class IntegrationSpec
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with Inside
     with BeforeAndAfterAll

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
@@ -16,13 +16,14 @@ import akka.stream.{ActorMaterializer, Materializer}
 import akka.{Done, NotUsed}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
-class GooglePubSubSpec extends FlatSpec with MockitoSugar with ScalaFutures with Matchers {
+class GooglePubSubSpec extends AnyFlatSpec with MockitoSugar with ScalaFutures with Matchers {
 
   implicit val defaultPatience =
     PatienceConfig(timeout = 5.seconds, interval = 100.millis)

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/ModelSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/ModelSpec.scala
@@ -4,11 +4,12 @@
 
 package akka.stream.alpakka.googlecloud.pubsub
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import scala.collection.immutable.Seq
 import java.time.Instant
 
-class ModelSpec extends FunSuite with Matchers {
+class ModelSpec extends AnyFunSuite with Matchers {
 
   val publishMessage1 = PublishMessage("abcde", Map("k1" -> "v1", "k2" -> "v2"))
   val publishMessage2 = PublishMessage("abcde", Map("k1" -> "v1"))

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/GoogleSessionSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/GoogleSessionSpec.scala
@@ -8,14 +8,16 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.googlecloud.pubsub.impl.GoogleTokenApi.AccessTokenExpiry
 import org.mockito.Mockito.{when, _}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class GoogleSessionSpec extends FlatSpec with ScalaFutures with MockitoSugar with BeforeAndAfterAll with Matchers {
+class GoogleSessionSpec extends AnyFlatSpec with ScalaFutures with MockitoSugar with BeforeAndAfterAll with Matchers {
 
   private trait Fixtures {
     val mockTokenApi = mock[GoogleTokenApi]

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/GoogleTokenApiSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/GoogleTokenApiSpec.scala
@@ -18,7 +18,9 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
 import pdi.jwt.{Jwt, JwtAlgorithm}
 import scala.concurrent.duration._
@@ -26,7 +28,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 
 class GoogleTokenApiSpec
     extends TestKit(ActorSystem())
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with ScalaFutures
     with MockitoSugar

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/PubSubApiSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/PubSubApiSpec.scala
@@ -20,8 +20,10 @@ import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, urlEqualTo}
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import javax.net.ssl.{SSLContext, X509TrustManager}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Await
@@ -39,7 +41,7 @@ class NoopTrustManager extends X509TrustManager {
   }
 }
 
-class PubSubApiSpec extends FlatSpec with BeforeAndAfterAll with ScalaFutures with Matchers {
+class PubSubApiSpec extends AnyFlatSpec with BeforeAndAfterAll with ScalaFutures with Matchers {
 
   implicit val system = ActorSystem()
   implicit val mat = ActorMaterializer()

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageExtSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageExtSpec.scala
@@ -6,14 +6,12 @@ package akka.stream.alpakka.googlecloud.storage
 
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.JavaConverters._
 
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
- */
-class GCStorageExtSpec extends FlatSpecLike with Matchers {
+class GCStorageExtSpec extends AnyFlatSpec with Matchers {
   "GCStorageExt" should "reuse application config from actor system" in {
     val projectId = "projectId"
     val clientEmail = "clientEmail"

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageSettingsSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageSettingsSpec.scala
@@ -5,10 +5,11 @@
 package akka.stream.alpakka.googlecloud.storage
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.collection.JavaConverters._
 
-class GCStorageSettingsSpec extends FlatSpecLike with Matchers {
+class GCStorageSettingsSpec extends AnyFlatSpec with Matchers {
   "GCStorageSettings" should "create settings from application config" in {
     val projectId = "projectId"
     val clientEmail = "clientEmail"

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/WithMaterializerGlobal.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/WithMaterializerGlobal.scala
@@ -6,14 +6,16 @@ package akka.stream.alpakka.googlecloud.storage
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
 trait WithMaterializerGlobal
-    extends WordSpecLike
+    extends AnyWordSpecLike
     with BeforeAndAfterAll
     with BeforeAndAfterEach
     with ScalaFutures

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/ChunkerSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/ChunkerSpec.scala
@@ -7,13 +7,15 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class ChunkerSpec extends WordSpec with ScalaFutures with Matchers with BeforeAndAfterAll {
+class ChunkerSpec extends AnyWordSpec with ScalaFutures with Matchers with BeforeAndAfterAll {
   implicit val system = ActorSystem("ChunkerSpec")
   implicit val mat = ActorMaterializer()
 

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
@@ -10,7 +10,9 @@ import akka.http.scaladsl.model.ContentTypes
 import akka.stream.alpakka.googlecloud.storage.WithMaterializerGlobal
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
-import org.scalatest._
+import org.scalatest.BeforeAndAfter
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Await
@@ -32,7 +34,7 @@ import scala.concurrent.Future
  * - create a rewrite `alpakka-rewrite` bucket for testing
  */
 class GCStorageStreamIntegrationSpec
-    extends WordSpec
+    extends AnyWordSpec
     with WithMaterializerGlobal
     with BeforeAndAfter
     with Matchers

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GoogleTokenApiSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GoogleTokenApiSpec.scala
@@ -15,15 +15,17 @@ import akka.stream.alpakka.googlecloud.storage.impl.GoogleTokenApi.AccessTokenEx
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 import pdi.jwt.{Jwt, JwtAlgorithm}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-class GoogleTokenApiSpec extends WordSpecLike with Matchers with ScalaFutures with MockitoSugar with BeforeAndAfterAll {
+class GoogleTokenApiSpec extends AnyWordSpec with Matchers with ScalaFutures with MockitoSugar with BeforeAndAfterAll {
 
   implicit val defaultPatience =
     PatienceConfig(timeout = 2.seconds, interval = 50.millis)

--- a/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSinkSpec.scala
+++ b/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSinkSpec.scala
@@ -4,22 +4,23 @@
 
 package docs.scaladsl
 
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
-import akka.stream.alpakka.googlecloud.storage.scaladsl.{GCStorage, GCStorageWiremockBase}
 import akka.http.scaladsl.model.ContentTypes
-import org.scalatest._
-import org.scalatest.concurrent._
-
-import scala.util.Random
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.googlecloud.storage.StorageObject
+import akka.stream.alpakka.googlecloud.storage.scaladsl.{GCStorage, GCStorageWiremockBase}
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.concurrent.Future
+import scala.util.Random
 
 class GCStorageSinkSpec
     extends GCStorageWiremockBase
-    with WordSpecLike
+    with AnyWordSpecLike
     with BeforeAndAfterAll
     with ScalaFutures
     with IntegrationPatience

--- a/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSourceSpec.scala
+++ b/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSourceSpec.scala
@@ -11,14 +11,16 @@ import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.{ActorMaterializer, Attributes}
 import akka.util.ByteString
 import akka.{Done, NotUsed}
-import org.scalatest._
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.concurrent._
 
 import scala.concurrent.Future
 
 class GCStorageSourceSpec
     extends GCStorageWiremockBase
-    with WordSpecLike
+    with AnyWordSpecLike
     with BeforeAndAfterAll
     with ScalaFutures
     with IntegrationPatience

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/ConditionBuilderSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/ConditionBuilderSpec.scala
@@ -5,9 +5,10 @@
 package akka.stream.alpakka.google.firebase.fcm
 
 import akka.stream.alpakka.google.firebase.fcm.FcmNotificationModels.Condition._
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class ConditionBuilderSpec extends WordSpecLike with Matchers {
+class ConditionBuilderSpec extends AnyWordSpec with Matchers {
 
   "ConditionBuilder" must {
 

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/FcmNotificationSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/FcmNotificationSpec.scala
@@ -5,9 +5,10 @@
 package akka.stream.alpakka.google.firebase.fcm
 
 import akka.stream.alpakka.google.firebase.fcm.FcmNotificationModels.{Condition, Token, Topic}
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class FcmNotificationSpec extends WordSpecLike with Matchers {
+class FcmNotificationSpec extends AnyWordSpec with Matchers {
 
   "SendableNotification" should {
 

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmSenderSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmSenderSpec.scala
@@ -19,14 +19,16 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 class FcmSenderSpec
     extends TestKit(ActorSystem())
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with ScalaFutures
     with MockitoSugar

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleTokenApiSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleTokenApiSpec.scala
@@ -18,7 +18,9 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 import pdi.jwt.{Jwt, JwtAlgorithm}
 
 import scala.concurrent.duration._
@@ -26,7 +28,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 
 class GoogleTokenApiSpec
     extends TestKit(ActorSystem())
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with ScalaFutures
     with MockitoSugar

--- a/hbase/src/test/scala/docs/scaladsl/HBaseStageSpec.scala
+++ b/hbase/src/test/scala/docs/scaladsl/HBaseStageSpec.scala
@@ -15,15 +15,17 @@ import org.apache.hadoop.hbase.client._
 import org.apache.hadoop.hbase.util.Bytes
 import org.apache.hadoop.hbase.{HBaseConfiguration, TableName}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.language.implicitConversions
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class HBaseStageSpec
     extends TestKit(ActorSystem("HBaseStageSpec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with ScalaFutures
     with BeforeAndAfterAll {

--- a/hdfs/src/test/scala/akka/stream/alpakka/hdfs/util/TestUtils.scala
+++ b/hdfs/src/test/scala/akka/stream/alpakka/hdfs/util/TestUtils.scala
@@ -15,11 +15,11 @@ import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.apache.hadoop.hdfs.{HdfsConfiguration, MiniDFSCluster}
 import org.apache.hadoop.io.compress.CompressionCodec
 import org.apache.hadoop.io.{SequenceFile, Text}
-import org.scalatest.Matchers
 
 import scala.collection.mutable.ListBuffer
 import scala.language.higherKinds
 import scala.util.Random
+import org.scalatest.matchers.should.Matchers
 
 sealed trait TestUtils {
 

--- a/hdfs/src/test/scala/docs/scaladsl/HdfsReaderSpec.scala
+++ b/hdfs/src/test/scala/docs/scaladsl/HdfsReaderSpec.scala
@@ -15,12 +15,14 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.hdfs.MiniDFSCluster
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.io.compress.DefaultCodec
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContextExecutor, Future}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class HdfsReaderSpec extends WordSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
+class HdfsReaderSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
 
   private var hdfsCluster: MiniDFSCluster = _
   private val destination = "/tmp/alpakka/"

--- a/hdfs/src/test/scala/docs/scaladsl/HdfsWriterSpec.scala
+++ b/hdfs/src/test/scala/docs/scaladsl/HdfsWriterSpec.scala
@@ -21,8 +21,10 @@ import org.scalatest._
 
 import scala.concurrent.duration.{Duration, _}
 import scala.concurrent.{Await, ExecutionContextExecutor}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class HdfsWriterSpec extends WordSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
+class HdfsWriterSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
 
   private var hdfsCluster: MiniDFSCluster = _
   private val destination = "/tmp/alpakka/"

--- a/influxdb/src/test/scala/docs/scaladsl/FlowSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/FlowSpec.scala
@@ -15,15 +15,17 @@ import akka.stream.alpakka.influxdb.scaladsl.{InfluxDbFlow, InfluxDbSource}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.testkit.TestKit
 import org.influxdb.InfluxDB
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, MustMatchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.concurrent.ScalaFutures
 import docs.javadsl.TestUtils._
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.influxdb.dto.{Point, Query}
 
 import scala.concurrent.duration._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class FlowSpec extends WordSpec with MustMatchers with BeforeAndAfterEach with BeforeAndAfterAll with ScalaFutures {
+class FlowSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach with BeforeAndAfterAll with ScalaFutures {
 
   implicit val system = ActorSystem()
   implicit val mat = ActorMaterializer()

--- a/influxdb/src/test/scala/docs/scaladsl/InfluxDbSourceSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/InfluxDbSourceSpec.scala
@@ -11,15 +11,17 @@ import akka.stream.alpakka.influxdb.scaladsl.InfluxDbSource
 import akka.stream.scaladsl.Sink
 import akka.testkit.TestKit
 import org.influxdb.{InfluxDB, InfluxDBException}
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, MustMatchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.concurrent.ScalaFutures
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import docs.javadsl.TestUtils._
 import org.influxdb.dto.Query
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class InfluxDbSourceSpec
-    extends WordSpec
-    with MustMatchers
+    extends AnyWordSpec
+    with Matchers
     with BeforeAndAfterEach
     with BeforeAndAfterAll
     with ScalaFutures {

--- a/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpec.scala
@@ -8,7 +8,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import org.influxdb.{InfluxDB, InfluxDBFactory}
 import org.influxdb.dto.{Point, Query, QueryResult}
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, MustMatchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.concurrent.ScalaFutures
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.{Done, NotUsed}
@@ -21,8 +21,10 @@ import akka.stream.scaladsl.Sink
 import scala.collection.JavaConverters._
 
 import docs.javadsl.TestConstants.{INFLUXDB_URL, PASSWORD, USERNAME}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class InfluxDbSpec extends WordSpec with MustMatchers with BeforeAndAfterEach with BeforeAndAfterAll with ScalaFutures {
+class InfluxDbSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach with BeforeAndAfterAll with ScalaFutures {
 
   implicit val system = ActorSystem()
   implicit val mat = ActorMaterializer()

--- a/ironmq/src/test/scala/akka/stream/alpakka/ironmq/IronMqSpec.scala
+++ b/ironmq/src/test/scala/akka/stream/alpakka/ironmq/IronMqSpec.scala
@@ -11,13 +11,15 @@ import akka.stream.alpakka.ironmq.impl.IronMqClient
 import akka.stream.{ActorMaterializer, Materializer}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterEach
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 import scala.util.hashing.MurmurHash3
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-abstract class IronMqSpec extends WordSpec with Matchers with ScalaFutures with BeforeAndAfterEach {
+abstract class IronMqSpec extends AnyWordSpec with Matchers with ScalaFutures with BeforeAndAfterEach {
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 15.seconds, interval = 1.second)
   val DefaultActorSystemTerminateTimeout: Duration = 10.seconds

--- a/ironmq/src/test/scala/docs/scaladsl/IronMqDocsSpec.scala
+++ b/ironmq/src/test/scala/docs/scaladsl/IronMqDocsSpec.scala
@@ -12,13 +12,20 @@ import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import akka.{Done, NotUsed}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class IronMqDocsSpec extends WordSpec with IronMqClientForTests with Matchers with ScalaFutures with BeforeAndAfterAll {
+class IronMqDocsSpec
+    extends AnyWordSpec
+    with IronMqClientForTests
+    with Matchers
+    with ScalaFutures
+    with BeforeAndAfterAll {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 250.millis)
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsSpec.scala
@@ -8,15 +8,17 @@ import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Supervision}
 import akka.testkit.TestKit
 import javax.jms._
+import jmstestkit.JmsBroker
 import org.mockito.ArgumentMatchers.{any, anyBoolean, anyInt}
 import org.mockito.Mockito.when
-import org.scalatest._
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
-import jmstestkit.JmsBroker
 
 abstract class JmsSpec
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with BeforeAndAfterAll
     with BeforeAndAfterEach

--- a/jms/src/test/scala/akka/stream/alpakka/jms/impl/SoftReferenceCacheSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/impl/SoftReferenceCacheSpec.scala
@@ -6,12 +6,13 @@ package akka.stream.alpakka.jms.impl
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
 import scala.concurrent.duration._
 
-class SoftReferenceCacheSpec extends WordSpec with Matchers {
+class SoftReferenceCacheSpec extends AnyWordSpec with Matchers {
 
   "soft reference cache lookup" should {
     "return default value on miss" in {

--- a/json-streaming/src/test/scala/docs/scaladsl/JsonReaderTest.scala
+++ b/json-streaming/src/test/scala/docs/scaladsl/JsonReaderTest.scala
@@ -11,12 +11,14 @@ import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import org.jsfr.json.compiler.JsonPathCompiler
 import org.jsfr.json.exception.JsonSurfingException
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class JsonReaderTest extends WordSpec with Matchers with BeforeAndAfterAll {
+class JsonReaderTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   implicit val system: ActorSystem = ActorSystem("Test")
   implicit val mat: Materializer = ActorMaterializer()
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
@@ -16,13 +16,14 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.kinesis.model._
 
 import scala.collection.JavaConverters._
 
-class KinesisFlowSpec extends WordSpecLike with Matchers with KinesisMock {
+class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock {
 
   "KinesisFlow" must {
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSourceSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSourceSpec.scala
@@ -16,13 +16,14 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.kinesis.model._
 
 import scala.concurrent.duration._
 
-class KinesisSourceSpec extends WordSpecLike with Matchers with KinesisMock {
+class KinesisSourceSpec extends AnyWordSpec with Matchers with KinesisMock {
 
   implicit class recordToString(r: Record) {
     def utf8String: String = ByteString(r.data.asByteBuffer).utf8String

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/ShardSettingsSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/ShardSettingsSpec.scala
@@ -6,10 +6,11 @@ package akka.stream.alpakka.kinesis
 
 import java.time.Instant
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.must.Matchers
 import software.amazon.awssdk.services.kinesis.model.ShardIteratorType
 
-class ShardSettingsSpec extends WordSpec with Matchers {
+class ShardSettingsSpec extends AnyWordSpec with Matchers {
   val baseSettings = ShardSettings("name", "shardid")
   "ShardSettings" must {
     "require a timestamp for shard iterator type is AT_TIMESTAMP" in {

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSpec.scala
@@ -16,13 +16,14 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.firehose.model._
 
 import scala.collection.JavaConverters._
 
-class KinesisFirehoseFlowSpec extends WordSpecLike with Matchers with KinesisFirehoseMock {
+class KinesisFirehoseFlowSpec extends AnyWordSpec with Matchers with KinesisFirehoseMock {
 
   "KinesisFirehoseFlow" must {
 

--- a/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala
+++ b/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala
@@ -14,15 +14,17 @@ import akka.testkit.TestKit
 import org.apache.kudu.client.{CreateTableOptions, KuduClient, PartialRow}
 import org.apache.kudu.{ColumnSchema, Schema, Type}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class KuduTableSpec
     extends TestKit(ActorSystem())
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures {

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
@@ -21,13 +21,10 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class MongoSinkSpec
-    extends WordSpec
-    with ScalaFutures
-    with BeforeAndAfterEach
-    with BeforeAndAfterAll
-    with MustMatchers {
+class MongoSinkSpec extends AnyWordSpec with ScalaFutures with BeforeAndAfterEach with BeforeAndAfterAll with Matchers {
 
   // case class and codec for mongodb macros
   case class Number(_id: Int)

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
@@ -19,13 +19,15 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent._
 import scala.concurrent.duration._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class MongoSourceSpec
-    extends WordSpec
+    extends AnyWordSpec
     with ScalaFutures
     with BeforeAndAfterEach
     with BeforeAndAfterAll
-    with MustMatchers {
+    with Matchers {
 
   // #init-mat
   implicit val system = ActorSystem()

--- a/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/MqttFrameStageSpec.scala
+++ b/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/MqttFrameStageSpec.scala
@@ -12,11 +12,13 @@ import akka.stream.testkit.scaladsl.TestSource
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.testkit.TestKit
 import akka.util.ByteString
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class MqttFrameStageSpec
     extends TestKit(ActorSystem("MqttFrameStageSpec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll {
 

--- a/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/QueueOfferStateSpec.scala
+++ b/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/QueueOfferStateSpec.scala
@@ -11,13 +11,15 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.stream.alpakka.mqtt.streaming.impl.QueueOfferState.QueueOfferCompleted
 import akka.stream.QueueOfferResult
 import akka.testkit.TestKit
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class QueueOfferStateSpec
     extends TestKit(ActorSystem("QueueOfferStateSpec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll {
 

--- a/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/RequestStateSpec.scala
+++ b/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/RequestStateSpec.scala
@@ -8,12 +8,14 @@ package impl
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.Promise
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class RequestStateSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+class RequestStateSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
 
   val testKit = ActorTestKit()
   override def afterAll(): Unit = testKit.shutdownTestKit()

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttCodecSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttCodecSpec.scala
@@ -7,11 +7,12 @@ import java.nio.ByteOrder
 
 import akka.stream.alpakka.mqtt.streaming._
 import akka.util.{ByteString, ByteStringBuilder}
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class MqttCodecSpec extends WordSpec with Matchers {
+class MqttCodecSpec extends AnyWordSpec with Matchers {
 
   private implicit val byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN
   import MqttCodec._

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -20,6 +20,8 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class UntypedMqttFlowSpec
     extends ParametrizedTestKit("untyped-flow-spec/flow", "typed-flow-spec/topic1", ActorSystem("UntypedMqttFlowSpec"))
@@ -32,7 +34,7 @@ class TypedMqttFlowSpec
 
 class ParametrizedTestKit(val clientId: String, val topic: String, system: ActorSystem) extends TestKit(system)
 
-trait MqttFlowSpec extends WordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures {
+trait MqttFlowSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures {
   self: ParametrizedTestKit =>
 
   private implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = 5.seconds, interval = 100.millis)

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -19,16 +19,18 @@ import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.{ActorMaterializer, Materializer, OverflowStrategy}
 import akka.testkit._
 import akka.util.{ByteString, Timeout}
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Span}
 
 import scala.concurrent.{ExecutionContext, Promise}
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class MqttSessionSpec
     extends TestKit(ActorSystem("mqtt-spec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with BeforeAndAfterAll
     with ScalaFutures
     with Matchers {

--- a/mqtt/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -19,10 +19,12 @@ import org.scalatest.time.{Seconds, Span}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class MqttFlowSpec
     extends TestKit(ActorSystem("MqttFlowSpec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures

--- a/mqtt/src/test/scala/docs/scaladsl/MqttSinkSpec.scala
+++ b/mqtt/src/test/scala/docs/scaladsl/MqttSinkSpec.scala
@@ -20,10 +20,12 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class MqttSinkSpec
     extends TestKit(ActorSystem("MqttSinkSpec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures {

--- a/mqtt/src/test/scala/docs/scaladsl/MqttSourceSpec.scala
+++ b/mqtt/src/test/scala/docs/scaladsl/MqttSourceSpec.scala
@@ -23,10 +23,12 @@ import org.slf4j.LoggerFactory
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class MqttSourceSpec
     extends TestKit(ActorSystem("MqttSourceSpec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures {

--- a/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala
+++ b/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala
@@ -27,13 +27,15 @@ import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal
 import com.orientechnologies.orient.core.record.impl.ODocument
 import docs.javadsl.OrientDbTest
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class OrientDbSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+class OrientDbSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 100.millis)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,10 +48,15 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
         "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion % Test,
         "ch.qos.logback" % "logback-classic" % "1.2.3" % Test, // Eclipse Public License 1.0
-        "org.scalatest" %% "scalatest" % "3.0.8" % Test, // ApacheV2
+        "org.scalatest" %% "scalatest" % "3.1.0" % Test, // ApacheV2
         "com.novocode" % "junit-interface" % "0.11" % Test, // BSD-style
         "junit" % "junit" % "4.12" % Test // Eclipse Public License 1.0
       )
+  )
+
+  val Mockito = Seq(
+    "org.mockito" % "mockito-core" % mockitoVersion % Test,
+    "org.scalatestplus" %% "mockito-1-10" % "3.1.0.0" % Test
   )
 
   // Releases https://github.com/FasterXML/jackson-databind/releases
@@ -66,9 +71,8 @@ object Dependencies {
 
   val Amqp = Seq(
     libraryDependencies ++= Seq(
-        "com.rabbitmq" % "amqp-client" % "5.3.0", // APLv2
-        "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
-      )
+        "com.rabbitmq" % "amqp-client" % "5.3.0" // APLv2
+      ) ++ Mockito
   )
 
   val AwsLambda = Seq(
@@ -82,9 +86,9 @@ object Dependencies {
         (
           ExclusionRule("software.amazon.awssdk", "apache-client"),
           ExclusionRule("software.amazon.awssdk", "netty-nio-client")
-        ),
-        "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
+        )
       ) ++ JacksonDatabindDependencies
+      ++ Mockito
   )
 
   val AzureStorageQueue = Seq(
@@ -181,9 +185,8 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
         "com.pauldijou" %% "jwt-core" % JwtCoreVersion, // ApacheV2
-        "org.mockito" % "mockito-core" % mockitoVersion % Test, // MIT
         "com.github.tomakehurst" % "wiremock" % "2.25.1" % Test // ApacheV2
-      )
+      ) ++ Mockito
   )
 
   val GooglePubSubGrpc = Seq(
@@ -204,9 +207,8 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "com.pauldijou" %% "jwt-core" % JwtCoreVersion, // ApacheV2
-        "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
-      )
+        "com.pauldijou" %% "jwt-core" % JwtCoreVersion // ApacheV2
+      ) ++ Mockito
   )
 
   val GoogleStorage = Seq(
@@ -214,9 +216,8 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
         "com.pauldijou" %% "jwt-core" % JwtCoreVersion, //ApacheV2
-        "org.mockito" % "mockito-core" % mockitoVersion % Test, // MIT
         "com.github.tomakehurst" % "wiremock" % "2.25.1" % Test // ApacheV2
-      )
+      ) ++ Mockito
   )
 
   val HBase = {
@@ -264,9 +265,8 @@ object Dependencies {
         "com.ibm.mq" % "com.ibm.mq.allclient" % "9.1.3.0" % Test, // IBM International Program License Agreement https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/maven/licenses/L-APIG-AZYF2E/LI_en.html
         "org.apache.activemq" % "activemq-broker" % "5.15.9" % Test, // ApacheV2
         "org.apache.activemq" % "activemq-client" % "5.15.9" % Test, // ApacheV2
-        "io.github.sullis" %% "jms-testkit" % "0.2.8" % Test, // ApacheV2
-        "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
-      ),
+        "io.github.sullis" %% "jms-testkit" % "0.2.8" % Test // ApacheV2
+      ) ++ Mockito,
     // Having JBoss as a first resolver is a workaround for https://github.com/coursier/coursier/issues/200
     externalResolvers := ("jboss" at "https://repository.jboss.org/nexus/content/groups/public") +: externalResolvers.value
   )
@@ -294,9 +294,9 @@ object Dependencies {
         (
           ExclusionRule("software.amazon.awssdk", "apache-client"),
           ExclusionRule("software.amazon.awssdk", "netty-nio-client")
-        ),
-        "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
+        )
       ) ++ JacksonDatabindDependencies
+      ++ Mockito
   )
 
   val KuduVersion = "1.7.1"
@@ -387,9 +387,9 @@ object Dependencies {
           ExclusionRule("software.amazon.awssdk", "apache-client"),
           ExclusionRule("software.amazon.awssdk", "netty-nio-client")
         ),
-        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion, // ApacheV2
-        "org.mockito" % "mockito-core" % mockitoVersion % Test // MIT
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion // ApacheV2
       ) ++ JacksonDatabindDependencies
+      ++ Mockito
   )
 
   val SolrjVersion = "7.7.2"
@@ -416,9 +416,9 @@ object Dependencies {
           ExclusionRule("software.amazon.awssdk", "netty-nio-client")
         ),
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion, // ApacheV2
-        "org.mockito" % "mockito-core" % mockitoVersion % Test, // MIT
         "org.mockito" % "mockito-inline" % mockitoVersion % Test // MIT
       ) ++ JacksonDatabindDependencies
+      ++ Mockito
   )
 
   val Sse = Seq(

--- a/reference/src/test/scala/docs/scaladsl/ReferenceSpec.scala
+++ b/reference/src/test/scala/docs/scaladsl/ReferenceSpec.scala
@@ -13,15 +13,17 @@ import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable
 import scala.concurrent.Future
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 /**
  * Append "Spec" to every Scala test suite.
  */
-class ReferenceSpec extends WordSpec with BeforeAndAfterAll with ScalaFutures with Matchers {
+class ReferenceSpec extends AnyWordSpec with BeforeAndAfterAll with ScalaFutures with Matchers {
 
   implicit val sys = ActorSystem("ReferenceSpec")
   implicit val mat: Materializer = ActorMaterializer()

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/DiskBufferSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/DiskBufferSpec.scala
@@ -13,11 +13,13 @@ import akka.testkit.{EventFilter, TestKit}
 import akka.util.ByteString
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class DiskBufferSpec(_system: ActorSystem)
     extends TestKit(_system)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -19,10 +19,11 @@ import akka.testkit.{SocketUtil, TestKit, TestProbe}
 import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.regions.providers._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FlatSpec, Matchers}
 import software.amazon.awssdk.regions.Region
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
+class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
   // test fixtures
   def getSettings(

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/MarshallingSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/MarshallingSpec.scala
@@ -12,13 +12,15 @@ import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.stream.alpakka.s3.{ListBucketResultCommonPrefixes, ListBucketResultContents}
 import akka.testkit.TestKit
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable.Seq
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class MarshallingSpec(_system: ActorSystem)
     extends TestKit(_system)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with ScalaFutures
     with BeforeAndAfterAll {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/MemoryBufferSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/MemoryBufferSpec.scala
@@ -10,12 +10,14 @@ import akka.stream.scaladsl.{Sink, Source}
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class MemoryBufferSpec(_system: ActorSystem)
     extends TestKit(_system)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3HeadersSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3HeadersSpec.scala
@@ -7,9 +7,10 @@ package akka.stream.alpakka.s3.impl
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.stream.alpakka.s3.{MetaHeaders, S3Headers}
 import akka.stream.alpakka.s3.headers.{CannedAcl, ServerSideEncryption, StorageClass}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class S3HeadersSpec extends FlatSpec with Matchers {
+class S3HeadersSpec extends AnyFlatSpec with Matchers {
 
   "ServerSideEncryption" should "create well formed headers for AES-256 encryption" in {
     ServerSideEncryption.aes256().headers should contain(RawHeader("x-amz-server-side-encryption", "AES256"))

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
@@ -16,14 +16,16 @@ import akka.util.ByteString
 import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.regions.providers._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers, PrivateMethodTester}
+import org.scalatest.{BeforeAndAfterAll, PrivateMethodTester}
 import software.amazon.awssdk.regions.Region
 
 import scala.concurrent.Future
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class S3StreamSpec(_system: ActorSystem)
     extends TestKit(_system)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with PrivateMethodTester

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/SplitAfterSizeSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/SplitAfterSizeSpec.scala
@@ -10,13 +10,15 @@ import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import akka.util.ByteString
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class SplitAfterSizeSpec(_system: ActorSystem)
     extends TestKit(_system)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/CanonicalRequestSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/CanonicalRequestSpec.scala
@@ -7,9 +7,10 @@ package akka.stream.alpakka.s3.impl.auth
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CanonicalRequestSpec extends FlatSpec with Matchers {
+class CanonicalRequestSpec extends AnyFlatSpec with Matchers {
 
   it should "correctly build a canonicalString for eu-central-1" in {
     val req = HttpRequest(

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SignerSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SignerSpec.scala
@@ -13,17 +13,19 @@ import akka.stream.scaladsl.Sink
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.testkit.TestKit
 import software.amazon.awssdk.auth.credentials._
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.OptionValues._
 import org.scalatest.time.{Millis, Seconds, Span}
 import software.amazon.awssdk.regions.Region
 
 import scala.compat.java8.OptionConverters._
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class SignerSpec(_system: ActorSystem)
     extends TestKit(_system)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SigningKeySpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SigningKeySpec.scala
@@ -7,10 +7,11 @@ package akka.stream.alpakka.s3.impl.auth
 import java.time.{ZoneId, ZonedDateTime}
 
 import software.amazon.awssdk.auth.credentials._
-import org.scalatest.{FlatSpec, Matchers}
 import software.amazon.awssdk.regions.Region
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class SigningKeySpec extends FlatSpec with Matchers {
+class SigningKeySpec extends AnyFlatSpec with Matchers {
   behavior of "A Signing Key"
 
   val credentials = StaticCredentialsProvider.create(

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/StreamUtilsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/StreamUtilsSpec.scala
@@ -16,11 +16,13 @@ import akka.util.ByteString
 import com.google.common.jimfs.{Configuration, Jimfs}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class StreamUtilsSpec(_system: ActorSystem)
     extends TestKit(_system)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with ScalaFutures
     with BeforeAndAfterAll {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/authSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/authSpec.scala
@@ -4,9 +4,9 @@
 
 package akka.stream.alpakka.s3.impl.auth
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class authSpec extends FlatSpec {
+class authSpec extends AnyFlatSpec {
 
   "encodeHex" should "encode string to hex string" in {
     assert(encodeHex("1234+abcd".getBytes()) == "313233342b61626364")

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ClientIntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ClientIntegrationSpec.scala
@@ -9,9 +9,11 @@ import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 trait S3ClientIntegrationSpec
-    extends FlatSpecLike
+    extends AnyFlatSpecLike
     with BeforeAndAfterAll
     with BeforeAndAfterEach
     with Matchers

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ExtSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ExtSpec.scala
@@ -6,15 +6,16 @@ package akka.stream.alpakka.s3.scaladsl
 
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{FlatSpecLike, Matchers}
 import akka.stream.alpakka.s3.S3Ext
 
 import scala.collection.JavaConverters._
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 /*
  * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
  */
-class S3ExtSpec extends FlatSpecLike with Matchers {
+class S3ExtSpec extends AnyFlatSpecLike with Matchers {
   it should "reuse application config from actor system" in {
     val config = ConfigFactory.parseMap(
       Map(

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -24,8 +24,15 @@ import software.amazon.awssdk.regions.Region
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
-trait S3IntegrationSpec extends FlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures with OptionValues {
+trait S3IntegrationSpec
+    extends AnyFlatSpecLike
+    with BeforeAndAfterAll
+    with Matchers
+    with ScalaFutures
+    with OptionValues {
 
   implicit val actorSystem: ActorSystem = ActorSystem(
     "S3IntegrationSpec",

--- a/simple-codecs/src/test/scala/docs/scaladsl/RecordIOFramingSpec.scala
+++ b/simple-codecs/src/test/scala/docs/scaladsl/RecordIOFramingSpec.scala
@@ -15,14 +15,16 @@ import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class RecordIOFramingSpec(_system: ActorSystem)
     extends TestKit(_system)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with ScalaFutures
     with BeforeAndAfterAll {

--- a/slick/src/test/scala/docs/scaladsl/SlickSpec.scala
+++ b/slick/src/test/scala/docs/scaladsl/SlickSpec.scala
@@ -18,12 +18,14 @@ import slick.jdbc.{GetResult, JdbcProfile}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 /**
  * This unit test is run using a local H2 database using
  * `/tmp/alpakka-slick-h2-test` for temporary storage.
  */
-class SlickSpec extends WordSpec with ScalaFutures with BeforeAndAfterEach with BeforeAndAfterAll with MustMatchers {
+class SlickSpec extends AnyWordSpec with ScalaFutures with BeforeAndAfterEach with BeforeAndAfterAll with Matchers {
   //#init-mat
   implicit val system = ActorSystem()
   implicit val mat = ActorMaterializer()

--- a/sns/src/test/scala/akka/stream/alpakka/sns/SnsPublishMockingSpec.scala
+++ b/sns/src/test/scala/akka/stream/alpakka/sns/SnsPublishMockingSpec.scala
@@ -11,13 +11,14 @@ import akka.stream.scaladsl.{Keep, Sink}
 import akka.stream.testkit.scaladsl.TestSource
 import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito._
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
 import software.amazon.awssdk.services.sns.model.{PublishRequest, PublishResponse}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class SnsPublishMockingSpec extends FlatSpec with DefaultTestContext with MustMatchers {
+class SnsPublishMockingSpec extends AnyFlatSpec with DefaultTestContext with Matchers {
 
   it should "publish a single PublishRequest message to sns" in {
     val publishRequest = PublishRequest.builder().topicArn("topic-arn").message("sns-message").build()

--- a/sns/src/test/scala/docs/scaladsl/SnsPublisherSpec.scala
+++ b/sns/src/test/scala/docs/scaladsl/SnsPublisherSpec.scala
@@ -9,13 +9,14 @@ import akka.stream.alpakka.sns.IntegrationTestContext
 import akka.stream.alpakka.sns.scaladsl.SnsPublisher
 import akka.stream.scaladsl.{Sink, Source}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.sns.model.PublishRequest
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class SnsPublisherSpec extends FlatSpec with Matchers with ScalaFutures with IntegrationTestContext {
+class SnsPublisherSpec extends AnyFlatSpec with Matchers with ScalaFutures with IntegrationTestContext {
 
   implicit val defaultPatience =
     PatienceConfig(timeout = 15.seconds, interval = 100.millis)

--- a/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
+++ b/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
@@ -25,13 +25,15 @@ import org.apache.solr.cloud.{MiniSolrCloudCluster, ZkTestServer}
 import org.apache.solr.common.SolrInputDocument
 import org.junit.Assert.assertTrue
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SolrSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+class SolrSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds)
 

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/SqsModelSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/SqsModelSpec.scala
@@ -6,11 +6,12 @@ package akka.stream.alpakka.sqs
 
 import akka.stream.alpakka.sqs.SqsAckResult._
 import akka.stream.alpakka.sqs.SqsAckResultEntry._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.awscore.DefaultAwsResponseMetadata
 import software.amazon.awssdk.services.sqs.model._
 
-class SqsModelSpec extends FlatSpec with Matchers {
+class SqsModelSpec extends AnyFlatSpec with Matchers {
 
   val msg = Message.builder().build()
   val otherMsg = Message.builder().body("other-body").build()

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
@@ -11,7 +11,8 @@ import akka.actor.{ActorSystem, Terminated}
 import akka.stream.alpakka.sqs.SqsSourceSettings
 import akka.stream.{ActorMaterializer, Materializer}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, Suite, Tag}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, Suite, Tag}
 //#init-client
 import com.github.matsluni.akkahttpspi.AkkaHttpClient
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/MessageAttributeNameSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/MessageAttributeNameSpec.scala
@@ -5,9 +5,10 @@
 package akka.stream.alpakka.sqs.scaladsl
 
 import akka.stream.alpakka.sqs.MessageAttributeName
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MessageAttributeNameSpec extends FlatSpec with Matchers {
+class MessageAttributeNameSpec extends AnyFlatSpec with Matchers {
 
   it should "not allow names which have periods at the beginning" in {
     a[IllegalArgumentException] should be thrownBy {

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
@@ -15,15 +15,16 @@ import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSource
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar.mock
-import org.scalatest.{FlatSpec, Matchers}
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class SqsPublishSinkSpec extends FlatSpec with Matchers with DefaultTestContext {
+class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestContext {
 
   "SqsPublishSink" should "send a message" in assertAllStagesStopped {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceMockSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceMockSpec.scala
@@ -13,7 +13,8 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.{atMost => atMostTimes, _}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar.mock
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.{Message, ReceiveMessageRequest, ReceiveMessageResponse}
@@ -22,7 +23,7 @@ import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class SqsSourceMockSpec extends FlatSpec with Matchers with DefaultTestContext {
+class SqsSourceMockSpec extends AnyFlatSpec with Matchers with DefaultTestContext {
 
   override def createAsyncClient(sqsEndpoint: String): SqsAsyncClient = ???
   override def closeSqsClient(): Unit = ()

--- a/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
@@ -16,7 +16,8 @@ import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{spy, times, verify, when}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar.mock
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
@@ -24,7 +25,7 @@ import software.amazon.awssdk.services.sqs.model._
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
-class SqsAckSpec extends FlatSpec with Matchers with DefaultTestContext {
+class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext {
 
   trait IntegrationFixture {
     val queueUrl: String = randomQueueUrl()

--- a/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
@@ -11,14 +11,15 @@ import akka.stream.alpakka.sqs._
 import akka.stream.alpakka.sqs.scaladsl._
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.{Message, ReceiveMessageRequest, SendMessageRequest}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
-class SqsPublishSpec extends FlatSpec with Matchers with DefaultTestContext {
+class SqsPublishSpec extends AnyFlatSpec with Matchers with DefaultTestContext {
 
   abstract class IntegrationFixture(fifo: Boolean = false) {
     val queueUrl: String = if (fifo) randomFifoQueueUrl() else randomQueueUrl()

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -15,7 +15,8 @@ import akka.stream.scaladsl.{Keep, Sink}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import com.github.matsluni.akkahttpspi.AkkaHttpClient
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient
 import software.amazon.awssdk.regions.Region
@@ -33,7 +34,7 @@ import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class SqsSourceSpec extends FlatSpec with ScalaFutures with Matchers with DefaultTestContext {
+class SqsSourceSpec extends AnyFlatSpec with ScalaFutures with Matchers with DefaultTestContext {
 
   import SqsSourceSpec._
 

--- a/sse/src/test/scala/docs/scaladsl/EventSourceSpec.scala
+++ b/sse/src/test/scala/docs/scaladsl/EventSourceSpec.scala
@@ -19,7 +19,7 @@ import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.{ActorMaterializer, ThrottleMode}
 import akka.testkit.SocketUtil
 import akka.{Done, NotUsed}
-import org.scalatest.{AsyncWordSpec, BeforeAndAfterAll, Matchers}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable
 import scala.concurrent.duration.DurationInt
@@ -29,6 +29,8 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.sse.ServerSentEvent
 import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse, Uri}
 import akka.stream.alpakka.sse.scaladsl.EventSource
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
 
 //#event-source
 

--- a/text/src/test/scala/akka/stream/alpakka/text/scaladsl/CharsetCodingFlowsSpec.scala
+++ b/text/src/test/scala/akka/stream/alpakka/text/scaladsl/CharsetCodingFlowsSpec.scala
@@ -15,16 +15,18 @@ import akka.stream.{ActorMaterializer, IOResult, Materializer}
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, RecoverMethods, WordSpecLike}
+import org.scalatest.{BeforeAndAfterAll, RecoverMethods}
 
 import scala.collection.immutable
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.Success
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class CharsetCodingFlowsSpec
     extends TestKit(ActorSystem("charset"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures

--- a/text/src/test/scala/docs/scaladsl/CharsetCodingFlowsDoc.scala
+++ b/text/src/test/scala/docs/scaladsl/CharsetCodingFlowsDoc.scala
@@ -13,15 +13,17 @@ import akka.stream.{ActorMaterializer, IOResult, Materializer}
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, RecoverMethods, WordSpecLike}
+import org.scalatest.{BeforeAndAfterAll, RecoverMethods}
 
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.Success
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class CharsetCodingFlowsDoc
     extends TestKit(ActorSystem("charset"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures

--- a/udp/src/test/scala/docs/scaladsl/UdpSpec.scala
+++ b/udp/src/test/scala/docs/scaladsl/UdpSpec.scala
@@ -15,14 +15,16 @@ import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class UdpSpec
     extends TestKit(ActorSystem("UdpSpec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with ScalaFutures
     with BeforeAndAfterAll {

--- a/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala
+++ b/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala
@@ -20,6 +20,8 @@ import org.scalatest._
 
 import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpecLike
 
 class UnixDomainSocketSpec
     extends TestKit(ActorSystem("UnixDomainSocketSpec"))

--- a/xml/src/test/scala/docs/scaladsl/XmlCoalesceSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlCoalesceSpec.scala
@@ -10,12 +10,14 @@ import akka.stream.alpakka.xml._
 import akka.stream.alpakka.xml.scaladsl.XmlParsing
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.util.ByteString
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class XmlCoalesceSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+class XmlCoalesceSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   implicit val system: ActorSystem = ActorSystem("Test")
   implicit val mat: Materializer = ActorMaterializer()
 

--- a/xml/src/test/scala/docs/scaladsl/XmlProcessingSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlProcessingSpec.scala
@@ -11,13 +11,15 @@ import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class XmlProcessingSpec extends WordSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
+class XmlProcessingSpec extends AnyWordSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
   implicit val system: ActorSystem = ActorSystem("Test")
   implicit val mat: Materializer = ActorMaterializer()
   implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = 2.seconds, interval = 50.millis)

--- a/xml/src/test/scala/docs/scaladsl/XmlSubsliceSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlSubsliceSpec.scala
@@ -10,12 +10,14 @@ import akka.stream.alpakka.xml._
 import akka.stream.alpakka.xml.scaladsl.XmlParsing
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.util.ByteString
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class XmlSubsliceSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+class XmlSubsliceSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   implicit val system: ActorSystem = ActorSystem("Test")
   implicit val mat: Materializer = ActorMaterializer()
 

--- a/xml/src/test/scala/docs/scaladsl/XmlSubtreeSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlSubtreeSpec.scala
@@ -10,12 +10,14 @@ import akka.stream.alpakka.xml.scaladsl.XmlParsing
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.util.ByteString
 import docs.javadsl.XmlHelper
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class XmlSubtreeSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+class XmlSubtreeSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   implicit val system: ActorSystem = ActorSystem("Test")
   implicit val mat: Materializer = ActorMaterializer()
 

--- a/xml/src/test/scala/docs/scaladsl/XmlWritingSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlWritingSpec.scala
@@ -12,12 +12,14 @@ import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import javax.xml.stream.XMLOutputFactory
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class XmlWritingSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+class XmlWritingSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
   implicit val system: ActorSystem = ActorSystem("Test")
   implicit val mat: Materializer = ActorMaterializer()
 


### PR DESCRIPTION
## Purpose

Update to use Scalatest 3.1.0 with the new modular structure.

## Changes

* Scalatest 3.1.0
* Scalatest plus for Mockito
* Rewrite the imports with help of Scalafix
