### PR TITLE
S3 request uri: include empty trailing slashes for the key

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -221,7 +221,7 @@ import scala.concurrent.{ExecutionContext, Future}
       Uri.Path.Empty
     }
     val path = key.fold(basePath) { someKey =>
-      someKey.split("/").foldLeft(basePath)((acc, p) => acc / p)
+      someKey.split("/", -1).foldLeft(basePath)((acc, p) => acc / p)
     }
     val uri = Uri(path = path, authority = requestAuthority(bucket, conf.s3RegionProvider.getRegion))
       .withHost(requestAuthority(bucket, conf.s3RegionProvider.getRegion).host)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -183,6 +183,19 @@ class HttpRequestsSpec extends FlatSpec with Matchers with ScalaFutures {
     req.uri.rawQueryString shouldBe empty
   }
 
+  it should "support download requests with keys ending with /" in {
+    // object with a slash at the end of the filename should be accessible
+    implicit val settings = getSettings()
+
+    val location = S3Location("bucket", "/test//")
+
+    val req = HttpRequests.getDownloadRequest(location)
+
+    req.uri.authority.host.toString shouldEqual "bucket.s3.amazonaws.com"
+    req.uri.path.toString shouldEqual "//test//"
+    req.uri.rawQueryString shouldBe empty
+  }
+
   it should "support download requests with keys containing spaces" in {
     implicit val settings = getSettings()
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->
## Purpose

prevent vanishing trailing slash in s3 objects keys 

## References

References #2089 

## Changes
* change key split in a way it does not remove trailing empty slashes
## Background Context

-