### PR TITLE
AWS S3: change default to virtual-host-style access

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -350,6 +350,7 @@ object Dependencies {
         "com.google.jimfs" % "jimfs" % "1.1" % Test, // ApacheV2
         "com.github.tomakehurst" % "wiremock" % "2.25.1" % Test // ApacheV2
       ) ++ JacksonDatabindDependencies
+      ++ Silencer
   )
 
   val SpringWeb = {

--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -73,11 +73,10 @@ alpakka.s3 {
     }
   }
 
-  # Enable path style access to s3, i.e. "https://s3-eu-west-1.amazonaws.com/my.bucket/myobject"
-  # Set to false to enable virtual-hosted style.
-  # When using virtual hosted–style buckets with SSL, the S3 wild card certificate only matches buckets that do not contain periods.
-  # Buckets containing periods will lead to certificate errors. In those cases it's useful to enable path-style access.
-  path-style-access = true
+  # DEPRECATED (since Alpakka 2.0.0)
+  # AWS S3 is going to retire path-style access, thus prefer the virutal-host-style access
+  # https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
+  path-style-access = false
 
   # Custom endpoint url, used for alternate s3 implementations
   # endpoint-url = null

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -11,7 +11,7 @@ import akka.annotation.InternalApi
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport._
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.Uri.{Authority, Query}
-import akka.http.scaladsl.model.headers.{Host, RawHeader, `Raw-Request-URI`}
+import akka.http.scaladsl.model.headers.{`Raw-Request-URI`, Host, RawHeader}
 import akka.http.scaladsl.model.{ContentTypes, RequestEntity, _}
 import akka.stream.alpakka.s3.{ApiVersion, S3Settings}
 import akka.stream.scaladsl.Source
@@ -173,7 +173,9 @@ import scala.concurrent.{ExecutionContext, Future}
   @throws(classOf[IllegalUriException])
   private[this] def requestAuthority(bucket: String, region: Region)(implicit conf: S3Settings): Authority = {
     if (conf.pathStyleAccess) {
-      log.warn("AWS S3 is going to retire path-style access (https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/)")
+      log.warn(
+        "AWS S3 is going to retire path-style access (https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/)"
+      )
     }
     conf.endpointUrl match {
       case Some(endpointUrl) => Uri(endpointUrl).authority

--- a/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
@@ -223,6 +223,11 @@ final class S3Settings private (
   def withCredentialsProvider(value: AwsCredentialsProvider): S3Settings =
     copy(credentialsProvider = value)
   def withS3RegionProvider(value: AwsRegionProvider): S3Settings = copy(s3RegionProvider = value)
+
+  @deprecated(
+    "AWS S3 is going to retire path-style access https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/",
+    since = "2.0.0"
+  )
   def withPathStyleAccess(value: Boolean): S3Settings =
     if (pathStyleAccess == value) this else copy(pathStyleAccess = value)
   def withEndpointUrl(value: String): S3Settings = copy(endpointUrl = Option(value))

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -86,7 +86,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "throw an error if path-style access is false and the bucket name contains non-LDH characters" in {
-    implicit val settings = getSettings(s3Region = Region.EU_WEST_1).withPathStyleAccess(false)
+    implicit val settings = getSettings(s3Region = Region.EU_WEST_1)
 
     assertThrows[IllegalUriException](
       HttpRequests.getDownloadRequest(S3Location("invalid_bucket_name", "image-1024@2x"))
@@ -94,7 +94,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "throw an error if the key uses `..`" in {
-    implicit val settings = getSettings(s3Region = Region.EU_WEST_1).withPathStyleAccess(false)
+    implicit val settings = getSettings(s3Region = Region.EU_WEST_1)
 
     assertThrows[IllegalUriException](
       HttpRequests.getDownloadRequest(S3Location("validbucket", "../other-bucket/image-1024@2x"))
@@ -102,6 +102,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "throw an error when using `..` with path-style access" in {
+    @com.github.ghik.silencer.silent
     implicit val settings = getSettings(s3Region = Region.EU_WEST_1).withPathStyleAccess(true)
 
     assertThrows[IllegalUriException](
@@ -119,6 +120,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "initiate multipart upload with path-style access in region us-east-1" in {
+    @com.github.ghik.silencer.silent
     implicit val settings = getSettings(s3Region = Region.US_EAST_1).withPathStyleAccess(true)
 
     val req =
@@ -133,6 +135,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "support download requests with path-style access in region us-east-1" in {
+    @com.github.ghik.silencer.silent
     implicit val settings = getSettings(s3Region = Region.US_EAST_1).withPathStyleAccess(true)
 
     val req = HttpRequests.getDownloadRequest(location)
@@ -143,6 +146,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "initiate multipart upload with path-style access in other regions" in {
+    @com.github.ghik.silencer.silent
     implicit val settings = getSettings(s3Region = Region.US_WEST_2).withPathStyleAccess(true)
 
     val req =
@@ -157,6 +161,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "support download requests with path-style access in other regions" in {
+    @com.github.ghik.silencer.silent
     implicit val settings = getSettings(s3Region = Region.EU_WEST_1).withPathStyleAccess(true)
 
     val req = HttpRequests.getDownloadRequest(location)
@@ -228,6 +233,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "support download requests with keys containing spaces with path-style access in other regions" in {
+    @com.github.ghik.silencer.silent
     implicit val settings = getSettings(s3Region = Region.EU_WEST_1).withPathStyleAccess(true)
 
     val location = S3Location("bucket", "test folder/test file.txt")
@@ -240,6 +246,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "add versionId query parameter when provided" in {
+    @com.github.ghik.silencer.silent
     implicit val settings = getSettings().withPathStyleAccess(true)
 
     val location = S3Location("bucket", "test/foo.txt")
@@ -280,6 +287,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "properly multipart upload part request with customer keys server side encryption" in {
+    @com.github.ghik.silencer.silent
     implicit val settings = getSettings(s3Region = Region.EU_WEST_1).withPathStyleAccess(true)
     val myKey = "my-key"
     val md5Key = "md5-key"
@@ -350,6 +358,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "properly construct the list bucket request with no prefix, continuation token or delimiter passed" in {
+    @com.github.ghik.silencer.silent
     implicit val settings = getSettings(s3Region = Region.US_EAST_2).withPathStyleAccess(true)
 
     val req =
@@ -359,6 +368,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "properly construct the list bucket request with a prefix and token passed" in {
+    @com.github.ghik.silencer.silent
     implicit val settings = getSettings(s3Region = Region.US_EAST_2).withPathStyleAccess(true)
 
     val req =
@@ -370,6 +380,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "properly construct the list bucket request with a delimiter and token passed" in {
+    @com.github.ghik.silencer.silent
     implicit val settings = getSettings(s3Region = Region.US_EAST_2).withPathStyleAccess(true)
 
     val req =
@@ -379,6 +390,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "properly construct the list bucket request when using api version 1" in {
+    @com.github.ghik.silencer.silent
     implicit val settings =
       getSettings(s3Region = Region.US_EAST_2, listBucketApiVersion = ApiVersion.ListBucketVersion1)
         .withPathStyleAccess(true)
@@ -390,6 +402,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   }
 
   it should "properly construct the list bucket request when using api version set to 1 and a continuation token" in {
+    @com.github.ghik.silencer.silent
     implicit val settings =
       getSettings(s3Region = Region.US_EAST_2, listBucketApiVersion = ApiVersion.ListBucketVersion1)
         .withPathStyleAccess(true)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -65,6 +65,7 @@ trait S3IntegrationSpec
       |}
     """.stripMargin)
 
+  @com.github.ghik.silencer.silent
   def otherRegionSettings =
     S3Settings().withPathStyleAccess(true).withS3RegionProvider(otherRegionProvider)
   def listBucketVersion1Settings =
@@ -521,12 +522,14 @@ class MinioS3IntegrationSpec extends S3IntegrationSpec {
                                  |}
     """.stripMargin).withFallback(super.config())
 
+  @com.github.ghik.silencer.silent
   override def otherRegionSettings =
     S3Settings()
       .withCredentialsProvider(staticProvider)
       .withEndpointUrl(endpointUrl)
       .withPathStyleAccess(true)
 
+  @com.github.ghik.silencer.silent
   override def invalidCredentials: S3Settings =
     S3Settings()
       .withCredentialsProvider(invalidCredentialsProvider)

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -519,6 +519,8 @@ class MinioS3IntegrationSpec extends S3IntegrationSpec {
                                  |    }
                                  |  }
                                  |  endpoint-url = "$endpointUrl"
+                                 |  # Use of endpoint-url requires path-style-access
+                                 |  path-style-access = true
                                  |}
     """.stripMargin).withFallback(super.config())
 

--- a/s3/src/test/scala/docs/scaladsl/S3SourceSpec.scala
+++ b/s3/src/test/scala/docs/scaladsl/S3SourceSpec.scala
@@ -189,6 +189,7 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
   }
 
   it should "fail for illegal bucket names" in {
+    @com.github.ghik.silencer.silent
     val dnsStyleAccess = S3Ext(system).settings
       .withPathStyleAccess(true)
       .withEndpointUrl(null)


### PR DESCRIPTION
## Purpose

Set virtual-host-style access as the default for AWS S3 (from being path-style before).

**This change may break existing usages as it applies much harder restrictions on the bucket names.**

## References

https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
#1679
#2053 
#2086
#1993 
#1308

## Changes

* Mark the `path-style-access` setting as deprecated with references to the blog post
* Issue warnings if `path-style-access` is enabled

## Background Context

Even though virtual-host-style access is much more restrictive on bucket names, it is the designated way forward for S3.
