### PR TITLE
JMS: test case for TX sources with broker restart

### DIFF
--- a/docs/src/main/paradox/jms/browse.md
+++ b/docs/src/main/paradox/jms/browse.md
@@ -55,7 +55,6 @@ connectionFactory       | Factory to use for creating JMS connections           
 destination             | The queue to browse                                                  | Must be set in code |
 credentials             | JMS broker credentials                                               | Empty               |
 connectionRetrySettings | Retry characteristics if the connection failed to be established or is taking a long time. | See @ref[Connection Retries](producer.md#connection-retries) 
-connectionStatusSubscriptionTimeout | 5 seconds | Time to wait for subscriber of connection status events before starting to discard them |
 
 reference.conf
 : @@snip [snip](/jms/src/main/resources/reference.conf) { #browse }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsAckSourceStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsAckSourceStage.scala
@@ -29,75 +29,76 @@ private[jms] final class JmsAckSourceStage(settings: JmsConsumerSettings, destin
   override def createLogicAndMaterializedValue(
       inheritedAttributes: Attributes
   ): (GraphStageLogic, JmsConsumerMatValue) = {
+    val logic = new JmsAckSourceStageLogic(inheritedAttributes)
+    (logic, logic.consumerControl)
+  }
 
-    val logic = new SourceStageLogic[AckEnvelope](shape, out, settings, destination, inheritedAttributes) {
-      private val maxPendingAck = settings.bufferSize
+  private final class JmsAckSourceStageLogic(inheritedAttributes: Attributes)
+      extends SourceStageLogic[AckEnvelope](shape, out, settings, destination, inheritedAttributes) {
+    private val maxPendingAck = settings.bufferSize
 
-      protected def createSession(connection: jms.Connection,
-                                  createDestination: jms.Session => javax.jms.Destination): JmsAckSession = {
-        val session =
-          connection.createSession(false, settings.acknowledgeMode.getOrElse(AcknowledgeMode.ClientAcknowledge).mode)
-        new JmsAckSession(connection, session, createDestination(session), destination, settings.bufferSize)
-      }
-
-      protected def pushMessage(msg: AckEnvelope): Unit = push(out, msg)
-
-      override protected def onSessionOpened(jmsSession: JmsConsumerSession): Unit =
-        jmsSession match {
-          case session: JmsAckSession =>
-            session
-              .createConsumer(settings.selector)
-              .map { consumer =>
-                consumer.setMessageListener(new jms.MessageListener {
-
-                  var listenerStopped = false
-
-                  def onMessage(message: jms.Message): Unit = {
-
-                    @tailrec
-                    def ackQueued(): Unit =
-                      OptionVal(session.ackQueue.poll()) match {
-                        case OptionVal.Some(action) =>
-                          try {
-                            action()
-                            session.pendingAck -= 1
-                          } catch {
-                            case _: StopMessageListenerException =>
-                              listenerStopped = true
-                          }
-                          if (!listenerStopped) ackQueued()
-                        case OptionVal.None =>
-                      }
-
-                    if (!listenerStopped)
-                      try {
-                        handleMessage.invoke(AckEnvelope(message, session))
-                        session.pendingAck += 1
-                        if (session.pendingAck > maxPendingAck) {
-                          val action = session.ackQueue.take()
-                          action()
-                          session.pendingAck -= 1
-                        }
-                        ackQueued()
-                      } catch {
-                        case _: StopMessageListenerException =>
-                          listenerStopped = true
-                        case e: jms.JMSException =>
-                          handleError.invoke(e)
-                      }
-                  }
-                })
-              }
-              .onComplete(sessionOpenedCB.invoke)
-
-          case _ =>
-            throw new IllegalArgumentException(
-              "Session must be of type JMSAckSession, it is a " +
-              jmsSession.getClass.getName
-            )
-        }
+    protected def createSession(connection: jms.Connection,
+                                createDestination: jms.Session => javax.jms.Destination): JmsAckSession = {
+      val session =
+        connection.createSession(false, settings.acknowledgeMode.getOrElse(AcknowledgeMode.ClientAcknowledge).mode)
+      new JmsAckSession(connection, session, createDestination(session), destination, settings.bufferSize)
     }
 
-    (logic, logic.consumerControl)
+    protected def pushMessage(msg: AckEnvelope): Unit = push(out, msg)
+
+    override protected def onSessionOpened(jmsSession: JmsConsumerSession): Unit =
+      jmsSession match {
+        case session: JmsAckSession =>
+          session
+            .createConsumer(settings.selector)
+            .map { consumer =>
+              consumer.setMessageListener(new jms.MessageListener {
+
+                var listenerStopped = false
+
+                def onMessage(message: jms.Message): Unit = {
+
+                  @tailrec
+                  def ackQueued(): Unit =
+                    OptionVal(session.ackQueue.poll()) match {
+                      case OptionVal.Some(action) =>
+                        try {
+                          action()
+                          session.pendingAck -= 1
+                        } catch {
+                          case _: StopMessageListenerException =>
+                            listenerStopped = true
+                        }
+                        if (!listenerStopped) ackQueued()
+                      case OptionVal.None =>
+                    }
+
+                  if (!listenerStopped)
+                    try {
+                      handleMessage.invoke(AckEnvelope(message, session))
+                      session.pendingAck += 1
+                      if (session.pendingAck > maxPendingAck) {
+                        val action = session.ackQueue.take()
+                        action()
+                        session.pendingAck -= 1
+                      }
+                      ackQueued()
+                    } catch {
+                      case _: StopMessageListenerException =>
+                        listenerStopped = true
+                      case e: jms.JMSException =>
+                        handleError.invoke(e)
+                    }
+                }
+              })
+            }
+            .onComplete(sessionOpenedCB.invoke)
+
+        case _ =>
+          throw new IllegalArgumentException(
+            "Session must be of type JMSAckSession, it is a " +
+            jmsSession.getClass.getName
+          )
+      }
   }
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsConnector.scala
@@ -325,7 +325,7 @@ private[jms] trait JmsConnector[S <: JmsSession] {
     jmsConnection.map { connection =>
       connection.setExceptionListener(new jms.ExceptionListener {
         override def onException(ex: jms.JMSException): Unit = {
-          closeConnection(connection) // best effort closing the connection.
+          closeConnection(connection)
           connectionFailedCB.invoke(ex)
         }
       })

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsConnector.scala
@@ -258,9 +258,9 @@ private[jms] trait JmsConnector[S <: JmsSession] {
     }
     try {
       connection.close()
-      log.info("JMS connection {} closed", connection)
+      log.debug("JMS connection {} closed", connection)
     } catch {
-      case NonFatal(e) => log.error(e, "Error closing JMS connection {}", connection)
+      case NonFatal(e) => log.warning("Error closing JMS connection {}: {}", connection, e)
     }
   }
 

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsTxSourceStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsTxSourceStage.scala
@@ -28,60 +28,62 @@ private[jms] final class JmsTxSourceStage(settings: JmsConsumerSettings, destina
   override def createLogicAndMaterializedValue(
       inheritedAttributes: Attributes
   ): (GraphStageLogic, JmsConsumerMatValue) = {
-    val logic = new SourceStageLogic[TxEnvelope](shape, out, settings, destination, inheritedAttributes) {
-      protected def createSession(connection: jms.Connection,
-                                  createDestination: jms.Session => javax.jms.Destination) = {
-        val session =
-          connection.createSession(true, settings.acknowledgeMode.getOrElse(AcknowledgeMode.SessionTransacted).mode)
-        new JmsConsumerSession(connection, session, createDestination(session), destination)
-      }
-
-      protected def pushMessage(msg: TxEnvelope): Unit = push(out, msg)
-
-      override protected def onSessionOpened(jmsSession: JmsConsumerSession): Unit =
-        jmsSession match {
-          case session: JmsSession =>
-            session
-              .createConsumer(settings.selector)
-              .map { consumer =>
-                consumer.setMessageListener(new jms.MessageListener {
-
-                  def onMessage(message: jms.Message): Unit =
-                    try {
-                      val envelope = TxEnvelope(message, session)
-                      handleMessage.invoke(envelope)
-                      try {
-                        // JMS spec defines that commit/rollback must be done on the same thread.
-                        // While some JMS implementations work without this constraint, IBM MQ is
-                        // very strict about the spec and throws exceptions when called from a different thread.
-                        val action = Await.result(envelope.commitFuture, settings.ackTimeout)
-                        action()
-                      } catch {
-                        case _: TimeoutException =>
-                          val exception = new JmsTxAckTimeout(settings.ackTimeout)
-                          session.session.rollback()
-                          if (settings.failStreamOnAckTimeout) {
-                            handleError.invoke(exception)
-                          } else {
-                            log.warning(exception.getMessage)
-                          }
-                      }
-                    } catch {
-                      case e: IllegalArgumentException => handleError.invoke(e) // Invalid envelope. Fail the stage.
-                      case e: jms.JMSException => handleError.invoke(e)
-                    }
-                })
-              }
-              .onComplete(sessionOpenedCB.invoke)
-
-          case _ =>
-            throw new IllegalArgumentException(
-              "Session must be of type JmsAckSession, it is a " +
-              jmsSession.getClass.getName
-            )
-        }
-    }
-
+    val logic = new JmsTxSourceStageLogic(inheritedAttributes)
     (logic, logic.consumerControl)
   }
+
+  private final class JmsTxSourceStageLogic(inheritedAttributes: Attributes)
+      extends SourceStageLogic[TxEnvelope](shape, out, settings, destination, inheritedAttributes) {
+    protected def createSession(connection: jms.Connection, createDestination: jms.Session => javax.jms.Destination) = {
+      val session =
+        connection.createSession(true, settings.acknowledgeMode.getOrElse(AcknowledgeMode.SessionTransacted).mode)
+      new JmsConsumerSession(connection, session, createDestination(session), destination)
+    }
+
+    protected def pushMessage(msg: TxEnvelope): Unit = push(out, msg)
+
+    override protected def onSessionOpened(jmsSession: JmsConsumerSession): Unit =
+      jmsSession match {
+        case session: JmsSession =>
+          session
+            .createConsumer(settings.selector)
+            .map { consumer =>
+              consumer.setMessageListener(new jms.MessageListener {
+
+                def onMessage(message: jms.Message): Unit =
+                  try {
+                    val envelope = TxEnvelope(message, session)
+                    handleMessage.invoke(envelope)
+                    try {
+                      // JMS spec defines that commit/rollback must be done on the same thread.
+                      // While some JMS implementations work without this constraint, IBM MQ is
+                      // very strict about the spec and throws exceptions when called from a different thread.
+                      val action = Await.result(envelope.commitFuture, settings.ackTimeout)
+                      action()
+                    } catch {
+                      case _: TimeoutException =>
+                        val exception = new JmsTxAckTimeout(settings.ackTimeout)
+                        session.session.rollback()
+                        if (settings.failStreamOnAckTimeout) {
+                          handleError.invoke(exception)
+                        } else {
+                          log.warning(exception.getMessage)
+                        }
+                    }
+                  } catch {
+                    case e: IllegalArgumentException => handleError.invoke(e) // Invalid envelope. Fail the stage.
+                    case e: jms.JMSException => handleError.invoke(e)
+                  }
+              })
+            }
+            .onComplete(sessionOpenedCB.invoke)
+
+        case _ =>
+          throw new IllegalArgumentException(
+            "Session must be of type JmsSession, it is a " +
+            jmsSession.getClass.getName
+          )
+      }
+  }
+
 }

--- a/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
@@ -10,17 +10,20 @@ import akka.Done
 import akka.stream._
 import akka.stream.alpakka.jms._
 import akka.stream.alpakka.jms.scaladsl.{JmsConsumer, JmsConsumerControl, JmsProducer}
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.scaladsl.{Flow, Keep, RestartSource, Sink, Source}
 import javax.jms.{JMSException, TextMessage}
 import org.scalatest.Inspectors._
+import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
 import scala.collection.{immutable, mutable}
-import scala.concurrent.Future
+import scala.concurrent.{Await, Future, Promise}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 class JmsTxConnectorsSpec extends JmsSharedServerSpec {
+
+  private final val log = LoggerFactory.getLogger(classOf[JmsTxConnectorsSpec])
 
   override implicit val patienceConfig = PatienceConfig(2.minutes)
 
@@ -208,6 +211,52 @@ class JmsTxConnectorsSpec extends JmsSharedServerSpec {
       val ex = result.failed.futureValue
       ex shouldBe a[ConnectionRetryException]
       ex.getCause shouldBe a[JMSException]
+    }
+
+    // Trying to illustrate https://github.com/akka/alpakka/issues/2103
+    // Unfinished: this requires a broker persisting its data
+    "read messages after broker restart" ignore withServer() { server =>
+      val queueName = createName("restarting")
+      val connectionFactory = server.createConnectionFactory
+
+      val in = 0 to 25 map (i => ('a' + i).asInstanceOf[Char].toString)
+      Source(in)
+        .runWith(
+          JmsProducer.textSink(JmsProducerSettings(producerConfig, connectionFactory).withQueue(queueName))
+        )
+        .futureValue shouldBe Done
+
+      val triggerRestart = Promise[Done]
+
+      val result = RestartSource
+        .onFailuresWithBackoff(5.seconds, 1.minute, 0.25) { () =>
+          JmsConsumer
+            .txSource(
+              JmsConsumerSettings(consumerConfig, connectionFactory)
+                .withQueue(queueName)
+            )
+            .map(env => (env, env.message.asInstanceOf[TextMessage].getText))
+            .log("received", _._2)
+            .map {
+              case tup @ (_, "e") =>
+                triggerRestart.success(Done)
+                tup
+              case tup =>
+                tup
+            }
+            .map { case (env, text) => env.commit(); text }
+        }
+        .take(in.size)
+        .runWith(Sink.seq)
+
+      Await.result(triggerRestart.future, 20.seconds)
+      log.debug("-- Stopping broker")
+      server.stop()
+      Thread.sleep(1000)
+      log.debug("-- Re-starting broker")
+      server.start()
+
+      result.futureValue should contain theSameElementsAs in
     }
 
     "publish and consume elements through a topic " in withConnectionFactory() { connectionFactory =>


### PR DESCRIPTION
## Purpose

Try to isolate the commit failure problem reported in #2103 into a test case.

## References

References #2103

## Changes

* Unfinished test case in `JmsTxConnectorsSpec`
* Change consumer stage logic classes to named classes
* Change logging severity for connection closing
* Remove the browse stage `connectionStatusSubscriptionTimeout` docs (as it didn't get added in #2067) 
