### PR TITLE
Files: Compare input data in zip archive tests

### DIFF
--- a/file/src/test/java/docs/javadsl/ArchiveHelper.java
+++ b/file/src/test/java/docs/javadsl/ArchiveHelper.java
@@ -6,45 +6,36 @@ package docs.javadsl;
 
 import akka.util.ByteString;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.nio.file.Path;
-import java.util.List;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
+import java.util.zip.ZipInputStream;
 
 public class ArchiveHelper {
 
-  public void createReferenceZipFile(List<Path> inputFilePaths, String resultFileName)
-      throws Exception {
-    FileOutputStream fout = new FileOutputStream(resultFileName);
-    ZipOutputStream zout = new ZipOutputStream(fout);
-    for (Path inputFilePath : inputFilePaths) {
-      File fileToZip = inputFilePath.toFile();
-      FileInputStream fis = new FileInputStream(fileToZip);
-      ZipEntry zipEntry = new ZipEntry(fileToZip.getName());
-      zout.putNextEntry(zipEntry);
-      byte[] bytes = new byte[1024];
-      int length;
-      while ((length = fis.read(bytes)) >= 0) {
-        zout.write(bytes, 0, length);
-      }
-      fis.close();
-    }
-    zout.close();
-  }
+  public Map<String, ByteString> unzip(ByteString zipArchive) throws Exception {
+    ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipArchive.toArray()));
+    ZipEntry entry;
+    Map<String, ByteString> result = new HashMap<>();
+    try {
+      while ((entry = zis.getNextEntry()) != null) {
+        int count;
+        byte[] data = new byte[1024];
 
-  public void createReferenceZipFileFromMemory(
-      Map<String, ByteString> inputFilePaths, String resultFileName) throws Exception {
-    FileOutputStream fout = new FileOutputStream(resultFileName);
-    ZipOutputStream zout = new ZipOutputStream(fout);
-    for (Map.Entry<String, ByteString> file : inputFilePaths.entrySet()) {
-      ZipEntry zipEntry = new ZipEntry(file.getKey());
-      zout.putNextEntry(zipEntry);
-      zout.write(file.getValue().toArray(), 0, file.getValue().toArray().length);
+        ByteArrayOutputStream dest = new ByteArrayOutputStream();
+        while ((count = zis.read(data, 0, 1024)) != -1) {
+          dest.write(data, 0, count);
+        }
+        dest.flush();
+        dest.close();
+        zis.closeEntry();
+        result.putIfAbsent(entry.getName(), ByteString.fromArray(dest.toByteArray()));
+      }
+    } finally {
+      zis.close();
     }
-    zout.close();
+    return result;
   }
 }

--- a/file/src/test/java/docs/javadsl/ArchiveTest.java
+++ b/file/src/test/java/docs/javadsl/ArchiveTest.java
@@ -96,16 +96,13 @@ public class ArchiveTest {
           }
         };
 
-    archiveHelper.createReferenceZipFileFromMemory(inputFiles, "logo-reference.zip");
-
     ByteString resultFileContent = readFileAsByteString(Paths.get("logo.zip"));
-    ByteString referenceFileContent = readFileAsByteString(Paths.get("logo-reference.zip"));
+    Map<String, ByteString> unzip = archiveHelper.unzip(resultFileContent);
 
-    assertEquals(resultFileContent, referenceFileContent);
+    assertEquals(inputFiles, unzip);
 
     // cleanup
     new File("logo.zip").delete();
-    new File("logo-reference.zip").delete();
   }
 
   @After


### PR DESCRIPTION
## Purpose
Improve stability of File archive tests

## References
References #1989 and #1909

## Changes
- improved stability in java and scala archive zip test

## Background Context
Before, archive created by zip stream was compared with archive created with plan java.
Unfortunately, while creating zip file current time is taken https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/zip/ZipOutputStream.java#L197
So, when the tests were slow, time didn't match in result archive. 
In this fix, archives are not compared. Only input files with files after zip -> unzip.

Fix as discussed with @ennru  https://github.com/akka/alpakka/issues/1909#issuecomment-576184708 
