### PR TITLE
Unix domain socket: upgrade dependencies; remove classifier

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -440,8 +440,8 @@ object Dependencies {
 
   val UnixDomainSocket = Seq(
     libraryDependencies ++= Seq(
-        "com.github.jnr" % "jffi" % "1.2.17" classifier "complete", // ApacheV2
-        "com.github.jnr" % "jnr-unixsocket" % "0.22" // BSD/ApacheV2/CPL/MIT as per https://github.com/akka/alpakka/issues/620#issuecomment-348727265
+        "com.github.jnr" % "jffi" % "1.2.22", // classifier "complete", // Is the classifier needed anymore?
+        "com.github.jnr" % "jnr-unixsocket" % "0.25" // BSD/ApacheV2/CPL/MIT as per https://github.com/akka/alpakka/issues/620#issuecomment-348727265
       )
   )
 


### PR DESCRIPTION
## Purpose

Upgrade to later versions of "jiffi" and "jnr-unixsocket" and remove the classifier on "jiffi".

## References

The classifier puts sbt-whitesource off https://travis-ci.com/akka/alpakka/jobs/280329800#L356

## Background Context

I'm not sure if the classifier is needed anymore. It works locally on OSX for me.