### PR TITLE
FTP: error on failed delete/move

### DIFF
--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/CommonFtpOperations.scala
@@ -77,11 +77,13 @@ private[ftp] trait CommonFtpOperations {
     if (os != null) os else throw new IOException(s"Could not write to $name")
   }
 
-  def move(fromPath: String, destinationPath: String, handler: Handler): Unit =
-    handler.rename(fromPath, destinationPath)
+  def move(fromPath: String, destinationPath: String, handler: Handler): Unit = {
+    if (!handler.rename(fromPath, destinationPath)) throw new IOException(s"Could not move $fromPath")
+  }
 
-  def remove(path: String, handler: Handler): Unit =
-    handler.deleteFile(path)
+  def remove(path: String, handler: Handler): Unit = {
+    if (!handler.deleteFile(path)) throw new IOException(s"Could not delete $path")
+  }
 
   def completePendingCommand(handler: Handler): Boolean =
     handler.completePendingCommand()

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -370,7 +370,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
 
       val ex = result.status.failed.get
       ex shouldBe an[IOException]
-      ex should have message s"Could not delete /$fileName"
+      ex should (have message s"Could not delete /$fileName" or have message "No such file")
 
       extraWaitForStageShutdown()
     }
@@ -415,7 +415,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
 
       val ex = result.status.failed.get
       ex shouldBe an[IOException]
-      ex should have message s"Could not move /$fileName"
+      ex should (have message s"Could not move /$fileName" or have message "No such file")
 
       extraWaitForStageShutdown()
     }

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.stream.alpakka.ftp
 
+import java.io.IOException
 import java.net.InetAddress
 import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.{Files, Paths}
@@ -350,6 +351,29 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
       }
       extraWaitForStageShutdown()
     }
+
+    "fail when the file does not exist" in {
+      val fileName = "sample_io_" + Instant.now().getNano
+      val file = FtpFile(
+        name = fileName,
+        path = s"/$fileName",
+        isDirectory = false,
+        size = 999,
+        lastModified = 0,
+        permissions = Set.empty
+      )
+
+      val result = Source
+        .single(file)
+        .runWith(remove())
+        .futureValue
+
+      val ex = result.status.failed.get
+      ex shouldBe an[IOException]
+      ex should have message s"Could not delete /$fileName"
+
+      extraWaitForStageShutdown()
+    }
   }
 
   "FtpMoveSink" should {
@@ -368,6 +392,31 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
         fileExists(fileName) shouldBe false
         fileExists(fileName2) shouldBe true
       }
+      extraWaitForStageShutdown()
+    }
+
+    "fail when the source file does not exist" in {
+      val fileName = "sample_io_" + Instant.now().getNano
+      val fileName2 = "sample_io2_" + Instant.now().getNano
+
+      val file = FtpFile(
+        name = fileName,
+        path = s"/$fileName",
+        isDirectory = false,
+        size = 999,
+        lastModified = 0,
+        permissions = Set.empty
+      )
+
+      val result = Source
+        .single(file)
+        .runWith(move(_ => fileName2))
+        .futureValue
+
+      val ex = result.status.failed.get
+      ex shouldBe an[IOException]
+      ex should have message s"Could not move /$fileName"
+
       extraWaitForStageShutdown()
     }
   }


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

`Ftp.remove` and `Ftp.move` emit the result in its materialized value of `Future[IOResult]`. Currently there's no way to know if the delete/move failed, e.g. if the file does not exist. A successful and failed delete will both materialize as a `Future.successful(IOResult(1, Success(Done)))`. After this PR, a failed delete will materialize as a `Future.successful(IOResult(1, Failure(IOException)))`.