### PR TITLE
Docs: link to Akka update strategy

### DIFF
--- a/docs/src/main/paradox/mqtt-streaming.md
+++ b/docs/src/main/paradox/mqtt-streaming.md
@@ -33,6 +33,14 @@ The table below shows direct dependencies of this module and the second tab show
 @@dependencies { projectId="mqtt-streaming" }
 
 
+@@@ warning
+
+The current Alpakka MQTT streaming library works **only with Akka 2.5.27+** due to non-binary-compatible changes in the Akka Typed modules. 
+See the Akka blog: [Akka 2.5.22 Brings Akka Typed To Production Ready](https://akka.io/blog/news/2019/04/10/akka-tyoed-prod-ready).  
+
+@@@
+
+
 ## Flow through a client session
 
 The following code illustrates how to establish an MQTT client session and join it with a TCP connection:

--- a/docs/src/main/paradox/other-docs/versioning.md
+++ b/docs/src/main/paradox/other-docs/versioning.md
@@ -30,7 +30,7 @@ Read about the details in the @extref:[Akka documentation](akka:common/binary-co
 
 With Akka though, it is important to be strictly using one version (never blend eg. `akka-actor 2.5.21` and `akka-stream 2.5.12`), and do not use an Akka version lower than the one the Alpakka dependency requires (sometimes Alpakka modules depend on features of the latest Akka release).
 
-Alpakka’s Akka and Akka HTTP dependencies are upgraded only if that version brings features leveraged by Alpakka or important fixes. As Akka itself is binary-compatible, the Akka version may be upgraded with an Alpakka patch release.
+Alpakka’s Akka and Akka HTTP dependencies are upgraded only if that version brings features leveraged by Alpakka or important fixes. As Akka itself is binary-compatible, the Akka version may be upgraded with an Alpakka patch release. See Akka's [Downstream upgrade strategy](https://doc.akka.io/docs/akka/current/project/downstream-upgrade-strategy.html) <!-- current, page not available in Akka 2.5 -->.
 
 @@@ note 
 

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -17,6 +17,8 @@ The code in this documentation is compiled against
 * Akka Streams $akka.version$ (all modules are compatible with Akka 2.6.0+) (@extref:[Reference](akka:stream/index.html), [Github](https://github.com/akka/akka))
 * Akka Http $akka-http.version$ (@extref:[Reference](akka-http:), [Github](https://github.com/akka/akka-http))
 
+See @ref:[Alpakka versioning](other-docs/versioning.md) for more details.
+
 Release notes are found at @ref:[Release Notes](release-notes/index.md).
 
 If you want to try out a connector that has not yet been released, give @ref[snapshots](other-docs/snapshots.md) a spin which are published after every merged PR.


### PR DESCRIPTION
Add a link to the new upgrade strategy docs in main Akka.