### PR TITLE
Fix Java Unit Test docs example in Unix Domain Sockets

### DIFF
--- a/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
+++ b/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
@@ -63,7 +63,6 @@ public class UnixDomainSocketTest {
     // #binding
     java.nio.file.Path path = // ...
         // #binding
-        // Files.createTempFile("aUnixDomainSocketShouldReceiveWhatIsSent1", ".sock");
         Files.createTempDirectory("UnixDomainSocketSpec").resolve("sock1");
     path.toFile().deleteOnExit();
 
@@ -72,7 +71,7 @@ public class UnixDomainSocketTest {
         UnixDomainSocket.get(system).bind(path);
     // #binding
 
-    CompletableFuture<ByteString> received = new CompletableFuture<>();
+    final CompletableFuture<ByteString> received = new CompletableFuture<>();
 
     // #outgoingConnection
     ByteString sendBytes = ByteString.fromString("Hello");

--- a/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
+++ b/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
@@ -74,7 +74,6 @@ public class UnixDomainSocketTest {
     final CompletableFuture<ByteString> received = new CompletableFuture<>();
 
     // #outgoingConnection
-    ByteString sendBytes = ByteString.fromString("Hello");
     CompletionStage<ServerBinding> streamCompletion =
         connections
             .map(
@@ -95,6 +94,7 @@ public class UnixDomainSocketTest {
             .run(materializer);
 
     // #outgoingConnection
+    final ByteString sendBytes = ByteString.fromString("Hello");
     Source.single(sendBytes)
         .via(UnixDomainSocket.get(system).outgoingConnection(path))
         .runWith(Sink.ignore(), materializer);


### PR DESCRIPTION
The lone Java test in unix-domain-socket used for docs has always failed, but we never noticed it because we didn't block on stream completion before the test completed.  The blocking was added #2040 (https://github.com/akka/alpakka/pull/2040/files#r368017011), but the test failure got confused with a transient test failure and the PR was merged.

Changes
* Use a temp directory instead of a file.  `jnr-unixsocket` will create the socket files on our behalf, if the file already exists then we'll observe an `Address in use` exception (https://travis-ci.com/akka/alpakka/jobs/277967218#L358)
* Actually send data through socket!
* Remove framing boilerplate and just parse as a `ByteString` like the Scala docs example does.