### PR TITLE
Allow filtering LogCapturing by source actor system

### DIFF
--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -38,6 +38,8 @@ class ParametrizedTestKit(val clientId: String, val topic: String, system: Actor
 trait MqttFlowSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures with LogCapturing {
   self: ParametrizedTestKit =>
 
+  override def sourceActorSytem = Some(system.name)
+
   private implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = 5.seconds, interval = 100.millis)
 
   private implicit val mat: Materializer = ActorMaterializer()

--- a/testkit/src/main/scala/akka.stream.alpakka.testkit/LogbackUtil.scala
+++ b/testkit/src/main/scala/akka.stream.alpakka.testkit/LogbackUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.stream.alpakka.testkit

--- a/testkit/src/main/scala/akka.stream.alpakka.testkit/javadsl/LogCapturingJunit4.scala
+++ b/testkit/src/main/scala/akka.stream.alpakka.testkit/javadsl/LogCapturingJunit4.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.stream.alpakka.testkit.javadsl


### PR DESCRIPTION
To make the logs for failures more useful.

If this works out we should perhaps apply it upstream, https://github.com/akka/akka/issues/28571