### PR TITLE
Don't create ~/.coursier on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -177,7 +177,6 @@ before_cache:
 cache:
   directories:
     - $HOME/.cache/coursier
-    - $HOME/.coursier
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot
     - $HOME/.sbt/launchers


### PR DESCRIPTION
That is the 'old' location, and if that exists we might risk
coursier accidentally using that dir instead
https://get-coursier.io/docs/cache.html#compatibility-with-former-versions