### PR TITLE
Support AWS EventBridge (#2151)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ lazy val alpakka = project
     csv,
     dynamodb,
     elasticsearch,
+    eventbridge,
     files,
     ftp,
     geode,
@@ -140,6 +141,14 @@ lazy val elasticsearch = alpakkaProject(
   "elasticsearch",
   Dependencies.Elasticsearch,
   // For elasticsearch-cluster-runner https://github.com/akka/alpakka/issues/479
+  parallelExecution in Test := false
+)
+
+lazy val eventbridge = alpakkaProject(
+  "eventbridge",
+  "aws.eventbridge",
+  Dependencies.Eventbridge,
+  // For mockito https://github.com/akka/alpakka/issues/390
   parallelExecution in Test := false
 )
 

--- a/eventbridge/src/main/scala/akka/stream/alpakka/eventbridge/EventBridgePublishSettings.scala
+++ b/eventbridge/src/main/scala/akka/stream/alpakka/eventbridge/EventBridgePublishSettings.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.eventbridge
+
+final class EventBridgePublishSettings private (val concurrency: Int) {
+  require(concurrency > 0)
+
+  def withConcurrency(concurrency: Int): EventBridgePublishSettings = copy(concurrency = concurrency)
+
+  def copy(concurrency: Int) = new EventBridgePublishSettings(concurrency)
+
+  override def toString: String =
+    "EventBridgePublishSettings(" +
+    s"concurrency=$concurrency" +
+    ")"
+}
+
+object EventBridgePublishSettings {
+  val Defaults: EventBridgePublishSettings = new EventBridgePublishSettings(concurrency = 10)
+
+  /** Scala API */
+  def apply(): EventBridgePublishSettings = Defaults
+
+  /** Java API */
+  def create(): EventBridgePublishSettings = Defaults
+}

--- a/eventbridge/src/main/scala/akka/stream/alpakka/eventbridge/javadsl/EventBridgePublisher.scala
+++ b/eventbridge/src/main/scala/akka/stream/alpakka/eventbridge/javadsl/EventBridgePublisher.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.eventbridge.javadsl
+
+import java.util.concurrent.CompletionStage
+
+import akka.stream.alpakka.eventbridge.EventBridgePublishSettings
+import akka.stream.javadsl.{Flow, Keep, Sink}
+import akka.{Done, NotUsed}
+import software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient
+import software.amazon.awssdk.services.eventbridge.model.{PutEventsRequest, PutEventsResponse}
+
+/**
+ * Scala API
+ * Amazon EventBridge publisher factory.
+ */
+object EventBridgePublisher {
+
+  /**
+   * creates a [[akka.stream.scaladsl.Flow Flow]] to publish event to a EventBridge EventBus using an [[software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient EventBridgeAsyncClient]]
+   */
+  def createFlow(eventBusName: String,
+                 source: String,
+                 detailType: String,
+                 settings: EventBridgePublishSettings,
+                 eventBridgeClient: EventBridgeAsyncClient): Flow[String, PutEventsResponse, NotUsed] =
+    akka.stream.alpakka.eventbridge.scaladsl.EventBridgePublisher
+      .flow(eventBusName, source, detailType, settings)(eventBridgeClient)
+      .asJava
+
+  /**
+   * creates a [[akka.stream.scaladsl.Flow Flow]] to publish event to a EventBridge EventBus using an [[software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient EventBridgeAsyncClient]]
+   */
+  def createFlow(eventBusName: String,
+                 source: String,
+                 detailType: String,
+                 eventBridgeClient: EventBridgeAsyncClient): Flow[String, PutEventsResponse, NotUsed] =
+    akka.stream.alpakka.eventbridge.scaladsl.EventBridgePublisher
+      .flow(eventBusName, source, detailType, EventBridgePublishSettings())(eventBridgeClient)
+      .asJava
+
+  /**
+   * creates a [[akka.stream.scaladsl.Flow Flow]] to publish event to EventBridge EventBus based on the event bus name using an [[software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient EventBridgeAsyncClient]]
+   */
+  def createPutEventsFlow(
+      settings: EventBridgePublishSettings,
+      eventBridgeClient: EventBridgeAsyncClient
+  ): Flow[PutEventsRequest, PutEventsResponse, NotUsed] =
+    akka.stream.alpakka.eventbridge.scaladsl.EventBridgePublisher.putEventsFlow(settings)(eventBridgeClient).asJava
+
+  /**
+   * creates a [[akka.stream.scaladsl.Flow Flow]] to publish messages to EventBridge EventBus based on the event bus name using an [[software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient EventBridgeAsyncClient]]
+   */
+  def createPutEventsFlow(
+      eventBridgeClient: EventBridgeAsyncClient
+  ): Flow[PutEventsRequest, PutEventsResponse, NotUsed] =
+    akka.stream.alpakka.eventbridge.scaladsl.EventBridgePublisher
+      .putEventsFlow(EventBridgePublishSettings())(eventBridgeClient)
+      .asJava
+
+  /**
+   * creates a [[akka.stream.scaladsl.Sink Sink]] to publish messages to a EventBridge EventBus using an [[software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient EventBridgeAsyncClient]]
+   */
+  def createSink(eventBus: String,
+                 source: String,
+                 detailType: String,
+                 settings: EventBridgePublishSettings,
+                 eventBridgeClient: EventBridgeAsyncClient): Sink[String, CompletionStage[Done]] =
+    createFlow(eventBus, source, detailType, settings, eventBridgeClient)
+      .toMat(Sink.ignore(), Keep.right[NotUsed, CompletionStage[Done]])
+
+  /**
+   * creates a [[akka.stream.scaladsl.Sink Sink]] to publish messages to a EventBridge EventBus using an [[software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient EventBridgeAsyncClient]]
+   */
+  def createSink(eventBus: String,
+                 source: String,
+                 detailType: String,
+                 eventBridgeClient: EventBridgeAsyncClient): Sink[String, CompletionStage[Done]] =
+    createFlow(eventBus, source, detailType, EventBridgePublishSettings(), eventBridgeClient)
+      .toMat(Sink.ignore(), Keep.right[NotUsed, CompletionStage[Done]])
+
+  /**
+   * creates a [[akka.stream.scaladsl.Sink Sink]] to publish messages to a EventBridge EventBus using an [[software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient EventBridgeAsyncClient]]
+   */
+  def createPutEventsSink(settings: EventBridgePublishSettings,
+                          eventBridgeClient: EventBridgeAsyncClient): Sink[PutEventsRequest, CompletionStage[Done]] =
+    createPutEventsFlow(EventBridgePublishSettings(), eventBridgeClient)
+      .toMat(Sink.ignore(), Keep.right[NotUsed, CompletionStage[Done]])
+
+  /**
+   * creates a [[akka.stream.scaladsl.Sink Sink]] to publish messages to a EventBridge EventBus using an [[software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient EventBridgeAsyncClient]]
+   */
+  def createPutEventsSink(eventBridgeClient: EventBridgeAsyncClient): Sink[PutEventsRequest, CompletionStage[Done]] =
+    createPutEventsFlow(EventBridgePublishSettings(), eventBridgeClient)
+      .toMat(Sink.ignore(), Keep.right[NotUsed, CompletionStage[Done]])
+}

--- a/eventbridge/src/main/scala/akka/stream/alpakka/eventbridge/scaladsl/EventBridgePublisher.scala
+++ b/eventbridge/src/main/scala/akka/stream/alpakka/eventbridge/scaladsl/EventBridgePublisher.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.eventbridge.scaladsl
+
+import akka.stream.alpakka.eventbridge.EventBridgePublishSettings
+import akka.stream.scaladsl.{Flow, Keep, Sink}
+import akka.{Done, NotUsed}
+import software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient
+import software.amazon.awssdk.services.eventbridge.model.{PutEventsRequest, PutEventsRequestEntry, PutEventsResponse}
+
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.Future
+
+/**
+ * Scala API
+ * Amazon EventBridge publisher factory.
+ */
+object EventBridgePublisher {
+
+  /**
+   * creates a [[akka.stream.scaladsl.Flow Flow]] to publish event to a EventBridge EventBus using an [[software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient EventBridgeAsyncClient]]
+   */
+  def flow(eventBusName: String,
+           source: String,
+           detailType: String,
+           settings: EventBridgePublishSettings = EventBridgePublishSettings())(
+      implicit eventBridgeClient: EventBridgeAsyncClient
+  ): Flow[String, PutEventsResponse, NotUsed] =
+    Flow
+      .fromFunction(
+        (message: String) =>
+          PutEventsRequest
+            .builder()
+            .entries(
+              PutEventsRequestEntry
+                .builder()
+                .eventBusName(eventBusName)
+                .source(source)
+                .detailType(detailType)
+                .detail(message)
+                .build()
+            )
+            .build()
+      )
+      .via(putEventsFlow(settings))
+
+  /**
+   * creates a [[akka.stream.scaladsl.Flow Flow]] to publish event to EventBridge EventBus based on the event bus name using an [[software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient EventBridgeAsyncClient]]
+   */
+  def putEventsFlow(settings: EventBridgePublishSettings)(
+      implicit eventBridgeClient: EventBridgeAsyncClient
+  ): Flow[PutEventsRequest, PutEventsResponse, NotUsed] =
+    Flow[PutEventsRequest]
+      .mapAsyncUnordered(settings.concurrency)(eventBridgeClient.putEvents(_).toScala)
+
+  /**
+   * creates a [[akka.stream.scaladsl.Flow Flow]] to publish messages to EventBridge EventBus based on the event bus name using an [[software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient EventBridgeAsyncClient]]
+   */
+  def putEventsFlow()(
+      implicit eventBridgeClient: EventBridgeAsyncClient
+  ): Flow[PutEventsRequest, PutEventsResponse, NotUsed] =
+    putEventsFlow(EventBridgePublishSettings())
+
+  /**
+   * creates a [[akka.stream.scaladsl.Sink Sink]] to publish messages to a EventBridge EventBus using an [[software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient EventBridgeAsyncClient]]
+   */
+  def sink(eventBus: String,
+           source: String,
+           detailType: String,
+           settings: EventBridgePublishSettings = EventBridgePublishSettings())(
+      implicit eventBridgeClient: EventBridgeAsyncClient
+  ): Sink[String, Future[Done]] =
+    flow(eventBus, source, detailType, settings).toMat(Sink.ignore)(Keep.right)
+
+  /**
+   * creates a [[akka.stream.scaladsl.Sink Sink]] to publish messages to a EventBridge EventBus using an [[software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient EventBridgeAsyncClient]]
+   */
+  def putEventsSink(settings: EventBridgePublishSettings = EventBridgePublishSettings())(
+      implicit eventBridgeClient: EventBridgeAsyncClient
+  ): Sink[PutEventsRequest, Future[Done]] =
+    putEventsFlow(settings).toMat(Sink.ignore)(Keep.right)
+
+  /**
+   * creates a [[akka.stream.scaladsl.Sink Sink]] to publish messages to EventBridge EventBus based on the event bus name using an [[software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient EventBridgeAsyncClient]]
+   */
+  def putEventsSink()(implicit eventBridgeClient: EventBridgeAsyncClient): Sink[PutEventsRequest, Future[Done]] =
+    putEventsFlow(EventBridgePublishSettings()).toMat(Sink.ignore)(Keep.right)
+}

--- a/eventbridge/src/test/java/docs/javadsl/EventBridgePublisherTest.java
+++ b/eventbridge/src/test/java/docs/javadsl/EventBridgePublisherTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.javadsl;
+
+import akka.Done;
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.alpakka.eventbridge.javadsl.EventBridgePublisher;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.testkit.javadsl.TestKit;
+import com.github.matsluni.akkahttpspi.AkkaHttpClient;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient;
+import software.amazon.awssdk.services.eventbridge.model.CreateEventBusRequest;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+
+import java.net.URI;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+// #init-client
+// #init-client
+
+public class EventBridgePublisherTest {
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
+  static ActorSystem system;
+  static Materializer materializer;
+  static EventBridgeAsyncClient eventBridgeClient;
+  static String eventBusName;
+  static String source;
+  static String detailType;
+
+  static final String endpoint = "http://localhost:4100";
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws ExecutionException, InterruptedException {
+    system = ActorSystem.create("SnsPublisherTest");
+    materializer = ActorMaterializer.create(system);
+    eventBusName = "alpakka-java-event-bus-1";
+    source = "source";
+    detailType = "detailType";
+    eventBridgeClient = createEventBridgeClient();
+    eventBridgeClient
+        .createEventBus(CreateEventBusRequest.builder().name(eventBusName).build())
+        .get();
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() {
+    TestKit.shutdownActorSystem(system);
+  }
+
+  static EventBridgeAsyncClient createEventBridgeClient() {
+    // #init-client
+
+    // Don't encode credentials in your source code!
+    // see https://doc.akka.io/docs/alpakka/current/aws-shared-configuration.html
+    StaticCredentialsProvider credentialsProvider =
+        StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x"));
+    final EventBridgeAsyncClient eventBridgeClient =
+        EventBridgeAsyncClient.builder()
+            .credentialsProvider(credentialsProvider)
+            // #init-client
+            .endpointOverride(URI.create(endpoint))
+            // #init-client
+            .region(Region.EU_CENTRAL_1)
+            .httpClient(AkkaHttpClient.builder().withActorSystem(system).build())
+            // Possibility to configure the retry policy
+            // see https://doc.akka.io/docs/alpakka/current/aws-shared-configuration.html
+            // .overrideConfiguration(...)
+            .build();
+
+    system.registerOnTermination(() -> eventBridgeClient.close());
+    // #init-client
+
+    return eventBridgeClient;
+  }
+
+  void documentation() {
+    // #init-system
+    ActorSystem system = ActorSystem.create();
+    Materializer materializer = ActorMaterializer.create(system);
+    // #init-system
+  }
+
+  @Test
+  public void sinkShouldPutEventString() throws Exception {
+    CompletionStage<Done> completion =
+        // #use-sink
+        Source.single("message")
+            .runWith(
+                EventBridgePublisher.createSink(
+                    eventBusName, source, detailType, eventBridgeClient),
+                materializer);
+
+    // #use-sink
+    assertThat(completion.toCompletableFuture().get(2, TimeUnit.SECONDS), is(Done.getInstance()));
+  }
+
+  @Test
+  public void sinkShouldPutEventRequestWithDefaultEventBus() throws Exception {
+    CompletionStage<Done> completion =
+        // #use-sink
+        Source.single(
+                PutEventsRequest.builder()
+                    .entries(
+                        PutEventsRequestEntry.builder()
+                            .source("source")
+                            .detailType("detail-type")
+                            .detail("event-detail")
+                            .build())
+                    .build())
+            .runWith(EventBridgePublisher.createPutEventsSink(eventBridgeClient), materializer);
+
+    // #use-sink
+    assertThat(completion.toCompletableFuture().get(2, TimeUnit.SECONDS), is(Done.getInstance()));
+  }
+
+  @Test
+  public void sinkShouldPutEventRequestWithCustomEventBus() throws Exception {
+    CompletionStage<Done> completion =
+        // #use-sink
+        Source.single(
+                PutEventsRequest.builder()
+                    .entries(
+                        PutEventsRequestEntry.builder()
+                            .eventBusName("event-bus")
+                            .source("source")
+                            .detailType("detail-type")
+                            .detail("event-detail")
+                            .build())
+                    .build())
+            .runWith(EventBridgePublisher.createPutEventsSink(eventBridgeClient), materializer);
+    // #use-sink
+    assertThat(completion.toCompletableFuture().get(2, TimeUnit.SECONDS), is(Done.getInstance()));
+  }
+
+  @Test
+  public void flowShouldPutEventString() throws Exception {
+    CompletionStage<Done> completion =
+        // #use-flow
+        Source.single("message")
+            .via(
+                EventBridgePublisher.createFlow(
+                    eventBusName, source, detailType, eventBridgeClient))
+            .runWith(
+                Sink.foreach(
+                    resp -> resp.entries().forEach(res -> System.out.println(res.eventId()))),
+                materializer);
+
+    // #use-flow
+    assertThat(completion.toCompletableFuture().get(2, TimeUnit.SECONDS), is(Done.getInstance()));
+  }
+
+  @Test
+  public void flowShouldPublishRequestWithDefaultEventBus() throws Exception {
+    CompletionStage<Done> completion =
+        // #use-flow
+        Source.single(
+                PutEventsRequest.builder()
+                    .entries(
+                        PutEventsRequestEntry.builder()
+                            .source("source")
+                            .detailType("detail-type")
+                            .detail("event-detail")
+                            .build())
+                    .build())
+            .via(EventBridgePublisher.createPutEventsFlow(eventBridgeClient))
+            .runWith(
+                Sink.foreach(
+                    resp -> resp.entries().forEach(res -> System.out.println(res.eventId()))),
+                materializer);
+
+    // #use-flow
+    assertThat(completion.toCompletableFuture().get(2, TimeUnit.SECONDS), is(Done.getInstance()));
+  }
+
+  @Test
+  public void flowShouldPublishRequestWithCustomEventBus() throws Exception {
+    CompletionStage<Done> completion =
+        // #use-flow
+        Source.single(
+                PutEventsRequest.builder()
+                    .entries(
+                        PutEventsRequestEntry.builder()
+                            .eventBusName("event-bus")
+                            .source("source")
+                            .detailType("detail-type")
+                            .detail("event-detail")
+                            .build())
+                    .build())
+            .via(EventBridgePublisher.createPutEventsFlow(eventBridgeClient))
+            .runWith(
+                Sink.foreach(
+                    resp -> resp.entries().forEach(res -> System.out.println(res.eventId()))),
+                materializer);
+
+    // #use-flow
+    assertThat(completion.toCompletableFuture().get(2, TimeUnit.SECONDS), is(Done.getInstance()));
+  }
+}

--- a/eventbridge/src/test/resources/application.conf
+++ b/eventbridge/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  loglevel = "DEBUG"
+}

--- a/eventbridge/src/test/resources/logback-test.xml
+++ b/eventbridge/src/test/resources/logback-test.xml
@@ -1,0 +1,27 @@
+<configuration>
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>target/sns.log</file>
+    <append>false</append>
+    <encoder>
+      <pattern>%d{ISO8601} %-5level [%thread] [%logger{36}]  %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="CapturingAppender" class="akka.stream.alpakka.testkit.CapturingAppender"/>
+
+  <logger name="akka.stream.alpakka.testkit.CapturingAppenderDelegate">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
+  <logger name="akka" level="DEBUG"/>
+  <root level="debug">
+    <appender-ref ref="CapturingAppender"/>
+    <appender-ref ref="FILE" />
+  </root>
+</configuration>

--- a/eventbridge/src/test/scala/akka/stream/alpakka/eventbridge/DefaultTestContext.scala
+++ b/eventbridge/src/test/scala/akka/stream/alpakka/eventbridge/DefaultTestContext.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.eventbridge
+
+import akka.actor.ActorSystem
+import akka.stream.{ActorMaterializer, Materializer}
+import org.mockito.Mockito.reset
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
+import org.scalatestplus.mockito.MockitoSugar
+import software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+trait DefaultTestContext extends BeforeAndAfterAll with BeforeAndAfterEach with MockitoSugar {
+  this: Suite =>
+
+  implicit protected val system: ActorSystem = ActorSystem()
+  implicit protected val mat: Materializer = ActorMaterializer()
+  implicit protected val eventBridgeClient: EventBridgeAsyncClient = mock[EventBridgeAsyncClient]
+
+  override protected def beforeEach(): Unit =
+    reset(eventBridgeClient)
+
+  override protected def afterAll(): Unit =
+    Await.ready(system.terminate(), 5.seconds)
+
+}

--- a/eventbridge/src/test/scala/akka/stream/alpakka/eventbridge/EventBridgePublishMockingSpec.scala
+++ b/eventbridge/src/test/scala/akka/stream/alpakka/eventbridge/EventBridgePublishMockingSpec.scala
@@ -1,0 +1,412 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.eventbridge
+
+import java.util.concurrent.CompletableFuture
+
+import akka.stream.alpakka.eventbridge.scaladsl.EventBridgePublisher
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
+import akka.stream.scaladsl.{Keep, Sink}
+import akka.stream.testkit.scaladsl.TestSource
+import org.mockito.ArgumentMatchers.{any, eq => meq}
+import org.mockito.Mockito._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import software.amazon.awssdk.services.eventbridge.model.{
+  PutEventsRequest,
+  PutEventsRequestEntry,
+  PutEventsResponse,
+  PutEventsResultEntry
+}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class EventBridgePublishMockingSpec extends AnyFlatSpec with DefaultTestContext with Matchers with LogCapturing {
+
+  it should "put a single PutEventsRequest events to EventBridge" in {
+    val putEventsRequest = PutEventsRequest
+      .builder()
+      .entries(
+        PutEventsRequestEntry
+          .builder()
+          .eventBusName("event-bus")
+          .source("source")
+          .detailType("detail-type")
+          .detail("event-detail")
+          .build()
+      )
+      .build()
+    val putEventsResponse =
+      PutEventsResponse.builder().entries(PutEventsResultEntry.builder().eventId("event-id").build()).build()
+
+    when(eventBridgeClient.putEvents(meq(putEventsRequest)))
+      .thenReturn(CompletableFuture.completedFuture(putEventsResponse))
+
+    val (probe, future) =
+      TestSource.probe[PutEventsRequest].via(EventBridgePublisher.putEventsFlow()).toMat(Sink.seq)(Keep.both).run()
+
+    probe
+      .sendNext(
+        PutEventsRequest
+          .builder()
+          .entries(
+            PutEventsRequestEntry
+              .builder()
+              .eventBusName("event-bus")
+              .source("source")
+              .detailType("detail-type")
+              .detail("event-detail")
+              .build()
+          )
+          .build()
+      )
+      .sendComplete()
+
+    Await.result(future, 1.second) mustBe putEventsResponse :: Nil
+
+    verify(eventBridgeClient, times(1)).putEvents(meq(putEventsRequest))
+  }
+
+  it should "put multiple PutEventsRequest events to EventBridge" in {
+    val putEventsResponse =
+      PutEventsResponse.builder().entries(PutEventsResultEntry.builder().eventId("event-id").build()).build()
+
+    when(eventBridgeClient.putEvents(any[PutEventsRequest]()))
+      .thenReturn(CompletableFuture.completedFuture(putEventsResponse))
+
+    val (probe, future) =
+      TestSource.probe[PutEventsRequest].via(EventBridgePublisher.putEventsFlow()).toMat(Sink.seq)(Keep.both).run()
+
+    probe
+      .sendNext(
+        PutEventsRequest
+          .builder()
+          .entries(
+            PutEventsRequestEntry
+              .builder()
+              .eventBusName("event-bus")
+              .source("source")
+              .detailType("detail-type")
+              .detail("event-detail-1")
+              .build()
+          )
+          .build()
+      )
+      .sendNext(
+        PutEventsRequest
+          .builder()
+          .entries(
+            PutEventsRequestEntry
+              .builder()
+              .eventBusName("event-bus")
+              .source("source")
+              .detailType("detail-type")
+              .detail("event-detail-2")
+              .build()
+          )
+          .build()
+      )
+      .sendNext(
+        PutEventsRequest
+          .builder()
+          .entries(
+            PutEventsRequestEntry
+              .builder()
+              .eventBusName("event-bus")
+              .source("source")
+              .detailType("detail-type")
+              .detail("event-detail-3")
+              .build()
+          )
+          .build()
+      )
+      .sendComplete()
+
+    Await.result(future, 1.second) mustBe putEventsResponse :: putEventsResponse :: putEventsResponse :: Nil
+
+    val expectedFirst = PutEventsRequest
+      .builder()
+      .entries(
+        PutEventsRequestEntry
+          .builder()
+          .eventBusName("event-bus")
+          .source("source")
+          .detailType("detail-type")
+          .detail("event-detail-1")
+          .build()
+      )
+      .build()
+    verify(eventBridgeClient, times(1)).putEvents(meq(expectedFirst))
+
+    val expectedSecond = PutEventsRequest
+      .builder()
+      .entries(
+        PutEventsRequestEntry
+          .builder()
+          .eventBusName("event-bus")
+          .source("source")
+          .detailType("detail-type")
+          .detail("event-detail-2")
+          .build()
+      )
+      .build()
+    verify(eventBridgeClient, times(1)).putEvents(meq(expectedSecond))
+
+    val expectedThird = PutEventsRequest
+      .builder()
+      .entries(
+        PutEventsRequestEntry
+          .builder()
+          .eventBusName("event-bus")
+          .source("source")
+          .detailType("detail-type")
+          .detail("event-detail-3")
+          .build()
+      )
+      .build()
+    verify(eventBridgeClient, times(1)).putEvents(meq(expectedThird))
+  }
+
+  it should "put multiple PutEventsRequest events to multiple EventBridge EventBuses" in {
+    val putEventsResponse =
+      PutEventsResponse.builder().entries(PutEventsResultEntry.builder().eventId("event-id").build()).build()
+
+    when(eventBridgeClient.putEvents(any[PutEventsRequest]()))
+      .thenReturn(CompletableFuture.completedFuture(putEventsResponse))
+
+    val (probe, future) =
+      TestSource.probe[PutEventsRequest].via(EventBridgePublisher.putEventsFlow()).toMat(Sink.seq)(Keep.both).run()
+
+    probe
+      .sendNext(
+        PutEventsRequest
+          .builder()
+          .entries(
+            PutEventsRequestEntry
+              .builder()
+              .eventBusName("event-bus-1")
+              .source("source")
+              .detailType("detail-type")
+              .detail("event-detail-1")
+              .build()
+          )
+          .build()
+      )
+      .sendNext(
+        PutEventsRequest
+          .builder()
+          .entries(
+            PutEventsRequestEntry
+              .builder()
+              .eventBusName("event-bus-2")
+              .source("source")
+              .detailType("detail-type")
+              .detail("event-detail-2")
+              .build()
+          )
+          .build()
+      )
+      .sendNext(
+        PutEventsRequest
+          .builder()
+          .entries(
+            PutEventsRequestEntry
+              .builder()
+              .eventBusName("event-bus-3")
+              .source("source")
+              .detailType("detail-type")
+              .detail("event-detail-3")
+              .build()
+          )
+          .build()
+      )
+      .sendComplete()
+
+    Await.result(future, 1.second) mustBe putEventsResponse :: putEventsResponse :: putEventsResponse :: Nil
+
+    val expectedFirst = PutEventsRequest
+      .builder()
+      .entries(
+        PutEventsRequestEntry
+          .builder()
+          .eventBusName("event-bus-1")
+          .source("source")
+          .detailType("detail-type")
+          .detail("event-detail-1")
+          .build()
+      )
+      .build()
+    verify(eventBridgeClient, times(1)).putEvents(meq(expectedFirst))
+
+    val expectedSecond = PutEventsRequest
+      .builder()
+      .entries(
+        PutEventsRequestEntry
+          .builder()
+          .eventBusName("event-bus-2")
+          .source("source")
+          .detailType("detail-type")
+          .detail("event-detail-2")
+          .build()
+      )
+      .build()
+    verify(eventBridgeClient, times(1)).putEvents(meq(expectedSecond))
+
+    val expectedThird = PutEventsRequest
+      .builder()
+      .entries(
+        PutEventsRequestEntry
+          .builder()
+          .eventBusName("event-bus-3")
+          .source("source")
+          .detailType("detail-type")
+          .detail("event-detail-3")
+          .build()
+      )
+      .build()
+    verify(eventBridgeClient, times(1)).putEvents(meq(expectedThird))
+  }
+
+  it should "put a single string events to EventBridge" in {
+    val putEventsRequest = PutEventsRequest
+      .builder()
+      .entries(
+        PutEventsRequestEntry
+          .builder()
+          .eventBusName("event-bus")
+          .source("source")
+          .detailType("detail-type")
+          .detail("event-detail")
+          .build()
+      )
+      .build()
+    val putEventsResponse =
+      PutEventsResponse.builder().entries(PutEventsResultEntry.builder().eventId("event-id").build()).build()
+
+    when(eventBridgeClient.putEvents(meq(putEventsRequest)))
+      .thenReturn(CompletableFuture.completedFuture(putEventsResponse))
+
+    val (probe, future) = TestSource
+      .probe[String]
+      .via(EventBridgePublisher.flow("event-bus", "source", "detail-type"))
+      .toMat(Sink.seq)(Keep.both)
+      .run()
+    probe.sendNext("event-detail").sendComplete()
+
+    Await.result(future, 1.second) mustBe putEventsResponse :: Nil
+    verify(eventBridgeClient, times(1)).putEvents(meq(putEventsRequest))
+  }
+
+  it should "put multiple string events to EventBridge" in {
+    val putEventsResponse =
+      PutEventsResponse.builder().entries(PutEventsResultEntry.builder().eventId("event-id").build()).build()
+
+    when(eventBridgeClient.putEvents(any[PutEventsRequest]()))
+      .thenReturn(CompletableFuture.completedFuture(putEventsResponse))
+
+    val (probe, future) = TestSource
+      .probe[String]
+      .via(EventBridgePublisher.flow("event-bus", "source", "detail-type"))
+      .toMat(Sink.seq)(Keep.both)
+      .run()
+    probe.sendNext("event-detail-1").sendNext("event-detail-2").sendNext("event-detail-3").sendComplete()
+
+    Await.result(future, 1.second) mustBe putEventsResponse :: putEventsResponse :: putEventsResponse :: Nil
+
+    val expectedFirst = PutEventsRequest
+      .builder()
+      .entries(
+        PutEventsRequestEntry
+          .builder()
+          .eventBusName("event-bus")
+          .source("source")
+          .detailType("detail-type")
+          .detail("event-detail-1")
+          .build()
+      )
+      .build()
+    verify(eventBridgeClient, times(1)).putEvents(meq(expectedFirst))
+
+    val expectedSecond = PutEventsRequest
+      .builder()
+      .entries(
+        PutEventsRequestEntry
+          .builder()
+          .eventBusName("event-bus")
+          .source("source")
+          .detailType("detail-type")
+          .detail("event-detail-2")
+          .build()
+      )
+      .build()
+    verify(eventBridgeClient, times(1)).putEvents(meq(expectedSecond))
+
+    val expectedThird = PutEventsRequest
+      .builder()
+      .entries(
+        PutEventsRequestEntry
+          .builder()
+          .eventBusName("event-bus")
+          .source("source")
+          .detailType("detail-type")
+          .detail("event-detail-3")
+          .build()
+      )
+      .build()
+    verify(eventBridgeClient, times(1)).putEvents(meq(expectedThird))
+  }
+
+  it should "fail stage if AmazonEventBridgeAsyncClient request failed" in {
+    val putEventsRequest = PutEventsRequest
+      .builder()
+      .entries(
+        PutEventsRequestEntry
+          .builder()
+          .eventBusName("event-bus")
+          .source("source")
+          .detailType("detail-type")
+          .detail("event-detail")
+          .build()
+      )
+      .build()
+
+    val promise = new CompletableFuture[PutEventsResponse]()
+    promise.completeExceptionally(new RuntimeException("publish error"))
+
+    when(eventBridgeClient.putEvents(meq(putEventsRequest))).thenReturn(promise)
+
+    val (probe, future) = TestSource
+      .probe[String]
+      .via(EventBridgePublisher.flow("event-bus", "source", "detail-type"))
+      .toMat(Sink.seq)(Keep.both)
+      .run()
+    probe.sendNext("event-detail").sendComplete()
+
+    a[RuntimeException] should be thrownBy {
+      Await.result(future, 1.second)
+    }
+
+    verify(eventBridgeClient, times(1)).putEvents(meq(putEventsRequest))
+  }
+
+  it should "fail stage if upstream failure occurs" in {
+    case class MyCustomException(message: String) extends Exception(message)
+
+    val (probe, future) = TestSource
+      .probe[String]
+      .via(EventBridgePublisher.flow("event-bus", "source", "detail-type"))
+      .toMat(Sink.seq)(Keep.both)
+      .run()
+    probe.sendError(MyCustomException("upstream failure"))
+
+    a[MyCustomException] should be thrownBy {
+      Await.result(future, 1.second)
+    }
+
+    verify(eventBridgeClient, never()).putEvents(any[PutEventsRequest]())
+  }
+
+}

--- a/eventbridge/src/test/scala/akka/stream/alpakka/eventbridge/IntegrationTestContext.scala
+++ b/eventbridge/src/test/scala/akka/stream/alpakka/eventbridge/IntegrationTestContext.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.eventbridge
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.actor.ActorSystem
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.testkit.TestKit
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, Suite}
+import software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient
+import software.amazon.awssdk.services.eventbridge.model.CreateEventBusRequest
+
+import scala.concurrent.duration.FiniteDuration
+
+trait IntegrationTestContext extends BeforeAndAfterAll with ScalaFutures {
+  this: Suite =>
+
+  //#init-system
+  implicit val system: ActorSystem = ActorSystem()
+  implicit val mat: Materializer = ActorMaterializer()
+  //#init-system
+
+  def snsEndpoint: String = s"http://localhost:4100"
+
+  implicit var eventBridgeClient: EventBridgeAsyncClient = _
+  var eventBusName: String = _
+  val source: String = "source"
+  val detailType: String = "detail-type"
+
+  private val eventBusNumber = new AtomicInteger()
+
+  def createEventBus(): String = {
+    val eventBusName = s"alpakka-event-bus-${eventBusNumber.incrementAndGet()}"
+    eventBridgeClient
+      .createEventBus(CreateEventBusRequest.builder().name(eventBusName).build())
+      .get()
+    eventBusName
+  }
+
+  override protected def beforeAll(): Unit = {
+    eventBridgeClient = createAsyncClient(snsEndpoint)
+    eventBusName = createEventBus()
+  }
+
+  override protected def afterAll(): Unit = TestKit.shutdownActorSystem(system)
+
+  def createAsyncClient(endEndpoint: String): EventBridgeAsyncClient = {
+    //#init-client
+    import java.net.URI
+
+    import com.github.matsluni.akkahttpspi.AkkaHttpClient
+    import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+    import software.amazon.awssdk.regions.Region
+
+    // Don't encode credentials in your source code!
+    // see https://doc.akka.io/docs/alpakka/current/aws-shared-configuration.html
+    val credentialsProvider = StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x"))
+    implicit val awsEventBridgeClient: EventBridgeAsyncClient =
+      EventBridgeAsyncClient
+        .builder()
+        .credentialsProvider(credentialsProvider)
+        //#init-client
+        .endpointOverride(URI.create(endEndpoint))
+        //#init-client
+        .region(Region.EU_CENTRAL_1)
+        .httpClient(AkkaHttpClient.builder().withActorSystem(system).build())
+        // Possibility to configure the retry policy
+        // see https://doc.akka.io/docs/alpakka/current/aws-shared-configuration.html
+        // .overrideConfiguration(...)
+        .build()
+
+    system.registerOnTermination(awsEventBridgeClient.close())
+    //#init-client
+    awsEventBridgeClient
+  }
+
+  def sleep(d: FiniteDuration): Unit = Thread.sleep(d.toMillis)
+
+}

--- a/eventbridge/src/test/scala/docs/scaladsl/EventBridgePublisherSpec.scala
+++ b/eventbridge/src/test/scala/docs/scaladsl/EventBridgePublisherSpec.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.scaladsl
+
+import akka.Done
+import akka.stream.alpakka.eventbridge.IntegrationTestContext
+import akka.stream.alpakka.eventbridge.scaladsl.EventBridgePublisher
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
+import akka.stream.scaladsl.{Sink, Source}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.services.eventbridge.model.{PutEventsRequest, PutEventsRequestEntry}
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class EventBridgePublisherSpec
+    extends AnyFlatSpec
+    with Matchers
+    with ScalaFutures
+    with IntegrationTestContext
+    with LogCapturing {
+
+  implicit val defaultPatience =
+    PatienceConfig(timeout = 15.seconds, interval = 100.millis)
+
+  "EventBridge Publisher sink" should "put string event" in {
+    val published: Future[Done] =
+      //#use-sink
+      Source
+        .single("message")
+        .runWith(EventBridgePublisher.sink(eventBusName, source, detailType))
+
+    //#use-sink
+    published.futureValue should be(Done)
+  }
+
+  it should "put event request with default event bus" in {
+    val published: Future[Done] =
+      //#use-sink
+      Source
+        .single(
+          PutEventsRequest
+            .builder()
+            .entries(
+              PutEventsRequestEntry
+                .builder()
+                .source("source")
+                .detailType("detail-type")
+                .detail("event-detail")
+                .build()
+            )
+            .build()
+        )
+        .runWith(EventBridgePublisher.putEventsSink())
+
+    //#use-sink
+    published.futureValue should be(Done)
+  }
+
+  it should "put event request with custom event bus" in {
+    val published: Future[Done] =
+      //#use-sink
+      Source
+        .single(
+          PutEventsRequest
+            .builder()
+            .entries(
+              PutEventsRequestEntry
+                .builder()
+                .eventBusName("event-bus")
+                .source("source")
+                .detailType("detail-type")
+                .detail("event-detail")
+                .build()
+            )
+            .build()
+        )
+        .runWith(EventBridgePublisher.putEventsSink())
+    //#use-sink
+    published.futureValue should be(Done)
+  }
+
+  "EventBridge Publisher flow" should "put string event" in {
+    val published: Future[Done] =
+      //#use-flow
+      Source
+        .single("message")
+        .via(EventBridgePublisher.flow("event-bus", "source", "detail-type"))
+        .runWith(Sink.foreach(resp => println(resp.entries())))
+
+    //#use-flow
+    published.futureValue should be(Done)
+  }
+
+  it should "put event request to default event bus" in {
+    val published: Future[Done] =
+      //#use-flow
+      Source
+        .single(
+          PutEventsRequest
+            .builder()
+            .entries(
+              PutEventsRequestEntry
+                .builder()
+                .source("source")
+                .detailType("detail-type")
+                .detail("event-detail")
+                .build()
+            )
+            .build()
+        )
+        .via(EventBridgePublisher.putEventsFlow())
+        .runWith(Sink.foreach(resp => println(resp.entries())))
+
+    //#use-flow
+    published.futureValue should be(Done)
+  }
+
+  it should "put event request with custom event bus" in {
+    val published: Future[Done] =
+      //#use-flow
+      Source
+        .single(
+          PutEventsRequest
+            .builder()
+            .entries(
+              PutEventsRequestEntry
+                .builder()
+                .eventBusName("event-bus")
+                .source("source")
+                .detailType("detail-type")
+                .detail("event-detail")
+                .build()
+            )
+            .build()
+        )
+        .via(EventBridgePublisher.putEventsFlow())
+        .runWith(Sink.foreach(resp => println(resp.entries())))
+    //#use-flow
+    published.futureValue should be(Done)
+  }
+
+}

--- a/eventbridge/src/test/travis/goaws.yaml
+++ b/eventbridge/src/test/travis/goaws.yaml
@@ -1,0 +1,13 @@
+Local:                              # Environment name that can be passed on the command line
+                                    #     (i.e.: ./goaws [Local | Dev]  -- defaults to 'Local')
+  Host: localhost                   # hostname of the goaws system  (for docker-compose this is the tag name of the container)
+  Port: 4100                        # port to listen on.
+  Region: local-01
+  LogMessages: true                 # Log messages (true/false)
+  LogFile: ./goaws_messages.log  # Log filename (for message logging
+
+Dev:                                # Another environment
+  Host: localhost
+  Port: 4100
+  LogMessages: true
+  LogFile: ./goaws_messages.log

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -156,6 +156,22 @@ object Dependencies {
       ) ++ JacksonDatabindDependencies
   )
 
+  val Eventbridge = Seq(
+    libraryDependencies ++= Seq(
+        "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion excludeAll // ApacheV2
+        (
+          ExclusionRule(organization = "com.typesafe.akka")
+        ),
+        "software.amazon.awssdk" % "eventbridge" % AwsSdk2Version excludeAll // ApacheV2
+        (
+          ExclusionRule("software.amazon.awssdk", "apache-client"),
+          ExclusionRule("software.amazon.awssdk", "netty-nio-client")
+        ),
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion // ApacheV2
+      ) ++ JacksonDatabindDependencies
+      ++ Mockito
+  )
+
   val File = Seq(
     libraryDependencies ++= Seq(
         "com.google.jimfs" % "jimfs" % "1.1" % Test // ApacheV2


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #2151

Adds support for AWS EventBridge quite similarly as SNS is being supported at the moment.

Creates Flow and Sink factory for PutEvents API calls. The events in events bridge are identified by pairs of `source` and `detail-type` that needs to be specified per individual event. Additionally the events can publish to dedicated event bus, identified by name. When event bus parameter is undefined events will be publish to `default` event bus.

Some additional improvements ideas:
* EventBridge supports batching up to 10 events similarly like SQS does on event indigestion.

Reference:
https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEvents.html
