### PR TITLE
FTP: enrich ConnectException; track failures

### DIFF
--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
@@ -19,7 +19,16 @@ private[ftp] trait FtpOperations extends CommonFtpOperations { _: FtpLike[FTPCli
   def connect(connectionSettings: FtpSettings)(implicit ftpClient: FTPClient): Try[Handler] = Try {
     connectionSettings.proxy.foreach(ftpClient.setProxy)
 
-    ftpClient.connect(connectionSettings.host, connectionSettings.port)
+    try {
+      ftpClient.connect(connectionSettings.host, connectionSettings.port)
+    } catch {
+      case e: java.net.ConnectException =>
+        throw new java.net.ConnectException(
+          e.getMessage + s" host=[${connectionSettings.host}], port=${connectionSettings.port} ${connectionSettings.proxy
+            .map("proxy=" + _.toString)
+            .getOrElse("")}"
+        )
+    }
 
     connectionSettings.configureConnection(ftpClient)
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/CommonFtpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/CommonFtpStageTest.java
@@ -38,7 +38,7 @@ interface CommonFtpStageTest extends BaseSupport, AkkaSupport {
   Sink<FtpFile, CompletionStage<IOResult>> getMoveSink(Function<FtpFile, String> destinationPath)
       throws Exception;
 
-  default IOResult await(CompletionStage<IOResult> result)
+  default <T> T await(CompletionStage<T> result)
       throws InterruptedException, java.util.concurrent.ExecutionException,
           java.util.concurrent.TimeoutException {
     return result.toCompletableFuture().get(10, TimeUnit.SECONDS);
@@ -110,6 +110,9 @@ interface CommonFtpStageTest extends BaseSupport, AkkaSupport {
 
     final Materializer materializer = getMaterializer();
     Source<FtpFile, NotUsed> source = getBrowserSource("/");
+    // check that the file is listed
+    await(source.runWith(Sink.head(), materializer));
+
     Sink<FtpFile, CompletionStage<IOResult>> sink = getRemoveSink();
     CompletionStage<IOResult> resultCompletionStage = source.runWith(sink, materializer);
 
@@ -128,6 +131,9 @@ interface CommonFtpStageTest extends BaseSupport, AkkaSupport {
 
     final Materializer materializer = getMaterializer();
     Source<FtpFile, NotUsed> source = getBrowserSource("/");
+    // check that the file is listed
+    await(source.runWith(Sink.head(), materializer));
+
     Sink<FtpFile, CompletionStage<IOResult>> sink = getMoveSink((ftpFile) -> fileName2);
     CompletionStage<IOResult> resultCompletionStage = source.runWith(sink, materializer);
 


### PR DESCRIPTION
Make the `java.net.ConnectException` show the host, port, and the proxy settings the `connect` tried.

Ensure the failing move/remove tests actually see the file before they try. #2126 