### PR TITLE
Docs: show akka-stream with symbolic version

### DIFF
--- a/docs/src/main/paradox/amqp.md
+++ b/docs/src/main/paradox/amqp.md
@@ -12,6 +12,11 @@ AMQP 1.0 is currently not supported (Qpid, ActiveMQ, Solace, etc.).
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-amqp_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/avroparquet.md
+++ b/docs/src/main/paradox/avroparquet.md
@@ -12,6 +12,11 @@ For more information about Apache Parquet please visit the [official documentati
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-avroparquet_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/awslambda.md
+++ b/docs/src/main/paradox/awslambda.md
@@ -12,6 +12,11 @@ For more information about AWS Lambda please visit the [AWS lambda documentation
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-awslambda_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/azure-storage-queue.md
+++ b/docs/src/main/paradox/azure-storage-queue.md
@@ -12,6 +12,11 @@ Azure Storage Queue is a queuing service similar to Amazon's SQS. It is designed
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-azure-storage-queue_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/cassandra.md
+++ b/docs/src/main/paradox/cassandra.md
@@ -12,6 +12,11 @@ Unlogged batches are also supported.
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-cassandra_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/couchbase.md
+++ b/docs/src/main/paradox/couchbase.md
@@ -24,6 +24,11 @@ The Couchbase connector supports all document formats which are supported by the
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-couchbase_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/data-transformations/csv.md
+++ b/docs/src/main/paradox/data-transformations/csv.md
@@ -26,6 +26,11 @@ Lines are separated by either Line Feed (`\n` = ASCII 10) or Carriage Return and
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-csv_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/data-transformations/json.md
+++ b/docs/src/main/paradox/data-transformations/json.md
@@ -67,6 +67,11 @@ even: only the `doc` inside each element of the array.
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-json-streaming_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/data-transformations/simple-codecs.md
+++ b/docs/src/main/paradox/data-transformations/simple-codecs.md
@@ -26,6 +26,11 @@ is parsed into frames:
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-simple-codecs_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/data-transformations/text.md
+++ b/docs/src/main/paradox/data-transformations/text.md
@@ -18,6 +18,11 @@ parser does only support UTF-8.
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-text_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 

--- a/docs/src/main/paradox/data-transformations/xml.md
+++ b/docs/src/main/paradox/data-transformations/xml.md
@@ -11,6 +11,11 @@ XML parsing module offers Flows for parsing, processing and writing XML document
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-xml_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/dynamodb.md
+++ b/docs/src/main/paradox/dynamodb.md
@@ -10,6 +10,16 @@ The AWS DynamoDB connector provides a flow for streaming DynamoDB requests. For 
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-dynamodb_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
+  symbol3=AkkaHttpVersion
+  value3=$akka-http.version$
+  group3=com.typesafe.akka
+  artifact3=akka-http_$scala.binary.version$
+  version3=AkkaHttpVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -12,6 +12,11 @@ For more information about Elasticsearch, please visit the [Elasticsearch docume
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-elasticsearch_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/file.md
+++ b/docs/src/main/paradox/file.md
@@ -12,6 +12,11 @@ the sources and sinks for files already included in core Akka Streams
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-file_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -13,6 +13,11 @@ The FTP connector provides Akka Stream sources to connect to FTP, FTPs and SFTP 
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-ftp_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/geode.md
+++ b/docs/src/main/paradox/geode.md
@@ -12,6 +12,11 @@ Alpakka Geode provides flows and sinks to put elements into Geode, and a source 
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-geode_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/google-cloud-pub-sub-grpc.md
+++ b/docs/src/main/paradox/google-cloud-pub-sub-grpc.md
@@ -20,9 +20,14 @@ Akka gRPC uses Akka Discovery internally. Make sure to add Akka Discovery with t
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-google-cloud-pub-sub-grpc_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
   group2=com.typesafe.akka
-  artifact2=akka-discovery_$scala.binary.version$
-  version2=Your-Akka-version
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
+  group3=com.typesafe.akka
+  artifact3=akka-discovery_$scala.binary.version$
+  version3=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/google-cloud-pub-sub.md
+++ b/docs/src/main/paradox/google-cloud-pub-sub.md
@@ -16,6 +16,19 @@ This connector communicates to Pub/Sub via HTTP requests (i.e. https://pubsub.go
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-google-cloud-pub-sub_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
+  symbol3=AkkaHttpVersion
+  value3=$akka-http.version$
+  group3=com.typesafe.akka
+  artifact3=akka-http_$scala.binary.version$
+  version3=AkkaHttpVersion
+  group4=com.typesafe.akka
+  artifact4=akka-http-spray-json_$scala.binary.version$
+  version4=AkkaHttpVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/google-cloud-storage.md
+++ b/docs/src/main/paradox/google-cloud-storage.md
@@ -13,6 +13,19 @@ This connector communicates to Cloud Storage via HTTP requests.
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-google-cloud-storage_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
+  symbol3=AkkaHttpVersion
+  value3=$akka-http.version$
+  group3=com.typesafe.akka
+  artifact3=akka-http_$scala.binary.version$
+  version3=AkkaHttpVersion
+  group4=com.typesafe.akka
+  artifact4=akka-http-spray-json_$scala.binary.version$
+  version4=AkkaHttpVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/google-fcm.md
+++ b/docs/src/main/paradox/google-fcm.md
@@ -18,6 +18,19 @@ The Alpakka Google Firebase Cloud Messaging connector provides a way to send not
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-google-fcm_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
+  symbol3=AkkaHttpVersion
+  value3=$akka-http.version$
+  group3=com.typesafe.akka
+  artifact3=akka-http_$scala.binary.version$
+  version3=AkkaHttpVersion
+  group4=com.typesafe.akka
+  artifact4=akka-http-spray-json_$scala.binary.version$
+  version4=AkkaHttpVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/hbase.md
+++ b/docs/src/main/paradox/hbase.md
@@ -13,6 +13,11 @@ For more information about HBase, please visit the [HBase documentation](http://
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-hbase_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/hdfs.md
+++ b/docs/src/main/paradox/hdfs.md
@@ -12,6 +12,11 @@ For more information about Hadoop, please visit the [Hadoop documentation](https
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-hdfs_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/influxdb.md
+++ b/docs/src/main/paradox/influxdb.md
@@ -22,6 +22,11 @@ Furthermore, the major InfluxDB update to [version 2.0](https://www.influxdata.c
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-influxdb_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/ironmq.md
+++ b/docs/src/main/paradox/ironmq.md
@@ -14,6 +14,16 @@ queue and set other queue as subscribers. More information about that could be f
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-ironmq_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
+  symbol3=AkkaHttpVersion
+  value3=$akka-http.version$
+  group3=com.typesafe.akka
+  artifact3=akka-http_$scala.binary.version$
+  version3=AkkaHttpVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/kinesis.md
+++ b/docs/src/main/paradox/kinesis.md
@@ -30,6 +30,16 @@ Please read more about it at [GitHub 500px/kinesis-stream](https://github.com/50
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-kinesis_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
+  symbol3=AkkaHttpVersion
+  value3=$akka-http.version$
+  group3=com.typesafe.akka
+  artifact3=akka-http_$scala.binary.version$
+  version3=AkkaHttpVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/kudu.md
+++ b/docs/src/main/paradox/kudu.md
@@ -13,6 +13,11 @@ Apache Kudu is a free and open source column-oriented data store in the Apache H
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-kudu_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/mongodb.md
+++ b/docs/src/main/paradox/mongodb.md
@@ -22,6 +22,11 @@ Please read more about it in the [ReactiveMongo documentation](http://reactivemo
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-mongodb_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/mqtt-streaming.md
+++ b/docs/src/main/paradox/mqtt-streaming.md
@@ -26,6 +26,14 @@ The Alpakka MQTT connector provides an Akka Stream flow to connect to MQTT broke
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-mqtt-streaming_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka26.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
+  group3=com.typesafe.akka
+  artifact3=akka-actor-typed_$scala.binary.version$
+  version3=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/mqtt.md
+++ b/docs/src/main/paradox/mqtt.md
@@ -24,6 +24,11 @@ The Alpakka MQTT connector provides an Akka Stream source, sink and flow to conn
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-mqtt_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/orientdb.md
+++ b/docs/src/main/paradox/orientdb.md
@@ -20,6 +20,11 @@ The Alpakka OrientDB connector provides Akka Stream sources and sinks for Orient
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-orientdb_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/reference.md
+++ b/docs/src/main/paradox/reference.md
@@ -15,6 +15,11 @@ about the technology the connector is using.
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-reference_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/s3.md
+++ b/docs/src/main/paradox/s3.md
@@ -11,6 +11,19 @@ S3 stands for Simple Storage Service and is an object storage service with a web
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-s3_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
+  symbol3=AkkaHttpVersion
+  value3=$akka-http.version$
+  group3=com.typesafe.akka
+  artifact3=akka-http_$scala.binary.version$
+  version3=AkkaHttpVersion
+  group4=com.typesafe.akka
+  artifact4=akka-http-xml_$scala.binary.version$
+  version4=AkkaHttpVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/slick.md
+++ b/docs/src/main/paradox/slick.md
@@ -10,6 +10,11 @@ The Slick connector provides Scala and Java DSLs to create a `Source` to stream 
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-slick_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 You will also need to add the JDBC driver(s) for the specific relational database(s) to your project. Most of those database have drivers that are not available from public repositories so unfortunately some manual steps will probably be required. The Slick documentation has @extref[information on where to download the drivers](slick:supported-databases.html).

--- a/docs/src/main/paradox/sns.md
+++ b/docs/src/main/paradox/sns.md
@@ -12,6 +12,16 @@ For more information about AWS SNS please visit the [official documentation](htt
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-sns_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
+  symbol3=AkkaHttpVersion
+  value3=$akka-http.version$
+  group3=com.typesafe.akka
+  artifact3=akka-http_$scala.binary.version$
+  version3=AkkaHttpVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/solr.md
+++ b/docs/src/main/paradox/solr.md
@@ -20,6 +20,11 @@ For more information about Solr please visit the [Solr documentation](http://luc
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-solr_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/spring-web.md
+++ b/docs/src/main/paradox/spring-web.md
@@ -18,6 +18,11 @@ This Alpakka module makes it possible to directly return a `Source` in your Spri
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-spring-web_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -19,6 +19,16 @@ The AWS SQS connector provides Akka Stream sources and sinks for AWS SQS queues.
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-sqs_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
+  symbol3=AkkaHttpVersion
+  value3=$akka-http.version$
+  group3=com.typesafe.akka
+  artifact3=akka-http_$scala.binary.version$
+  version3=AkkaHttpVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/sse.md
+++ b/docs/src/main/paradox/sse.md
@@ -10,6 +10,16 @@ The SSE connector provides a continuous source of server-sent events recovering 
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-sse_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
+  symbol3=AkkaHttpVersion
+  value3=$akka-http.version$
+  group3=com.typesafe.akka
+  artifact3=akka-http_$scala.binary.version$
+  version3=AkkaHttpVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/udp.md
+++ b/docs/src/main/paradox/udp.md
@@ -10,6 +10,11 @@ The UDP connector provides Akka Stream flows that allow to send and receive UDP 
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-udp_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/docs/src/main/paradox/unix-domain-socket.md
+++ b/docs/src/main/paradox/unix-domain-socket.md
@@ -21,6 +21,11 @@ The binding and connecting APIs are extremely similar to the `Tcp` Akka Streams 
   group=com.lightbend.akka
   artifact=akka-stream-alpakka-unix-domain-socket_$scala.binary.version$
   version=$project.version$
+  symbol2=AkkaVersion
+  value2=$akka.version$
+  group2=com.typesafe.akka
+  artifact2=akka-stream_$scala.binary.version$
+  version2=AkkaVersion
 }
 
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.4")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.18")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.5.0")
 // docs
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.29")
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.31")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.2.1")
 addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.1")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")


### PR DESCRIPTION
List the `akka-stream` dependency with a symbolic `AkkaVersion` so that it becomes easier not pull consistent Akka dependencies over 2.5/2.6.

Even list `akka-http` dependencies with to help people with the upcoming 10.1/10.2 switch.

Let MQTT streaming show Akka 2.6 as suggested Akka version, as it doesn't work with Akka 2.5 anymore.