### PR TITLE
Docs: use `@apidoc` much more

### DIFF
--- a/docs/src/main/paradox/avroparquet.md
+++ b/docs/src/main/paradox/avroparquet.md
@@ -20,7 +20,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Source Initiation
 
-We will need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and an @scaladoc[ActorMaterializer](akka.stream.ActorMaterializer).
+We will need an @apidoc[akka.actor.ActorSystem] and an @apidoc[akka.stream.Materializer].
 
 Scala
 : @@snip (/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala) { #init-system }

--- a/docs/src/main/paradox/awslambda.md
+++ b/docs/src/main/paradox/awslambda.md
@@ -30,7 +30,7 @@ Java
 
 The example above uses @extref:[Akka HTTP](akka-http:) as the default HTTP client implementation. For more details about the HTTP client, configuring request retrying and best practices for credentials, see @ref[AWS client configuration](aws-shared-configuration.md) for more details.
 
-We will also need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and an @scaladoc[ActorMaterializer](akka.stream.ActorMaterializer).
+We will also need an @apidoc[akka.actor.ActorSystem] and an @apidoc[akka.stream.Materializer].
 
 Scala
 : @@snip (/awslambda/src/test/scala/docs/scaladsl/Examples.scala) { #init-mat }

--- a/docs/src/main/paradox/couchbase.md
+++ b/docs/src/main/paradox/couchbase.md
@@ -34,13 +34,13 @@ The table below shows direct dependencies of this module and the second tab show
 
 Alpakka Couchbase offers both @ref:[Akka Streams APIs](#reading-from-couchbase-in-akka-streams) and a more @ref:[direct API](#using-couchbasesession-directly) to access Couchbase:
 
-* `CouchbaseSession` (@scala[@scaladoc[API](akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession)]@java[@scaladoc[API](akka.stream.alpakka.couchbase.javadsl.CouchbaseSession)]) offers a direct API for one-off operations
-* `CouchbaseSessionRegistry` (@scaladoc[API](akka.stream.alpakka.couchbase.CouchbaseSessionRegistry$)) is an Akka extension to keep track and share `CouchbaseSession`s within an `ActorSystem`
-* `CouchbaseSource` (@scala[@scaladoc[API](akka.stream.alpakka.couchbase.scaladsl.CouchbaseSource$)]@java[@scaladoc[API](akka.stream.alpakka.couchbase.javadsl.CouchbaseSource$)]), `CouchbaseFlow` (@scala[@scaladoc[API](akka.stream.alpakka.couchbase.scaladsl.CouchbaseFlow$)]@java[@scaladoc[API](akka.stream.alpakka.couchbase.javadsl.CouchbaseFlow$)]), and `CouchbaseSink` (@scala[@scaladoc[API](akka.stream.alpakka.couchbase.scaladsl.CouchbaseSink$)]@java[@scaladoc[API](akka.stream.alpakka.couchbase.javadsl.CouchbaseSink$)]) offer factory methods to create Akka Stream operators
+* @apidoc[CouchbaseSession] offers a direct API for one-off operations
+* @apidoc[CouchbaseSessionRegistry$] is an Akka extension to keep track and share `CouchbaseSession`s within an `ActorSystem`
+* @apidoc[CouchbaseSource$], @apidoc[CouchbaseFlow$], and @apidoc[CouchbaseSink$] offer factory methods to create Akka Stream operators
 
 ## Configuration
 
-All operations use the `CouchbaseSession` internally. A session is configured with `CouchbaseSessionSettings` (@scaladoc[API](akka.stream.alpakka.couchbase.CouchbaseSessionSettings$)) and a Couchbase bucket name. The Akka Stream factory methods create and access the corresponding session instance behind the scenes.
+All operations use the `CouchbaseSession` internally. A session is configured with @apidoc[CouchbaseSessionSettings$] and a Couchbase bucket name. The Akka Stream factory methods create and access the corresponding session instance behind the scenes.
 
 By default the `CouchbaseSessionSettings` are read from the `alpakka.couchbase.session` section from the configuration eg. in your `application.conf`.
 
@@ -49,7 +49,7 @@ Settings
 
 ## Using Akka Discovery
 
-To delegate the configuration of Couchbase nodes to any of [Akka Discovery's lookup mechanisms](https://doc.akka.io/docs/akka/current/discovery/index.html), specify a service name and lookup timeout in the Couchbase section, and pass in @scala[@scaladoc[DiscoverySupport](akka.stream.alpakka.couchbase.scaladsl.DiscoverySupport$)]@java[@scaladoc[DiscoverySupport](akka.stream.alpakka.couchbase.javadsl.DiscoverySupport)] nodes lookup to `enrichAsync` and configure Akka Discovery accordingly.
+To delegate the configuration of Couchbase nodes to any of @extref:[Akka Discovery's lookup mechanisms](akka:discovery/index.html), specify a service name and lookup timeout in the Couchbase section, and pass in @apidoc[DiscoverySupport$] nodes lookup to `enrichAsync` and configure Akka Discovery accordingly.
 
 **The Akka Discovery dependency has to be added explicitly**.
 
@@ -103,7 +103,7 @@ Java
 
 # Writing to Couchbase in Akka Streams
 
-For each mutation operation we need to create `CouchbaseWriteSettings` instance which consists of the following parameters
+For each mutation operation we need to create @apidoc[CouchbaseWriteSettings] instance which consists of the following parameters
 
 - Parallelism in access to Couchbase (default 1)
 - Couchbase Replication Factor (default `ReplicateTo.NONE`) 
@@ -231,4 +231,4 @@ Scala
 Java
 : @@snip [snip](/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java) { #sessionFromBucket }
 
-To learn about the full range of operations on `CouchbaseSession`, read the @scala[@scaladoc[API docs](akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession)]@java[@scaladoc[API docs](akka.stream.alpakka.couchbase.javadsl.CouchbaseSession)].
+To learn about the full range of operations on `CouchbaseSession`, read the @apidoc[CouchbaseSession] API documentation.

--- a/docs/src/main/paradox/data-transformations/compression.md
+++ b/docs/src/main/paradox/data-transformations/compression.md
@@ -1,9 +1,12 @@
 ## Compressing/decompressing
 
-Akka Stream contains support for compressing and decompressing streams of @scaladoc[ByteString](akka.util.ByteString) 
+Akka Stream contains support for compressing and decompressing streams of @apidoc[ByteString](akka.util.ByteString)
 elements.
 
-Use @scaladoc[ScalaDSL Compression](akka.stream.scaladsl.Compression$) or 
-@scaladoc[JavaDSL Compression](akka.stream.javadsl.Compression$) as described in the Akka Stream documentation:
+Use @apidoc[Compression](Compression$) as described in the Akka Stream documentation:
 
 @extref:[Akka documentation](akka:stream/stream-cookbook.html#dealing-with-compressed-data-streams)
+
+### ZIP
+
+@ref[Alpakka File](../file.md#zip-archive) supports creating flows in ZIP-format.

--- a/docs/src/main/paradox/data-transformations/json.md
+++ b/docs/src/main/paradox/data-transformations/json.md
@@ -2,10 +2,10 @@
 
 ## JSON Framing
 
-Use Akka Stream JsonFraming to split a stream of @scaladoc[ByteString](akka.util.ByteString) elements into 
+Use Akka Stream JsonFraming to split a stream of @apidoc[akka.util.ByteString] elements into 
 ByteString snippets of valid JSON objects. 
 
-See @scaladoc[ScalaDSL JsonFraming](akka.stream.scaladsl.JsonFraming$) or @scaladoc[JavaDSL JsonFraming](akka.stream.javadsl.JsonFraming$)
+See @apidoc[JsonFraming$]
 
 
 @extref:[Akka documentation](akka:stream/stream-io.html#using-framing-in-your-protocol)

--- a/docs/src/main/paradox/data-transformations/parsing-lines.md
+++ b/docs/src/main/paradox/data-transformations/parsing-lines.md
@@ -1,7 +1,6 @@
 ## Parsing Lines
 
-Most Alpakka sources stream @scaladoc[ByteString](akka.util.ByteString) elements which normally won't contain data line by line. To 
-split these at line separators use @scaladoc[ScalaDSL Framing](akka.stream.scaladsl.Framing$) or 
-@scaladoc[JavaDSL Framing](akka.stream.javadsl.Framing$) as described in the Akka Stream documentation.
+Most Alpakka sources stream @apidoc[akka.util.ByteString] elements which normally won't contain data line by line. To 
+split these at line separators use @apidoc[Framing$] as described in the Akka Stream documentation.
 
 @extref:[Akka documentation](akka:stream/stream-cookbook.html#parsing-lines-from-a-stream-of-bytestrings)

--- a/docs/src/main/paradox/data-transformations/simple-codecs.md
+++ b/docs/src/main/paradox/data-transformations/simple-codecs.md
@@ -35,7 +35,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Usage
 
-The flow factory `RecordIOFraming` (@scala[@scaladoc[API](akka.stream.alpakka.recordio.scaladsl.RecordIOFraming$)]@java[@scaladoc[API](akka.stream.alpakka.recordio.javadsl.RecordIOFraming$)]) provides a `scanner`
+The flow factory @apidoc[RecordIOFraming$] provides a `scanner`
 factory method for a @scala[`Flow[ByteString, ByteString, _]`]@java[`Flow<ByteString, ByteString, ?>`] which parses out RecordIO frames.
 
 Scala

--- a/docs/src/main/paradox/data-transformations/xml.md
+++ b/docs/src/main/paradox/data-transformations/xml.md
@@ -20,7 +20,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## XML parsing
 
-XML processing pipeline starts with an @scaladoc[XmlParsing.parser](akka.stream.alpakka.xml.scaladsl.XmlParsing$) flow which parses a stream of @scaladoc[ByteString](akka.util.ByteString)s to XML parser events.
+XML processing pipeline starts with an @apidoc[XmlParsing.parser](XmlParsing$) flow which parses a stream of @apidoc[akka.util.ByteString]s to XML parser events.
 
 Scala
 : @@snip [snip](/xml/src/test/scala/docs/scaladsl/XmlProcessingSpec.scala) { #parser }
@@ -47,7 +47,7 @@ Java
 
 ## XML writing
 
-XML processing pipeline ends with an @scaladoc[XmlWriting.writer](akka.stream.alpakka.xml.scaladsl.XmlWriting$) flow which writes a stream of XML parser events to @scaladoc[ByteString](akka.util.ByteString)s.
+XML processing pipeline ends with an @apidoc[XmlWriting.writer](XmlWriting$) flow which writes a stream of XML parser events to @apidoc[akka.util.ByteString]s.
 
 Scala
 : @@snip [snip](/xml/src/test/scala/docs/scaladsl/XmlWritingSpec.scala) { #writer }
@@ -65,7 +65,7 @@ Java
 
 ## XML Subslice
 
-Use @scaladoc[XmlParsing.subslice](akka.stream.alpakka.xml.scaladsl.XmlParsing$) to filter out all elements not corresponding to a certain path.
+Use @apidoc[XmlParsing.subslice](XmlParsing$) to filter out all elements not corresponding to a certain path.
 
 Scala
 : @@snip [snip](/xml/src/test/scala/docs/scaladsl/XmlSubsliceSpec.scala) { #subslice }
@@ -83,7 +83,7 @@ Java
 
 ## XML Subtree
 
-Use @scaladoc[XmlParsing.subtree](akka.stream.alpakka.xml.scaladsl.XmlParsing$) to handle elements matched to a certain path and their child nodes as `org.w3c.dom.Element`.
+Use @apidoc[XmlParsing.subtree](XmlParsing$) to handle elements matched to a certain path and their child nodes as `org.w3c.dom.Element`.
 
 Scala
 : @@snip [snip](/xml/src/test/scala/docs/scaladsl/XmlSubtreeSpec.scala) { #subtree }

--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -33,11 +33,7 @@ Java
 ## Elasticsearch as Source and Sink
 
 Now we can stream messages from or to Elasticsearch by providing the `RestClient` to the
-@scala[@scaladoc[ElasticsearchSource](akka.stream.alpakka.elasticsearch.scaladsl.ElasticsearchSource$)]
-@java[@scaladoc[ElasticsearchSource](akka.stream.alpakka.elasticsearch.javadsl.ElasticsearchSource$)]
-or the
-@scala[@scaladoc[ElasticsearchSink](akka.stream.alpakka.elasticsearch.scaladsl.ElasticsearchSink$).]
-@java[@scaladoc[ElasticsearchSink](akka.stream.alpakka.elasticsearch.javadsl.ElasticsearchSink$).]
+@apidoc[ElasticsearchSource$], @apidoc[ElasticsearchFlow$] or the @apidoc[ElasticsearchSink$].
 
 
 Scala
@@ -147,9 +143,7 @@ In case of write failures the order of messages downstream is guaranteed to be p
 
 ## Elasticsearch as Flow
 
-You can also build flow stages with
-@scala[@scaladoc[ElasticsearchFlow](akka.stream.alpakka.elasticsearch.scaladsl.ElasticsearchFlow$).]
-@java[@scaladoc[ElasticsearchFlow](akka.stream.alpakka.elasticsearch.javadsl.ElasticsearchFlow$).]
+You can also build flow stages with @apidoc[ElasticsearchFlow$].
 The API is similar to creating Sinks.
 
 Scala

--- a/docs/src/main/paradox/file.md
+++ b/docs/src/main/paradox/file.md
@@ -2,7 +2,7 @@
 
 The File connectors provide additional connectors for filesystems complementing
 the sources and sinks for files already included in core Akka Streams
-(which can be found in @java[@javadoc[akka.stream.javadsl.FileIO](akka.stream.javadsl.FileIO$)]@scala[@scaladoc[akka.stream.scaladsl.FileIO](akka.stream.scaladsl.FileIO$)]).
+(which can be found in @aipdoc[FileIO$]).
 
 @@project-info{ projectId="file" }
 
@@ -47,10 +47,10 @@ Java
 ### Shutdown stream when file is deleted
 
 The `FileTailSource` stream will not shutdown or throw an error when the file it is tailing is deleted from the filesystem. 
-If you would like to shutdown the stream, or throw an error, you can do so by merging in a @scala[@scaladoc[DirectoryChangesSource](akka.stream.alpakka.file.scaladsl.DirectoryChangesSource)]@java[@javadoc[DirectoryChangesSource](akka.stream.alpakka.file.javadsl.DirectoryChangesSource)] that listens to filesystem events in the directory that contains the file.
+If you would like to shutdown the stream, or throw an error, you can do so by merging in a @apidoc[(javadsl|scaladsl).DirectoryChangesSource$] that listens to filesystem events in the directory that contains the file.
 
 In the following example, a `DirectoryChangesSource` is used to watch for events in a directory. 
-If a file delete event is observed for the file we are tailing then we shutdown the stream gracefully by using a @scala[@scaladoc[Flow.recoverWithRetries](akka.stream.scaladsl.Flow$)]@java[@javadoc[Flow.recoverWith](akka.stream.javadsl.Flow$)] to switch to a @scala[@scaladoc[Source.empty](akka.stream.scaladsl.Source$)]@java[@javadoc[Source.empty](akka.stream.javadsl.Source$)], which with immediately send an `OnComplete` signal and shutdown the stream.
+If a file delete event is observed for the file we are tailing then we shutdown the stream gracefully by using a @apidoc[Flow.recoverWithRetries](Flow$) to switch to a @apidoc[Source.empty](Source$), which with immediately send an `OnComplete` signal and shutdown the stream.
 
 Scala
 : @@snip [snip](/file/src/test/scala/docs/scaladsl/FileTailSourceExtrasSpec.scala) { #shutdown-on-delete }
@@ -68,7 +68,7 @@ If the file is detected as deleted and the stream is shutdown before the last el
 ### Shutdown stream after an idle timeout
 
 It may be useful to shutdown the stream when no new data has been added for awhile to a file being tailed by `FileTailSource`.
-In the following example, a @scala[@scaladoc[Flow.idleTimeout](akka.stream.scaladsl.Flow$)]@java[@javadoc[Flow.idleTimeout](akka.stream.javadsl.Flow$)] operator is used to trigger a `TimeoutException` that can be recovered with @scala[@scaladoc[Flow.recoverWithRetries](akka.stream.scaladsl.Flow$)]@java[@javadoc[Flow.recoverWith](akka.stream.javadsl.Flow$)] and a @scala[@scaladoc[Source.empty](akka.stream.scaladsl.Source$)]@java[@javadoc[Source.empty](akka.stream.javadsl.Source$)] to successfully shutdown the stream.
+In the following example, a @apidoc[Flow.idleTimeout](Flow$) operator is used to trigger a `TimeoutException` that can be recovered with @apidoc[Flow.recoverWithRetries](Flow$) and a @apidoc[Source.empty](Source$) to successfully shutdown the stream.
 
 Scala
 : @@snip [snip](/file/src/test/scala/docs/scaladsl/FileTailSourceExtrasSpec.scala) { #shutdown-on-idle-timeout }
@@ -125,8 +125,7 @@ Java
 
 ## Rotating the file to stream into 
 
-The @scala[@scaladoc[LogRotatatorSink](akka.stream.alpakka.file.scaladsl.LogRotatorSink$)]
- @java[@scaladoc[LogRotatatorSink](akka.stream.alpakka.file.javadsl.LogRotatorSink$)] will create and 
+The @apidoc[LogRotatorSink$] will create and 
  write to multiple files.  
 This sink takes a creator as parameter which returns a
  @scala[`Bytestring => Option[Path]` function]@java[`Function<ByteString, Optional<Path>>`]. If the generated function returns a path
@@ -134,7 +133,7 @@ This sink takes a creator as parameter which returns a
   written to this new file too.
  With this approach the user can define a custom stateful file generation implementation.
 
-This example usage shows the built-in target file creation and a custom sink factory which is required to use @scala[@scaladoc[Compression](akka.stream.scaladsl.Compression$)]@java[@scaladoc[Compression](akka.stream.javadsl.Compression$)] for the target files.
+This example usage shows the built-in target file creation and a custom sink factory which is required to use @apidoc[Compression$] for the target files.
 
 Scala
 : @@snip [snip](/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala) { #sample }
@@ -164,7 +163,7 @@ This example can be found in the @ref:[self-contained example documentation sect
 
 ## ZIP Archive
 
-The @scala[@scaladoc[Archive](akka.stream.alpakka.file.scaladsl.Archive$)]  @java[@scaladoc[Archive](akka.stream.alpakka.file.javadsl.Archive$)]
+The @apidoc[Archive$]
 contains flow for compressing multiple files into one ZIP file.
 
 Result of flow can be send to sink even before whole ZIP file is created, so size of resulting ZIP archive

--- a/docs/src/main/paradox/google-cloud-storage.md
+++ b/docs/src/main/paradox/google-cloud-storage.md
@@ -32,7 +32,7 @@ HOCON:
 
 ## Store a file in Google Cloud Storage
 
-A file can be uploaded to Google Cloud Storage by creating a source of @scala[@scaladoc[ByteString](akka.util.ByteString)]@java[@javadoc[ByteString](akka.util.ByteString)] and running that with a sink created from @scala[@scaladoc[GCStorage.resumableUpload](akka.stream.alpakka.googlecloud.storage.scaladsl.GCStorage$)]@java[@scaladoc[GCStorage.resumableUpload](akka.stream.alpakka.googlecloud.storage.javadsl.GCStorage$)].
+A file can be uploaded to Google Cloud Storage by creating a source of @apidoc[akka.util.ByteString] and running that with a sink created from @scala[@scaladoc[GCStorage.resumableUpload](akka.stream.alpakka.googlecloud.storage.scaladsl.GCStorage$)]@java[@scaladoc[GCStorage.resumableUpload](akka.stream.alpakka.googlecloud.storage.javadsl.GCStorage$)].
 
 Scala
 : @@snip [snip](/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSinkSpec.scala) { #upload }

--- a/docs/src/main/paradox/jms/consumer.md
+++ b/docs/src/main/paradox/jms/consumer.md
@@ -12,11 +12,11 @@ The JMS message model supports several types of message bodies in (see @javadoc[
 
 ## Receiving messages
 
-@java[@scaladoc[JmsConsumer](akka.stream.alpakka.jms.javadsl.JmsConsumer$)]@scala[@scaladoc[JmsConsumer](akka.stream.alpakka.jms.scaladsl.JmsConsumer$)] offers factory methods to consume JMS messages in a number of ways.
+@apidoc[JmsConsumer$] offers factory methods to consume JMS messages in a number of ways.
 
 This examples shows how to listen to a JMS queue and emit @javadoc[javax.jms.Message](javax.jms.Message) elements into the stream.
 
-The materialized value `JmsConsumerControl` is used to shut down the consumer (it is a @scaladoc[Killswitch](akka.stream.KillSwitch)) and offers the possibility to inspect the connectivity state of the consumer. 
+The materialized value @apidoc[JmsConsumerControl] is used to shut down the consumer (it is a @apidoc[KillSwitch]) and offers the possibility to inspect the connectivity state of the consumer. 
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #jms-source }
@@ -38,7 +38,7 @@ Java
 
 The created @javadoc[ConnectionFactory](javax.jms.ConnectionFactory) is then used for the creation of the different JMS sources.
 
-The `JmsConsumerSettings` factories allow for passing the actor system to read from the default `alpakka.jms.consumer` section, or you may pass a `Config` instance which is resolved to a section of the same structure. 
+The @apidoc[JmsConsumerSettings$] factories allow for passing the actor system to read from the default `alpakka.jms.consumer` section, or you may pass a `Config` instance which is resolved to a section of the same structure. 
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsSettingsSpec.scala) { #consumer-settings }
@@ -195,8 +195,8 @@ Java
 
 ## Request / Reply
 
-The request / reply pattern can be implemented by streaming a @java[@scaladoc[JmsConsumer](akka.stream.alpakka.jms.javadsl.JmsConsumer$)]@scala[@scaladoc[JmsConsumer](akka.stream.alpakka.jms.scaladsl.JmsConsumer$)]
-to a @java[@scaladoc[JmsProducer](akka.stream.alpakka.jms.javadsl.JmsProducer$)]@scala[@scaladoc[JmsProducer](akka.stream.alpakka.jms.scaladsl.JmsProducer$)],
+The request / reply pattern can be implemented by streaming a @apidoc[JmsConsumer$]
+to a @apidoc[JmsProducer$],
 with a stage in between that extracts the `ReplyTo` and `CorrelationID` from the original message and adds them to the response.
 
 Scala

--- a/docs/src/main/paradox/jms/producer.md
+++ b/docs/src/main/paradox/jms/producer.md
@@ -38,8 +38,8 @@ The created @javadoc[ConnectionFactory](javax.jms.ConnectionFactory) is then use
 
 ### A `JmsMessage` sub-type sink
 
-Use a case class with the subtype of @scaladoc[JmsMessage](akka.stream.alpakka.jms.JmsMessage) to wrap the messages you want to send and optionally set message specific properties or headers.
-@java[@scaladoc[JmsProducer](akka.stream.alpakka.jms.javadsl.JmsProducer$)]@scala[@scaladoc[JmsProducer](akka.stream.alpakka.jms.scaladsl.JmsProducer$)] contains factory methods to facilitate the creation of sinks according to the message type.
+Use a case class with the subtype of @apidoc[JmsMessage] to wrap the messages you want to send and optionally set message specific properties or headers.
+@apidoc[JmsProducer$] contains factory methods to facilitate the creation of sinks according to the message type.
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #create-jms-sink }
@@ -50,7 +50,7 @@ Java
 
 #### Setting JMS message properties
 
-For every @scaladoc[JmsMessage](akka.stream.alpakka.jms.JmsMessage) you can set JMS message properties.
+For every @apidoc[JmsMessage] you can set JMS message properties.
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #create-messages-with-properties }
@@ -60,7 +60,7 @@ Java
 
 
 #### Setting JMS message header attributes
-For every @scaladoc[JmsMessage](akka.stream.alpakka.jms.JmsMessage) you can set also JMS message headers.
+For every @apidoc[JmsMessage] you can set also JMS message headers.
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #create-messages-with-headers }
@@ -73,7 +73,7 @@ Java
 
 #### Text sinks
 
-Create a sink, that accepts and forwards @scaladoc[JmsTextMessage](akka.stream.alpakka.jms.JmsTextMessage$)s to the JMS provider:
+Create a sink, that accepts and forwards @apidoc[JmsTextMessage$]s to the JMS provider:
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #text-sink }
@@ -83,7 +83,7 @@ Java
 
 #### Byte array sinks
 
-Create a sink, that accepts and forwards @scaladoc[JmsByteMessage](akka.stream.alpakka.jms.JmsByteMessage$)s to the JMS provider.
+Create a sink, that accepts and forwards @apidoc[JmsByteMessage$]s to the JMS provider.
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #bytearray-sink }
@@ -94,7 +94,7 @@ Java
 
 #### Map message sink
 
-Create a sink, that accepts and forwards @scaladoc[JmsMapMessage](akka.stream.alpakka.jms.JmsMapMessage$)s to the JMS provider:
+Create a sink, that accepts and forwards @apidoc[JmsMapMessage$]s to the JMS provider:
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #map-sink }
@@ -107,7 +107,7 @@ Java
 
 Create and configure ActiveMQ connection factory to support serialization.
 See [ActiveMQ Security](http://activemq.apache.org/objectmessage.html) for more information on this.
-Create a sink, that accepts and forwards @scaladoc[JmsObjectMessage](akka.stream.alpakka.jms.JmsObjectMessage$)s to the JMS provider:
+Create a sink, that accepts and forwards @apidoc[JmsObjectMessage$]s to the JMS provider:
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #object-sink }

--- a/docs/src/main/paradox/mongodb.md
+++ b/docs/src/main/paradox/mongodb.md
@@ -58,7 +58,7 @@ Scala
 Java
 : @@snip [snip](/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java) { #init-connection }
 
-We will also need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and an @scaladoc[ActorMaterializer](akka.stream.ActorMaterializer).
+We will also need an @apidoc[akka.actor.ActorSystem] and an @apidoc[akka.stream.Materializer].
 
 Scala
 : @@snip [snip](/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala) { #init-mat }

--- a/docs/src/main/paradox/s3.md
+++ b/docs/src/main/paradox/s3.md
@@ -27,7 +27,7 @@ All of the available configuration settings can be found in the @github[referenc
 
 ## Store a file in S3
 
-A file can be uploaded to S3 by creating a source of @scala[@scaladoc[ByteString](akka.util.ByteString)]@java[@javadoc[ByteString](akka.util.ByteString)] and running that with a sink created from @scala[@scaladoc[S3.multipartUpload](akka.stream.alpakka.s3.scaladsl.S3$)]@java[@scaladoc[S3.multipartUpload](akka.stream.alpakka.s3.javadsl.S3$)].
+A file can be uploaded to S3 by creating a source of @apidoc[akka.util.ByteString] and running that with a sink created from @scala[@scaladoc[S3.multipartUpload](akka.stream.alpakka.s3.scaladsl.S3$)]@java[@scaladoc[S3.multipartUpload](akka.stream.alpakka.s3.javadsl.S3$)].
 
 Scala
 : @@snip [snip](/s3/src/test/scala/docs/scaladsl/S3SinkSpec.scala) { #upload }

--- a/docs/src/main/paradox/slick.md
+++ b/docs/src/main/paradox/slick.md
@@ -21,7 +21,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Initialization
 
-As always, before we get started we will need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and a @scaladoc[Materializer](akka.stream.Materializer).
+As always, before we get started we will need an @apidoc[akka.actor.ActorSystem] and a @scaladoc[Materializer](akka.stream.Materializer).
 
 Scala
 : @@snip [snip](/slick/src/test/scala/docs/scaladsl/SlickSpec.scala) { #init-mat }

--- a/docs/src/main/paradox/sns.md
+++ b/docs/src/main/paradox/sns.md
@@ -33,7 +33,7 @@ Java
 
 The example above uses @extref:[Akka HTTP](akka-http:) as the default HTTP client implementation. For more details about the HTTP client, configuring request retrying and best practices for credentials, see @ref[AWS client configuration](aws-shared-configuration.md) for more details.
 
-We will also need an @scaladoc[ActorSystem](akka.actor.ActorSystem) and an @scaladoc[ActorMaterializer](akka.stream.ActorMaterializer).
+We will also need an @apidoc[akka.actor.ActorSystem] and an @apidoc[akka.stream.Materializer].
 
 Scala
 : @@snip [snip](/sns/src/test/scala/akka/stream/alpakka/sns/IntegrationTestContext.scala) { #init-system }
@@ -46,7 +46,7 @@ This is all preparation that we are going to need.
 ## Publish messages to an SNS topic
 
 Now we can publish a message to any SNS topic where we have access to by providing the topic ARN to the
-@scaladoc[SnsPublisher](akka.stream.alpakka.sns.scaladsl.SnsPublisher$) Flow or Sink factory method.
+@apidoc[SnsPublisher$] Flow or Sink factory method.
 
 ### Using a Flow
 

--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -28,7 +28,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Setup
 
-Prepare an @scaladoc[ActorSystem](akka.actor.ActorSystem) and a @scaladoc[Materializer](akka.stream.Materializer).
+Prepare an @apidoc[akka.actor.ActorSystem] and a @apidoc[Materializer].
 
 Scala
 : @@snip [snip](/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala) { #init-mat }
@@ -51,7 +51,7 @@ The example above uses @extref:[Akka HTTP](akka-http:) as the default HTTP clien
 
 ## Read from an SQS queue
 
-The @scala[@scaladoc[SqsSource](akka.stream.alpakka.sqs.scaladsl.SqsSource$)]@java[@scaladoc[SqsSource](akka.stream.alpakka.sqs.javadsl.SqsSource$)] created source reads AWS Java SDK SQS `Message` objects from any SQS queue given by the queue URL.
+The @apidoc[SqsSource$] created source reads AWS Java SDK SQS `Message` objects from any SQS queue given by the queue URL.
 
 Scala
 : @@snip [snip](/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala) { #run }
@@ -116,7 +116,7 @@ Java
 : @@snip [snip](/sqs/src/test/java/docs/javadsl/SqsPublishTest.java) { #run-send-request }
 
 You can also build flow stages which publish messages to SQS queues, backpressure on queue response, and then forward 
-@scaladoc[SqsPublishResult](akka.stream.alpakka.sqs.SqsPublishResult) further down the stream.
+@apidoc[SqsPublishResult] further down the stream.
 
 Scala
 : @@snip [snip](/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala) { #flow }
@@ -130,7 +130,7 @@ Java
 ### Group messages and publish batches to an SQS queue
 
 Create a sink, that forwards `String` to the SQS queue. However, the main difference from the previous use case, 
-it batches items and sends as a one request and forwards a @scaladoc[SqsPublishResultEntry](akka.stream.alpakka.sqs.SqsPublishResultEntry)
+it batches items and sends as a one request and forwards a @apidoc[SqsPublishResultEntry]
 further down the stream for each item processed.
 
 Note: There is also another option to send batch of messages to SQS which is using `AmazonSQSBufferedAsyncClient`.
@@ -204,7 +204,7 @@ Options:
 ## Updating message statuses
 
 `SqsAckSink` and `SqsAckFlow` provide the possibility to acknowledge (delete), ignore, or postpone messages on an SQS queue.
-They accept @scaladoc[MessageAction](akka.stream.alpakka.sqs.MessageAction) sub-classes to select the action to be taken.
+They accept @apidoc[MessageAction] sub-classes to select the action to be taken.
 
 For every message you may decide which action to take and push it together with message back to the queue:
 
@@ -244,7 +244,7 @@ Java
 
 ### Update message status in a flow
 
-The `SqsAckFlow` forwards a @scaladoc[SqsAckResult](akka.stream.alpakka.sqs.SqsAckResult) sub-class down the stream:
+The `SqsAckFlow` forwards a @apidoc[SqsAckResult] sub-class down the stream:
 
 - `DeleteResult` to acknowledge message deletion
 - `ChangeMessageVisibilityResult` to acknowledge message visibility change
@@ -274,7 +274,7 @@ Options:
 
 ### Updating message statuses in batches with grouping
 
-`SqsAckFlow.grouped` batches actions on their type and forwards a @scaladoc[SqsAckResultEntry](akka.stream.alpakka.sqs.SqsAckResultEntry) 
+`SqsAckFlow.grouped` batches actions on their type and forwards a @apidoc[SqsAckResultEntry] 
 sub-class for each item processed:
 
 - `DeleteResultEntry` to acknowledge message deletion

--- a/docs/src/main/paradox/udp.md
+++ b/docs/src/main/paradox/udp.md
@@ -20,7 +20,7 @@ The table below shows direct dependencies of this module and the second tab show
 ## Sending
 
 Datagrams can be sent to remote destinations by using a `Udp.sendFlow` or `Udp.sendSink` which can be found in the
-@scaladoc[Udp](akka.stream.alpakka.udp.scaladsl.Udp$) factory object.
+@apidoc[(javadsl|scaladsl).Udp$] factory object.
 
 Scala
 : @@snip [snip](/udp/src/test/scala/docs/scaladsl/UdpSpec.scala) { #send-datagrams }


### PR DESCRIPTION
Simplify some docs by relying on `@apidoc`.
It actually catched some misspellings, as well.