### PR TITLE
Google pub/sub gRPC: allow sync poll using PullRequest

### DIFF
--- a/docs/src/main/paradox/google-cloud-pub-sub-grpc.md
+++ b/docs/src/main/paradox/google-cloud-pub-sub-grpc.md
@@ -119,18 +119,42 @@ Java
 
 ## Subscribing
 
+To receive messages from a subscription, there are two options: `StreamingPullRequest`s or synchronous `PullRequest`s.
+To decide whether you should use `StreamingPullRequest` or `PullRequest`, see [StreamingPull: Dealing with large backlogs of small messages](https://cloud.google.com/pubsub/docs/pull#streamingpull_dealing_with_large_backlogs_of_small_messages) and [Synchronous Pull](https://cloud.google.com/pubsub/docs/pull#synchronous_pull) from Google Cloud PubSub's documentation
+
+### StreamingPullRequest
 To receive message from a subscription, first we create a `StreamingPullRequest` with a FQRS of a subscription and
 a deadline for acknowledgements in seconds. Google requires that only the first `StreamingPullRequest` has the subscription
 and the deadline set. This connector takes care of that and clears up the subscription FQRS and the deadline for subsequent
 `StreamingPullRequest` messages.
 
 Scala
-: @@snip (/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala) { #subscribe }
+: @@snip (/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala) { #subscribe-stream }
 
 Java
-: @@snip (/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java) { #subscribe }
+: @@snip (/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java) { #subscribe-stream }
 
 Here `pollInterval` is the time between `StreamingPullRequest`s are sent when there are no messages in the subscription.
+
+### PullRequest
+
+With `PullRequest`, each request receives a batch of messages, up to a maximum specified by the `maxMessages`.
+
+Scala
+: @@snip (/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala) { #subscribe-sync }
+
+Java
+: @@snip (/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java) { #subscribe-sync }
+
+Here `pollInterval` is the time between `PullRequest` messages.
+
+In order to minimise latency between requests you can set a buffer on the source. The buffer size depends on the usual
+number of messages you receive per each request, if you usually receive the maximum number of messages, it's a good idea
+to set the buffer size to be the same as the `maxMessages` parameter. Please note that by having a buffer, you are allowing
+messages to spend some of their lease time in the buffer, hence reducing the time to process them before the acknowledgement
+deadline is reached. This will depend on your acknowledgement deadline and processing time.
+
+### Acknowledge
 
 Messages received from the subscription need to be acknowledged or they will be sent again. To do that create
 `AcknowledgeRequest` that contains `ackId`s of the messages to be acknowledged and send them to a sink
@@ -141,7 +165,6 @@ Scala
 
 Java
 : @@snip (/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java) { #acknowledge }
-
 
 ## Running the test code
 

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GooglePubSub.scala
@@ -76,7 +76,7 @@ object GooglePubSub {
    * @param request the subscription FQRS field is mandatory for the request
    * @param pollInterval time between PullRequest messages are being sent
    */
-  def subscribe(
+  def subscribePolling(
       request: PullRequest,
       pollInterval: Duration
   ): Source[ReceivedMessage, CompletableFuture[Cancellable]] =

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GooglePubSub.scala
@@ -58,7 +58,7 @@ object GooglePubSub {
               .single(request)
               .concat(
                 Source
-                  .tick(pollInterval, pollInterval, subsequentRequest)
+                  .tick(Duration.ZERO, pollInterval, subsequentRequest)
                   .mapMaterializedValue(japiFunction(cancellable.complete))
               )
           )
@@ -87,7 +87,7 @@ object GooglePubSub {
         val client = subscriber(mat, attr).client
 
         Source
-          .tick(pollInterval, pollInterval, request)
+          .tick(Duration.ZERO, pollInterval, request)
           .mapAsync(1, client.pull)
           .mapConcat(japiFunction(_.getReceivedMessagesList))
           .mapMaterializedValue(japiFunction(cancellable.complete))

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/scaladsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/scaladsl/GooglePubSub.scala
@@ -77,7 +77,7 @@ object GooglePubSub {
    * @param request the subscription FQRS field is mandatory for the request
    * @param pollInterval time between PullRequest messages are being sent
    */
-  def subscribe(
+  def subscribePolling(
       request: PullRequest,
       pollInterval: FiniteDuration
   ): Source[ReceivedMessage, Future[Cancellable]] =

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/scaladsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/scaladsl/GooglePubSub.scala
@@ -34,7 +34,7 @@ object GooglePubSub {
       .mapMaterializedValue(_ => NotUsed)
 
   /**
-   * Create a source that emits messages for a given subscription.
+   * Create a source that emits messages for a given subscription using a StreamingPullRequest.
    *
    * The materialized value can be used to cancel the source.
    *
@@ -64,6 +64,31 @@ object GooglePubSub {
                   .mapMaterializedValue(cancellable.success)
               )
           )
+          .mapConcat(_.receivedMessages.toVector)
+          .mapMaterializedValue(_ => cancellable.future)
+      }
+      .mapMaterializedValue(_.flatMap(identity)(ExecutionContexts.sameThreadExecutionContext))
+
+  /**
+   * Create a source that emits messages for a given subscription using a synchronous PullRequest.
+   *
+   * The materialized value can be used to cancel the source.
+   *
+   * @param request the subscription FQRS field is mandatory for the request
+   * @param pollInterval time between PullRequest messages are being sent
+   */
+  def subscribe(
+      request: PullRequest,
+      pollInterval: FiniteDuration
+  ): Source[ReceivedMessage, Future[Cancellable]] =
+    Source
+      .setup { (mat, attr) =>
+        val cancellable = Promise[Cancellable]
+        val client = subscriber(mat, attr).client
+        Source
+          .tick(0.seconds, pollInterval, request)
+          .mapMaterializedValue(cancellable.success)
+          .mapAsync(1)(client.pull(_))
           .mapConcat(_.receivedMessages.toVector)
           .mapMaterializedValue(_ => cancellable.future)
       }

--- a/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java
+++ b/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java
@@ -104,8 +104,9 @@ public class IntegrationTest {
   }
 
   @Test
-  public void shouldSubscribe() throws InterruptedException, ExecutionException, TimeoutException {
-    // #subscribe
+  public void shouldSubscribeStream()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    // #subscribe-stream
     final String projectId = "alpakka";
     final String subscription = "simpleSubscription";
 
@@ -118,7 +119,47 @@ public class IntegrationTest {
     final Duration pollInterval = Duration.ofSeconds(1);
     final Source<ReceivedMessage, CompletableFuture<Cancellable>> subscriptionSource =
         GooglePubSub.subscribe(request, pollInterval);
-    // #subscribe
+    // #subscribe-stream
+
+    final CompletionStage<ReceivedMessage> first =
+        subscriptionSource.runWith(Sink.head(), materializer);
+
+    final String topic = "simpleTopic";
+    final ByteString msg = ByteString.copyFromUtf8("Hello world!");
+
+    final PubsubMessage publishMessage = PubsubMessage.newBuilder().setData(msg).build();
+
+    final PublishRequest publishRequest =
+        PublishRequest.newBuilder()
+            .setTopic("projects/" + projectId + "/topics/" + topic)
+            .addMessages(publishMessage)
+            .build();
+
+    Source.single(publishRequest).via(GooglePubSub.publish(1)).runWith(Sink.ignore(), materializer);
+
+    assertEquals(
+        "received and expected messages not the same",
+        msg,
+        first.toCompletableFuture().get(2, TimeUnit.SECONDS).getMessage().getData());
+  }
+
+  @Test
+  public void shouldSubscribeSync()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    // #subscribe-sync
+    final String projectId = "alpakka";
+    final String subscription = "simpleSubscription";
+
+    final PullRequest request =
+        PullRequest.newBuilder()
+            .setSubscription("projects/" + projectId + "/subscriptions/" + subscription)
+            .setMaxMessages(10)
+            .build();
+
+    final Duration pollInterval = Duration.ofSeconds(1);
+    final Source<ReceivedMessage, CompletableFuture<Cancellable>> subscriptionSource =
+        GooglePubSub.subscribe(request, pollInterval);
+    // #subscribe-sync
 
     final CompletionStage<ReceivedMessage> first =
         subscriptionSource.runWith(Sink.head(), materializer);

--- a/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java
+++ b/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java
@@ -158,7 +158,7 @@ public class IntegrationTest {
 
     final Duration pollInterval = Duration.ofSeconds(1);
     final Source<ReceivedMessage, CompletableFuture<Cancellable>> subscriptionSource =
-        GooglePubSub.subscribe(request, pollInterval);
+        GooglePubSub.subscribePolling(request, pollInterval);
     // #subscribe-sync
 
     final CompletionStage<ReceivedMessage> first =

--- a/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
+++ b/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
@@ -136,7 +136,7 @@ class IntegrationSpec
         .withMaxMessages(10)
 
       val subscriptionSource: Source[ReceivedMessage, Future[Cancellable]] =
-        GooglePubSub.subscribe(request, pollInterval = 1.second)
+        GooglePubSub.subscribePolling(request, pollInterval = 1.second)
       //#subscribe-sync
 
       val first = subscriptionSource.runWith(Sink.head)

--- a/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
+++ b/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
@@ -95,8 +95,8 @@ class IntegrationSpec
       published.futureValue should not be empty
     }
 
-    "subscribe" in {
-      //#subscribe
+    "subscribe streaming" in {
+      //#subscribe-stream
       val projectId = "alpakka"
       val subscription = "simpleSubscription"
 
@@ -106,7 +106,38 @@ class IntegrationSpec
 
       val subscriptionSource: Source[ReceivedMessage, Future[Cancellable]] =
         GooglePubSub.subscribe(request, pollInterval = 1.second)
-      //#subscribe
+      //#subscribe-stream
+
+      val first = subscriptionSource.runWith(Sink.head)
+
+      val topic = "simpleTopic"
+      val msg = ByteString.copyFromUtf8("Hello world!")
+
+      val publishMessage: PubsubMessage =
+        PubsubMessage().withData(msg)
+
+      val publishRequest: PublishRequest =
+        PublishRequest()
+          .withTopic(s"projects/$projectId/topics/$topic")
+          .addMessages(publishMessage)
+
+      Source.single(publishRequest).via(GooglePubSub.publish(parallelism = 1)).runWith(Sink.ignore)
+
+      first.futureValue.message.value.data shouldBe msg
+    }
+
+    "subscribe sync" in {
+      //#subscribe-sync
+      val projectId = "alpakka"
+      val subscription = "simpleSubscription"
+
+      val request = PullRequest()
+        .withSubscription(s"projects/$projectId/subscriptions/$subscription")
+        .withMaxMessages(10)
+
+      val subscriptionSource: Source[ReceivedMessage, Future[Cancellable]] =
+        GooglePubSub.subscribe(request, pollInterval = 1.second)
+      //#subscribe-sync
 
       val first = subscriptionSource.runWith(Sink.head)
 


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #2141 

Here is a simple approach to have synchronous pull. I tried this in our environment (scala) and it worked well, the only quirk being that we have to tune the `maxMessages` parameter and interval finely. Wondering if there is a better way to manage the amount of messages being pulled.

This is what the usage looks like:

```
  private val request: PullRequest =
    PullRequest().withSubscription(Settings.PubSub.pubSubSubscription).withMaxMessages(100)

  lazy val source: Source[ReceivedMessage, Future[Cancellable]] = GooglePubSub.subscribe(request, 100.millis)
```
