### PR TITLE
Google PubSub: subscribe as a flow

### DIFF
--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/javadsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/javadsl/GooglePubSub.scala
@@ -14,6 +14,7 @@ import akka.{Done, NotUsed}
 
 import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
+import scala.concurrent.Future
 
 object GooglePubSub {
 
@@ -36,6 +37,11 @@ object GooglePubSub {
   def subscribe(subscription: String, config: PubSubConfig): Source[ReceivedMessage, Cancellable] =
     GPubSub
       .subscribe(subscription = subscription, config = config)
+      .asJava
+
+  def subscribeFlow(subscription: String, config: PubSubConfig): Flow[Done, ReceivedMessage, Future[NotUsed]] =
+    GPubSub
+      .subscribeFlow(subscription = subscription, config = config)
       .asJava
 
   @deprecated("Use `acknowledge` without `parallelism` param", since = "2.0.0")

--- a/google-cloud-pub-sub/src/test/java/docs/javadsl/ExampleUsageJava.java
+++ b/google-cloud-pub-sub/src/test/java/docs/javadsl/ExampleUsageJava.java
@@ -111,6 +111,24 @@ public class ExampleUsageJava {
         .to(ackSink);
     // #subscribe
 
+    // #subscribe-source-control
+    Source.tick(Duration.ofSeconds(0), Duration.ofSeconds(10), Done.getInstance())
+        .via(
+            RestartFlow.withBackoff(
+                Duration.ofSeconds(1),
+                Duration.ofSeconds(30),
+                0.2,
+                () -> GooglePubSub.subscribeFlow(subscription, config)))
+        .map(
+            message -> {
+              // do something fun
+              return message.ackId();
+            })
+        .groupedWithin(1000, Duration.ofMinutes(1))
+        .map(acks -> AcknowledgeRequest.create(acks))
+        .to(ackSink);
+    // #subscribe-source-control
+
     Sink<ReceivedMessage, CompletionStage<Done>> yourProcessingSink = Sink.ignore();
 
     // #subscribe-auto-ack

--- a/google-cloud-pub-sub/src/test/scala/docs/scaladsl/ExampleUsage.scala
+++ b/google-cloud-pub-sub/src/test/scala/docs/scaladsl/ExampleUsage.scala
@@ -11,12 +11,12 @@ import akka.actor.{ActorSystem, Cancellable}
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.googlecloud.pubsub._
 import akka.stream.alpakka.googlecloud.pubsub.scaladsl.GooglePubSub
-import akka.stream.scaladsl.{Flow, FlowWithContext, Sink, Source}
+import akka.stream.scaladsl.{Flow, FlowWithContext, RestartFlow, Sink, Source}
 import akka.{Done, NotUsed}
 
 import scala.collection.immutable.Seq
-import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration._
+import scala.concurrent.{Future, Promise}
 
 class ExampleUsage {
 
@@ -102,6 +102,24 @@ class ExampleUsage {
     .map(AcknowledgeRequest.apply)
     .to(ackSink)
   //#subscribe
+
+  //#subscribe-source-control
+  Source
+    .tick(0.seconds, 10.seconds, Done)
+    .via(
+      RestartFlow.withBackoff(1.second, 30.seconds, randomFactor = 0.2)(
+        () => GooglePubSub.subscribeFlow(subscription, config)
+      )
+    )
+    .map { message =>
+      // do something fun
+
+      message.ackId
+    }
+    .groupedWithin(1000, 1.minute)
+    .map(AcknowledgeRequest.apply)
+    .to(ackSink)
+  //#subscribe-source-control
 
   //#subscribe-auto-ack
   val subscribeMessageSoruce: Source[ReceivedMessage, NotUsed] = // ???


### PR DESCRIPTION
I have a small improvement for current PubSub API. Pulling from PubSub should be exposed as a flow, not the source. This gives the user more elasticity over stream composition. 

The benefits are: 
* User can set pulling frequency configuring source or attaching any source depends he needs
* Network failures happen from time to time when implementing backoff strategy for source we losing access materializer for original source. This means we cannot cancel the source anymore. When we use backoff strategy for flow we still have access to source materializer. As mention before more elasticity in composition. 

I left the old interface for backward compatibility.