### PR TITLE
Cassandra: Provide explicit executor when calling Futures.addCallback

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val alpakka = project
     ScalaUnidoc / unidoc / fullClasspath := {
       (ScalaUnidoc / unidoc / fullClasspath).value
         .filterNot(_.data.getAbsolutePath.contains("protobuf-java-2.5.0.jar"))
-        .filterNot(_.data.getAbsolutePath.contains("guava-28.1-android.jar"))
+        .filterNot(_.data.getAbsolutePath.contains("guava-28.2-android.jar"))
         .filterNot(_.data.getAbsolutePath.contains("commons-net-3.1.jar"))
         .filterNot(_.data.getAbsolutePath.contains("protobuf-java-2.6.1.jar"))
         // Some projects require (and introduce) Akka 2.6:

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/impl/GuavaFutures.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/impl/GuavaFutures.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.cassandra.impl
 
-import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture}
+import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture, MoreExecutors}
 
 import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}
@@ -30,7 +30,7 @@ private[cassandra] object GuavaFutures {
         override def onFailure(err: Throwable): Unit = p.failure(err)
       }
       // Alpakka build: if this fails during `unidoc` check the filters in build.sbt
-      Futures.addCallback(guavaFut, callback)
+      Futures.addCallback(guavaFut, callback, MoreExecutors.directExecutor())
       p.future
     }
   }


### PR DESCRIPTION
Guava initially deprecated and with [release 26.0](https://github.com/google/guava/releases/tag/v26.0) eventually [removed Futures methods that implicitly use directExecutor()](https://github.com/google/guava/commit/87d87f5cac5a540d46a6382683722ead7b72d1b3).

As a consequence, project dependency to Guava 26.0 or newer causes runtime `NoSuchMethodError`.
```
java.lang.NoSuchMethodError: com.google.common.util.concurrent.Futures.addCallback(Lcom/google/common/util/concurrent/ListenableFuture;Lcom/google/common/util/concurrent/FutureCallback;)V
	at akka.stream.alpakka.cassandra.impl.GuavaFutures$GuavaFutureOpts$.asScala$extension(GuavaFutures.scala:32)
	at akka.stream.alpakka.cassandra.scaladsl.CassandraSink$.$anonfun$apply$1(CassandraSink.scala:26)
	at akka.stream.impl.fusing.MapAsyncUnordered$$anon$31.onPush(Ops.scala:1376)
	at akka.stream.impl.fusing.GraphInterpreter.processPush(GraphInterpreter.scala:523)
	at akka.stream.impl.fusing.GraphInterpreter.execute(GraphInterpreter.scala:409)
	at akka.stream.impl.fusing.GraphInterpreterShell.runBatch(ActorGraphInterpreter.scala:606)
	at akka.stream.impl.fusing.GraphInterpreterShell.init(ActorGraphInterpreter.scala:576)
	at akka.stream.impl.fusing.ActorGraphInterpreter.tryInit(ActorGraphInterpreter.scala:682)
	at akka.stream.impl.fusing.ActorGraphInterpreter.preStart(ActorGraphInterpreter.scala:731)
	at akka.actor.Actor.aroundPreStart(Actor.scala:550)
	at akka.actor.Actor.aroundPreStart$(Actor.scala:550)
	at akka.stream.impl.fusing.ActorGraphInterpreter.aroundPreStart(ActorGraphInterpreter.scala:671)
	at akka.actor.ActorCell.create(ActorCell.scala:676)
	at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:547)
	at akka.actor.ActorCell.systemInvoke(ActorCell.scala:569)
	at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:293)
	at akka.dispatch.Mailbox.run(Mailbox.scala:228)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:241)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```

This fix is a simple workaround providing explicit direct executor, which is the same as the deprecated/removed code does.

It should be back-ported to 1.1.x.
