### PR TITLE
Google Cloud Storage: fix package names

### DIFF
--- a/google-cloud-storage/src/main/mima-filters/2.0.0-M3.backwards.excludes
+++ b/google-cloud-storage/src/main/mima-filters/2.0.0-M3.backwards.excludes
@@ -9,3 +9,9 @@ ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.alpakka.googl
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.alpakka.googlecloud.storage.StorageObject.contentLanguage")
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.alpakka.googlecloud.storage.StorageObject.contentEncoding")
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.alpakka.googlecloud.storage.StorageObject.contentDisposition")
+
+# move classes that ended up in wrong package https://github.com/akka/alpakka/pull/2177
+ProblemFilters.exclude[MissingClassProblem]("main.scala.*")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.googlecloud.storage.StorageObject.*")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.alpakka.googlecloud.storage.StorageObject.withCustomerEncryption")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.alpakka.googlecloud.storage.StorageObject.withOwner")

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/CustomerEncryption.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/CustomerEncryption.scala
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package main.scala.akka.stream.alpakka.googlecloud.storage
+package akka.stream.alpakka.googlecloud.storage
 
 final class CustomerEncryption private (encryptionAlgorithm: String, keySha256: String) {
   def withEncryptionAlgorithm(encryptionAlgorithm: String): CustomerEncryption =

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/ObjectAccessControls.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/ObjectAccessControls.scala
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package main.scala.akka.stream.alpakka.googlecloud.storage
+package akka.stream.alpakka.googlecloud.storage
 
 final class ObjectAccessControls private (
     kind: String,

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/Owner.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/Owner.scala
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package main.scala.akka.stream.alpakka.googlecloud.storage
+package akka.stream.alpakka.googlecloud.storage
 
 final class Owner private (entity: String, entityId: String) {
   def withEntity(entity: String): Owner = copy(entity = entity)

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/ProjectTeam.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/ProjectTeam.scala
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package main.scala.akka.stream.alpakka.googlecloud.storage
+package akka.stream.alpakka.googlecloud.storage
 
 final class ProjectTeam private (projectNumber: String, team: String) {
   def withProjectNumber(projectNumber: String): ProjectTeam =

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/StorageObject.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/StorageObject.scala
@@ -8,7 +8,6 @@ import java.time.OffsetDateTime
 import java.util.Optional
 
 import akka.http.scaladsl.model.ContentType
-import main.scala.akka.stream.alpakka.googlecloud.storage.{CustomerEncryption, ObjectAccessControls, Owner}
 import scala.compat.java8.OptionConverters._
 import scala.collection.JavaConverters._
 

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/impl/Formats.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/impl/Formats.scala
@@ -10,8 +10,6 @@ import akka.http.scaladsl.model.{ContentType, ContentTypes}
 import akka.stream.alpakka.googlecloud.storage._
 import spray.json.{DefaultJsonProtocol, JsObject, JsValue, RootJsonFormat, RootJsonReader}
 
-import java.time.OffsetDateTime
-
 import scala.util.Try
 
 @akka.annotation.InternalApi
@@ -253,14 +251,14 @@ object Formats extends DefaultJsonProtocol {
       kmsKeyName,
       customerEncryption.map(
         ce =>
-          main.scala.akka.stream.alpakka.googlecloud.storage
+          akka.stream.alpakka.googlecloud.storage
             .CustomerEncryption(ce.encryptionAlgorithm, ce.keySha256)
       ),
-      owner.map(o => main.scala.akka.stream.alpakka.googlecloud.storage.Owner(o.entity, o.entityId)),
+      owner.map(o => akka.stream.alpakka.googlecloud.storage.Owner(o.entity, o.entityId)),
       acl.map(
         _.map(
           a =>
-            main.scala.akka.stream.alpakka.googlecloud.storage.ObjectAccessControls(
+            akka.stream.alpakka.googlecloud.storage.ObjectAccessControls(
               a.kind,
               a.id,
               a.selfLink,
@@ -272,7 +270,7 @@ object Formats extends DefaultJsonProtocol {
               a.email,
               a.entityId,
               a.domain,
-              main.scala.akka.stream.alpakka.googlecloud.storage
+              akka.stream.alpakka.googlecloud.storage
                 .ProjectTeam(a.projectTeam.projectNumber, a.projectTeam.team),
               a.etag
             )


### PR DESCRIPTION
Something went wrong when these classes were created and their package names got the `main.scala` prefix.