### PR TITLE
AWS S3: virtual-host-style access with endpoint URL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -272,7 +272,7 @@ lazy val orientdb = alpakkaProject("orientdb",
 lazy val reference = internalProject("reference", Dependencies.Reference)
   .dependsOn(testkit % Test)
 
-lazy val s3 = alpakkaProject("s3", "aws.s3", Dependencies.S3)
+lazy val s3 = alpakkaProject("s3", "aws.s3", Dependencies.S3, Test / parallelExecution := false)
 
 lazy val springWeb = alpakkaProject("spring-web", "spring.web", Dependencies.SpringWeb)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,12 +178,13 @@ services:
     links:
       - kudu-master
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2020-03-09T18-26-53Z
     ports:
       - "9000:9000"
     environment:
       - "MINIO_ACCESS_KEY=TESTKEY"
       - "MINIO_SECRET_KEY=TESTSECRET"
+      - "MINIO_DOMAIN=s3minio.alpakka"
     command: server /data
   minio_prep:
     image: mesosphere/aws-cli

--- a/s3/src/main/mima-filters/2.0.0-M3.backwards.excludes/PR2183
+++ b/s3/src/main/mima-filters/2.0.0-M3.backwards.excludes/PR2183
@@ -1,4 +1,4 @@
-# MiMa upgrade
+# MiMa upgrade shows new error, method is private
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.s3.S3Settings.this")
 
 # override of apply in extension with the concrete type instead of the generic type

--- a/s3/src/main/mima-filters/2.0.0-M3.backwards.excludes/PR2193
+++ b/s3/src/main/mima-filters/2.0.0-M3.backwards.excludes/PR2193
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.s3.ForwardProxy.this")

--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -74,7 +74,7 @@ alpakka.s3 {
   }
 
   # DEPRECATED (since Alpakka 2.0.0)
-  # AWS S3 is going to retire path-style access, thus prefer the virtutal-host-style access
+  # AWS S3 is going to retire path-style access, thus prefer the virtual-host-style access
   # https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
   # To switch off the logged warning: use `force`
   path-style-access = false

--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -18,6 +18,7 @@ alpakka.s3 {
 
   # An address of a proxy that will be used for all connections using HTTP CONNECT tunnel.
   # forward-proxy {
+  #   scheme = "https"
   #   host = "proxy"
   #   port = 8080
   #   credentials {

--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -77,8 +77,13 @@ alpakka.s3 {
   # AWS S3 is going to retire path-style access, thus prefer the virutal-host-style access
   # https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
   path-style-access = false
+  # Don't use! Possibility to switch off the logged warning when using `path-style-access`.
+  path-style-access-warning = true
 
   # Custom endpoint url, used for alternate s3 implementations
+  # To enable DNS-style access with Alpakka S3 use the placeholder `{bucket}` in the URL
+  # eg. enpoint-url = "http://{bucket}.s3minio.alpakka:9000"
+  #
   # endpoint-url = null
 
   # Which version of the list bucket api to use. Set to 1 to use the old style version 1 API.

--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -74,15 +74,14 @@ alpakka.s3 {
   }
 
   # DEPRECATED (since Alpakka 2.0.0)
-  # AWS S3 is going to retire path-style access, thus prefer the virutal-host-style access
+  # AWS S3 is going to retire path-style access, thus prefer the virtutal-host-style access
   # https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
+  # To switch off the logged warning: use `force`
   path-style-access = false
-  # Don't use! Possibility to switch off the logged warning when using `path-style-access`.
-  path-style-access-warning = true
 
   # Custom endpoint url, used for alternate s3 implementations
-  # To enable DNS-style access with Alpakka S3 use the placeholder `{bucket}` in the URL
-  # eg. enpoint-url = "http://{bucket}.s3minio.alpakka:9000"
+  # To enable virtual-host-style access with Alpakka S3 use the placeholder `{bucket}` in the URL
+  # eg. endpoint-url = "http://{bucket}.s3minio.alpakka:9000"
   #
   # endpoint-url = null
 

--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -77,7 +77,11 @@ alpakka.s3 {
   # DEPRECATED (since Alpakka 2.0.0)
   # AWS S3 is going to retire path-style access, thus prefer the virtual-host-style access
   # https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
-  # To switch off the logged warning: use `force`
+  #
+  # Possible values:
+  #  - false: use virtual-host style access
+  #  - true: use legacy path-style access, warnings will be logged
+  #  - force: use legacy path-style access, disable warnings
   path-style-access = false
 
   # Custom endpoint url, used for alternate s3 implementations

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -28,7 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @InternalApi private[impl] object HttpRequests {
 
   private final val log = LoggerFactory.getLogger(getClass)
-  private final val PatternBucket = "{bucket}"
+  private final val BucketPattern = "{bucket}"
 
   def listBucket(
       bucket: String,
@@ -199,7 +199,7 @@ import scala.concurrent.{ExecutionContext, Future}
         Uri(endpointUrl).authority
 
       case Some(endpointUrl) =>
-        Uri(endpointUrl.replace(PatternBucket, bucket)).authority
+        Uri(endpointUrl.replace(BucketPattern, bucket)).authority
     }
   }
 
@@ -218,7 +218,7 @@ import scala.concurrent.{ExecutionContext, Future}
       case None =>
         uri.withScheme("https")
       case Some(endpointUri) =>
-        uri.withScheme(Uri(endpointUri.replace(PatternBucket, "b")).scheme)
+        uri.withScheme(Uri(endpointUri.replace(BucketPattern, "b")).scheme)
     }
   }
 

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -10,6 +10,7 @@ import java.time.{Instant, ZoneOffset, ZonedDateTime}
 import akka.actor.ActorSystem
 import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts
+import akka.http.scaladsl.Http.OutgoingConnection
 import akka.http.scaladsl.model.StatusCodes.{NoContent, NotFound, OK}
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.{headers => http, _}
@@ -21,7 +22,7 @@ import akka.stream.alpakka.s3._
 import akka.stream.alpakka.s3.headers.ServerSideEncryption
 import akka.stream.alpakka.s3.impl.auth.{CredentialScope, Signer, SigningKey}
 import akka.stream.alpakka.s3.impl.backport.RetryFlow
-import akka.stream.scaladsl.{Flow, Keep, RunnableGraph, Sink, Source}
+import akka.stream.scaladsl.{Flow, Keep, RunnableGraph, Sink, Source, Tcp}
 import akka.stream.{ActorMaterializer, Attributes, Materializer}
 import akka.util.ByteString
 import akka.{Done, NotUsed}
@@ -571,19 +572,33 @@ import scala.util.{Failure, Success, Try}
 
   private def poolSettings(implicit settings: S3Settings, system: ActorSystem) =
     settings.forwardProxy.map(proxy => {
-      // clientTransport is used in tests to overwrite the address to connect to
-      val transport: ClientTransport = proxy.clientTransport.getOrElse {
-        val address: InetSocketAddress = InetSocketAddress.createUnresolved(proxy.host, proxy.port)
-        proxy.credentials.fold(ClientTransport.httpsProxy(address))(
-          c => ClientTransport.httpsProxy(address, BasicHttpCredentials(c.username, c.password))
-        )
+      val address = InetSocketAddress.createUnresolved(proxy.host, proxy.port)
+      val transport: ClientTransport = proxy.scheme match {
+        case "https" =>
+          proxy.credentials.fold(ClientTransport.httpsProxy(address))(
+            c => ClientTransport.httpsProxy(address, BasicHttpCredentials(c.username, c.password))
+          )
+        case "http" =>
+          TCPTransport(address)
       }
-      ConnectionPoolSettings(system)
-        .withConnectionSettings(
-          ClientConnectionSettings(system)
-            .withTransport(transport)
-        )
+      ConnectionPoolSettings(system).withConnectionSettings(ClientConnectionSettings(system).withTransport(transport))
     })
+
+  private case class TCPTransport(address: InetSocketAddress) extends ClientTransport {
+    def connectTo(ignoredHost: String, ignoredPort: Int, settings: ClientConnectionSettings)(
+        implicit system: ActorSystem
+    ): Flow[ByteString, ByteString, Future[OutgoingConnection]] =
+      Tcp()
+        .outgoingConnection(address,
+                            settings.localAddress,
+                            settings.socketOptions,
+                            halfClose = true,
+                            settings.connectingTimeout,
+                            settings.idleTimeout)
+        .mapMaterializedValue(
+          _.map(tcpConn => OutgoingConnection(tcpConn.localAddress, tcpConn.remoteAddress))(system.dispatcher)
+        )
+  }
 
   private def singleRequest(req: HttpRequest)(implicit settings: S3Settings, system: ActorSystem) =
     poolSettings.fold(Http().singleRequest(req))(s => Http().singleRequest(req, settings = s))

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -579,12 +579,12 @@ import scala.util.{Failure, Success, Try}
             c => ClientTransport.httpsProxy(address, BasicHttpCredentials(c.username, c.password))
           )
         case "http" =>
-          TCPTransport(address)
+          ChangeTargetEndpointTransport(address)
       }
       ConnectionPoolSettings(system).withConnectionSettings(ClientConnectionSettings(system).withTransport(transport))
     })
 
-  private case class TCPTransport(address: InetSocketAddress) extends ClientTransport {
+  private case class ChangeTargetEndpointTransport(address: InetSocketAddress) extends ClientTransport {
     def connectTo(ignoredHost: String, ignoredPort: Int, settings: ClientConnectionSettings)(
         implicit system: ActorSystem
     ): Flow[ByteString, ByteString, Future[OutgoingConnection]] =

--- a/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
@@ -184,6 +184,7 @@ final class S3Settings private (
     val credentialsProvider: AwsCredentialsProvider,
     val s3RegionProvider: AwsRegionProvider,
     val pathStyleAccess: Boolean,
+    val pathStyleAccessWarning: Boolean,
     val endpointUrl: Option[String],
     val listBucketApiVersion: ApiVersion,
     val forwardProxy: Option[ForwardProxy],
@@ -258,6 +259,7 @@ final class S3Settings private (
     credentialsProvider = credentialsProvider,
     s3RegionProvider = s3RegionProvider,
     pathStyleAccess = pathStyleAccess,
+    pathStyleAccessWarning,
     endpointUrl = endpointUrl,
     listBucketApiVersion = listBucketApiVersion,
     forwardProxy = forwardProxy,
@@ -271,6 +273,7 @@ final class S3Settings private (
     s"credentialsProvider=$credentialsProvider," +
     s"s3RegionProvider=$s3RegionProvider," +
     s"pathStyleAccess=$pathStyleAccess," +
+    s"pathStyleAccessWarning=$pathStyleAccessWarning," +
     s"endpointUrl=$endpointUrl," +
     s"listBucketApiVersion=$listBucketApiVersion," +
     s"forwardProxy=$forwardProxy," +
@@ -283,6 +286,7 @@ final class S3Settings private (
       Objects.equals(this.credentialsProvider, that.credentialsProvider) &&
       Objects.equals(this.s3RegionProvider, that.s3RegionProvider) &&
       Objects.equals(this.pathStyleAccess, that.pathStyleAccess) &&
+      Objects.equals(this.pathStyleAccessWarning, that.pathStyleAccessWarning) &&
       Objects.equals(this.endpointUrl, that.endpointUrl) &&
       Objects.equals(this.listBucketApiVersion, that.listBucketApiVersion) &&
       Objects.equals(this.forwardProxy, that.forwardProxy) &&
@@ -296,6 +300,7 @@ final class S3Settings private (
       credentialsProvider,
       s3RegionProvider,
       Boolean.box(pathStyleAccess),
+      Boolean.box(pathStyleAccessWarning),
       endpointUrl,
       listBucketApiVersion,
       forwardProxy,
@@ -345,6 +350,7 @@ object S3Settings {
     } else None
 
     val pathStyleAccess = c.getBoolean("path-style-access")
+    val pathStyleAccessWarning = c.getBoolean("path-style-access-warning")
 
     val endpointUrl = if (c.hasPath("endpoint-url")) {
       Option(c.getString("endpoint-url"))
@@ -418,6 +424,7 @@ object S3Settings {
       credentialsProvider = credentialsProvider,
       s3RegionProvider = regionProvider,
       pathStyleAccess = pathStyleAccess,
+      pathStyleAccessWarning,
       endpointUrl = endpointUrl,
       listBucketApiVersion = apiVersion,
       forwardProxy = maybeForwardProxy,
@@ -446,9 +453,10 @@ object S3Settings {
     credentialsProvider,
     s3RegionProvider,
     pathStyleAccess,
+    pathStyleAccessWarning = true,
     endpointUrl,
     listBucketApiVersion,
-    None,
+    forwardProxy = None,
     validateObjectKey = true,
     MultipartUploadSettings(RetrySettings.default)
   )
@@ -463,10 +471,11 @@ object S3Settings {
     bufferType,
     credentialsProvider,
     s3RegionProvider,
-    false,
-    None,
+    pathStyleAccess = false,
+    pathStyleAccessWarning = true,
+    endpointUrl = None,
     listBucketApiVersion,
-    None,
+    forwardProxy = None,
     validateObjectKey = true,
     MultipartUploadSettings(RetrySettings.default)
   )

--- a/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
@@ -266,14 +266,14 @@ final class S3Settings private (
       validateObjectKey: Boolean = validateObjectKey,
       multipartUploadSettings: MultipartUploadSettings = multipartUploadSettings
   ): S3Settings = new S3Settings(
-    bufferType = bufferType,
-    credentialsProvider = credentialsProvider,
-    s3RegionProvider = s3RegionProvider,
-    pathStyleAccess = pathStyleAccess,
+    bufferType,
+    credentialsProvider,
+    s3RegionProvider,
+    pathStyleAccess,
     pathStyleAccessWarning,
-    endpointUrl = endpointUrl,
-    listBucketApiVersion = listBucketApiVersion,
-    forwardProxy = forwardProxy,
+    endpointUrl,
+    listBucketApiVersion,
+    forwardProxy,
     validateObjectKey,
     multipartUploadSettings
   )

--- a/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
@@ -360,8 +360,9 @@ object S3Settings {
       Option(ForwardProxy(c.getString("forward-proxy.host"), c.getInt("forward-proxy.port"), maybeCredentials))
     } else None
 
-    val pathStyleAccess = c.getBoolean("path-style-access")
-    val pathStyleAccessWarning = c.getBoolean("path-style-access-warning")
+    val (pathStyleAccess, pathStyleAccessWarning) =
+      if (c.getString("path-style-access") == "force") (true, false)
+      else (c.getBoolean("path-style-access"), true)
 
     val endpointUrl = if (c.hasPath("endpoint-url")) {
       Option(c.getString("endpoint-url"))
@@ -431,14 +432,14 @@ object S3Settings {
     )
 
     new S3Settings(
-      bufferType = bufferType,
-      credentialsProvider = credentialsProvider,
-      s3RegionProvider = regionProvider,
-      pathStyleAccess = pathStyleAccess,
+      bufferType,
+      credentialsProvider,
+      regionProvider,
+      pathStyleAccess,
       pathStyleAccessWarning,
-      endpointUrl = endpointUrl,
-      listBucketApiVersion = apiVersion,
-      forwardProxy = maybeForwardProxy,
+      endpointUrl,
+      apiVersion,
+      maybeForwardProxy,
       validateObjectKey,
       multipartUploadSettings
     )

--- a/s3/src/test/scala/akka/stream/alpakka/s3/S3SettingsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/S3SettingsSpec.scala
@@ -18,6 +18,7 @@ class S3SettingsSpec extends S3WireMockBase with S3ClientIntegrationSpec with Op
         s"""
           |buffer = memory
           |path-style-access = false
+          |path-style-access-warning = true
           |validate-object-key = true
           |multipart-upload.retry-settings {
           |  max-retries = 3

--- a/s3/src/test/scala/akka/stream/alpakka/s3/S3SettingsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/S3SettingsSpec.scala
@@ -18,7 +18,6 @@ class S3SettingsSpec extends S3WireMockBase with S3ClientIntegrationSpec with Op
         s"""
           |buffer = memory
           |path-style-access = false
-          |path-style-access-warning = true
           |validate-object-key = true
           |multipart-upload.retry-settings {
           |  max-retries = 3
@@ -158,7 +157,23 @@ class S3SettingsSpec extends S3WireMockBase with S3ClientIntegrationSpec with Op
     )
 
     settings.pathStyleAccess shouldBe true
+    settings.pathStyleAccessWarning shouldBe true
     settings.s3RegionProvider.getRegion shouldBe otherRegion
+    settings.endpointUrl.value shouldEqual endpointUrl
+  }
+
+  it should "force path-style-access" in {
+    val endpointUrl = "http://localhost:9000"
+
+    val settings: S3Settings = mkSettings(
+      s"""
+           |path-style-access = force
+           |endpoint-url = "$endpointUrl"
+        """
+    )
+
+    settings.pathStyleAccess shouldBe true
+    settings.pathStyleAccessWarning shouldBe false
     settings.endpointUrl.value shouldEqual endpointUrl
   }
 


### PR DESCRIPTION
## Purpose 

Enable use of DNS-style access while setting an endpoint URL so to use other S3 compatible solutions such as [MinIO](https://min.io/).

Introduce a new flag `path-style-access-warning` which can be used to switch off the logged warning when path-style access is enabled.

References #2171

## Solution

Support a placeholder `{bucket}` in the `endpoint-url` setting which is replaced with the bucket name.

The second commit makes use of Akka HTTP `ClientTransport` to force requests to `localhost` even if the request authority is something different, to allow the dynamic hostnames to contain the bucket names. This affects the `S3IntegrationSpec` quite significantly, as now all requests need to get the `S3Settings` passed explicitly. (This shows the motivation for #2139.)

## Background

As #2099 (issue #1679) switched the default bucket access back to virtual host-style, non-AWS endpoints did not work with Alpakka Kafka by default anymore.