### PR TITLE
MQTT streaming: ClassicActorSystemProvider in the API

### DIFF
--- a/mqtt-streaming/src/main/mima-filters/2.0.0-M3.backwards.excludes/ClassicActorSystemProvider
+++ b/mqtt-streaming/src/main/mima-filters/2.0.0-M3.backwards.excludes/ClassicActorSystemProvider
@@ -1,0 +1,11 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.javadsl.ActorMqttServerSession.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.javadsl.ActorMqttServerSession.create")
+
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.javadsl.ActorMqttClientSession.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.javadsl.ActorMqttClientSession.create")
+
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.scaladsl.ActorMqttServerSession.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.scaladsl.ActorMqttServerSession.this")
+
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.scaladsl.ActorMqttClientSession.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.scaladsl.ActorMqttClientSession.this")

--- a/mqtt-streaming/src/main/mima-filters/2.0.0-M3.backwards.excludes/ClassicActorSystemProvider
+++ b/mqtt-streaming/src/main/mima-filters/2.0.0-M3.backwards.excludes/ClassicActorSystemProvider
@@ -1,3 +1,4 @@
+# Incompatible changes for major release, now Akka 2.6 only
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.javadsl.ActorMqttServerSession.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.javadsl.ActorMqttServerSession.create")
 

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/javadsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/javadsl/MqttSession.scala
@@ -6,8 +6,7 @@ package akka.stream.alpakka.mqtt.streaming
 package javadsl
 
 import akka.NotUsed
-import akka.actor.ActorSystem
-import akka.stream.Materializer
+import akka.actor.ClassicActorSystemProvider
 import akka.stream.alpakka.mqtt.streaming.scaladsl.{
   ActorMqttClientSession => ScalaActorMqttClientSession,
   ActorMqttServerSession => ScalaActorMqttServerSession,
@@ -52,8 +51,8 @@ abstract class MqttClientSession extends MqttSession {
 }
 
 object ActorMqttClientSession {
-  def create(settings: MqttSessionSettings, mat: Materializer, system: ActorSystem): ActorMqttClientSession =
-    new ActorMqttClientSession(settings, mat, system)
+  def create(settings: MqttSessionSettings, system: ClassicActorSystemProvider): ActorMqttClientSession =
+    new ActorMqttClientSession(settings, system)
 }
 
 /**
@@ -61,10 +60,10 @@ object ActorMqttClientSession {
  *
  * @param settings session settings
  */
-final class ActorMqttClientSession(settings: MqttSessionSettings, mat: Materializer, system: ActorSystem)
+final class ActorMqttClientSession(settings: MqttSessionSettings, system: ClassicActorSystemProvider)
     extends MqttClientSession {
   override protected[javadsl] val underlying: ScalaActorMqttClientSession =
-    ScalaActorMqttClientSession(settings)(mat, system)
+    ScalaActorMqttClientSession(settings)(system)
 }
 
 object MqttServerSession {
@@ -96,8 +95,8 @@ abstract class MqttServerSession extends MqttSession {
 }
 
 object ActorMqttServerSession {
-  def create(settings: MqttSessionSettings, mat: Materializer, system: ActorSystem): ActorMqttServerSession =
-    new ActorMqttServerSession(settings, mat, system)
+  def create(settings: MqttSessionSettings, system: ClassicActorSystemProvider): ActorMqttServerSession =
+    new ActorMqttServerSession(settings, system)
 }
 
 /**
@@ -105,12 +104,12 @@ object ActorMqttServerSession {
  *
  * @param settings session settings
  */
-final class ActorMqttServerSession(settings: MqttSessionSettings, mat: Materializer, system: ActorSystem)
+final class ActorMqttServerSession(settings: MqttSessionSettings, system: ClassicActorSystemProvider)
     extends MqttServerSession {
   import MqttServerSession._
 
   override protected[javadsl] val underlying: ScalaActorMqttServerSession =
-    ScalaActorMqttServerSession(settings)(mat, system)
+    ScalaActorMqttServerSession(settings)(system)
 
   override def watchClientSessions: Source[ClientSessionTerminated, NotUsed] =
     underlying.watchClientSessions.map {

--- a/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -101,7 +101,7 @@ public class MqttFlowTest {
 
     // #create-streaming-flow
     MqttSessionSettings settings = MqttSessionSettings.create();
-    MqttClientSession session = ActorMqttClientSession.create(settings, materializer, system);
+    MqttClientSession session = ActorMqttClientSession.create(settings, system);
 
     Flow<ByteString, ByteString, CompletionStage<Tcp.OutgoingConnection>> connection =
         Tcp.get(system).outgoingConnection("localhost", 1883);
@@ -160,7 +160,7 @@ public class MqttFlowTest {
 
     // #create-streaming-bind-flow
     MqttSessionSettings settings = MqttSessionSettings.create();
-    MqttServerSession session = ActorMqttServerSession.create(settings, materializer, system);
+    MqttServerSession session = ActorMqttServerSession.create(settings, system);
 
     int maxConnections = 1;
 
@@ -244,7 +244,7 @@ public class MqttFlowTest {
     Flow<ByteString, ByteString, CompletionStage<Tcp.OutgoingConnection>> connection =
         Tcp.get(system).outgoingConnection(host, port);
 
-    MqttClientSession clientSession = new ActorMqttClientSession(settings, materializer, system);
+    MqttClientSession clientSession = new ActorMqttClientSession(settings, system);
 
     Flow<Command<Object>, DecodeErrorOrEvent<Object>, NotUsed> mqttFlow =
         Mqtt.clientSessionFlow(clientSession, ByteString.fromString("1")).join(connection);

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttActorSystemsSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttActorSystemsSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+package docs.scaladsl
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.stream.alpakka.mqtt.streaming.MqttSessionSettings
+import akka.stream.alpakka.mqtt.streaming.scaladsl.{ActorMqttClientSession, ActorMqttServerSession}
+import org.scalatest.wordspec.AnyWordSpec
+
+class MqttTypedActorSystemSpec extends AnyWordSpec {
+
+  implicit val actorSystem = akka.actor.typed.ActorSystem(Behaviors.ignore, "MqttTypedActorSystemSpec")
+
+  "A typed actor system" should {
+    "allow client creation" in {
+      val settings = MqttSessionSettings()
+      val session = ActorMqttClientSession(settings)
+      session.shutdown()
+    }
+
+    "allow server creation" in {
+      val settings = MqttSessionSettings()
+      val session = ActorMqttServerSession(settings)
+      session.shutdown()
+    }
+  }
+
+}
+
+class MqttClassicActorSystemSpec extends AnyWordSpec {
+
+  implicit val actorSystem = akka.actor.ActorSystem("MqttClassicActorSystemSpec")
+
+  "A typed actor system" should {
+    "allow client creation" in {
+      val settings = MqttSessionSettings()
+      val session = ActorMqttClientSession(settings)
+      session.shutdown()
+    }
+
+    "allow server creation" in {
+      val settings = MqttSessionSettings()
+      val session = ActorMqttServerSession(settings)
+      session.shutdown()
+    }
+  }
+
+}


### PR DESCRIPTION
Changes the factory methods and constructors of the `MqttSession`s to just require a `ClassicActorSystemProvider` instead of `akka.actor.ActorSystem` and `akka.stream.Materializer`.

This is possible as Alpakka MQTT Streaming is only compatible with Akka 2.6.

This makes it easier to use with the new actor APIs and hides the existence of the materializer form the users.

References #2118
