### PR TITLE
Couchbase: add methods for new actors API

### DIFF
--- a/couchbase/src/main/mima-filters/2.0.0-M3.backwards.excludes/ClassicActorSystemProvider
+++ b/couchbase/src/main/mima-filters/2.0.0-M3.backwards.excludes/ClassicActorSystemProvider
@@ -1,0 +1,2 @@
+# Result type change CouchbaseSessionRegistry rather than akka.actor.Extension
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.alpakka.couchbase.CouchbaseSessionRegistry.apply")

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/CouchbaseSessionRegistry.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/CouchbaseSessionRegistry.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.couchbase
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.atomic.AtomicReference
 
-import akka.actor.{ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import akka.actor.{ClassicActorSystemProvider, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
 import akka.dispatch.ExecutionContexts
 import akka.stream.alpakka.couchbase.impl.CouchbaseClusterRegistry
 import akka.stream.alpakka.couchbase.javadsl.{CouchbaseSession => JCouchbaseSession}
@@ -27,9 +27,29 @@ object CouchbaseSessionRegistry extends ExtensionId[CouchbaseSessionRegistry] wi
     new CouchbaseSessionRegistry(system)
 
   /**
-   * Java API: get the session registry
+   * Get the session registry with new actors API.
    */
-  override def get(system: ActorSystem): CouchbaseSessionRegistry =
+  // This is not source compatible with Akka 2.6 as it lacks `overrride`
+  def apply(system: ClassicActorSystemProvider): CouchbaseSessionRegistry =
+    super.get(system.classicSystem)
+
+  /**
+   * Get the session registry with the classic actors API.
+   */
+  override def apply(system: akka.actor.ActorSystem): CouchbaseSessionRegistry =
+    super.get(system)
+
+  /**
+   * Java API: Get the session registry with new actors API.
+   */
+  // This is not source compatible with Akka 2.6 as it lacks `overrride`
+  def get(system: ClassicActorSystemProvider): CouchbaseSessionRegistry =
+    super.get(system.classicSystem)
+
+  /**
+   * Java API: Get the session registry with the classic actors API.
+   */
+  override def get(system: akka.actor.ActorSystem): CouchbaseSessionRegistry =
     super.get(system)
 
   override def lookup(): ExtensionId[CouchbaseSessionRegistry] = this

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/CouchbaseSessionRegistry.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/CouchbaseSessionRegistry.scala
@@ -31,26 +31,26 @@ object CouchbaseSessionRegistry extends ExtensionId[CouchbaseSessionRegistry] wi
    */
   // This is not source compatible with Akka 2.6 as it lacks `overrride`
   def apply(system: ClassicActorSystemProvider): CouchbaseSessionRegistry =
-    super.get(system.classicSystem)
+    super.apply(system.classicSystem)
 
   /**
    * Get the session registry with the classic actors API.
    */
   override def apply(system: akka.actor.ActorSystem): CouchbaseSessionRegistry =
-    super.get(system)
+    super.apply(system)
 
   /**
    * Java API: Get the session registry with new actors API.
    */
   // This is not source compatible with Akka 2.6 as it lacks `overrride`
   def get(system: ClassicActorSystemProvider): CouchbaseSessionRegistry =
-    super.get(system.classicSystem)
+    super.apply(system.classicSystem)
 
   /**
    * Java API: Get the session registry with the classic actors API.
    */
   override def get(system: akka.actor.ActorSystem): CouchbaseSessionRegistry =
-    super.get(system)
+    super.apply(system)
 
   override def lookup(): ExtensionId[CouchbaseSessionRegistry] = this
 


### PR DESCRIPTION
Complement the `CouchbaseSessionRegistry` extension with access methods for `ClassicActorSystemProvider` which makes it usable without changed for the new actors API's `akka.actor.typed.ActorSystem` without depending on that module.

This can't be compiled against Akka 2.6 as `ExtensionId` in that version contains the `apply(ClassicActorSystemProvider)` method so it requires an `override` modifier in `CasssandraSessionRegistry`.

See #2194, #2195 