### PR TITLE
Google Cloud Pub/Sub gRPC: hide materializer, support new actors API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -328,7 +328,6 @@ lazy val docs = project
         "akka.version" -> Dependencies.AkkaVersion,
         "akka26.version" -> Dependencies.Akka26Version,
         "akka-http.version" -> Dependencies.AkkaHttpVersion,
-        "couchbase.version" -> Dependencies.CouchbaseVersion,
         "hadoop.version" -> Dependencies.HadoopVersion,
         "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.AkkaBinaryVersion}/%s",
         "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.AkkaBinaryVersion}",
@@ -336,8 +335,13 @@ lazy val docs = project
         "extref.akka-http.base_url" -> s"https://doc.akka.io/docs/akka-http/${Dependencies.AkkaHttpBinaryVersion}/%s",
         "scaladoc.akka.http.base_url" -> s"https://doc.akka.io/api/akka-http/${Dependencies.AkkaHttpBinaryVersion}/",
         "javadoc.akka.http.base_url" -> s"https://doc.akka.io/japi/akka-http/${Dependencies.AkkaHttpBinaryVersion}/",
-        "extref.akka-grpc.base_url" -> s"https://doc.akka.io/docs/akka-grpc/current/%s",
+        // Akka gRPC
+        "akka-grpc.version" -> Dependencies.AkkaGrpcBinaryVersion,
+        "extref.akka-grpc.base_url" -> s"https://doc.akka.io/docs/akka-grpc/${Dependencies.AkkaGrpcBinaryVersion}/%s",
+        // Couchbase
+        "couchbase.version" -> Dependencies.CouchbaseVersion,
         "extref.couchbase.base_url" -> s"https://docs.couchbase.com/java-sdk/${Dependencies.CouchbaseVersionForDocs}/%s",
+        // Java
         "extref.java-api.base_url" -> "https://docs.oracle.com/javase/8/docs/api/index.html?%s.html",
         "extref.geode.base_url" -> s"https://geode.apache.org/docs/guide/${Dependencies.GeodeVersionForDocs}/%s",
         "extref.javaee-api.base_url" -> "https://docs.oracle.com/javaee/7/api/index.html?%s.html",

--- a/docs/src/main/paradox/google-cloud-pub-sub-grpc.md
+++ b/docs/src/main/paradox/google-cloud-pub-sub-grpc.md
@@ -6,8 +6,8 @@ Google Cloud Pub/Sub provides many-to-many, asynchronous messaging that decouple
 Further information at the official [Google Cloud documentation website](https://cloud.google.com/pubsub/docs/overview).
 @@@
 
-This connector communicates to Pub/Sub via the gRPC protocol. The integration between Akka Stream and gRPC is handled by the
-[Akka gRPC library](https://github.com/akka/akka-grpc). For a connector that uses HTTP for the communication, take a
+This connector communicates to Pub/Sub via the gRPC protocol. The integration between Akka Stream and gRPC is handled by
+@extref[Akka gRPC $akka-grpc.version$](akka-grpc:). For a connector that uses HTTP for the communication, take a
 look at the alternative @ref[Alpakka Google Cloud Pub/Sub](google-cloud-pub-sub.md) connector.
 
 @@project-info{ projectId="google-cloud-pub-sub-grpc" }
@@ -33,6 +33,15 @@ Akka gRPC uses Akka Discovery internally. Make sure to add Akka Discovery with t
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.
 
 @@dependencies { projectId="google-cloud-pub-sub-grpc" }
+
+## Binary compatibility
+
+@@@warning
+
+This connector contains code generated from Protobuf files which is bound to @extref:[Akka gRPC $akka-grpc.version$](akka-grpc:). This makes it @extref:[NOT binary-compatible](akka-grpc:/binary-compatibility.html) with later versions of Akka gRPC.
+You can not use a different version of Akka gRPC within the same JVM instance.
+
+@@@
 
 ## Build setup
 

--- a/google-cloud-pub-sub-grpc/src/main/mima-filters/2.0.0-M3.backwards.excludes/Akka-gRPC-upgrade
+++ b/google-cloud-pub-sub-grpc/src/main/mima-filters/2.0.0-M3.backwards.excludes/Akka-gRPC-upgrade
@@ -1,3 +1,4 @@
+# The upgrade to Akka gRPC 0.8.0 changes the generated code, that's OK as we go for Alpakka 2.0.0
 ProblemFilters.exclude[Problem]("com.google.*")
 
 ProblemFilters.exclude[Problem]("akka.stream.alpakka.googlecloud.pubsub.grpc.javadsl.GrpcPublisher.create")

--- a/google-cloud-pub-sub-grpc/src/main/mima-filters/2.0.0-M3.backwards.excludes/Akka-gRPC-upgrade
+++ b/google-cloud-pub-sub-grpc/src/main/mima-filters/2.0.0-M3.backwards.excludes/Akka-gRPC-upgrade
@@ -1,0 +1,11 @@
+ProblemFilters.exclude[Problem]("com.google.*")
+
+ProblemFilters.exclude[Problem]("akka.stream.alpakka.googlecloud.pubsub.grpc.javadsl.GrpcPublisher.create")
+ProblemFilters.exclude[Problem]("akka.stream.alpakka.googlecloud.pubsub.grpc.javadsl.GrpcPublisher.this")
+ProblemFilters.exclude[Problem]("akka.stream.alpakka.googlecloud.pubsub.grpc.javadsl.GrpcSubscriber.create")
+ProblemFilters.exclude[Problem]("akka.stream.alpakka.googlecloud.pubsub.grpc.javadsl.GrpcSubscriber.this")
+
+ProblemFilters.exclude[Problem]("akka.stream.alpakka.googlecloud.pubsub.grpc.scaladsl.GrpcPublisher.apply")
+ProblemFilters.exclude[Problem]("akka.stream.alpakka.googlecloud.pubsub.grpc.scaladsl.GrpcPublisher.this")
+ProblemFilters.exclude[Problem]("akka.stream.alpakka.googlecloud.pubsub.grpc.scaladsl.GrpcSubscriber.apply")
+ProblemFilters.exclude[Problem]("akka.stream.alpakka.googlecloud.pubsub.grpc.scaladsl.GrpcSubscriber.this")

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/PubSubSettings.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/PubSubSettings.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.googlecloud.pubsub.grpc
 
-import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.stream.alpakka.googlecloud.pubsub.grpc.impl.GrpcCredentials
 import com.typesafe.config.Config
 import io.grpc.CallCredentials
@@ -89,9 +89,14 @@ object PubSubSettings {
   }
 
   /**
-   * Create settings from ActorSystem's config.
+   * Create settings from the new actor API's ActorSystem config.
    */
-  def apply(system: ActorSystem): PubSubSettings =
+  def apply(system: ClassicActorSystemProvider): PubSubSettings = apply(system.classicSystem)
+
+  /**
+   * Create settings from a classic ActorSystem's config.
+   */
+  def apply(system: akka.actor.ActorSystem): PubSubSettings =
     PubSubSettings(system.settings.config.getConfig("alpakka.google.cloud.pubsub.grpc"))
 
   /**
@@ -116,6 +121,13 @@ object PubSubSettings {
    *
    * Create settings from ActorSystem's config.
    */
-  def create(system: ActorSystem): PubSubSettings =
+  def create(system: ClassicActorSystemProvider): PubSubSettings = PubSubSettings(system.classicSystem)
+
+  /**
+   * Java API
+   *
+   * Create settings from a classic ActorSystem's config.
+   */
+  def create(system: akka.actor.ActorSystem): PubSubSettings =
     PubSubSettings(system)
 }

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GrpcPublisher.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GrpcPublisher.scala
@@ -4,40 +4,60 @@
 
 package akka.stream.alpakka.googlecloud.pubsub.grpc.javadsl
 
-import akka.actor.{ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import akka.actor.{
+  ActorSystem,
+  ClassicActorSystemProvider,
+  ExtendedActorSystem,
+  Extension,
+  ExtensionId,
+  ExtensionIdProvider
+}
 import akka.annotation.ApiMayChange
 import akka.stream.alpakka.googlecloud.pubsub.grpc.PubSubSettings
 import akka.stream.alpakka.googlecloud.pubsub.grpc.impl.AkkaGrpcSettings
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.SystemMaterializer
 import com.google.pubsub.v1.{PublisherClient => JavaPublisherClient}
 
 /**
  * Holds the gRPC java publisher client instance.
  */
-final class GrpcPublisher private (settings: PubSubSettings, sys: ActorSystem, mat: Materializer) {
+final class GrpcPublisher private (settings: PubSubSettings, sys: ActorSystem) {
 
   @ApiMayChange
   final val client =
-    JavaPublisherClient.create(AkkaGrpcSettings.fromPubSubSettings(settings)(sys), mat, sys.dispatcher)
+    JavaPublisherClient.create(AkkaGrpcSettings.fromPubSubSettings(settings)(sys),
+                               SystemMaterializer(sys).materializer,
+                               sys.dispatcher)
 
   sys.registerOnTermination(client.close())
 }
 
 object GrpcPublisher {
-  def create(settings: PubSubSettings, sys: ActorSystem, mat: Materializer): GrpcPublisher =
-    new GrpcPublisher(settings, sys, mat)
 
-  def create(sys: ActorSystem, mat: Materializer): GrpcPublisher =
-    create(PubSubSettings(sys), sys, mat)
+  /**
+   * Creates a publisher with the new actors API.
+   */
+  def create(settings: PubSubSettings, sys: ClassicActorSystemProvider): GrpcPublisher =
+    create(settings, sys.classicSystem)
+
+  def create(settings: PubSubSettings, sys: ActorSystem): GrpcPublisher =
+    new GrpcPublisher(settings, sys)
+
+  /**
+   * Creates a publisher with the new actors API.
+   */
+  def create(sys: ClassicActorSystemProvider): GrpcPublisher =
+    create(sys.classicSystem)
+
+  def create(sys: ActorSystem): GrpcPublisher =
+    create(PubSubSettings(sys), sys)
 }
 
 /**
  * An extension that manages a single gRPC java publisher client per actor system.
  */
 final class GrpcPublisherExt private (sys: ExtendedActorSystem) extends Extension {
-  private[this] val systemMaterializer = ActorMaterializer()(sys)
-
-  implicit val publisher = GrpcPublisher.create(sys, systemMaterializer)
+  implicit val publisher = GrpcPublisher.create(sys)
 }
 
 object GrpcPublisherExt extends ExtensionId[GrpcPublisherExt] with ExtensionIdProvider {
@@ -55,4 +75,11 @@ object GrpcPublisherExt extends ExtensionId[GrpcPublisherExt] with ExtensionIdPr
    * Access to extension.
    */
   override def get(system: ActorSystem): GrpcPublisherExt = super.get(system)
+
+  /**
+   * Java API
+   *
+   * Access to the extension from the new actors API.
+   */
+  def get(system: ClassicActorSystemProvider): GrpcPublisherExt = super.get(system.classicSystem)
 }

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GrpcSubscriber.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GrpcSubscriber.scala
@@ -4,40 +4,59 @@
 
 package akka.stream.alpakka.googlecloud.pubsub.grpc.javadsl
 
-import akka.actor.{ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import akka.actor.{
+  ActorSystem,
+  ClassicActorSystemProvider,
+  ExtendedActorSystem,
+  Extension,
+  ExtensionId,
+  ExtensionIdProvider
+}
 import akka.annotation.ApiMayChange
 import akka.stream.alpakka.googlecloud.pubsub.grpc.PubSubSettings
 import akka.stream.alpakka.googlecloud.pubsub.grpc.impl.AkkaGrpcSettings
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.SystemMaterializer
 import com.google.pubsub.v1.{SubscriberClient => JavaSubscriberClient}
 
 /**
  * Holds the gRPC java subscriber client instance.
  */
-final class GrpcSubscriber private (settings: PubSubSettings, sys: ActorSystem, mat: Materializer) {
+final class GrpcSubscriber private (settings: PubSubSettings, sys: ActorSystem) {
 
   @ApiMayChange
   final val client =
-    JavaSubscriberClient.create(AkkaGrpcSettings.fromPubSubSettings(settings)(sys), mat, sys.dispatcher)
+    JavaSubscriberClient.create(AkkaGrpcSettings.fromPubSubSettings(settings)(sys),
+                                SystemMaterializer(sys).materializer,
+                                sys.dispatcher)
 
   sys.registerOnTermination(client.close())
 }
 
 object GrpcSubscriber {
-  def create(settings: PubSubSettings, sys: ActorSystem, mat: Materializer): GrpcSubscriber =
-    new GrpcSubscriber(settings, sys, mat)
 
-  def create(sys: ActorSystem, mat: Materializer): GrpcSubscriber =
-    create(PubSubSettings(sys), sys, mat)
+  /**
+   * Creates a publisher with the new actors API.
+   */
+  def create(settings: PubSubSettings, sys: ClassicActorSystemProvider): GrpcSubscriber =
+    create(settings, sys.classicSystem)
+
+  def create(settings: PubSubSettings, sys: ActorSystem): GrpcSubscriber =
+    new GrpcSubscriber(settings, sys)
+
+  /**
+   * Creates a publisher with the new actors API.
+   */
+  def create(sys: ClassicActorSystemProvider): GrpcSubscriber = create(sys.classicSystem)
+
+  def create(sys: ActorSystem): GrpcSubscriber =
+    create(PubSubSettings(sys), sys)
 }
 
 /**
  * An extension that manages a single gRPC java subscriber client per actor system.
  */
 final class GrpcSubscriberExt private (sys: ExtendedActorSystem) extends Extension {
-  private[this] val systemMaterializer = ActorMaterializer()(sys)
-
-  implicit val subscriber = GrpcSubscriber.create(sys, systemMaterializer)
+  implicit val subscriber = GrpcSubscriber.create(sys)
 }
 
 object GrpcSubscriberExt extends ExtensionId[GrpcSubscriberExt] with ExtensionIdProvider {
@@ -55,4 +74,11 @@ object GrpcSubscriberExt extends ExtensionId[GrpcSubscriberExt] with ExtensionId
    * Access to extension.
    */
   override def get(system: ActorSystem): GrpcSubscriberExt = super.get(system)
+
+  /**
+   * Java API
+   *
+   * Access to the extension from the new actors API.
+   */
+  def get(system: ClassicActorSystemProvider): GrpcSubscriberExt = super.get(system.classicSystem)
 }

--- a/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java
+++ b/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java
@@ -176,7 +176,7 @@ public class IntegrationTest {
   public void customPublisher() {
     // #attributes
     final PubSubSettings settings = PubSubSettings.create(system);
-    final GrpcPublisher publisher = GrpcPublisher.create(settings, system, materializer);
+    final GrpcPublisher publisher = GrpcPublisher.create(settings, system);
 
     final Flow<PublishRequest, PublishResponse, NotUsed> publishFlow =
         GooglePubSub.publish(1).withAttributes(PubSubAttributes.publisher(publisher));

--- a/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
+++ b/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
@@ -173,7 +173,7 @@ class IntegrationSpec
       val subNoAckResp = GooglePubSub.subscribe(sub, 1.second).runWith(Sink.head)
 
       inside(subNoAckResp.futureValue.message) {
-        case Some(PubsubMessage(data, _, _, _, _)) => data.toStringUtf8 shouldBe msg
+        case Some(PubsubMessage(data, _, _, _, _, _)) => data.toStringUtf8 shouldBe msg
       }
 
       // subscribe and get the republished message, and ack this time
@@ -187,7 +187,7 @@ class IntegrationSpec
         .runWith(Sink.head)
 
       inside(subWithAckResp.futureValue.message) {
-        case Some(PubsubMessage(data, _, _, _, _)) => data.toStringUtf8 shouldBe msg
+        case Some(PubsubMessage(data, _, _, _, _, _)) => data.toStringUtf8 shouldBe msg
       }
 
       // check if the message is not republished again

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,6 +20,8 @@ object Dependencies {
   val AwsSdkVersion = "1.11.476"
   val AwsSdk2Version = "2.10.60"
   val AwsSpiAkkaHttpVersion = "0.0.7"
+  // Sync with plugins.sbt
+  val AkkaGrpcBinaryVersion = "0.8"
   val AkkaHttpVersion = "10.1.11"
   val AkkaHttpBinaryVersion = "10.1"
   val mockitoVersion = "3.1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -218,9 +218,9 @@ object Dependencies {
     // see Akka gRPC version in plugins.sbt
     libraryDependencies ++= Seq(
         // https://github.com/googleapis/java-pubsub/tree/master/proto-google-cloud-pubsub-v1/
-        "com.google.api.grpc" % "grpc-google-cloud-pubsub-v1" % "1.84.0" % "protobuf", // ApacheV2
-        "io.grpc" % "grpc-auth" % "1.25.0", // ApacheV2
-        "com.google.auth" % "google-auth-library-oauth2-http" % "0.19.0", // BSD 3-clause
+        "com.google.api.grpc" % "grpc-google-cloud-pubsub-v1" % "1.85.1" % "protobuf", // ApacheV2
+        "io.grpc" % "grpc-auth" % "1.28.0", // ApacheV2
+        "com.google.auth" % "google-auth-library-oauth2-http" % "0.20.0", // BSD 3-clause
         // pull in Akka Discovery for our Akka version
         "com.typesafe.akka" %% "akka-discovery" % AkkaVersion
       ) ++ Silencer

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.1")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
-// Akka gRPC
+// Akka gRPC -- sync with version in Dependencies.scala
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.8.0")
 // #grpc-agent
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
 // Akka gRPC
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.7.3")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.8.0")
 // #grpc-agent
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")
 // #grpc-agent


### PR DESCRIPTION
Complement the factory methods with methods for `ClassicActorSystemProvider` which makes it usable without changed for the new actors API's `akka.actor.typed.ActorSystem` without depending on that module.

This can't be compiled against Akka 2.6 as `ExtensionId` in that version contains the `get(ClassicActorSystemProvider)` method so it requires an `override`.

**Upgrades to Akka 2.5.30 and Akka gRPC 0.8.0**


See #2194, #2195, #2197 