### PR TITLE
AWS connectos: mark com.github.matsluni.aws-spi-akka-http as test

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -87,7 +87,7 @@ object Dependencies {
   val AwsLambda = Seq(
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion, // ApacheV2
-        "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion excludeAll // ApacheV2
+        "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion % Test excludeAll // ApacheV2
         (
           ExclusionRule(organization = "com.typesafe.akka")
         ),
@@ -145,7 +145,7 @@ object Dependencies {
 
   val DynamoDB = Seq(
     libraryDependencies ++= Seq(
-        "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion excludeAll // ApacheV2
+        "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion % Test excludeAll // ApacheV2
         (
           ExclusionRule(organization = "com.typesafe.akka")
         ),
@@ -304,7 +304,7 @@ object Dependencies {
   val Kinesis = Seq(
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion, // ApacheV2
-        "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion excludeAll ExclusionRule(
+        "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion % Test excludeAll ExclusionRule(
           organization = "com.typesafe.akka"
         )
       ) ++ Seq(
@@ -401,7 +401,7 @@ object Dependencies {
 
   val Sns = Seq(
     libraryDependencies ++= Seq(
-        "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion excludeAll // ApacheV2
+        "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion % Test excludeAll // ApacheV2
         (
           ExclusionRule(organization = "com.typesafe.akka")
         ),
@@ -429,7 +429,7 @@ object Dependencies {
 
   val Sqs = Seq(
     libraryDependencies ++= Seq(
-        "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion excludeAll // ApacheV2
+        "com.github.matsluni" %% "aws-spi-akka-http" % AwsSpiAkkaHttpVersion % Test excludeAll // ApacheV2
         (
           ExclusionRule(organization = "com.typesafe.akka")
         ),


### PR DESCRIPTION
Trying to construct an aws client when depending on alpakka and the aws sdk v2 library fails due to the following exception:

> software.amazon.awssdk.core.exception.SdkClientException: Multiple HTTP implementations were found on the classpath. To avoid non-deterministic loading implementations, please explicitly provide an HTTP client via the client builders, set the software.amazon.awssdk.http.async.service.impl system property with the FQCN of the HTTP service to use as the default, or remove all but one
HTTP implementation from the classpath

Excluding the akka spi http transitive dependency fixes the problem:

```
"com.lightbend.akka" %% "akka-stream-alpakka-dynamodb" % versions.alpakka exclude("com.github.matsluni", "aws-spi-akka-http")
```

Since this library is only used in examples, I suggest that we mark it as a test dependency so that users must explicitly include the akka spi http client if they wish to use it, and only those users will have to handle this exception (by specifying the akka spi http client within the aws client builder).