### PR TITLE
API docs: exclude MQTT streaming

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,12 +76,14 @@ lazy val alpakka = project
         .filterNot(_.data.getAbsolutePath.contains("guava-28.1-android.jar"))
         .filterNot(_.data.getAbsolutePath.contains("commons-net-3.1.jar"))
         .filterNot(_.data.getAbsolutePath.contains("protobuf-java-2.6.1.jar"))
-        // Some projects require (and introduce) Akka 2.6:
-        .filterNot(_.data.getAbsolutePath.contains("akka-stream_2.12-2.5.27.jar"))
     },
-    ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(`doc-examples`,
-                                                                             csvBench,
-                                                                             mqttStreamingBench),
+    ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject --
+      inProjects(`doc-examples`,
+                 csvBench,
+                 // Add back when on Akka 2.6
+                 // https://github.com/akka/alpakka/issues/2203
+                 mqttStreaming,
+                 mqttStreamingBench),
     crossScalaVersions := List() // workaround for https://github.com/sbt/sbt/issues/3465
   )
 


### PR DESCRIPTION
Fixes #2203

The API doc generation can be added back to Unidoc when we drop Akka 2.5 #2054