### PR TITLE
MQTT Streaming: improve logging

### DIFF
--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/scaladsl/MqttSession.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import akka.actor.ExtendedActorSystem
 import akka.actor.typed.scaladsl.adapter._
-import akka.event.Logging
+import akka.event.{Logging, LoggingAdapter}
 import akka.stream._
 import akka.stream.alpakka.mqtt.streaming.impl._
 import akka.stream.scaladsl.{BroadcastHub, Flow, Keep, Source}
@@ -160,6 +160,8 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit mat: 
   import MqttCodec._
   import MqttSession._
   import system.dispatcher
+
+  private implicit val loggingAdapter: LoggingAdapter = Logging(system, this.getClass)
 
   override def ![A](cp: Command[A]): Unit = cp match {
     case Command(cp: Publish, _, carry) =>
@@ -499,6 +501,8 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit mat: 
   import MqttCodec._
   import MqttSession._
   import system.dispatcher
+
+  private implicit val loggingAdapter: LoggingAdapter = Logging(system, this.getClass)
 
   override def ![A](cp: Command[A]): Unit = cp match {
     case Command(cp: Publish, _, carry) =>

--- a/mqtt-streaming/src/test/resources/logback-test.xml
+++ b/mqtt-streaming/src/test/resources/logback-test.xml
@@ -19,8 +19,8 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <logger name="akka" level="DEBUG"/>
-    <logger name="akka.stream" level="info" />
+    <logger name="akka" level="INFO"/>
+    <logger name="akka.stream" level="INFO" />
     <logger name="akka.stream.alpakka" level="debug" />
     <logger name="akka.stream.alpakka.mqtt.streaming.impl" level="info" />
 

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -26,7 +26,9 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class UntypedMqttFlowSpec
-    extends ParametrizedTestKit("untyped-flow-spec/flow", "typed-flow-spec/topic1", ActorSystem("UntypedMqttFlowSpec"))
+    extends ParametrizedTestKit("untyped-flow-spec/flow",
+                                "untyped-flow-spec/topic1",
+                                ActorSystem("UntypedMqttFlowSpec"))
     with MqttFlowSpec
 class TypedMqttFlowSpec
     extends ParametrizedTestKit("typed-flow-spec/flow",

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -8,6 +8,7 @@ import akka.{Done, NotUsed}
 import akka.actor.ActorSystem
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
+import akka.event.{Logging, LoggingAdapter}
 import akka.stream.alpakka.mqtt.streaming._
 import akka.stream.alpakka.mqtt.streaming.scaladsl.{ActorMqttClientSession, ActorMqttServerSession, Mqtt}
 import akka.stream.scaladsl.{BroadcastHub, Flow, Keep, Sink, Source, SourceQueueWithComplete, Tcp}
@@ -43,6 +44,8 @@ trait MqttFlowSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll 
   private implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = 5.seconds, interval = 100.millis)
 
   private implicit val dispatcherExecutionContext: ExecutionContext = system.dispatcher
+
+  implicit val logAdapter: LoggingAdapter = Logging(system, this.getClass.getName)
 
   override def afterAll(): Unit =
     TestKit.shutdownActorSystem(system)
@@ -155,6 +158,7 @@ trait MqttFlowSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll 
         Source
           .queue(2, OverflowStrategy.fail)
           .via(mqttFlow)
+          .log("received")
           .collect {
             case Right(Event(p: Publish, _)) => p
           }


### PR DESCRIPTION
Add logging adapters so that log messages get the FQCN that issues it as log category instead of `Materializer`.

Add an extra logging that may help to identify the cause of #1549 