### PR TITLE
AWS S3: add methods for the new actors API

### DIFF
--- a/s3/src/main/mima-filters/2.0.0-M3.backwards.excludes
+++ b/s3/src/main/mima-filters/2.0.0-M3.backwards.excludes
@@ -1,2 +1,5 @@
 # MiMa upgrade
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.s3.S3Settings.this")
+
+# override of apply in extension with the concrete type instead of the generic type
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.alpakka.s3.S3Ext.apply")

--- a/s3/src/main/scala/akka/stream/alpakka/s3/S3Ext.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/S3Ext.scala
@@ -3,7 +3,7 @@
  */
 
 package akka.stream.alpakka.s3
-import akka.actor.{ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import akka.actor.{ClassicActorSystemProvider, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
 
 /**
  * Manages one [[S3Settings]] per `ActorSystem`.
@@ -18,6 +18,27 @@ object S3Ext extends ExtensionId[S3Ext] with ExtensionIdProvider {
   override def lookup = S3Ext
   override def createExtension(system: ExtendedActorSystem) = new S3Ext(system)
 
-  /** Java API */
-  override def get(system: ActorSystem): S3Ext = super.get(system)
+  /**
+   * Get the S3 extension with the classic actors API.
+   */
+  override def apply(system: akka.actor.ActorSystem): S3Ext = super.apply(system)
+
+  // This is not source compatible with Akka 2.6 as it lacks `overrride`
+  /**
+   * Get the S3 extension with the new actors API.
+   */
+  def apply(system: ClassicActorSystemProvider): S3Ext = super.apply(system.classicSystem)
+
+  /**
+   * Java API.
+   * Get the S3 extension with the classic actors API.
+   */
+  override def get(system: akka.actor.ActorSystem): S3Ext = super.apply(system)
+
+  // This is not source compatible with Akka 2.6 as it lacks `overrride`
+  /**
+   * Java API.
+   * Get the S3 extension with the new actors API.
+   */
+  def get(system: ClassicActorSystemProvider): S3Ext = super.apply(system.classicSystem)
 }


### PR DESCRIPTION
Complement the `S3Ext` extension with access methods for `ClassicActorSystemProvider` which makes it usable without changed for the new actors API's `akka.actor.typed.ActorSystem` without depending on that module.

This can't be compiled against Akka 2.6 as `ExtensionId` in that version contains the `apply(ClassicActorSystemProvider)` method so it requires an `override` modifier in `S3Ext`.

See #2194, #2195, #2197