### PR TITLE
Unix Domain Socket: add access with new actors API

### DIFF
--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/javadsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/javadsl/UnixDomainSocket.scala
@@ -12,8 +12,7 @@ import java.util.concurrent.CompletionStage
 import scala.compat.java8.OptionConverters._
 import scala.compat.java8.FutureConverters._
 import akka.NotUsed
-import akka.actor.{ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
-import akka.stream.alpakka.unixdomainsocket.scaladsl.{UnixDomainSocket => ScalaUnixDomainSocket}
+import akka.actor.{ClassicActorSystemProvider, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
 import akka.stream.javadsl.{Flow, Source}
 import akka.stream.Materializer
 import akka.util.ByteString
@@ -25,7 +24,7 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
   /**
    * Represents a prospective UnixDomainSocket server binding.
    */
-  final class ServerBinding private[akka] (delegate: ScalaUnixDomainSocket.ServerBinding) {
+  final class ServerBinding private[akka] (delegate: scaladsl.UnixDomainSocket.ServerBinding) {
 
     /**
      * The local address of the endpoint bound by the materialization of the `connections` [[akka.stream.javadsl.Source Source]].
@@ -44,7 +43,7 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
   /**
    * Represents an accepted incoming UnixDomainSocket connection.
    */
-  final class IncomingConnection private[akka] (delegate: ScalaUnixDomainSocket.IncomingConnection) {
+  final class IncomingConnection private[akka] (delegate: scaladsl.UnixDomainSocket.IncomingConnection) {
 
     /**
      * The local address this connection is bound to.
@@ -75,7 +74,7 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
   /**
    * Represents a prospective outgoing UnixDomainSocket connection.
    */
-  final class OutgoingConnection private[akka] (delegate: ScalaUnixDomainSocket.OutgoingConnection) {
+  final class OutgoingConnection private[akka] (delegate: scaladsl.UnixDomainSocket.OutgoingConnection) {
 
     /**
      * The remote address this connection is or will be bound to.
@@ -88,8 +87,15 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
     def localAddress: UnixSocketAddress = delegate.localAddress
   }
 
-  override def get(system: ActorSystem): UnixDomainSocket =
-    super.get(system)
+  /**
+   * Get the UnixDomainSocket extension with the classic actors API.
+   */
+  override def get(system: akka.actor.ActorSystem): UnixDomainSocket = super.apply(system)
+
+  /**
+   * Get the UnixDomainSocket extension with the new actors API.
+   */
+  def get(system: ClassicActorSystemProvider): UnixDomainSocket = super.apply(system.classicSystem)
 
   def lookup(): ExtensionId[_ <: Extension] =
     UnixDomainSocket
@@ -102,7 +108,7 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends akka.actor.Ext
   import UnixDomainSocket._
   import akka.dispatch.ExecutionContexts.{sameThreadExecutionContext => ec}
 
-  private lazy val delegate: ScalaUnixDomainSocket = ScalaUnixDomainSocket(system)
+  private lazy val delegate: scaladsl.UnixDomainSocket = scaladsl.UnixDomainSocket(system)
 
   /**
    * Creates a [[UnixDomainSocket.ServerBinding]] instance which represents a prospective UnixDomainSocket server binding on the given `endpoint`.

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -8,7 +8,7 @@ package scaladsl
 import java.nio.file.Path
 
 import akka.NotUsed
-import akka.actor.{ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import akka.actor.{ClassicActorSystemProvider, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
 import akka.stream._
 import akka.stream.alpakka.unixdomainsocket.impl.UnixDomainSocketImpl
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
@@ -19,7 +19,15 @@ import scala.concurrent.duration.Duration
 
 object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdProvider {
 
-  def apply()(implicit system: ActorSystem): UnixDomainSocket = super.apply(system)
+  /**
+   * Get the UnixDomainSocket extension with the classic actors API.
+   */
+  def apply()(implicit system: akka.actor.ActorSystem): UnixDomainSocket = super.apply(system)
+
+  /**
+   * Get the UnixDomainSocket extension with the new actors API.
+   */
+  def apply(system: ClassicActorSystemProvider): UnixDomainSocket = super.apply(system.classicSystem)
 
   override def createExtension(system: ExtendedActorSystem) =
     new UnixDomainSocket(system)


### PR DESCRIPTION
Complement the `UnixDomainSocket` extensions with access methods for `ClassicActorSystemProvider` which makes it usable without changed for the new actors API's `akka.actor.typed.ActorSystem` without depending on that module.

This can't be compiled against Akka 2.6 as `ExtensionId` in that version contains the `apply(ClassicActorSystemProvider)` method so it requires an `override` modifier in `UnixDomainSocket`.

See #2194, #2195, #2197, #2211