### PR TITLE
Google Cloud Storage: add access with new actors API

### DIFF
--- a/google-cloud-storage/src/main/mima-filters/2.0.0-M3.backwards.excludes
+++ b/google-cloud-storage/src/main/mima-filters/2.0.0-M3.backwards.excludes
@@ -15,3 +15,6 @@ ProblemFilters.exclude[MissingClassProblem]("main.scala.*")
 ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.googlecloud.storage.StorageObject.*")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.alpakka.googlecloud.storage.StorageObject.withCustomerEncryption")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.alpakka.googlecloud.storage.StorageObject.withOwner")
+
+# override of apply in extension with the concrete type instead of the generic type
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.alpakka.googlecloud.storage.GCStorageExt.apply")

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/GCStorageExt.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/GCStorageExt.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.googlecloud.storage
 
-import akka.actor.{ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import akka.actor.{ClassicActorSystemProvider, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
 
 /**
  * Manages one [[GCStorageSettings]] per `ActorSystem`.
@@ -19,6 +19,25 @@ object GCStorageExt extends ExtensionId[GCStorageExt] with ExtensionIdProvider {
   override def lookup = GCStorageExt
   override def createExtension(system: ExtendedActorSystem) = new GCStorageExt(system)
 
-  /** Java API */
-  override def get(system: ActorSystem): GCStorageExt = super.get(system)
+  /**
+   * Get the GCS extension with the classic actors API.
+   */
+  override def apply(system: akka.actor.ActorSystem): GCStorageExt = super.apply(system)
+
+  /**
+   * Get the GCS extension with the new actors API.
+   */
+  def apply(system: ClassicActorSystemProvider): GCStorageExt = super.apply(system.classicSystem)
+
+  /**
+   * Java API.
+   * Get the GCS extension with the classic actors API.
+   */
+  override def get(system: akka.actor.ActorSystem): GCStorageExt = super.apply(system)
+
+  /**
+   * Java API.
+   * Get the GCS extension with the new actors API.
+   */
+  def get(system: ClassicActorSystemProvider): GCStorageExt = super.apply(system.classicSystem)
 }


### PR DESCRIPTION
Complement the `GCStorageExt` extension with access methods for `ClassicActorSystemProvider` which makes it usable without changed for the new actors API's `akka.actor.typed.ActorSystem` without depending on that module.

This can't be compiled against Akka 2.6 as `ExtensionId` in that version contains the `apply(ClassicActorSystemProvider)` method so it requires an `override` modifier in `GCStorageExt`.

See #2194, #2195, #2197, #2211, #2212 