### PR TITLE
Cassandra: new actors API in Metrics Registry

### DIFF
--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/CassandraMetricsRegistry.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/CassandraMetricsRegistry.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.cassandra
 
-import akka.actor._
+import akka.actor.{ClassicActorSystemProvider, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
 import akka.annotation.InternalApi
 import com.codahale.metrics.MetricRegistry
 
@@ -38,6 +38,26 @@ object CassandraMetricsRegistry extends ExtensionId[CassandraMetricsRegistry] wi
   override def lookup = CassandraMetricsRegistry
   override def createExtension(system: ExtendedActorSystem) =
     new CassandraMetricsRegistry
-  override def get(system: ActorSystem): CassandraMetricsRegistry =
-    super.get(system)
+
+  /**
+   * Get the CassandraMetricsRegistry extension with the classic actors API.
+   */
+  override def apply(system: akka.actor.ActorSystem): CassandraMetricsRegistry = super.apply(system)
+
+  /**
+   * Get the CassandraMetricsRegistry extension with the new actors API.
+   */
+  def apply(system: ClassicActorSystemProvider): CassandraMetricsRegistry = super.apply(system.classicSystem)
+
+  /**
+   * Java API.
+   * Get the CassandraMetricsRegistry extension with the classic actors API.
+   */
+  override def get(system: akka.actor.ActorSystem): CassandraMetricsRegistry = super.apply(system)
+
+  /**
+   * Java API.
+   * Get the CassandraMetricsRegistry extension with the classic actors API.
+   */
+  def get(system: ClassicActorSystemProvider): CassandraMetricsRegistry = super.apply(system.classicSystem)
 }


### PR DESCRIPTION
Follow-up on #2195 to make support creating the Metrics Registry from the new actors API.

References #2195