### PR TITLE
Google Cloud Pub/Sub: require JSON responses

### DIFF
--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/impl/PubSubApi.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/impl/PubSubApi.scala
@@ -164,7 +164,7 @@ private[pubsub] trait PubSubApi {
       .mapAsync(1) {
         case Success(response) =>
           response.status match {
-            case StatusCodes.Success(_) =>
+            case StatusCodes.Success(_) if response.entity.contentType == ContentTypes.`application/json` =>
               Unmarshal(response).to[PullResponse]
             case status =>
               Unmarshal(response)
@@ -226,7 +226,7 @@ private[pubsub] trait PubSubApi {
       .mapAsync(parallelism) {
         case Success(response) =>
           response.status match {
-            case StatusCodes.Success(_) =>
+            case StatusCodes.Success(_) if response.entity.contentType == ContentTypes.`application/json` =>
               Unmarshal(response.entity).to[PublishResponse].map(_.messageIds)
             case status =>
               Unmarshal(response)

--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/impl/PubSubApi.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/impl/PubSubApi.scala
@@ -203,7 +203,9 @@ private[pubsub] trait PubSubApi {
               Unmarshal(response)
                 .to[String]
                 .map { entity =>
-                  throw new RuntimeException(s"Unexpected acknowledge response. Code: [$status]. Entity: [$entity]")
+                  throw new RuntimeException(
+                    s"Unexpected acknowledge response. Code [$status] Content-type [${response.entity.contentType}] Entity [$entity]"
+                  )
                 }
           }
         case Failure(NonFatal(ex)) => Future.failed(ex)
@@ -232,7 +234,9 @@ private[pubsub] trait PubSubApi {
               Unmarshal(response)
                 .to[String]
                 .map { entity =>
-                  throw new RuntimeException(s"Unexpected publish response. Code: [$status]. Entity: [$entity]")
+                  throw new RuntimeException(
+                    s"Unexpected publish response. Code [$status] Content-type [${response.entity.contentType}] Entity [$entity]"
+                  )
                 }
           }
         case Failure(NonFatal(ex)) =>

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
@@ -14,8 +14,10 @@ import akka.stream.alpakka.googlecloud.pubsub.scaladsl.GooglePubSub
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Flow, FlowWithContext, Sink, Source}
 import akka.stream.{ActorMaterializer, Materializer}
+import akka.testkit.TestKit
 import akka.{Done, NotUsed}
 import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -24,13 +26,23 @@ import org.scalatestplus.mockito.MockitoSugar
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
-class GooglePubSubSpec extends AnyFlatSpec with MockitoSugar with ScalaFutures with Matchers with LogCapturing {
+class GooglePubSubSpec
+    extends AnyFlatSpec
+    with MockitoSugar
+    with ScalaFutures
+    with Matchers
+    with LogCapturing
+    with BeforeAndAfterAll {
 
   implicit val defaultPatience =
     PatienceConfig(timeout = 5.seconds, interval = 100.millis)
 
   implicit val system = ActorSystem()
   implicit val mat = ActorMaterializer()
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
 
   private trait Fixtures {
     lazy val mockHttpApi = mock[PubSubApi]


### PR DESCRIPTION
Guard the HTTP response to be JSON before trying to deserialize it so that missing subscriptions aren't reported as marshalling problems.

References #1840
