### PR TITLE
Kinesis: more descriptive Source error log

### DIFF
--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisErrors.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/KinesisErrors.scala
@@ -11,14 +11,15 @@ object KinesisErrors {
   sealed trait KinesisSourceError extends NoStackTrace
   case object NoShardsError extends KinesisSourceError
   class GetShardIteratorError(val shardId: String, e: Throwable)
-      extends RuntimeException(s"Failed to get a shard iterator for shard [$shardId]", e)
+      extends RuntimeException(s"Failed to get a shard iterator for shard [$shardId]. Reason : ${e.getMessage}", e)
       with KinesisSourceError
   class GetRecordsError(val shardId: String, e: Throwable)
-      extends RuntimeException(s"Failed to fetch records from Kinesis for shard [$shardId]", e)
+      extends RuntimeException(s"Failed to fetch records from Kinesis for shard [$shardId]. Reason : ${e.getMessage}",
+                               e)
       with KinesisSourceError
 
   sealed trait KinesisFlowErrors extends NoStackTrace
   case class FailurePublishingRecords(e: Throwable)
-      extends RuntimeException("Failure publishing records to Kinesis", e)
+      extends RuntimeException(s"Failure publishing records to Kinesis. Reason : ${e.getMessage}", e)
       with KinesisFlowErrors
 }

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/impl/KinesisSourceStage.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/impl/KinesisSourceStage.scala
@@ -78,8 +78,9 @@ private[kinesis] class KinesisSourceStage(shardSettings: ShardSettings, amazonKi
           requestRecords()
 
         case (_, GetShardIteratorFailure(ex)) =>
-          log.error(ex, "Failed to get a shard iterator for shard {}", shardId)
-          failStage(new Errors.GetShardIteratorError(shardId, ex))
+          val error = new Errors.GetShardIteratorError(shardId, ex)
+          log.error(ex, error.getMessage)
+          failStage(error)
 
         case (_, Pump) =>
         case (_, msg) =>
@@ -104,8 +105,9 @@ private[kinesis] class KinesisSourceStage(shardSettings: ShardSettings, amazonKi
           }
 
         case (_, GetRecordsFailure(ex)) =>
-          log.error(ex, "Failed to fetch records from Kinesis for shard {}", shardId)
-          failStage(new Errors.GetRecordsError(shardId, ex))
+          val error = new Errors.GetRecordsError(shardId, ex)
+          log.error(ex, error.getMessage)
+          failStage(error)
 
         case (_, Pump) =>
         case (_, msg) =>


### PR DESCRIPTION
In one of my project, I'd like to further understand easily what are the cause of the errors when using `KinesisSourceStage`, further in my downstream handler. 
When failing to fetch the Kinesis shard for example, it will now tell you more detailed error message (such as when the Kinesis HTTP server fails to respond)