### PR TITLE
Cassandra: apply Netty exclusion; exclude all Tinkerpop and Esri Geometry depenencies

### DIFF
--- a/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
@@ -12,6 +12,7 @@ import akka.japi.Pair;
 import akka.stream.Materializer;
 import akka.stream.alpakka.cassandra.CassandraWriteSettings;
 import akka.stream.alpakka.cassandra.javadsl.CassandraFlow;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.SourceWithContext;
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
@@ -23,6 +24,7 @@ import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -40,6 +42,8 @@ public class CassandraFlowTest {
   static final String TEST_NAME = "CassandraFlowTest";
 
   static CassandraTestHelper helper;
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @BeforeClass
   public static void beforeAll() {

--- a/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
@@ -16,6 +16,7 @@ import akka.stream.alpakka.cassandra.javadsl.CassandraSessionRegistry;
 import akka.stream.alpakka.cassandra.javadsl.CassandraSource;
 // #cql
 import akka.stream.alpakka.cassandra.scaladsl.CassandraAccess;
+import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 // #statement
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
@@ -23,6 +24,7 @@ import com.datastax.oss.driver.api.core.cql.Statement;
 // #statement
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -44,6 +46,8 @@ public class CassandraSourceTest {
 
   static String idtable;
   static final List<Integer> data = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8);
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @BeforeClass
   public static void beforeAll() throws InterruptedException, ExecutionException, TimeoutException {

--- a/cassandra/src/test/resources/application.conf
+++ b/cassandra/src/test/resources/application.conf
@@ -53,6 +53,7 @@ datastax-java-driver-illegal-contact-point {
     contact-points = [ "127.0.0.1:8088" ]
     load-balancing-policy.local-datacenter = datacenter1
   }
+  advanced.reconnect-on-init = false
 }
 
 without-akka-discovery: ${alpakka.cassandra} {

--- a/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSpecBase.scala
+++ b/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSpecBase.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.cassandra.scaladsl
 
 import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -22,7 +23,8 @@ abstract class CassandraSpecBase(_system: ActorSystem)
     with BeforeAndAfterEach
     with BeforeAndAfterAll
     with Matchers
-    with CassandraLifecycle {
+    with CassandraLifecycle
+    with LogCapturing {
 
   implicit val materializer: Materializer = SystemMaterializer(_system).materializer
   implicit val ec: ExecutionContext = system.dispatcher

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -112,6 +112,7 @@ object Dependencies {
   val CassandraVersionInDocs = "4.0"
   val CassandraDriverVersion = "4.5.0"
   val CassandraDriverVersionInDocs = "4.5"
+  // https://github.com/akka/alpakka/issues/2226
   // Performance dropped by ~40% when the driver upgraded to latest netty version
   // override for now https://datastax-oss.atlassian.net/browse/JAVA-2676
   val CassandraOverrideNettyVersion = "4.1.39.Final"
@@ -120,9 +121,9 @@ object Dependencies {
     libraryDependencies ++= Seq(
         ("com.datastax.oss" % "java-driver-core" % CassandraDriverVersion)
           .exclude("com.github.spotbugs", "spotbugs-annotations")
-          .exclude("org.apache.tinkerpop", "gremlin-core"), //https://github.com/akka/alpakka/issues/2200
+          .exclude("org.apache.tinkerpop", "gremlin-core") //https://github.com/akka/alpakka/issues/2200
+          .exclude("io.netty", "netty-handler"), // https://github.com/akka/alpakka/issues/2226
         "io.netty" % "netty-handler" % CassandraOverrideNettyVersion,
-        "io.netty" % "netty-all" % CassandraOverrideNettyVersion,
         "com.typesafe.akka" %% "akka-discovery" % AkkaVersion % Provided
       )
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -110,7 +110,7 @@ object Dependencies {
   )
 
   val CassandraVersionInDocs = "4.0"
-  val CassandraDriverVersion = "4.5.0"
+  val CassandraDriverVersion = "4.5.1"
   val CassandraDriverVersionInDocs = "4.5"
   // https://github.com/akka/alpakka/issues/2226
   // Performance dropped by ~40% when the driver upgraded to latest netty version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,8 +74,8 @@ object Dependencies {
   // Releases https://github.com/FasterXML/jackson-databind/releases
   // CVE issues https://github.com/FasterXML/jackson-databind/issues?utf8=%E2%9C%93&q=+label%3ACVE
   // This should align with the version used in Akka 2.6.x
-  // https://github.com/akka/akka/blob/master/project/Dependencies.scala#L24
-  val JacksonDatabindVersion = "2.10.0"
+  // https://github.com/akka/akka/blob/master/project/Dependencies.scala#L23
+  val JacksonDatabindVersion = "2.10.3"
   val JacksonDatabindDependencies = Seq(
     "com.fasterxml.jackson.core" % "jackson-core" % JacksonDatabindVersion,
     "com.fasterxml.jackson.core" % "jackson-databind" % JacksonDatabindVersion
@@ -121,11 +121,12 @@ object Dependencies {
     libraryDependencies ++= Seq(
         ("com.datastax.oss" % "java-driver-core" % CassandraDriverVersion)
           .exclude("com.github.spotbugs", "spotbugs-annotations")
-          .exclude("org.apache.tinkerpop", "gremlin-core") //https://github.com/akka/alpakka/issues/2200
+          .exclude("org.apache.tinkerpop", "*") //https://github.com/akka/alpakka/issues/2200
+          .exclude("com.esri.geometry", "esri-geometry-api") //https://github.com/akka/alpakka/issues/2225
           .exclude("io.netty", "netty-handler"), // https://github.com/akka/alpakka/issues/2226
         "io.netty" % "netty-handler" % CassandraOverrideNettyVersion,
         "com.typesafe.akka" %% "akka-discovery" % AkkaVersion % Provided
-      )
+      ) ++ JacksonDatabindDependencies
   )
 
   val Couchbase = Seq(


### PR DESCRIPTION
* Apply log capturing to Cassandra tests
* Exclude the Netty dependency
* Exclude all Tinkerpop dependencies (see #2200)
* Upgrade Jackson Databind to 2.10.3 to align with Akka 2.6 (add add explicitly to Cassandra dependencies)

## Background
The fix to the performance issued that were traced down to Netty, did not exclude the Netty dependency. https://github.com/akka/akka-persistence-cassandra/pull/730

This should be removed, once it is fixed in the Netty version the Cassandra Java driver pulls in. Filed #2226 