### PR TITLE
Akka 2.5.31 and prefer `ClassicActorSystemProvider`

### DIFF
--- a/cassandra/src/main/resources/reference.conf
+++ b/cassandra/src/main/resources/reference.conf
@@ -1,7 +1,7 @@
 alpakka.cassandra {
   # The implementation of `akka.stream.alpakka.cassandra.CqlSessionProvider`
   # used for creating the `CqlSession`.
-  # It may optionally have a constructor with an `ActorSystem` and `Config` parameters.
+  # It may optionally have a constructor with an `ClassicActorSystemProvider` and `Config` parameters.
   session-provider = "akka.stream.alpakka.cassandra.DefaultSessionProvider"
 
   # Configure Akka Discovery by setting a service name

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/AkkaDiscoverySessionProvider.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/AkkaDiscoverySessionProvider.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.cassandra
 
 import akka.ConfigurationException
-import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.discovery.Discovery
 import akka.util.JavaDurationConverters._
 import com.datastax.oss.driver.api.core.CqlSession
@@ -56,7 +56,7 @@ import scala.concurrent.{ExecutionContext, Future}
  */
 private[cassandra] object AkkaDiscoverySessionProvider {
 
-  def connect(system: ActorSystem, config: Config)(implicit ec: ExecutionContext): Future[CqlSession] = {
+  def connect(system: ClassicActorSystemProvider, config: Config)(implicit ec: ExecutionContext): Future[CqlSession] = {
     readNodes(config)(system, ec).flatMap { contactPoints =>
       val driverConfigWithContactPoints = ConfigFactory.parseString(s"""
         basic.contact-points = [${contactPoints.mkString("\"", "\", \"", "\"")}]
@@ -69,7 +69,7 @@ private[cassandra] object AkkaDiscoverySessionProvider {
   /**
    * Expect a `service` section in Config and use Akka Discovery to read the addresses for `name` within `lookup-timeout`.
    */
-  private def readNodes(config: Config)(implicit system: ActorSystem,
+  private def readNodes(config: Config)(implicit system: ClassicActorSystemProvider,
                                         ec: ExecutionContext): Future[immutable.Seq[String]] = {
     val serviceConfig = config.getConfig("service-discovery")
     val serviceName = serviceConfig.getString("name")
@@ -83,7 +83,7 @@ private[cassandra] object AkkaDiscoverySessionProvider {
   private def readNodes(
       serviceName: String,
       lookupTimeout: FiniteDuration
-  )(implicit system: ActorSystem, ec: ExecutionContext): Future[immutable.Seq[String]] = {
+  )(implicit system: ClassicActorSystemProvider, ec: ExecutionContext): Future[immutable.Seq[String]] = {
     Discovery(system).discovery.lookup(serviceName, lookupTimeout).map { resolved =>
       resolved.addresses.map { target =>
         target.host + ":" + target.port.getOrElse {

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/CassandraMetricsRegistry.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/CassandraMetricsRegistry.scala
@@ -40,16 +40,6 @@ object CassandraMetricsRegistry extends ExtensionId[CassandraMetricsRegistry] wi
     new CassandraMetricsRegistry
 
   /**
-   * Get the CassandraMetricsRegistry extension with the classic actors API.
-   */
-  override def apply(system: akka.actor.ActorSystem): CassandraMetricsRegistry = super.apply(system)
-
-  /**
-   * Get the CassandraMetricsRegistry extension with the new actors API.
-   */
-  def apply(system: ClassicActorSystemProvider): CassandraMetricsRegistry = super.apply(system.classicSystem)
-
-  /**
    * Java API.
    * Get the CassandraMetricsRegistry extension with the classic actors API.
    */
@@ -59,5 +49,5 @@ object CassandraMetricsRegistry extends ExtensionId[CassandraMetricsRegistry] wi
    * Java API.
    * Get the CassandraMetricsRegistry extension with the classic actors API.
    */
-  def get(system: ClassicActorSystemProvider): CassandraMetricsRegistry = super.apply(system.classicSystem)
+  override def get(system: ClassicActorSystemProvider): CassandraMetricsRegistry = super.apply(system)
 }

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/CqlSessionProvider.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/CqlSessionProvider.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.cassandra
 
-import akka.actor.{ClassicActorSystemProvider, ExtendedActorSystem}
+import akka.actor.{ActorSystem, ExtendedActorSystem}
 import com.datastax.oss.driver.api.core.CqlSession
 import com.typesafe.config.{Config, ConfigFactory}
 
@@ -36,7 +36,7 @@ trait CqlSessionProvider {
  * driver's configuration can be defined with `datastax-java-driver-config` property in the
  * given `config`.
  */
-class DefaultSessionProvider(system: ClassicActorSystemProvider, config: Config) extends CqlSessionProvider {
+class DefaultSessionProvider(system: ActorSystem, config: Config) extends CqlSessionProvider {
 
   /**
    * Check if Akka Discovery service lookup should be used. It is part of this class so it
@@ -70,7 +70,7 @@ object CqlSessionProvider {
     def instantiate(args: immutable.Seq[(Class[_], AnyRef)]) =
       dynamicAccess.createInstanceFor[CqlSessionProvider](clazz, args)
 
-    val params = List((classOf[ClassicActorSystemProvider], system), (classOf[Config], config))
+    val params = List((classOf[ActorSystem], system), (classOf[Config], config))
     instantiate(params)
       .recoverWith {
         case x: NoSuchMethodException => instantiate(params.take(1))
@@ -94,7 +94,7 @@ object CqlSessionProvider {
    * driver's configuration can be defined with `datastax-java-driver-config` property in the
    * given `config`. `datastax-java-driver` configuration section is also used as fallback.
    */
-  def driverConfig(system: ClassicActorSystemProvider, config: Config): Config = {
+  def driverConfig(system: ActorSystem, config: Config): Config = {
     val driverConfigPath = config.getString("datastax-java-driver-config")
     system.classicSystem.settings.config.getConfig(driverConfigPath).withFallback {
       if (driverConfigPath == "datastax-java-driver") ConfigFactory.empty()

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraSessionRegistry.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraSessionRegistry.scala
@@ -24,7 +24,7 @@ object CassandraSessionRegistry {
    * Get the session registry with new actors API.
    */
   def get(system: ClassicActorSystemProvider): CassandraSessionRegistry =
-    new CassandraSessionRegistry(scaladsl.CassandraSessionRegistry(system.classicSystem))
+    new CassandraSessionRegistry(scaladsl.CassandraSessionRegistry(system))
 
   /**
    * Get the session registry with the classic actors API.

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSessionRegistry.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSessionRegistry.scala
@@ -10,14 +10,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import akka.Done
-import akka.actor.{
-  ActorSystem,
-  ClassicActorSystemProvider,
-  ExtendedActorSystem,
-  Extension,
-  ExtensionId,
-  ExtensionIdProvider
-}
+import akka.actor.{ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
 import akka.annotation.InternalStableApi
 import akka.event.Logging
 import akka.stream.alpakka.cassandra.{CassandraSessionSettings, CqlSessionProvider}
@@ -33,12 +26,6 @@ object CassandraSessionRegistry extends ExtensionId[CassandraSessionRegistry] wi
 
   def createExtension(system: ExtendedActorSystem): CassandraSessionRegistry =
     new CassandraSessionRegistry(system)
-
-  override def apply(system: ActorSystem): CassandraSessionRegistry = super.apply(system)
-
-  // This is not source compatible with Akka 2.6 as it lacks `overrride`
-  def apply(system: ClassicActorSystemProvider): CassandraSessionRegistry =
-    apply(system.classicSystem)
 
   override def lookup(): ExtensionId[CassandraSessionRegistry] = this
 

--- a/couchbase/src/main/java/akka/stream/alpakka/couchbase/javadsl/DiscoverySupport.java
+++ b/couchbase/src/main/java/akka/stream/alpakka/couchbase/javadsl/DiscoverySupport.java
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.couchbase.javadsl;
 
 import akka.actor.ActorSystem;
+import akka.actor.ClassicActorSystemProvider;
 import akka.stream.alpakka.couchbase.CouchbaseSessionSettings;
 import com.typesafe.config.Config;
 
@@ -38,6 +39,16 @@ public final class DiscoverySupport {
       getNodes(ActorSystem system) {
     return SUPPORT.getNodes(
         system.settings().config().getConfig(CouchbaseSessionSettings.configPath()), system);
+  }
+
+  /**
+   * Expects a `service` section in the given Config and reads the given service name's address to
+   * be used as Couchbase `nodes`.
+   */
+  public static final java.util.function.Function<
+          CouchbaseSessionSettings, CompletionStage<CouchbaseSessionSettings>>
+      getNodes(ClassicActorSystemProvider system) {
+    return getNodes(system.classicSystem());
   }
 
   private DiscoverySupport() {}

--- a/couchbase/src/main/mima-filters/2.0.0-RC1.backwards.excludes/ClassicActorSystemProvider.excludes
+++ b/couchbase/src/main/mima-filters/2.0.0-RC1.backwards.excludes/ClassicActorSystemProvider.excludes
@@ -1,0 +1,2 @@
+# Internal API now accepts ClassicActorSystemProvider
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.alpakka.couchbase.scaladsl.DiscoverySupport.getNodes")

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/CouchbaseSessionRegistry.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/CouchbaseSessionRegistry.scala
@@ -27,24 +27,10 @@ object CouchbaseSessionRegistry extends ExtensionId[CouchbaseSessionRegistry] wi
     new CouchbaseSessionRegistry(system)
 
   /**
-   * Get the session registry with new actors API.
-   */
-  // This is not source compatible with Akka 2.6 as it lacks `overrride`
-  def apply(system: ClassicActorSystemProvider): CouchbaseSessionRegistry =
-    super.apply(system.classicSystem)
-
-  /**
-   * Get the session registry with the classic actors API.
-   */
-  override def apply(system: akka.actor.ActorSystem): CouchbaseSessionRegistry =
-    super.apply(system)
-
-  /**
    * Java API: Get the session registry with new actors API.
    */
-  // This is not source compatible with Akka 2.6 as it lacks `overrride`
-  def get(system: ClassicActorSystemProvider): CouchbaseSessionRegistry =
-    super.apply(system.classicSystem)
+  override def get(system: ClassicActorSystemProvider): CouchbaseSessionRegistry =
+    super.apply(system)
 
   /**
    * Java API: Get the session registry with the classic actors API.

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GooglePubSub.scala
@@ -131,11 +131,11 @@ object GooglePubSub {
     attr
       .get[PubSubAttributes.Publisher]
       .map(_.publisher)
-      .getOrElse(GrpcPublisherExt()(mat.system).publisher)
+      .getOrElse(GrpcPublisherExt.get(mat.system).publisher)
 
   private def subscriber(mat: ActorMaterializer, attr: Attributes) =
     attr
       .get[PubSubAttributes.Subscriber]
       .map(_.subscriber)
-      .getOrElse(GrpcSubscriberExt()(mat.system).subscriber)
+      .getOrElse(GrpcSubscriberExt.get(mat.system).subscriber)
 }

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GrpcPublisher.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GrpcPublisher.scala
@@ -67,6 +67,7 @@ object GrpcPublisherExt extends ExtensionId[GrpcPublisherExt] with ExtensionIdPr
   /**
    * Access to extension.
    */
+  @deprecated("use get() instead", since = "2.0.0")
   def apply()(implicit system: ActorSystem): GrpcPublisherExt = super.apply(system)
 
   /**
@@ -81,5 +82,5 @@ object GrpcPublisherExt extends ExtensionId[GrpcPublisherExt] with ExtensionIdPr
    *
    * Access to the extension from the new actors API.
    */
-  def get(system: ClassicActorSystemProvider): GrpcPublisherExt = super.get(system.classicSystem)
+  override def get(system: ClassicActorSystemProvider): GrpcPublisherExt = super.get(system)
 }

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GrpcSubscriber.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GrpcSubscriber.scala
@@ -66,6 +66,7 @@ object GrpcSubscriberExt extends ExtensionId[GrpcSubscriberExt] with ExtensionId
   /**
    * Access to extension.
    */
+  @deprecated("use get() instead", since = "2.0.0")
   def apply()(implicit system: ActorSystem): GrpcSubscriberExt = super.apply(system)
 
   /**
@@ -80,5 +81,5 @@ object GrpcSubscriberExt extends ExtensionId[GrpcSubscriberExt] with ExtensionId
    *
    * Access to the extension from the new actors API.
    */
-  def get(system: ClassicActorSystemProvider): GrpcSubscriberExt = super.get(system.classicSystem)
+  override def get(system: ClassicActorSystemProvider): GrpcSubscriberExt = super.get(system.classicSystem)
 }

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/scaladsl/GrpcPublisher.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/scaladsl/GrpcPublisher.scala
@@ -51,14 +51,14 @@ object GrpcPublisherExt extends ExtensionId[GrpcPublisherExt] with ExtensionIdPr
   override def createExtension(system: ExtendedActorSystem) = new GrpcPublisherExt(system)
 
   /**
-   * Access to extension.
+   * Access to extension from the new and classic actors API.
    */
-  def apply()(implicit system: ActorSystem): GrpcPublisherExt = super.apply(system)
+  def apply()(implicit system: ClassicActorSystemProvider): GrpcPublisherExt = super.apply(system)
 
   /**
-   * Access to the extension from the new actors API.
+   * Access to the extension from the classic actors API.
    */
-  def apply(system: ClassicActorSystemProvider): GrpcPublisherExt = super.apply(system.classicSystem)
+  override def apply(system: akka.actor.ActorSystem): GrpcPublisherExt = super.apply(system)
 
   /**
    * Java API
@@ -66,4 +66,11 @@ object GrpcPublisherExt extends ExtensionId[GrpcPublisherExt] with ExtensionIdPr
    * Access to extension.
    */
   override def get(system: ActorSystem): GrpcPublisherExt = super.get(system)
+
+  /**
+   * Java API
+   *
+   * Access to extension.
+   */
+  override def get(system: ClassicActorSystemProvider): GrpcPublisherExt = super.get(system)
 }

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/scaladsl/GrpcPublisher.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/scaladsl/GrpcPublisher.scala
@@ -32,18 +32,24 @@ final class GrpcPublisher private (settings: PubSubSettings, sys: ActorSystem) {
 }
 
 object GrpcPublisher {
-  def apply(settings: PubSubSettings)(implicit sys: ActorSystem): GrpcPublisher =
+  def apply(settings: PubSubSettings)(implicit sys: ClassicActorSystemProvider): GrpcPublisher =
+    new GrpcPublisher(settings, sys.classicSystem)
+
+  def apply(settings: PubSubSettings, sys: ActorSystem): GrpcPublisher =
     new GrpcPublisher(settings, sys)
 
-  def apply()(implicit sys: ActorSystem): GrpcPublisher =
+  def apply()(implicit sys: ClassicActorSystemProvider): GrpcPublisher =
     apply(PubSubSettings(sys))
+
+  def apply(sys: ActorSystem): GrpcPublisher =
+    apply(PubSubSettings(sys), sys)
 }
 
 /**
  * An extension that manages a single gRPC scala publisher client per actor system.
  */
 final class GrpcPublisherExt private (sys: ExtendedActorSystem) extends Extension {
-  implicit val publisher = GrpcPublisher()(sys)
+  implicit val publisher = GrpcPublisher(sys: ActorSystem)
 }
 
 object GrpcPublisherExt extends ExtensionId[GrpcPublisherExt] with ExtensionIdProvider {

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/scaladsl/GrpcSubscriber.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/scaladsl/GrpcSubscriber.scala
@@ -51,14 +51,14 @@ object GrpcSubscriberExt extends ExtensionId[GrpcSubscriberExt] with ExtensionId
   override def createExtension(system: ExtendedActorSystem) = new GrpcSubscriberExt(system)
 
   /**
-   * Access to extension.
+   * Access to extension from the new and classic actors API.
    */
-  def apply()(implicit system: ActorSystem): GrpcSubscriberExt = super.apply(system)
+  def apply()(implicit system: ClassicActorSystemProvider): GrpcSubscriberExt = super.apply(system)
 
   /**
-   * Access to the extension from the new actors API.
+   * Access to the extension from the classic actors API.
    */
-  def apply(system: ClassicActorSystemProvider): GrpcSubscriberExt = super.apply(system.classicSystem)
+  override def apply(system: ActorSystem): GrpcSubscriberExt = super.apply(system)
 
   /**
    * Java API
@@ -66,4 +66,11 @@ object GrpcSubscriberExt extends ExtensionId[GrpcSubscriberExt] with ExtensionId
    * Access to extension.
    */
   override def get(system: ActorSystem): GrpcSubscriberExt = super.get(system)
+
+  /**
+   * Java API
+   *
+   * Access to extension.
+   */
+  override def get(system: ClassicActorSystemProvider): GrpcSubscriberExt = super.get(system)
 }

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/scaladsl/GrpcSubscriber.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/scaladsl/GrpcSubscriber.scala
@@ -32,18 +32,24 @@ final class GrpcSubscriber private (settings: PubSubSettings, sys: ActorSystem) 
 }
 
 object GrpcSubscriber {
-  def apply(settings: PubSubSettings)(implicit sys: ActorSystem): GrpcSubscriber =
+  def apply(settings: PubSubSettings)(implicit sys: ClassicActorSystemProvider): GrpcSubscriber =
+    new GrpcSubscriber(settings, sys.classicSystem)
+
+  def apply(settings: PubSubSettings, sys: ActorSystem): GrpcSubscriber =
     new GrpcSubscriber(settings, sys)
 
-  def apply()(implicit sys: ActorSystem): GrpcSubscriber =
+  def apply()(implicit sys: ClassicActorSystemProvider): GrpcSubscriber =
     apply(PubSubSettings(sys))
+
+  def apply(sys: ActorSystem): GrpcSubscriber =
+    apply(PubSubSettings(sys), sys)
 }
 
 /**
  * An extension that manages a single gRPC scala subscriber client per actor system.
  */
 final class GrpcSubscriberExt private (sys: ExtendedActorSystem) extends Extension {
-  implicit val subscriber = GrpcSubscriber()(sys)
+  implicit val subscriber = GrpcSubscriber(sys: ActorSystem)
 }
 
 object GrpcSubscriberExt extends ExtensionId[GrpcSubscriberExt] with ExtensionIdProvider {

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/GCStorageExt.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/GCStorageExt.scala
@@ -20,16 +20,6 @@ object GCStorageExt extends ExtensionId[GCStorageExt] with ExtensionIdProvider {
   override def createExtension(system: ExtendedActorSystem) = new GCStorageExt(system)
 
   /**
-   * Get the GCS extension with the classic actors API.
-   */
-  override def apply(system: akka.actor.ActorSystem): GCStorageExt = super.apply(system)
-
-  /**
-   * Get the GCS extension with the new actors API.
-   */
-  def apply(system: ClassicActorSystemProvider): GCStorageExt = super.apply(system.classicSystem)
-
-  /**
    * Java API.
    * Get the GCS extension with the classic actors API.
    */
@@ -39,5 +29,5 @@ object GCStorageExt extends ExtensionId[GCStorageExt] with ExtensionIdProvider {
    * Java API.
    * Get the GCS extension with the new actors API.
    */
-  def get(system: ClassicActorSystemProvider): GCStorageExt = super.apply(system.classicSystem)
+  override def get(system: ClassicActorSystemProvider): GCStorageExt = super.apply(system)
 }

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/GCStorageSettings.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/GCStorageSettings.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.googlecloud.storage
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, ClassicActorSystemProvider}
 import com.typesafe.config.Config
 
 final class GCStorageSettings private (
@@ -170,12 +170,22 @@ object GCStorageSettings {
   )
 
   /**
+   * Scala API: Creates [[GCStorageSettings]] from the [[com.typesafe.config.Config Config]] attached to an actor system.
+   */
+  def apply()(implicit system: ClassicActorSystemProvider): GCStorageSettings = apply(system.classicSystem)
+
+  /**
    * Scala API: Creates [[GCStorageSettings]] from the [[com.typesafe.config.Config Config]] attached to an [[akka.actor.ActorSystem]].
    */
-  def apply()(implicit system: ActorSystem): GCStorageSettings = apply(system.settings.config.getConfig(ConfigPath))
+  def apply(system: ActorSystem): GCStorageSettings = apply(system.settings.config.getConfig(ConfigPath))
+
+  /**
+   * Java API: Creates [[S3Settings]] from the [[com.typesafe.config.Config Config]] attached to an actor system.
+   */
+  def create(system: ClassicActorSystemProvider): GCStorageSettings = apply(system.classicSystem)
 
   /**
    * Java API: Creates [[S3Settings]] from the [[com.typesafe.config.Config Config]] attached to an [[akka.actor.ActorSystem]].
    */
-  def create(system: ActorSystem): GCStorageSettings = apply()(system)
+  def create(system: ActorSystem): GCStorageSettings = apply(system)
 }

--- a/kudu/src/main/mima-filters/2.0.0-RC1.backwards.excludes/ClassicActorSystemProvider.excludes
+++ b/kudu/src/main/mima-filters/2.0.0-RC1.backwards.excludes/ClassicActorSystemProvider.excludes
@@ -1,0 +1,2 @@
+# the get override required for Java users was missing
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.alpakka.kudu.KuduClientExt.get")

--- a/kudu/src/main/scala/akka/stream/alpakka/kudu/KuduClientExt.scala
+++ b/kudu/src/main/scala/akka/stream/alpakka/kudu/KuduClientExt.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.kudu
 
-import akka.actor.{ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import akka.actor.{ClassicActorSystemProvider, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
 import org.apache.kudu.client.KuduClient
 
 /**
@@ -22,4 +22,16 @@ final class KuduClientExt private (sys: ExtendedActorSystem) extends Extension {
 object KuduClientExt extends ExtensionId[KuduClientExt] with ExtensionIdProvider {
   override def lookup = KuduClientExt
   override def createExtension(system: ExtendedActorSystem) = new KuduClientExt(system)
+
+  /**
+   * Get the Kudu Client extension with the classic actors API.
+   * Java API.
+   */
+  override def get(system: akka.actor.ActorSystem): KuduClientExt = super.get(system)
+
+  /**
+   * Get the Kudu Client extension with the new actors API.
+   * Java API.
+   */
+  override def get(system: ClassicActorSystemProvider): KuduClientExt = super.get(system)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val Scala213 = "2.13.1"
   val ScalaVersions = Seq(Scala212, Scala211, Scala213).filterNot(_ == Scala211 && Nightly)
 
-  val Akka25Version = "2.5.30"
+  val Akka25Version = "2.5.31"
   val Akka26Version = "2.6.4"
   val AkkaVersion = if (Nightly) Akka26Version else Akka25Version
   val AkkaBinaryVersion = if (Nightly) "2.6" else "2.5"

--- a/reference/src/main/scala/akka/stream/alpakka/reference/Resource.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/Resource.scala
@@ -87,15 +87,15 @@ object ResourceSettings {
   /**
    * Resolves settings from the `ActorSystem`s settings.
    */
-  def apply()(implicit sys: ActorSystem): ResourceSettings =
-    ResourceSettings(sys.settings.config.getConfig(ConfigPath))
+  def apply()(implicit sys: ClassicActorSystemProvider): ResourceSettings =
+    ResourceSettings(sys.classicSystem.settings.config.getConfig(ConfigPath))
 
   /**
    * Java Api
    *
    * Resolves settings from the `ActorSystem`s settings.
    */
-  def create(sys: ActorSystem): ResourceSettings =
+  def create(sys: ClassicActorSystemProvider): ResourceSettings =
     ResourceSettings()(sys)
 }
 

--- a/reference/src/main/scala/akka/stream/alpakka/reference/Resource.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/Resource.scala
@@ -3,7 +3,14 @@
  */
 
 package akka.stream.alpakka.reference
-import akka.actor.{ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import akka.actor.{
+  ActorSystem,
+  ClassicActorSystemProvider,
+  ExtendedActorSystem,
+  Extension,
+  ExtensionId,
+  ExtensionIdProvider
+}
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import com.typesafe.config.Config
@@ -110,12 +117,17 @@ object ResourceExt extends ExtensionId[ResourceExt] with ExtensionIdProvider {
   /**
    * Access to extension.
    */
-  def apply()(implicit system: ActorSystem): ResourceExt = super.apply(system)
+  def apply()(implicit system: ClassicActorSystemProvider): ResourceExt = super.apply(system)
 
   /**
-   * Java API
-   *
    * Access to extension.
+   * Java API.
    */
   override def get(system: ActorSystem): ResourceExt = super.get(system)
+
+  /**
+   * Access to extension.
+   * Java API.
+   */
+  override def get(system: ClassicActorSystemProvider): ResourceExt = super.get(system)
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/S3Ext.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/S3Ext.scala
@@ -19,26 +19,14 @@ object S3Ext extends ExtensionId[S3Ext] with ExtensionIdProvider {
   override def createExtension(system: ExtendedActorSystem) = new S3Ext(system)
 
   /**
-   * Get the S3 extension with the classic actors API.
-   */
-  override def apply(system: akka.actor.ActorSystem): S3Ext = super.apply(system)
-
-  // This is not source compatible with Akka 2.6 as it lacks `overrride`
-  /**
-   * Get the S3 extension with the new actors API.
-   */
-  def apply(system: ClassicActorSystemProvider): S3Ext = super.apply(system.classicSystem)
-
-  /**
    * Java API.
    * Get the S3 extension with the classic actors API.
    */
   override def get(system: akka.actor.ActorSystem): S3Ext = super.apply(system)
 
-  // This is not source compatible with Akka 2.6 as it lacks `overrride`
   /**
    * Java API.
    * Get the S3 extension with the new actors API.
    */
-  def get(system: ClassicActorSystemProvider): S3Ext = super.apply(system.classicSystem)
+  override def get(system: ClassicActorSystemProvider): S3Ext = super.apply(system)
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
@@ -9,7 +9,7 @@ import java.util.{Objects, Optional}
 import java.util.concurrent.TimeUnit
 
 import scala.util.Try
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, ClassicActorSystemProvider}
 import akka.http.scaladsl.model.Uri
 import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.regions.providers._
@@ -541,14 +541,24 @@ object S3Settings {
   )
 
   /**
+   * Scala API: Creates [[S3Settings]] from the [[com.typesafe.config.Config Config]] attached to an actor system.
+   */
+  def apply()(implicit system: ClassicActorSystemProvider): S3Settings = apply(system.classicSystem)
+
+  /**
    * Scala API: Creates [[S3Settings]] from the [[com.typesafe.config.Config Config]] attached to an [[akka.actor.ActorSystem]].
    */
-  def apply()(implicit system: ActorSystem): S3Settings = apply(system.settings.config.getConfig(ConfigPath))
+  def apply(system: ActorSystem): S3Settings = apply(system.settings.config.getConfig(ConfigPath))
+
+  /**
+   * Java API: Creates [[S3Settings]] from the [[com.typesafe.config.Config Config]] attached to an actor system.
+   */
+  def create(system: ClassicActorSystemProvider): S3Settings = apply(system.classicSystem)
 
   /**
    * Java API: Creates [[S3Settings]] from the [[com.typesafe.config.Config Config]] attached to an [[akka.actor.ActorSystem]].
    */
-  def create(system: ActorSystem): S3Settings = apply()(system)
+  def create(system: ActorSystem): S3Settings = apply(system)
 }
 
 sealed trait BufferType {

--- a/udp/src/main/scala/akka/stream/alpakka/udp/scaladsl/Udp.scala
+++ b/udp/src/main/scala/akka/stream/alpakka/udp/scaladsl/Udp.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.udp.scaladsl
 import java.net.InetSocketAddress
 
 import akka.NotUsed
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, ClassicActorSystemProvider}
 import akka.stream.alpakka.udp.Datagram
 import akka.stream.alpakka.udp.impl.{UdpBindFlow, UdpSendFlow}
 import akka.stream.scaladsl.Sink
@@ -22,14 +22,28 @@ object Udp {
    * contained in the message. All incoming messages are also emitted from the flow for
    * subsequent processing.
    */
-  def sendFlow()(implicit system: ActorSystem): Flow[Datagram, Datagram, NotUsed] =
-    Flow.fromGraph(new UdpSendFlow())
+  def sendFlow()(implicit system: ClassicActorSystemProvider): Flow[Datagram, Datagram, NotUsed] =
+    sendFlow(system.classicSystem)
+
+  /**
+   * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
+   * contained in the message. All incoming messages are also emitted from the flow for
+   * subsequent processing.
+   */
+  def sendFlow(system: ActorSystem): Flow[Datagram, Datagram, NotUsed] =
+    Flow.fromGraph(new UdpSendFlow()(system))
 
   /**
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message.
    */
-  def sendSink()(implicit system: ActorSystem): Sink[Datagram, NotUsed] = sendFlow().to(Sink.ignore)
+  def sendSink()(implicit system: ClassicActorSystemProvider): Sink[Datagram, NotUsed] = sendFlow().to(Sink.ignore)
+
+  /**
+   * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
+   * contained in the message.
+   */
+  def sendSink(system: ActorSystem): Sink[Datagram, NotUsed] = sendFlow(system).to(Sink.ignore)
 
   /**
    * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
@@ -38,6 +52,15 @@ object Udp {
    */
   def bindFlow(
       localAddress: InetSocketAddress
-  )(implicit system: ActorSystem): Flow[Datagram, Datagram, Future[InetSocketAddress]] =
-    Flow.fromGraph(new UdpBindFlow(localAddress))
+  )(implicit system: ClassicActorSystemProvider): Flow[Datagram, Datagram, Future[InetSocketAddress]] =
+    bindFlow(localAddress, system.classicSystem)
+
+  /**
+   * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
+   * messages to the `localAddress` are emitted from the flow. All incoming messages to the flow
+   * are sent to the remote address contained in the message.
+   */
+  def bindFlow(localAddress: InetSocketAddress,
+               system: ActorSystem): Flow[Datagram, Datagram, Future[InetSocketAddress]] =
+    Flow.fromGraph(new UdpBindFlow(localAddress)(system))
 }

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/javadsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/javadsl/UnixDomainSocket.scala
@@ -95,7 +95,7 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
   /**
    * Get the UnixDomainSocket extension with the new actors API.
    */
-  def get(system: ClassicActorSystemProvider): UnixDomainSocket = super.apply(system.classicSystem)
+  override def get(system: ClassicActorSystemProvider): UnixDomainSocket = super.apply(system.classicSystem)
 
   def lookup(): ExtensionId[_ <: Extension] =
     UnixDomainSocket
@@ -108,7 +108,7 @@ final class UnixDomainSocket(system: ExtendedActorSystem) extends akka.actor.Ext
   import UnixDomainSocket._
   import akka.dispatch.ExecutionContexts.{sameThreadExecutionContext => ec}
 
-  private lazy val delegate: scaladsl.UnixDomainSocket = scaladsl.UnixDomainSocket(system)
+  private lazy val delegate: scaladsl.UnixDomainSocket = scaladsl.UnixDomainSocket.apply(system)
 
   /**
    * Creates a [[UnixDomainSocket.ServerBinding]] instance which represents a prospective UnixDomainSocket server binding on the given `endpoint`.

--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -20,14 +20,14 @@ import scala.concurrent.duration.Duration
 object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdProvider {
 
   /**
-   * Get the UnixDomainSocket extension with the classic actors API.
+   * Get the UnixDomainSocket extension with the classic or new actors API.
    */
-  def apply()(implicit system: akka.actor.ActorSystem): UnixDomainSocket = super.apply(system)
+  def apply()(implicit system: ClassicActorSystemProvider): UnixDomainSocket = super.apply(system)
 
   /**
-   * Get the UnixDomainSocket extension with the new actors API.
+   * Get the UnixDomainSocket extension with the classic actors API.
    */
-  def apply(system: ClassicActorSystemProvider): UnixDomainSocket = super.apply(system.classicSystem)
+  override def apply(system: akka.actor.ActorSystem): UnixDomainSocket = super.apply(system)
 
   override def createExtension(system: ExtendedActorSystem) =
     new UnixDomainSocket(system)


### PR DESCRIPTION
In Akka 2.5.31 the `ClassicActorSystemProvider` is actually implemented by the `akka.actor.ActorSystem` and `akka.actor.typed.ActorSystem[_]` so that it can be used to accept both types of actor systems.

With this PR the Alpakka APIs prefer the provider so that integration with the new actor APIs doesn't need any adapter in user code.