### PR TITLE
JMS: create settings from new actors API

### DIFF
--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsBrowseSettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsBrowseSettings.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.jms
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, ClassicActorSystemProvider}
 import com.typesafe.config.{Config, ConfigValueType}
 
 /**
@@ -123,6 +123,16 @@ object JmsBrowseSettings {
     apply(actorSystem.settings.config.getConfig(configPath), connectionFactory)
 
   /**
+   * Reads from the default config provided by the actor system at `alpakka.jms.browse`.
+   *
+   * @param actorSystem The actor system
+   * @param connectionFactory Factory to use for creating JMS connections.
+   */
+  def apply(actorSystem: ClassicActorSystemProvider,
+            connectionFactory: javax.jms.ConnectionFactory): JmsBrowseSettings =
+    apply(actorSystem.classicSystem, connectionFactory)
+
+  /**
    * Java API: Reads from the default config provided by the actor system at `alpakka.jms.browse`.
    *
    * @param actorSystem The actor system
@@ -130,5 +140,15 @@ object JmsBrowseSettings {
    */
   def create(actorSystem: ActorSystem, connectionFactory: javax.jms.ConnectionFactory): JmsBrowseSettings =
     apply(actorSystem, connectionFactory)
+
+  /**
+   * Java API: Reads from the default config provided by the actor system at `alpakka.jms.browse`.
+   *
+   * @param actorSystem The actor system
+   * @param connectionFactory Factory to use for creating JMS connections.
+   */
+  def create(actorSystem: ClassicActorSystemProvider,
+             connectionFactory: javax.jms.ConnectionFactory): JmsBrowseSettings =
+    apply(actorSystem.classicSystem, connectionFactory)
 
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.jms
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, ClassicActorSystemProvider}
 import akka.util.JavaDurationConverters._
 import com.typesafe.config.{Config, ConfigValueType}
 
@@ -185,6 +185,16 @@ object JmsConsumerSettings {
     apply(actorSystem.settings.config.getConfig(configPath), connectionFactory)
 
   /**
+   * Reads from the default config provided by the actor system at `alpakka.jms.consumer`.
+   *
+   * @param actorSystem The actor system
+   * @param connectionFactory Factory to use for creating JMS connections.
+   */
+  def apply(actorSystem: ClassicActorSystemProvider,
+            connectionFactory: javax.jms.ConnectionFactory): JmsConsumerSettings =
+    apply(actorSystem.classicSystem, connectionFactory)
+
+  /**
    * Java API: Reads from the given config.
    *
    * @param c Config instance read configuration from
@@ -201,4 +211,14 @@ object JmsConsumerSettings {
    */
   def create(actorSystem: ActorSystem, connectionFactory: javax.jms.ConnectionFactory): JmsConsumerSettings =
     apply(actorSystem, connectionFactory)
+
+  /**
+   * Java API: Reads from the default config provided by the actor system at `alpakka.jms.consumer`.
+   *
+   * @param actorSystem The actor system
+   * @param connectionFactory Factory to use for creating JMS connections.
+   */
+  def create(actorSystem: ClassicActorSystemProvider,
+             connectionFactory: javax.jms.ConnectionFactory): JmsConsumerSettings =
+    apply(actorSystem.classicSystem, connectionFactory)
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerSettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsProducerSettings.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.jms
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, ClassicActorSystemProvider}
 import akka.util.JavaDurationConverters._
 import com.typesafe.config.{Config, ConfigValueType}
 
@@ -152,6 +152,16 @@ object JmsProducerSettings {
     apply(actorSystem.settings.config.getConfig(configPath), connectionFactory)
 
   /**
+   * Reads from the default config provided by the actor system at `alpakka.jms.producer`.
+   *
+   * @param actorSystem The actor system
+   * @param connectionFactory Factory to use for creating JMS connections.
+   */
+  def apply(actorSystem: ClassicActorSystemProvider,
+            connectionFactory: javax.jms.ConnectionFactory): JmsProducerSettings =
+    apply(actorSystem.classicSystem, connectionFactory)
+
+  /**
    * Java API: Reads from the given config.
    *
    * @param c Config instance read configuration from
@@ -168,5 +178,15 @@ object JmsProducerSettings {
    */
   def create(actorSystem: ActorSystem, connectionFactory: javax.jms.ConnectionFactory): JmsProducerSettings =
     apply(actorSystem, connectionFactory)
+
+  /**
+   * Java API: Reads from the default config provided by the actor system at `alpakka.jms.producer`.
+   *
+   * @param actorSystem The actor system
+   * @param connectionFactory Factory to use for creating JMS connections.
+   */
+  def create(actorSystem: ClassicActorSystemProvider,
+             connectionFactory: javax.jms.ConnectionFactory): JmsProducerSettings =
+    apply(actorSystem.classicSystem, connectionFactory)
 
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/SendRetrySettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/SendRetrySettings.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.alpakka.jms
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, ClassicActorSystemProvider}
 import com.typesafe.config.Config
 
 import scala.concurrent.duration._
@@ -100,10 +100,25 @@ object SendRetrySettings {
     apply(actorSystem.settings.config.getConfig(configPath))
 
   /**
+   * Reads from the default config provided by the actor system at `alpakka.jms.send-retry`.
+   *
+   * @param actorSystem The actor system
+   */
+  def apply(actorSystem: ClassicActorSystemProvider): SendRetrySettings =
+    apply(actorSystem.classicSystem)
+
+  /**
    * Java API: Reads from the default config provided by the actor system at `alpakka.jms.send-retry`.
    *
    * @param actorSystem The actor system
    */
   def create(actorSystem: ActorSystem): SendRetrySettings = apply(actorSystem)
+
+  /**
+   * Java API: Reads from the default config provided by the actor system at `alpakka.jms.send-retry`.
+   *
+   * @param actorSystem The actor system
+   */
+  def create(actorSystem: ClassicActorSystemProvider): SendRetrySettings = apply(actorSystem.classicSystem)
 
 }


### PR DESCRIPTION
Allows passing an actor system of the new actors API without conversion on the user side.