### PR TITLE
AMQP: fix StackOverflowException in AbstractAmqpAsyncFlowStageLogic

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AbstractAmqpAsyncFlowStageLogic.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AbstractAmqpAsyncFlowStageLogic.scala
@@ -114,7 +114,7 @@ import scala.concurrent.Promise
 
   override def onFailure(ex: Throwable): Unit = {
     streamCompletion.tryFailure(ex)
-    onFailure(ex)
+    super.onFailure(ex)
   }
 
   def dequeueAwaitingMessages(tag: DeliveryTag, multiple: Boolean): Iterable[AwaitingMessage[T]]


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Fixes StackOverflowException which occurs if AMQP publishing stage with delivery confirmation fails on connection, channel, ...  creation.