### PR TITLE
File: TAR archive reader

### DIFF
--- a/docs/src/main/paradox/file.md
+++ b/docs/src/main/paradox/file.md
@@ -184,8 +184,9 @@ Java
 
 ## TAR Archive
 
-The @apidoc[Archive$]
-contains flow for packaging multiple files into one TAR file.
+### Writing TAR archives
+
+@apidoc[Archive.tar()](Archive$) creates a flow for packaging multiple files into one TAR archive.
 
 Result of flow can be send to sink even before whole TAR file is created, so size of resulting TAR archive
 is not limited to memory size.
@@ -205,3 +206,16 @@ Scala
 
 Java
 : @@snip [snip](/file/src/test/java/docs/javadsl/ArchiveTest.java) { #sample-tar-gz }
+
+
+### Reading TAR archives
+
+@apidoc[Archive.tarReader()](Archive$) reads a stream of `ByteString`s as TAR format emitting the metadata entry and a `Source` for every file in the stream. It is essential to request all the emitted source's data, otherwise the stream will not reach the next file entry.
+
+The example below reads the incoming stream and stores all files in the local file system.
+
+Scala
+: @@snip [snip](/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala) { #tar-reader }
+
+Java
+: @@snip [snip](/file/src/test/java/docs/javadsl/ArchiveTest.java) { #tar-reader }

--- a/docs/src/main/paradox/file.md
+++ b/docs/src/main/paradox/file.md
@@ -193,7 +193,7 @@ is not limited to memory size.
 This example usage shows packaging files from disk.
 
 Scala
-: @@snip [snip](/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala) { #sample-tar }
+: @@snip [snip](/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala) { #sample-tar }
 
 Java
 : @@snip [snip](/file/src/test/java/docs/javadsl/ArchiveTest.java) { #sample-tar }
@@ -201,7 +201,7 @@ Java
 To produce a gzipped TAR file see the following example.
 
 Scala
-: @@snip [snip](/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala) { #sample-tar-gz }
+: @@snip [snip](/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala) { #sample-tar-gz }
 
 Java
 : @@snip [snip](/file/src/test/java/docs/javadsl/ArchiveTest.java) { #sample-tar-gz }

--- a/file/src/main/mima-filters/2.0.0-RC2.backwards.excludes/PR2268-tar-reader.excludes
+++ b/file/src/main/mima-filters/2.0.0-RC2.backwards.excludes/PR2268-tar-reader.excludes
@@ -1,0 +1,2 @@
+# change to private constructor
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.file.TarArchiveMetadata.this")

--- a/file/src/main/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntry.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntry.scala
@@ -143,7 +143,8 @@ import akka.util.ByteString
     val lastModificationBytes =
       padded(ByteString(toOctalString(metadata.lastModification.getEpochSecond)), lastModificationLength)
     // [345, 500)
-    val fileNamePrefixBytes = padded(ByteString(metadata.filePathPrefix), fileNamePrefixLength)
+    val fileNamePrefixBytes =
+      padded(metadata.filePathPrefix.map(ByteString.apply).getOrElse(ByteString.empty), fileNamePrefixLength)
 
     padded(
       fileNameBytes ++ fixedData1 ++ fileSizeBytes ++ lastModificationBytes ++ fixedData2 ++ fileNamePrefixBytes,

--- a/file/src/main/scala/akka/stream/alpakka/file/impl/archive/TarReaderStage.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/impl/archive/TarReaderStage.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.stream.alpakka.file.impl.archive
 
 import akka.NotUsed

--- a/file/src/main/scala/akka/stream/alpakka/file/impl/archive/TarReaderStage.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/impl/archive/TarReaderStage.scala
@@ -1,0 +1,232 @@
+package akka.stream.alpakka.file.impl.archive
+
+import akka.NotUsed
+import akka.annotation.InternalApi
+import akka.stream.alpakka.file.{TarArchiveMetadata, TarReaderException}
+import akka.stream.scaladsl.Source
+import akka.stream.stage._
+import akka.stream._
+import akka.util.ByteString
+
+/**
+ * Internal API.
+ */
+@InternalApi
+private[file] class TarReaderStage
+    extends GraphStage[FlowShape[ByteString, (TarArchiveMetadata, Source[ByteString, NotUsed])]] {
+
+  private val flowIn = Inlet[ByteString]("flowIn")
+  private val flowOut = Outlet[(TarArchiveMetadata, Source[ByteString, NotUsed])]("flowOut")
+  override val shape: FlowShape[ByteString, (TarArchiveMetadata, Source[ByteString, NotUsed])] =
+    FlowShape(flowIn, flowOut)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new TimerGraphStageLogic(shape) with StageLogging {
+
+      val ignoreFlowOutPull: OutHandler = new OutHandler {
+        override def onPull(): Unit = ()
+      }
+
+      val expectFlowPull: OutHandler = new OutHandler {
+        override def onPull(): Unit = {
+          pull(flowIn)
+          setHandler(flowOut, ignoreFlowOutPull)
+        }
+      }
+      val failOnFlowPush: InHandler = new InHandler {
+        override def onPush(): Unit = failStage(new TarReaderException("upstream pushed"))
+        override def onUpstreamFinish(): Unit = setKeepGoing(true)
+      }
+
+      setHandler(flowIn, readHeader(ByteString.empty))
+      setHandler(flowOut, expectFlowPull)
+
+      def readHeader(buffer: ByteString): InHandler = {
+        if (buffer.length >= TarArchiveEntry.headerLength) {
+          readFile(buffer)
+        } else new CollectHeader(buffer)
+      }
+
+      def readFile(headerBuffer: ByteString): InHandler = {
+        def pushSource(metadata: TarArchiveMetadata, buffer: ByteString): InHandler = {
+          if (buffer.length >= metadata.size) {
+            val (emit, remain) = buffer.splitAt(metadata.size.toInt)
+            log.debug(s"emitting completed source for $metadata")
+            push(flowOut, metadata -> Source.single(emit))
+            readTrailer(metadata, remain, subSource = None)
+          } else new CollectFile(metadata, buffer)
+        }
+
+        val metadata = TarArchiveEntry.parse(headerBuffer)
+        val buffer = headerBuffer.drop(TarArchiveEntry.headerLength)
+        if (isAvailable(flowOut)) {
+          pushSource(metadata, buffer)
+        } else {
+          // await flow demand
+          setHandler(flowOut, new OutHandler {
+            override def onPull(): Unit = {
+              setHandler(flowIn, pushSource(metadata, buffer))
+            }
+          })
+          failOnFlowPush
+        }
+      }
+
+      def readTrailer(metadata: TarArchiveMetadata,
+                      buffer: ByteString,
+                      subSource: Option[SubSourceOutlet[ByteString]]): InHandler = {
+        val trailerLength = TarArchiveEntry.trailerLength(metadata)
+        if (buffer.length >= trailerLength) {
+          subSource.foreach(_.complete())
+          if (isClosed(flowIn)) completeStage()
+          readHeader(buffer.drop(trailerLength))
+        } else new ReadPastTrailer(metadata, buffer, subSource)
+      }
+
+      private final case class SubscriptionTimeout(subSource: SubSourceOutlet[_])
+
+      override protected def onTimer(timerKey: Any): Unit = {
+        timerKey match {
+          case SubscriptionTimeout(subSource) =>
+            import StreamSubscriptionTimeoutTerminationMode._
+            val materializer = ActorMaterializerHelper.downcast(interpreter.materializer)
+            val timeoutSettings = materializer.settings.subscriptionTimeoutSettings
+            val timeout = timeoutSettings.timeout
+
+            timeoutSettings.mode match {
+              case CancelTermination =>
+                subSource.timeout(timeout)
+                failStage(
+                  new TarReaderException(
+                    s"The tar content source was not subscribed to within $timeout, it must be subscribed to to progress tar file reading."
+                  )
+                )
+              case WarnTermination =>
+                log.warning(
+                  "The tar content source was not subscribed to within {}, it must be subscribed to to progress tar file reading.",
+                  timeout
+                )
+              case NoopTermination =>
+            }
+        }
+      }
+
+      /**
+       * Handler until the header of 512 bytes is completely received.
+       */
+      private final class CollectHeader(var buffer: ByteString) extends InHandler {
+
+        override def onPush(): Unit = {
+          buffer ++= grab(flowIn)
+          if (buffer.length >= TarArchiveEntry.headerLength) {
+            setHandler(flowIn, readFile(buffer))
+          } else pull(flowIn)
+        }
+
+        override def onUpstreamFinish(): Unit = {
+          if (buffer.isEmpty) completeStage()
+          else
+            failStage(
+              new TarReaderException(
+                s"incomplete tar header: received ${buffer.length} bytes, expected ${TarArchiveEntry.headerLength} bytes"
+              )
+            )
+        }
+      }
+
+      /**
+       * Handler during file content reading.
+       */
+      private final class CollectFile(metadata: TarArchiveMetadata, var buffer: ByteString) extends InHandler {
+        private var emitted: Long = 0
+        private var flowInPulled = false
+
+        private val subSource: SubSourceOutlet[ByteString] = {
+          val sub = new SubSourceOutlet[ByteString]("fileOut")
+          val timeoutSignal = SubscriptionTimeout(sub)
+          sub.setHandler(new OutHandler {
+            override def onPull(): Unit = {
+              cancelTimer(timeoutSignal)
+              if (buffer.nonEmpty) {
+                subPush(buffer)
+                buffer = ByteString.empty
+                if (isClosed(flowIn)) onUpstreamFinish()
+              } else if (!flowInPulled) {
+                flowInPulled = true
+                pull(flowIn)
+              }
+            }
+          })
+          val timeout =
+            ActorMaterializerHelper.downcast(interpreter.materializer).settings.subscriptionTimeoutSettings.timeout
+          scheduleOnce(timeoutSignal, timeout)
+          sub
+        }
+
+        log.debug(s"emitting source for $metadata")
+        push(flowOut, metadata -> Source.fromGraph(subSource.source))
+        setHandler(flowOut, ignoreFlowOutPull)
+
+        def subPush(bs: ByteString) = {
+          val remaining = metadata.size - emitted
+          if (remaining <= bs.length) {
+            subSource.push(bs.take(remaining.toInt))
+            setHandler(flowIn, readTrailer(metadata, bs.drop(remaining.toInt), Some(subSource)))
+          } else {
+            subSource.push(bs)
+            emitted += bs.length
+          }
+        }
+
+        override def onPush(): Unit = {
+          flowInPulled = false
+          subPush(grab(flowIn))
+        }
+
+        override def onUpstreamFinish(): Unit = {
+          if (buffer.isEmpty) {
+            failStage(
+              new TarReaderException(
+                s"incomplete tar file contents for [${metadata.filePath}] expected ${metadata.size} bytes, received $emitted bytes"
+              )
+            )
+          } else setKeepGoing(true)
+        }
+
+      }
+
+      /**
+       * Handler to read past the padding trailer.
+       */
+      private final class ReadPastTrailer(metadata: TarArchiveMetadata,
+                                          var buffer: ByteString,
+                                          subSource: Option[SubSourceOutlet[ByteString]])
+          extends InHandler {
+        val trailerLength = TarArchiveEntry.trailerLength(metadata)
+
+        override def onPush(): Unit = {
+          // TODO the buffer content doesn't need to be kept
+          buffer ++= grab(flowIn)
+          if (buffer.length >= trailerLength) {
+            setHandler(flowIn, readHeader(buffer.drop(trailerLength)))
+            subSource.foreach { src =>
+              src.complete()
+              setHandler(flowOut, expectFlowPull)
+              if (isAvailable(flowOut)) pull(flowIn)
+            }
+          } else pull(flowIn)
+        }
+
+        override def onUpstreamFinish(): Unit = {
+          if (buffer.length == trailerLength) completeStage()
+          else
+            failStage(
+              new TarReaderException(
+                s"incomplete tar file trailer for [${metadata.filePath}] expected ${trailerLength} bytes, received ${buffer.length} bytes"
+              )
+            )
+        }
+      }
+
+    }
+}

--- a/file/src/main/scala/akka/stream/alpakka/file/javadsl/Archive.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/javadsl/Archive.scala
@@ -42,10 +42,10 @@ object Archive {
   def tarReader(): Flow[ByteString, Pair[TarArchiveMetadata, Source[ByteString, NotUsed]], NotUsed] =
     Flow
       .fromGraph(new TarReaderStage())
-      .map {
+      .map(func {
         case (metadata, source) =>
           Pair(metadata, source.asJava)
-      }
+      })
 
   private def func[T, R](f: T => R) = new akka.japi.function.Function[T, R] {
     override def apply(param: T): R = f(param)

--- a/file/src/main/scala/akka/stream/alpakka/file/javadsl/Archive.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/javadsl/Archive.scala
@@ -9,6 +9,7 @@ import akka.stream.alpakka.file.{scaladsl, ArchiveMetadata, TarArchiveMetadata}
 import akka.stream.javadsl.Flow
 import akka.util.ByteString
 import akka.japi.Pair
+import akka.stream.alpakka.file.impl.archive.TarReaderStage
 import akka.stream.javadsl.Source
 
 /**
@@ -33,6 +34,18 @@ object Archive {
       .create[Pair[TarArchiveMetadata, Source[ByteString, NotUsed]]]()
       .map(func(pair => (pair.first, pair.second.asScala)))
       .via(scaladsl.Archive.tar().asJava)
+
+  /**
+   * Parse incoming `ByteString`s into tar file entries and sources for the file contents.
+   * The file contents sources MUST be consumed to progress reading the file.
+   */
+  def tarReader(): Flow[ByteString, Pair[TarArchiveMetadata, Source[ByteString, NotUsed]], NotUsed] =
+    Flow
+      .fromGraph(new TarReaderStage())
+      .map {
+        case (metadata, source) =>
+          Pair(metadata, source.asJava)
+      }
 
   private def func[T, R](f: T => R) = new akka.japi.function.Function[T, R] {
     override def apply(param: T): R = f(param)

--- a/file/src/main/scala/akka/stream/alpakka/file/model.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/model.scala
@@ -31,7 +31,8 @@ final class TarArchiveMetadata private (
   override def equals(obj: Any): Boolean = {
     obj match {
       case that: TarArchiveMetadata =>
-        this.filePath == that.filePath &&
+        this.filePathPrefix == that.filePathPrefix &&
+        this.filePathName == that.filePathName &&
         this.size == that.size &&
         this.lastModification == that.lastModification
       case _ => false

--- a/file/src/main/scala/akka/stream/alpakka/file/model.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/model.scala
@@ -5,6 +5,8 @@
 package akka.stream.alpakka.file
 
 import java.time.Instant
+import java.time.temporal.{ChronoField, TemporalAdjusters, TemporalField}
+import java.util.Objects
 
 final class ArchiveMetadata private (
     val filePath: String
@@ -16,27 +18,62 @@ object ArchiveMetadata {
 }
 
 final class TarArchiveMetadata private (
-    val filePath: String,
+    val filePathPrefix: String,
+    val filePathName: String,
     val size: Long,
     val lastModification: Instant
 ) {
-  private val filePathSegments: Array[String] = filePath.split("/")
-  val filePathPrefix = Option(filePathSegments.init).filter(_.nonEmpty).map(_.mkString("/"))
-  val filePathName = filePathSegments.last
+  val filePath =
+    if (filePathPrefix.isEmpty) filePathName
+    else filePathPrefix + "/" + filePathName
 
-  require(
-    filePathPrefix.forall(fnp => fnp.length > 0 && fnp.length <= 154),
-    "File path prefix must be between 1 and 154 characters long"
-  )
-  require(filePathName.length > 0 && filePathName.length <= 99,
-          "File path name must be between 1 and 99 characters long")
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case that: TarArchiveMetadata =>
+        this.filePath == that.filePath &&
+        this.size == that.size &&
+        this.lastModification == that.lastModification
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = Objects.hash(filePath, Long.box(size), lastModification)
+
+  override def toString: String =
+    "TarArchiveMetadata(" +
+    s"filePathPrefix=$filePathPrefix," +
+    s"filePathName=$filePathName," +
+    s"size=$size," +
+    s"lastModification=${lastModification})"
 }
 
 object TarArchiveMetadata {
   def apply(filePath: String, size: Long): TarArchiveMetadata = apply(filePath, size, Instant.now)
-  def apply(filePath: String, size: Long, lastModification: Instant): TarArchiveMetadata =
-    new TarArchiveMetadata(filePath, size, lastModification)
-  def create(filePath: String, size: Long): TarArchiveMetadata = create(filePath, size, Instant.now)
+  def apply(filePath: String, size: Long, lastModification: Instant): TarArchiveMetadata = {
+    val filePathSegments = filePath.lastIndexOf("/")
+    val filePathPrefix = if (filePathSegments > -1) filePath.substring(0, filePathSegments) else ""
+    val filePathName = filePath.substring(filePathSegments + 1, filePath.length)
+    apply(filePathPrefix, filePathName, size, lastModification)
+  }
+
+  def apply(filePathPrefix: String, filePathName: String, size: Long, lastModification: Instant): TarArchiveMetadata = {
+    require(
+      filePathPrefix.length <= 154,
+      "File path prefix must be between 1 and 154 characters long"
+    )
+    require(filePathName.length > 0 && filePathName.length <= 99,
+            "File path name must be between 1 and 99 characters long")
+
+    new TarArchiveMetadata(filePathPrefix,
+                           filePathName,
+                           size,
+                           // tar timestamp granularity is in seconds
+                           lastModification.`with`(ChronoField.NANO_OF_SECOND, 0L))
+  }
+
+  def create(filePath: String, size: Long): TarArchiveMetadata = apply(filePath, size, Instant.now)
   def create(filePath: String, size: Long, lastModification: Instant): TarArchiveMetadata =
-    new TarArchiveMetadata(filePath, size, lastModification)
+    apply(filePath, size, lastModification)
 }
+
+final class TarReaderException(msg: String) extends Exception(msg)

--- a/file/src/main/scala/akka/stream/alpakka/file/model.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/model.scala
@@ -18,7 +18,7 @@ object ArchiveMetadata {
 }
 
 final class TarArchiveMetadata private (
-    val filePathPrefix: String,
+    val filePathPrefix: Option[String],
     val filePathName: String,
     val size: Long,
     val lastModification: Instant
@@ -51,16 +51,27 @@ object TarArchiveMetadata {
   def apply(filePath: String, size: Long): TarArchiveMetadata = apply(filePath, size, Instant.now)
   def apply(filePath: String, size: Long, lastModification: Instant): TarArchiveMetadata = {
     val filePathSegments = filePath.lastIndexOf("/")
-    val filePathPrefix = if (filePathSegments > -1) filePath.substring(0, filePathSegments) else ""
+    val filePathPrefix = if (filePathSegments > -1) {
+      Some(filePath.substring(0, filePathSegments))
+    } else None
     val filePathName = filePath.substring(filePathSegments + 1, filePath.length)
     apply(filePathPrefix, filePathName, size, lastModification)
   }
 
   def apply(filePathPrefix: String, filePathName: String, size: Long, lastModification: Instant): TarArchiveMetadata = {
-    require(
-      filePathPrefix.length <= 154,
-      "File path prefix must be between 1 and 154 characters long"
-    )
+    apply(Some(filePathPrefix), filePathName, size, lastModification)
+  }
+
+  private def apply(filePathPrefix: Option[String],
+                    filePathName: String,
+                    size: Long,
+                    lastModification: Instant): TarArchiveMetadata = {
+    filePathPrefix.foreach { value =>
+      require(
+        value.length <= 154,
+        "File path prefix must be between 1 and 154 characters long"
+      )
+    }
     require(filePathName.length > 0 && filePathName.length <= 99,
             "File path name must be between 1 and 99 characters long")
 

--- a/file/src/main/scala/akka/stream/alpakka/file/model.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/model.scala
@@ -23,9 +23,10 @@ final class TarArchiveMetadata private (
     val size: Long,
     val lastModification: Instant
 ) {
-  val filePath =
-    if (filePathPrefix.isEmpty) filePathName
-    else filePathPrefix + "/" + filePathName
+  val filePath = filePathPrefix match {
+    case None => filePathName
+    case Some(prefix) => prefix + "/" + filePathName
+  }
 
   override def equals(obj: Any): Boolean = {
     obj match {
@@ -37,7 +38,7 @@ final class TarArchiveMetadata private (
     }
   }
 
-  override def hashCode(): Int = Objects.hash(filePath, Long.box(size), lastModification)
+  override def hashCode(): Int = Objects.hash(filePathPrefix, filePathName, Long.box(size), lastModification)
 
   override def toString: String =
     "TarArchiveMetadata(" +
@@ -51,7 +52,7 @@ object TarArchiveMetadata {
   def apply(filePath: String, size: Long): TarArchiveMetadata = apply(filePath, size, Instant.now)
   def apply(filePath: String, size: Long, lastModification: Instant): TarArchiveMetadata = {
     val filePathSegments = filePath.lastIndexOf("/")
-    val filePathPrefix = if (filePathSegments > -1) {
+    val filePathPrefix = if (filePathSegments > 0) {
       Some(filePath.substring(0, filePathSegments))
     } else None
     val filePathName = filePath.substring(filePathSegments + 1, filePath.length)
@@ -59,7 +60,7 @@ object TarArchiveMetadata {
   }
 
   def apply(filePathPrefix: String, filePathName: String, size: Long, lastModification: Instant): TarArchiveMetadata = {
-    apply(Some(filePathPrefix), filePathName, size, lastModification)
+    apply(if (filePathPrefix.isEmpty) None else Some(filePathPrefix), filePathName, size, lastModification)
   }
 
   private def apply(filePathPrefix: Option[String],

--- a/file/src/main/scala/akka/stream/alpakka/file/model.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/model.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.file
 
 import java.time.Instant
-import java.time.temporal.{ChronoField, TemporalAdjusters, TemporalField}
+import java.time.temporal.ChronoField
 import java.util.Objects
 
 final class ArchiveMetadata private (

--- a/file/src/main/scala/akka/stream/alpakka/file/scaladsl/Archive.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/scaladsl/Archive.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.file.scaladsl
 
 import akka.NotUsed
 import akka.stream.alpakka.file.{ArchiveMetadata, TarArchiveMetadata}
-import akka.stream.alpakka.file.impl.archive.{TarArchiveManager, ZipArchiveManager}
+import akka.stream.alpakka.file.impl.archive.{TarArchiveManager, TarReaderStage, ZipArchiveManager}
 import akka.stream.scaladsl.{Flow, Source}
 import akka.util.ByteString
 
@@ -27,4 +27,10 @@ object Archive {
   def tar(): Flow[(TarArchiveMetadata, Source[ByteString, _]), ByteString, NotUsed] =
     TarArchiveManager.tarFlow()
 
+  /**
+   * Parse incoming `ByteString`s into tar file entries and sources for the file contents.
+   * The file contents sources MUST be consumed to progress reading the file.
+   */
+  def tarReader(): Flow[ByteString, (TarArchiveMetadata, Source[ByteString, NotUsed]), NotUsed] =
+    Flow.fromGraph(new TarReaderStage())
 }

--- a/file/src/test/java/docs/javadsl/ArchiveTest.java
+++ b/file/src/test/java/docs/javadsl/ArchiveTest.java
@@ -172,7 +172,7 @@ public class ArchiveTest {
     CompletionStage<ByteString> oneFileArchive =
         Source.single(Pair.create(metadata1, Source.single(tenDigits)))
             .via(Archive.tar())
-            .runWith(Sink.fold(ByteString.empty(), ByteString::concat), mat);
+            .runWith(Sink.fold(ByteString.emptyByteString(), ByteString::concat), mat);
 
     // #tar-reader
     Source<ByteString, NotUsed> bytesSource = // ???

--- a/file/src/test/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntrySpec.scala
+++ b/file/src/test/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntrySpec.scala
@@ -1,0 +1,24 @@
+package akka.stream.alpakka.file.impl.archive
+
+import java.time.{Instant, LocalDateTime, ZoneId, ZonedDateTime}
+
+import akka.stream.alpakka.file.TarArchiveMetadata
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class TarArchiveEntrySpec extends AnyFlatSpec with Matchers {
+  "Metadata entries" should "be created and parsed back" in {
+    val filePathPrefix = "dir1/dir2"
+    val filename = "thefile.txt"
+    val size = 100
+    val lastModified = Instant.from(ZonedDateTime.of(LocalDateTime.of(2020, 4, 11, 11, 34), ZoneId.of("CET")))
+    val data = TarArchiveMetadata(filePathPrefix, filename, size, lastModified)
+    val entry = new TarArchiveEntry(data)
+    val header = entry.headerBytes
+
+    val parsed = TarArchiveEntry.parse(header)
+    parsed.filePath shouldBe filePathPrefix + "/" + filename
+    parsed.size shouldBe size
+    parsed.lastModification shouldBe lastModified
+  }
+}

--- a/file/src/test/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntrySpec.scala
+++ b/file/src/test/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntrySpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.stream.alpakka.file.impl.archive
 
 import java.time.{Instant, LocalDateTime, ZoneId, ZonedDateTime}

--- a/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
@@ -5,8 +5,7 @@
 package docs.scaladsl
 
 import java.io._
-import java.nio.file.{Files, Path, Paths}
-import java.util.Comparator
+import java.nio.file.{Path, Paths}
 
 import akka.actor.ActorSystem
 import akka.stream.alpakka.file.ArchiveMetadata
@@ -138,28 +137,6 @@ class ArchiveSpec
         (ArchiveMetadata(title), Source(content.grouped(10).toList))
     }
     Source(sourceFiles)
-  }
-
-  // returns None if tar executable is not available on PATH
-  private def untar(tarPath: Path, args: String): Option[Map[String, ByteString]] = {
-    if (ExecutableUtils.isOnPath("tar")) {
-      val tmpDir = Files.createTempDirectory("ArchiveSpec")
-      try {
-        ExecutableUtils.run("tar", Seq(args, tarPath.toString, "-C", tmpDir.toString), tmpDir).futureValue
-        Some(
-          Files
-            .walk(tmpDir)
-            .sorted(Comparator.reverseOrder())
-            .iterator()
-            .asScala
-            .filter(path => Files.isRegularFile(path))
-            .map(path => tmpDir.relativize(path).toString -> ByteString(Files.readAllBytes(path)))
-            .toMap
-        )
-      } finally {
-        Files.walk(tmpDir).sorted(Comparator.reverseOrder()).iterator().asScala.foreach(p => Files.delete(p))
-      }
-    } else None
   }
 
   override def afterAll(): Unit = {

--- a/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
@@ -9,7 +9,7 @@ import java.nio.file.{Files, Path, Paths}
 import java.util.Comparator
 
 import akka.actor.ActorSystem
-import akka.stream.alpakka.file.{ArchiveMetadata, TarArchiveMetadata}
+import akka.stream.alpakka.file.ArchiveMetadata
 import akka.stream.alpakka.file.scaladsl.Archive
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{FileIO, Sink, Source}
@@ -24,7 +24,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.collection.JavaConverters._
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
 
 class ArchiveSpec
@@ -37,6 +37,7 @@ class ArchiveSpec
     with IntegrationPatience {
 
   implicit val mat: Materializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
 
   private val archiveHelper = new ArchiveHelper()
 
@@ -117,110 +118,12 @@ class ArchiveSpec
         archiveHelper.unzip(akkaZipped.futureValue).asScala shouldBe inputFiles
       }
     }
-
-    "tar flow is called" should {
-      "pass empty stream" in {
-        val sources = Source.empty
-        val tarFlow = Archive.tar()
-
-        val akkaTarred: Future[ByteString] =
-          sources
-            .via(tarFlow)
-            .runWith(Sink.fold(ByteString.empty)(_ ++ _))
-
-        akkaTarred.futureValue shouldBe ByteString.empty
-      }
-
-      "archive file" in {
-        val filePath1 = getPathFromResources("akka_full_color.svg")
-        val filePath2 = getPathFromResources("akka_icon_reverse.svg")
-        val fileStream1: Source[ByteString, Any] = FileIO.fromPath(filePath1)
-        val fileStream2: Source[ByteString, Any] = FileIO.fromPath(filePath2)
-        val fileContent1 = ByteString(Files.readAllBytes(filePath1))
-        val fileContent2 = ByteString(Files.readAllBytes(filePath2))
-        val fileSize1 = Files.size(filePath1)
-        val fileSize2 = Files.size(filePath2)
-
-        /*
-        // #sample-tar
-        val fileStream1: Source[ByteString,  Any] = ...
-        val fileStream2: Source[ByteString,  Any] = ...
-        val fileSize1: Long = ...
-        val fileSize2: Long = ...
-
-        // #sample-tar
-         */
-
-        // #sample-tar
-        val filesStream = Source(
-          List(
-            (TarArchiveMetadata("akka_full_color.svg", fileSize1), fileStream1),
-            (TarArchiveMetadata("akka_icon_reverse.svg", fileSize2), fileStream2)
-          )
-        )
-
-        val result = filesStream
-          .via(Archive.tar())
-          .runWith(FileIO.toPath(Paths.get("result.tar")))
-        // #sample-tar
-
-        // #sample-tar-gz
-        val resultGz = filesStream
-          .via(Archive.tar().via(akka.stream.scaladsl.Compression.gzip))
-          .runWith(FileIO.toPath(Paths.get("result.tar.gz")))
-        // #sample-tar-gz
-
-        result.futureValue shouldBe IOResult(3584, Success(Done))
-        resultGz.futureValue.status shouldBe Success(Done)
-
-        untar(Paths.get("result.tar").toRealPath(), "xf").foreach(
-          _ shouldBe Map(
-            "akka_full_color.svg" -> fileContent1,
-            "akka_icon_reverse.svg" -> fileContent2
-          )
-        )
-        untar(Paths.get("result.tar.gz").toRealPath(), "xfz").foreach(
-          _ shouldBe Map(
-            "akka_full_color.svg" -> fileContent1,
-            "akka_icon_reverse.svg" -> fileContent2
-          )
-        )
-
-        //cleanup
-        new File("result.tar").delete()
-        new File("result.tar.gz").delete()
-      }
-
-      "support long file paths" in {
-        val fileName = "folder1-".padTo(40, 'x') + "/" + "folder2-".padTo(40, 'x') + "/" + "file-".padTo(80, 'x') + ".txt"
-        val fileBytes = ByteString("test")
-
-        val file = (TarArchiveMetadata(fileName, fileBytes.size), Source.single(fileBytes))
-        val filesStream = Source.single(file)
-        val result = filesStream
-          .via(Archive.tar())
-          .runWith(FileIO.toPath(Paths.get("result.tar")))
-        result.futureValue shouldBe IOResult(1024, Success(Done))
-
-        untar(Paths.get("result.tar").toRealPath(), "xf").foreach(_ shouldBe Map(fileName -> fileBytes))
-
-        //cleanup
-        new File("result.tar").delete()
-      }
-
-      "fail if provided size and actual size do not match" in {
-        val file = (TarArchiveMetadata("file.txt", 10L), Source.single(ByteString("too long")))
-        val filesStream = Source.single(file)
-        val result = filesStream.via(Archive.tar()).runWith(Sink.ignore)
-        an[IllegalStateException] should be thrownBy (throw result.failed.futureValue)
-      }
-    }
   }
 
   private def getPathFromResources(fileName: String): Path =
     Paths.get(getClass.getClassLoader.getResource(fileName).getPath)
 
-  private def generateInputFiles(numberOfFiles: Int, lengthOfFile: Int): Map[String, Seq[Byte]] = {
+  private def generateInputFiles(numberOfFiles: Int, lengthOfFile: Int): Map[String, ByteString] = {
     val r = new scala.util.Random(31)
     (1 to numberOfFiles)
       .map(number => s"file-$number" -> ByteString.fromArray(r.nextString(lengthOfFile).getBytes))
@@ -228,11 +131,11 @@ class ArchiveSpec
   }
 
   private def filesToStream(
-      files: Map[String, Seq[Byte]]
+      files: Map[String, ByteString]
   ): Source[(ArchiveMetadata, Source[ByteString, NotUsed]), NotUsed] = {
     val sourceFiles = files.toList.map {
       case (title, content) =>
-        (ArchiveMetadata(title), Source(content.grouped(10).map(group => ByteString(group.toArray)).toList))
+        (ArchiveMetadata(title), Source(content.grouped(10).toList))
     }
     Source(sourceFiles)
   }

--- a/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
@@ -41,7 +41,7 @@ class TarArchiveSpec
 
   private val collectByteString: Sink[ByteString, Future[ByteString]] = Sink.fold(ByteString.empty)(_ ++ _)
 
-  "tar flow is called" should {
+  "tar writer" should {
     "pass empty stream" in {
       val sources = Source.empty
       val tarFlow = Archive.tar()

--- a/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
@@ -8,15 +8,15 @@ import java.io._
 import java.nio.file.{Files, Path, Paths}
 import java.util.Comparator
 
+import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.alpakka.file.scaladsl.Archive
-import akka.stream.alpakka.file.{ArchiveMetadata, TarArchiveMetadata, TarReaderException}
+import akka.stream.alpakka.file.{TarArchiveMetadata, TarReaderException}
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
-import akka.stream.scaladsl.{FileIO, Keep, Sink, Source}
+import akka.stream.scaladsl.{FileIO, Sink, Source}
 import akka.stream.{ActorMaterializer, IOResult, Materializer}
 import akka.testkit.TestKit
 import akka.util.ByteString
-import akka.{Done, NotUsed}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
@@ -24,7 +24,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
 
 class TarArchiveSpec

--- a/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
@@ -1,0 +1,337 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.scaladsl
+
+import java.io._
+import java.nio.file.{Files, Path, Paths}
+import java.util.Comparator
+
+import akka.actor.ActorSystem
+import akka.stream.alpakka.file.scaladsl.Archive
+import akka.stream.alpakka.file.{ArchiveMetadata, TarArchiveMetadata, TarReaderException}
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
+import akka.stream.scaladsl.{FileIO, Keep, Sink, Source}
+import akka.stream.{ActorMaterializer, IOResult, Materializer}
+import akka.testkit.TestKit
+import akka.util.ByteString
+import akka.{Done, NotUsed}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.Success
+
+class TarArchiveSpec
+    extends TestKit(ActorSystem("TarArchiveSpec"))
+    with AnyWordSpecLike
+    with Matchers
+    with ScalaFutures
+    with BeforeAndAfterAll
+    with LogCapturing
+    with IntegrationPatience {
+
+  implicit val mat: Materializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
+
+  private val collectByteString: Sink[ByteString, Future[ByteString]] = Sink.fold(ByteString.empty)(_ ++ _)
+
+  "tar flow is called" should {
+    "pass empty stream" in {
+      val sources = Source.empty
+      val tarFlow = Archive.tar()
+
+      val akkaTarred: Future[ByteString] =
+        sources
+          .via(tarFlow)
+          .runWith(collectByteString)
+
+      akkaTarred.futureValue shouldBe ByteString.empty
+    }
+
+    "archive file" in {
+      val filePath1 = getPathFromResources("akka_full_color.svg")
+      val filePath2 = getPathFromResources("akka_icon_reverse.svg")
+      val fileStream1: Source[ByteString, Any] = FileIO.fromPath(filePath1)
+      val fileStream2: Source[ByteString, Any] = FileIO.fromPath(filePath2)
+      val fileContent1 = ByteString(Files.readAllBytes(filePath1))
+      val fileContent2 = ByteString(Files.readAllBytes(filePath2))
+      val fileSize1 = Files.size(filePath1)
+      val fileSize2 = Files.size(filePath2)
+
+      /*
+        // #sample-tar
+        val fileStream1: Source[ByteString,  Any] = ...
+        val fileStream2: Source[ByteString,  Any] = ...
+        val fileSize1: Long = ...
+        val fileSize2: Long = ...
+
+        // #sample-tar
+       */
+
+      // #sample-tar
+      val filesStream = Source(
+        List(
+          (TarArchiveMetadata("akka_full_color.svg", fileSize1), fileStream1),
+          (TarArchiveMetadata("akka_icon_reverse.svg", fileSize2), fileStream2)
+        )
+      )
+
+      val result = filesStream
+        .via(Archive.tar())
+        .runWith(FileIO.toPath(Paths.get("result.tar")))
+      // #sample-tar
+
+      // #sample-tar-gz
+      val resultGz = filesStream
+        .via(Archive.tar().via(akka.stream.scaladsl.Compression.gzip))
+        .runWith(FileIO.toPath(Paths.get("result.tar.gz")))
+      // #sample-tar-gz
+
+      result.futureValue shouldBe IOResult(3584, Success(Done))
+      resultGz.futureValue.status shouldBe Success(Done)
+
+      untar(Paths.get("result.tar").toRealPath(), "xf").foreach(
+        _ shouldBe Map(
+          "akka_full_color.svg" -> fileContent1,
+          "akka_icon_reverse.svg" -> fileContent2
+        )
+      )
+      untar(Paths.get("result.tar.gz").toRealPath(), "xfz").foreach(
+        _ shouldBe Map(
+          "akka_full_color.svg" -> fileContent1,
+          "akka_icon_reverse.svg" -> fileContent2
+        )
+      )
+
+      //cleanup
+      new File("result.tar").delete()
+      new File("result.tar.gz").delete()
+    }
+
+    "support long file paths" in {
+      val fileName = "folder1-".padTo(40, 'x') + "/" + "folder2-".padTo(40, 'x') + "/" + "file-".padTo(80, 'x') + ".txt"
+      val fileBytes = ByteString("test")
+
+      val file = (TarArchiveMetadata(fileName, fileBytes.size), Source.single(fileBytes))
+      val filesStream = Source.single(file)
+      val result = filesStream
+        .via(Archive.tar())
+        .runWith(FileIO.toPath(Paths.get("result.tar")))
+      result.futureValue shouldBe IOResult(1024, Success(Done))
+
+      untar(Paths.get("result.tar").toRealPath(), "xf").foreach(_ shouldBe Map(fileName -> fileBytes))
+
+      //cleanup
+      new File("result.tar").delete()
+    }
+
+    "fail if provided size and actual size do not match" in {
+      val file = (TarArchiveMetadata("file.txt", 10L), Source.single(ByteString("too long")))
+      val filesStream = Source.single(file)
+      val result = filesStream.via(Archive.tar()).runWith(Sink.ignore)
+      an[IllegalStateException] should be thrownBy (throw result.failed.futureValue)
+    }
+  }
+
+  "tar reader" should {
+    val tenDigits = ByteString("1234567890")
+    val metadata1 = TarArchiveMetadata("dir/file1.txt", tenDigits.length)
+
+    val oneFileArchive = {
+      Source
+        .single(metadata1 -> Source.single(tenDigits))
+        .via(Archive.tar())
+        .runWith(collectByteString)
+    }
+
+    "emit one file" in {
+      val tar =
+        Source
+          .fromFuture(oneFileArchive)
+          .via(Archive.tarReader())
+          .mapAsync(1) {
+            case in @ (metadata, source) =>
+              source.runWith(collectByteString).map { bs =>
+                metadata -> bs
+              }
+          }
+          .runWith(Sink.head)
+      val result = tar.futureValue
+      result shouldBe metadata1 -> tenDigits
+    }
+
+    "emit empty file" in {
+      val metadataEmpty = TarArchiveMetadata("dir/empty.txt", 0L)
+      val tar =
+        Source
+          .single(metadataEmpty -> Source.single(ByteString.empty))
+          .via(Archive.tar())
+          .via(Archive.tarReader())
+          .mapAsync(1) {
+            case (metadata, source) =>
+              source.runWith(collectByteString).map { bs =>
+                metadata -> bs
+              }
+          }
+          .runWith(Sink.head)
+      val result = tar.futureValue
+      result shouldBe metadataEmpty -> ByteString.empty
+    }
+
+    "emit two files" in {
+      val Seq((name1, file1), (name2, file2)) = generateInputFiles(2, 400)
+
+      val metadata1 = TarArchiveMetadata(name1, file1.length)
+      val metadata2 = TarArchiveMetadata(name2, file2.length)
+      val tar = Source(
+        immutable.Seq(
+          metadata1 -> Source.single(file1),
+          metadata2 -> Source.single(file2)
+        )
+      ).via(Archive.tar())
+        // emit in short byte strings
+        .mapConcat(_.sliding(2, 2).toList)
+        .via(Archive.tarReader())
+        .mapAsync(1) {
+          case (metadata, source) =>
+            source.runWith(collectByteString).map { bs =>
+              (metadata -> bs)
+            }
+        }
+        .runWith(Sink.seq)
+      val result = tar.futureValue
+      result(0) shouldBe metadata1 -> file1
+      result(1) shouldBe metadata2 -> file2
+    }
+
+    "emit empty and another file" in {
+      val metadata1 = TarArchiveMetadata("empty.txt", 0)
+      val metadata2 = TarArchiveMetadata("file2.txt", tenDigits.length)
+      val tarFile = Source(
+        immutable.Seq(
+          metadata1 -> Source.single(ByteString.empty),
+          metadata2 -> Source.single(tenDigits)
+        )
+      ).via(Archive.tar())
+        // swallow the whole input as one ByteString
+        .runWith(collectByteString)
+
+      val tar = Source
+        .fromFuture(tarFile)
+        .via(Archive.tarReader())
+        .mapAsync(1) {
+          case (metadata, source) =>
+            source.runWith(collectByteString).map { bs =>
+              metadata -> bs
+            }
+        }
+        .runWith(Sink.seq)
+      val result = tar.futureValue
+      result(0) shouldBe metadata1 -> ByteString.empty
+      result(1) shouldBe metadata2 -> tenDigits
+    }
+
+    "fail for incomplete header" in {
+      val input = oneFileArchive.map(bs => bs.take(500))
+      val tar = Source
+        .fromFuture(input)
+        .via(Archive.tarReader())
+        .runWith(Sink.ignore)
+      val error = tar.failed.futureValue
+      error shouldBe a[TarReaderException]
+      error.getMessage shouldBe "incomplete tar header: received 500 bytes, expected 512 bytes"
+    }
+
+    "fail for incomplete file" in {
+      val input = oneFileArchive.map(bs => bs.take(518))
+      val tar = Source
+        .fromFuture(input)
+        .via(Archive.tarReader())
+        .mapAsync(1) {
+          case (metadata, source) =>
+            source.runWith(Sink.ignore)
+        }
+        .runWith(Sink.ignore)
+      val error = tar.failed.futureValue
+      error shouldBe a[TarReaderException]
+      error.getMessage shouldBe "incomplete tar file contents for [dir/file1.txt] expected 10 bytes, received 6 bytes"
+    }
+
+    "fail for incomplete trailer" in {
+      val input = oneFileArchive.map(bs => bs.take(535))
+      val tar = Source
+        .fromFuture(input)
+        .via(Archive.tarReader())
+        .mapAsync(1) {
+          case (metadata, source) =>
+            source.runWith(Sink.ignore)
+        }
+        .runWith(Sink.ignore)
+      val error = tar.failed.futureValue
+      error shouldBe a[TarReaderException]
+      error.getMessage shouldBe "incomplete tar file trailer for [dir/file1.txt] expected 502 bytes, received 13 bytes"
+    }
+
+    "accept empty input" in {
+      val tar = Source
+        .single(ByteString.empty)
+        .via(Archive.tarReader())
+        .runWith(Sink.seq)
+      tar.futureValue shouldBe Symbol("empty")
+    }
+
+    "fail on missing sub source subscription" in {
+      val tar =
+        Source
+          .fromFuture(oneFileArchive)
+          .mapConcat(_.sliding(2, 2).toList)
+          .via(Archive.tarReader())
+          .runWith(Sink.ignore)
+      val error = tar.failed.futureValue
+      error shouldBe a[TarReaderException]
+      error.getMessage shouldBe "The tar content source was not subscribed to within 5000 milliseconds, it must be subscribed to to progress tar file reading."
+    }
+  }
+
+  private def getPathFromResources(fileName: String): Path =
+    Paths.get(getClass.getClassLoader.getResource(fileName).getPath)
+
+  private def generateInputFiles(numberOfFiles: Int, lengthOfFile: Int): immutable.Seq[(String, ByteString)] = {
+    val r = new scala.util.Random(31)
+    (1 to numberOfFiles)
+      .map(number => s"file-$number" -> ByteString.fromArray(r.nextString(lengthOfFile).getBytes))
+  }
+
+  // returns None if tar executable is not available on PATH
+  private def untar(tarPath: Path, args: String): Option[Map[String, ByteString]] = {
+    if (ExecutableUtils.isOnPath("tar")) {
+      val tmpDir = Files.createTempDirectory("ArchiveSpec")
+      try {
+        ExecutableUtils.run("tar", Seq(args, tarPath.toString, "-C", tmpDir.toString), tmpDir).futureValue
+        Some(
+          Files
+            .walk(tmpDir)
+            .sorted(Comparator.reverseOrder())
+            .iterator()
+            .asScala
+            .filter(path => Files.isRegularFile(path))
+            .map(path => tmpDir.relativize(path).toString -> ByteString(Files.readAllBytes(path)))
+            .toMap
+        )
+      } finally {
+        Files.walk(tmpDir).sorted(Comparator.reverseOrder()).iterator().asScala.foreach(p => Files.delete(p))
+      }
+    } else None
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    TestKit.shutdownActorSystem(system)
+  }
+}


### PR DESCRIPTION
Add reading of tar-formatted streams of `ByteString`s.

Inspired by the recent addition of writing tar in #2241 by @choffmeister.

* Add `TarReaderStage`
* Tar header parsing in `TarArchiveEntry`
* Improve `ByteString` handling in `TarArchiveEntry` header creation
* Move tar tests into own spec

TODO
- [x] verify use of `SubSourceOutlet`
- [x] documentation