### PR TITLE
Avroparquet: Lower bound higher kinded 

### DIFF
--- a/avroparquet/src/main/mima-filters/2.0.0-RC2.backwards.excludes/PR2273-generics.excludes
+++ b/avroparquet/src/main/mima-filters/2.0.0-RC2.backwards.excludes/PR2273-generics.excludes
@@ -1,0 +1,7 @@
+# added generics type to the factory methods
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.avroparquet.javadsl.AvroParquetFlow.create")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.avroparquet.javadsl.AvroParquetSource.create")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.avroparquet.javadsl.AvroParquetSink.create")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.avroparquet.scaladsl.AvroParquetSink.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.avroparquet.scaladsl.AvroParquetFlow.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.avroparquet.scaladsl.AvroParquetSource.apply")

--- a/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/impl/AvroParquetFlow.scala
+++ b/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/impl/AvroParquetFlow.scala
@@ -13,12 +13,12 @@ import org.apache.parquet.hadoop.ParquetWriter
  * Internal API
  */
 @InternalApi
-private[avroparquet] class AvroParquetFlow(writer: ParquetWriter[GenericRecord])
-    extends GraphStage[FlowShape[GenericRecord, GenericRecord]] {
+private[avroparquet] class AvroParquetFlow[T <: GenericRecord](writer: ParquetWriter[T])
+    extends GraphStage[FlowShape[T, T]] {
 
-  val in: Inlet[GenericRecord] = Inlet("AvroParquetSink.in")
-  val out: Outlet[GenericRecord] = Outlet("AvroParquetSink.out")
-  override val shape: FlowShape[GenericRecord, GenericRecord] = FlowShape.of(in, out)
+  val in: Inlet[T] = Inlet("AvroParquetSink.in")
+  val out: Outlet[T] = Outlet("AvroParquetSink.out")
+  override val shape: FlowShape[T, T] = FlowShape.of(in, out)
 
   override protected def initialAttributes: Attributes =
     super.initialAttributes and ActorAttributes.IODispatcher

--- a/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/impl/AvroParquetSource.scala
+++ b/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/impl/AvroParquetSource.scala
@@ -13,10 +13,10 @@ import org.apache.parquet.hadoop.ParquetReader
  * Internal API
  */
 @InternalApi
-private[avroparquet] class AvroParquetSource(reader: ParquetReader[GenericRecord])
-    extends GraphStage[SourceShape[GenericRecord]] {
+private[avroparquet] class AvroParquetSource[T <: GenericRecord](reader: ParquetReader[T])
+    extends GraphStage[SourceShape[T]] {
 
-  val out: Outlet[GenericRecord] = Outlet("AvroParquetSource")
+  val out: Outlet[T] = Outlet("AvroParquetSource")
 
   override protected def initialAttributes: Attributes =
     super.initialAttributes and ActorAttributes.IODispatcher
@@ -44,5 +44,5 @@ private[avroparquet] class AvroParquetSource(reader: ParquetReader[GenericRecord
     override def postStop(): Unit = reader.close()
 
   }
-  override def shape: SourceShape[GenericRecord] = SourceShape.of(out)
+  override def shape: SourceShape[T] = SourceShape.of(out)
 }

--- a/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/javadsl/AvroParquetFlow.scala
+++ b/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/javadsl/AvroParquetFlow.scala
@@ -10,6 +10,6 @@ import org.apache.parquet.hadoop.ParquetWriter
 
 object AvroParquetFlow {
 
-  def create(writer: ParquetWriter[GenericRecord]): Flow[GenericRecord, GenericRecord, NotUsed] =
+  def create[T <: GenericRecord](writer: ParquetWriter[T]): Flow[T, T, NotUsed] =
     Flow.fromGraph(new akka.stream.alpakka.avroparquet.impl.AvroParquetFlow(writer))
 }

--- a/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/javadsl/AvroParquetSink.scala
+++ b/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/javadsl/AvroParquetSink.scala
@@ -12,9 +12,9 @@ import org.apache.parquet.hadoop.ParquetWriter
 
 object AvroParquetSink {
 
-  def create(writer: ParquetWriter[GenericRecord]): Sink[GenericRecord, CompletionStage[Done]] =
+  def create[T <: GenericRecord](writer: ParquetWriter[T]): Sink[T, CompletionStage[Done]] =
     Flow
-      .fromGraph(new akka.stream.alpakka.avroparquet.impl.AvroParquetFlow(writer: ParquetWriter[GenericRecord]))
+      .fromGraph(new akka.stream.alpakka.avroparquet.impl.AvroParquetFlow(writer: ParquetWriter[T]))
       .toMat(Sink.ignore(), Keep.right[NotUsed, CompletionStage[Done]])
 
 }

--- a/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/javadsl/AvroParquetSource.scala
+++ b/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/javadsl/AvroParquetSource.scala
@@ -11,6 +11,6 @@ import org.apache.parquet.hadoop.ParquetReader
 
 object AvroParquetSource {
 
-  def create(reader: ParquetReader[GenericRecord]): Source[GenericRecord, NotUsed] =
+  def create[T <: GenericRecord](reader: ParquetReader[T]): Source[T, NotUsed] =
     Source.fromGraph(new akka.stream.alpakka.avroparquet.impl.AvroParquetSource(reader))
 }

--- a/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/scaladsl/AvroParquetFlow.scala
+++ b/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/scaladsl/AvroParquetFlow.scala
@@ -10,6 +10,6 @@ import org.apache.parquet.hadoop.ParquetWriter
 
 object AvroParquetFlow {
 
-  def apply(writer: ParquetWriter[GenericRecord]): Flow[GenericRecord, GenericRecord, NotUsed] =
+  def apply[T <: GenericRecord](writer: ParquetWriter[T]): Flow[T, T, NotUsed] =
     Flow.fromGraph(new akka.stream.alpakka.avroparquet.impl.AvroParquetFlow(writer))
 }

--- a/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/scaladsl/AvroParquetSink.scala
+++ b/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/scaladsl/AvroParquetSink.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 
 object AvroParquetSink {
 
-  def apply(writer: ParquetWriter[GenericRecord]): Sink[GenericRecord, Future[Done]] =
+  def apply[T <: GenericRecord](writer: ParquetWriter[T]): Sink[T, Future[Done]] =
     Flow.fromGraph(new akka.stream.alpakka.avroparquet.impl.AvroParquetFlow(writer)).toMat(Sink.ignore)(Keep.right)
 
 }

--- a/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/scaladsl/AvroParquetSource.scala
+++ b/avroparquet/src/main/scala/akka/stream/alpakka/avroparquet/scaladsl/AvroParquetSource.scala
@@ -10,7 +10,7 @@ import org.apache.parquet.hadoop.ParquetReader
 
 object AvroParquetSource {
 
-  def apply(reader: ParquetReader[GenericRecord]): Source[GenericRecord, NotUsed] =
+  def apply[T <: GenericRecord](reader: ParquetReader[T]): Source[T, NotUsed] =
     Source.fromGraph(new akka.stream.alpakka.avroparquet.impl.AvroParquetSource(reader))
 
 }

--- a/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java
+++ b/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java
@@ -74,6 +74,7 @@ public class AvroParquetSinkTest {
   public void createNewParquetFile()
       throws InterruptedException, IOException, TimeoutException, ExecutionException {
     // #init-writer
+
     Configuration conf = new Configuration();
     conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, true);
     ParquetWriter<GenericRecord> writer =

--- a/avroparquet/src/test/java/docs/javadsl/Examples.java
+++ b/avroparquet/src/test/java/docs/javadsl/Examples.java
@@ -39,6 +39,7 @@ public class Examples {
   ActorMaterializer materializer = ActorMaterializer.create(system);
 
   // #init-reader
+
   Configuration conf = new Configuration();
 
   ParquetReader<GenericRecord> reader =

--- a/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
@@ -11,35 +11,42 @@ import akka.testkit.TestKit
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
 import org.apache.hadoop.conf.Configuration
-import org.apache.parquet.avro.AvroReadSupport
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.avro.{AvroParquetReader, AvroParquetWriter, AvroReadSupport}
+import org.apache.parquet.hadoop.ParquetWriter
+import org.apache.parquet.hadoop.util.HadoopInputFile
+import org.scalacheck.Gen
+import org.scalatest.BeforeAndAfterAll
 
+import scala.reflect.io.Directory
 import scala.util.Random
 
 trait AbstractAvroParquet {
-
   case class Document(id: String, body: String)
 
-  //#init-system
+  val genDocument: Gen[Document] =
+    Gen.oneOf(Seq(Document(id = Gen.alphaStr.sample.get, body = Gen.alphaLowerStr.sample.get)))
+  val genDocuments: Gen[List[Document]] = Gen.listOfN(3, genDocument)
+
+  val folder: String = "./" + Random.alphanumeric.take(8).mkString("")
+  val file = folder + "/test.parquet"
+  val filePath = new org.apache.hadoop.fs.Path(file)
+
   implicit val system: ActorSystem = ActorSystem()
   implicit val mat: ActorMaterializer = ActorMaterializer()
-  //#init-system
-
-  val conf = new Configuration()
-  conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, true)
 
   val schema: Schema = new Schema.Parser().parse(
     "{\"type\":\"record\",\"name\":\"Document\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"body\",\"type\":\"string\"}]}"
   )
 
-  val folder: String = "./" + Random.alphanumeric.take(8).mkString("")
+  val conf = new Configuration()
+  conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, true)
 
-  def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
+  def parquetWriter(file: String, conf: Configuration, schema: Schema): ParquetWriter[GenericRecord] =
+    AvroParquetWriter.builder[GenericRecord](new Path(file)).withConf(conf).withSchema(schema).build()
 
-    import scala.reflect.io.Directory
-    val directory = new Directory(new File(folder))
-    directory.deleteRecursively()
-  }
+  def parquetReader[T](file: String, conf: Configuration) =
+    AvroParquetReader.builder[T](HadoopInputFile.fromPath(new Path(file), conf)).withConf(conf).build()
 
   def docToRecord(document: Document): GenericRecord =
     new GenericRecordBuilder(schema)
@@ -47,4 +54,14 @@ trait AbstractAvroParquet {
       .set("body", document.body)
       .build()
 
+  def fromParquet[T <: GenericRecord](file: String, configuration: Configuration): List[T] = {
+    val reader = parquetReader(file, conf)
+    var record: T = reader.read()
+    var result: List[T] = List.empty[T]
+    while (record != null) {
+      result = result ::: record :: Nil
+      record = reader.read()
+    }
+    result
+  }
 }

--- a/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
@@ -16,9 +16,7 @@ import org.apache.parquet.avro.{AvroParquetReader, AvroParquetWriter, AvroReadSu
 import org.apache.parquet.hadoop.ParquetWriter
 import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.scalacheck.Gen
-import org.scalatest.BeforeAndAfterAll
 
-import scala.reflect.io.Directory
 import scala.util.Random
 
 trait AbstractAvroParquet {
@@ -26,7 +24,7 @@ trait AbstractAvroParquet {
 
   val genDocument: Gen[Document] =
     Gen.oneOf(Seq(Document(id = Gen.alphaStr.sample.get, body = Gen.alphaLowerStr.sample.get)))
-  val genDocuments: Gen[List[Document]] = Gen.listOfN(3, genDocument)
+  val genDocuments: Int => Gen[List[Document]] = n => Gen.listOfN(n, genDocument)
 
   val folder: String = "./" + Random.alphanumeric.take(8).mkString("")
   val file = folder + "/test.parquet"
@@ -45,7 +43,7 @@ trait AbstractAvroParquet {
   def parquetWriter(file: String, conf: Configuration, schema: Schema): ParquetWriter[GenericRecord] =
     AvroParquetWriter.builder[GenericRecord](new Path(file)).withConf(conf).withSchema(schema).build()
 
-  def parquetReader[T](file: String, conf: Configuration) =
+  def parquetReader[T <: GenericRecord](file: String, conf: Configuration) =
     AvroParquetReader.builder[T](HadoopInputFile.fromPath(new Path(file), conf)).withConf(conf).build()
 
   def docToRecord(document: Document): GenericRecord =

--- a/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
@@ -6,8 +6,6 @@ package docs.scaladsl
 
 import java.io.File
 
-import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, Materializer}
 import akka.testkit.TestKit
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
@@ -26,7 +24,7 @@ trait AbstractAvroParquet extends BeforeAndAfterAll {
   this: Suite with TestKit =>
 
   case class Document(id: String, body: String)
-  
+
   val schema: Schema = new Schema.Parser().parse(
     "{\"type\":\"record\",\"name\":\"Document\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"body\",\"type\":\"string\"}]}"
   )

--- a/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
@@ -94,7 +94,6 @@ trait AbstractAvroParquet extends BeforeAndAfterAll {
     val writer: ParquetWriter[Record] =
       AvroParquetWriter.builder[Record](new Path(file)).withConf(conf).withSchema(schema).build()
     // #prepare-sink
-    // #init-reader
     if (writer != null) { // forces val usage
     }
   }

--- a/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
@@ -45,7 +45,7 @@ trait AbstractAvroParquet extends BeforeAndAfterAll {
 
   // #prepare
 
-  private def documentation(): Unit = {
+  protected def documentation(): Unit = {
     // #init-writer
     val writer: ParquetWriter[GenericRecord] =
       AvroParquetWriter.builder[GenericRecord](new Path(file)).withConf(conf).withSchema(schema).build()

--- a/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
@@ -85,10 +85,10 @@ trait AbstractAvroParquet extends BeforeAndAfterAll {
     conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, true)
     // #prepare-source
 
-    () =>
+    () => //documentation for sink
       {
         // #prepare-sink
-        import com.sksamuel.avro4s.Record
+        import com.sksamuel.avro4s.{Record, RecordFormat}
         import org.apache.hadoop.conf.Configuration
         import org.apache.hadoop.fs.Path
         import org.apache.parquet.avro.AvroReadSupport

--- a/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
@@ -16,7 +16,6 @@ import org.apache.parquet.hadoop.{ParquetReader, ParquetWriter}
 import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.scalacheck.Gen
 import org.scalatest.{BeforeAndAfterAll, Suite}
-
 import scala.reflect.io.Directory
 import scala.util.Random
 
@@ -43,8 +42,8 @@ trait AbstractAvroParquet extends BeforeAndAfterAll {
   def parquetWriter(file: String, conf: Configuration, schema: Schema): ParquetWriter[GenericRecord] =
     AvroParquetWriter.builder[GenericRecord](new Path(file)).withConf(conf).withSchema(schema).build()
 
-  def parquetReader[T <: GenericRecord](file: String, conf: Configuration): ParquetReader[T] =
-    AvroParquetReader.builder[T](HadoopInputFile.fromPath(new Path(file), conf)).withConf(conf).build()
+  def parquetReader(file: String, conf: Configuration): ParquetReader[GenericRecord] =
+    AvroParquetReader.builder[GenericRecord](HadoopInputFile.fromPath(new Path(file), conf)).withConf(conf).build()
 
   def docToRecord(document: Document): GenericRecord =
     new GenericRecordBuilder(schema)
@@ -52,10 +51,10 @@ trait AbstractAvroParquet extends BeforeAndAfterAll {
       .set("body", document.body)
       .build()
 
-  def fromParquet[T <: GenericRecord](file: String, configuration: Configuration): List[T] = {
+  def fromParquet(file: String, configuration: Configuration): List[GenericRecord] = {
     val reader = parquetReader(file, conf)
-    var record: T = reader.read()
-    var result: List[T] = List.empty[T]
+    var record: GenericRecord = reader.read()
+    var result: List[GenericRecord] = List.empty[GenericRecord]
     while (record != null) {
       result = result ::: record :: Nil
       record = reader.read()

--- a/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
@@ -32,12 +32,31 @@ trait AbstractAvroParquet extends BeforeAndAfterAll {
     Gen.oneOf(Seq(Document(id = Gen.alphaStr.sample.get, body = Gen.alphaLowerStr.sample.get)))
   val genDocuments: Int => Gen[List[Document]] = n => Gen.listOfN(n, genDocument)
 
-  val folder: String = "./" + Random.alphanumeric.take(8).mkString("")
+  // #prepare
+  val folder: String = // ???
+    // #prepare
+    "./" + Random.alphanumeric.take(8).mkString("")
+  // #prepare
   val file = folder + "/test.parquet"
   val filePath = new org.apache.hadoop.fs.Path(file)
 
   val conf = new Configuration()
   conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, true)
+
+  // #prepare
+
+  private def documentation(): Unit = {
+    // #init-writer
+    val writer: ParquetWriter[GenericRecord] =
+      AvroParquetWriter.builder[GenericRecord](new Path(file)).withConf(conf).withSchema(schema).build()
+    // #init-writer
+    // #init-reader
+    val reader: ParquetReader[GenericRecord] =
+      AvroParquetReader.builder[GenericRecord](HadoopInputFile.fromPath(new Path(file), conf)).withConf(conf).build()
+    // #init-reader
+    if (writer != null && reader != null) { // forces val usage
+    }
+  }
 
   def parquetWriter(file: String, conf: Configuration, schema: Schema): ParquetWriter[GenericRecord] =
     AvroParquetWriter.builder[GenericRecord](new Path(file)).withConf(conf).withSchema(schema).build()

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
@@ -46,4 +46,5 @@ class AvroParquetFlowSpec
     }
 
   }
+
 }

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
@@ -4,9 +4,11 @@
 
 package docs.scaladsl
 
+import akka.actor.ActorSystem
 import akka.stream.alpakka.avroparquet.scaladsl.AvroParquetFlow
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import akka.testkit.TestKit
 import org.apache.avro.generic.GenericRecord
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -15,7 +17,8 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 
 class AvroParquetFlowSpec
-    extends AnyWordSpecLike
+    extends TestKit(ActorSystem("FlowSpec"))
+    with AnyWordSpecLike
     with Matchers
     with AbstractAvroParquet
     with ScalaFutures

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
@@ -35,7 +35,7 @@ class AvroParquetFlowSpec
       //given
       val n: Int = 2
       val file: String = genFinalFile.sample.get
-      val records: List[GenericRecord] = genDocuments(n).sample.get.map(docToRecord)
+      val records: List[GenericRecord] = genDocuments(n).sample.get.map(docToGenericRecord)
       val writer: ParquetWriter[GenericRecord] = parquetWriter(file, conf, schema)
 
       //when
@@ -69,20 +69,10 @@ class AvroParquetFlowSpec
       val writer: ParquetWriter[Record] = avro4sWriter[Record](file, conf, schema)
 
       //when
-      // #init-flow
-      val source: Source[Record, NotUsed] = // ???
-        // #init-flow
-        Source(avroDocuments)
-      // #init-flow
-
-      val avroParquet: Flow[Record, Record, NotUsed] = AvroParquetFlow[Record](writer)
-      val result: Future[immutable.Seq[Record]] =
-        source
-          .via(avroParquet)
-          .runWith(Sink.seq)
-      // #init-flow
-
-      result.futureValue
+      Source(avroDocuments)
+        .via(AvroParquetFlow[Record](writer))
+        .runWith(Sink.seq)
+        .futureValue
 
       //then
       val parquetContent: List[GenericRecord] = fromParquet(file, conf)

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
@@ -18,9 +18,6 @@ import org.apache.parquet.hadoop.ParquetWriter
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 
-import scala.collection.immutable
-import scala.concurrent.Future
-
 class AvroParquetFlowSpec
     extends TestKit(ActorSystem("FlowSpec"))
     with AnyWordSpecLike
@@ -66,7 +63,7 @@ class AvroParquetFlowSpec
       val file: String = genFinalFile.sample.get
       val documents: List[Document] = genDocuments(n).sample.get
       val avroDocuments: List[Record] = documents.map(format.to(_))
-      val writer: ParquetWriter[Record] = avro4sWriter[Record](file, conf, schema)
+      val writer: ParquetWriter[Record] = parquetWriter[Record](file, conf, schema)
 
       //when
       Source(avroDocuments)

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
@@ -10,12 +10,16 @@ import akka.stream.alpakka.avroparquet.scaladsl.AvroParquetFlow
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
+import com.sksamuel.avro4s.Record
 import org.apache.avro.generic.GenericRecord
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.apache.parquet.hadoop.ParquetWriter
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
+
+import scala.collection.immutable
+import scala.concurrent.Future
 
 class AvroParquetFlowSpec
     extends TestKit(ActorSystem("FlowSpec"))
@@ -30,18 +34,18 @@ class AvroParquetFlowSpec
     "insert avro records in parquet" in assertAllStagesStopped {
       //given
       val n: Int = 2
-      val records: List[GenericRecord] = genDocuments(n).sample.get.map(docToRecord)
-      val writer: ParquetWriter[GenericRecord] = parquetWriter(file, conf, schema)
+      val records: List[Record] = genDocuments(n).sample.get.map(format.to(_))
+      val writer: ParquetWriter[Record] = avro4sWriter[Record](file, conf, schema)
 
       //when
       // #init-flow
-      val source: Source[GenericRecord, NotUsed] = // ???
+      val source: Source[Record, NotUsed] = // ???
         // #init-flow
-        Source.fromIterator(() => records.iterator)
+        Source(records)
       // #init-flow
 
-      val avroParquet: Flow[GenericRecord, GenericRecord, NotUsed] = AvroParquetFlow(writer)
-      val result =
+      val avroParquet: Flow[Record, Record, NotUsed] = AvroParquetFlow[Record](writer)
+      val result: Future[immutable.Seq[Record]] =
         source
           .via(avroParquet)
           .runWith(Sink.seq)
@@ -52,9 +56,8 @@ class AvroParquetFlowSpec
       //then
       val parquetContent: List[GenericRecord] = fromParquet(file, conf)
       parquetContent.length shouldEqual n
-      parquetContent should contain theSameElementsAs records
+      parquetContent.map(format.from(_)) should contain theSameElementsAs records.map(format.from(_))
     }
-
   }
 
 }

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
@@ -32,16 +32,15 @@ class AvroParquetFlowSpec
       //given
       val n: Int = 2
       val file: String = genFinalFile.sample.get
-      val records: List[GenericRecord] = genDocuments(n).sample.get.map(docToGenericRecord)
+      // #init-flow
+      val records: List[GenericRecord]
+      // #init-flow
+      = genDocuments(n).sample.get.map(docToGenericRecord)
       val writer: ParquetWriter[GenericRecord] = parquetWriter(file, conf, schema)
 
       //when
       // #init-flow
-      val source: Source[GenericRecord, NotUsed] = // ???
-        // #init-flow
-        Source.fromIterator(() => records.iterator)
-      // #init-flow
-
+      val source: Source[GenericRecord, NotUsed] = Source(records)
       val avroParquet: Flow[GenericRecord, GenericRecord, NotUsed] = AvroParquetFlow(writer)
       val result =
         source

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
@@ -40,7 +40,7 @@ class AvroParquetFlowSpec
         .futureValue
 
       //then
-      val parquetContent: List[GenericRecord] = fromParquet[GenericRecord](file, conf)
+      val parquetContent: List[GenericRecord] = fromParquet(file, conf)
       parquetContent.length shouldEqual n
       parquetContent should contain theSameElementsAs records
     }

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
@@ -45,8 +45,9 @@ class AvroParquetFlowSpec
         source
           .via(avroParquet)
           .runWith(Sink.seq)
-          // #init-flow
-          .futureValue
+      // #init-flow
+
+      result.futureValue
 
       //then
       val parquetContent: List[GenericRecord] = fromParquet(file, conf)

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
@@ -10,7 +10,6 @@ import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import org.scalatest.concurrent.ScalaFutures
-
 import org.apache.avro.generic.GenericRecord
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
@@ -36,7 +35,7 @@ class AvroParquetSinkSpec
         .futureValue
 
       //when
-      val parquetContent: List[GenericRecord] = fromParquet[GenericRecord](file, conf)
+      val parquetContent: List[GenericRecord] = fromParquet(file, conf)
 
       //then
       parquetContent.length shouldEqual n

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
@@ -36,8 +36,7 @@ class AvroParquetSinkSpec
       val file: String = genFinalFile.sample.get
       val records: List[GenericRecord] = genDocuments(n).sample.get.map(docToGenericRecord)
 
-      val writer = parquetWriter(file, conf, schema)
-      Source(records).runWith(AvroParquetSink(writer)).futureValue
+      Source(records).runWith(AvroParquetSink(parquetWriter(file, conf, schema))).futureValue
 
       //when
       val parquetContent: List[GenericRecord] = fromParquet(file, conf)
@@ -58,7 +57,7 @@ class AvroParquetSinkSpec
       // #init-sink
       val source: Source[Record, NotUsed] = Source(records)
       // #init-sink
-      val writer: ParquetWriter[Record] = avro4sWriter[Record](file, conf, schema)
+      val writer: ParquetWriter[Record] = parquetWriter[Record](file, conf, schema)
       // #init-sink
       val result: Future[Done] = source
         .runWith(AvroParquetSink(writer))

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
@@ -5,52 +5,48 @@
 package docs.scaladsl
 
 import java.io.File
-import java.util.concurrent.TimeUnit
 
-import akka.Done
 import akka.stream.alpakka.avroparquet.scaladsl.AvroParquetSink
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
-import org.apache.parquet.avro.AvroParquetReader
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.matchers.should.Matchers
-import org.specs2.mutable.Specification
-import org.specs2.specification.AfterAll
 
-import scala.collection.{immutable, mutable}
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, Future}
 import scala.reflect.io.Directory
-//#init-writer
-import org.apache.hadoop.conf.Configuration
-import org.apache.parquet.hadoop.ParquetWriter
 import org.apache.avro.generic.GenericRecord
-import org.apache.hadoop.fs.Path
-import org.apache.parquet.hadoop.util.HadoopInputFile
-import org.apache.parquet.avro.{AvroParquetWriter, AvroReadSupport}
-//#init-writer
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class AvroParquetSinkSpec extends Specification with AbstractAvroParquet with ScalaFutures with AfterAll {
+class AvroParquetSinkSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with AbstractAvroParquet
+    with ScalaFutures
+    with BeforeAndAfterAll {
 
   "Parquet Sink" should {
 
     "create new parquet file" in assertAllStagesStopped {
-      val initialRecords: List[GenericRecord] = genDocuments.sample.get.map(docToRecord)
-
+      //given
+      val n: Int = 3
+      val records: List[GenericRecord] = genDocuments(n).sample.get.map(docToRecord)
       Source
-        .fromIterator(() => initialRecords.iterator)
+        .fromIterator(() => records.iterator)
         .runWith(AvroParquetSink(parquetWriter(file, conf, schema)))
         .futureValue
 
+      //when
       val parquetContent: List[GenericRecord] = fromParquet[GenericRecord](file, conf)
-      parquetContent.length shouldEqual 3
 
+      //then
+      parquetContent.length shouldEqual n
+      parquetContent should contain theSameElementsAs records
     }
 
   }
 
-  def afterAll(): Unit = {
+  override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
     val directory = new Directory(new File(folder))
     directory.deleteRecursively()

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
@@ -6,8 +6,9 @@ package docs.scaladsl
 
 import java.io.File
 
+import akka.actor.ActorSystem
 import akka.stream.alpakka.avroparquet.scaladsl.AvroParquetSink
-import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import org.scalatest.concurrent.ScalaFutures
@@ -19,7 +20,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class AvroParquetSinkSpec
-    extends AnyWordSpecLike
+    extends TestKit(ActorSystem("SinkSpec"))
+    with AnyWordSpecLike
     with Matchers
     with AbstractAvroParquet
     with ScalaFutures

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
@@ -10,7 +10,7 @@ import akka.stream.alpakka.avroparquet.scaladsl.AvroParquetSink
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
-import com.sksamuel.avro4s.Record
+import com.sksamuel.avro4s.{Record, RecordFormat}
 import org.scalatest.concurrent.ScalaFutures
 import org.apache.avro.generic.GenericRecord
 import org.apache.parquet.hadoop.ParquetWriter
@@ -51,14 +51,10 @@ class AvroParquetSinkSpec
       val n: Int = 3
       val file: String = genFinalFile.sample.get
       val documents: List[Document] = genDocuments(n).sample.get
-      // #init-sink
-      val records: List[Record] = // ???
-        documents.map(format.to(_))
-      // #init-sink
-      val source: Source[Record, NotUsed] = Source(records)
-      // #init-sink
       val writer: ParquetWriter[Record] = parquetWriter[Record](file, conf, schema)
       // #init-sink
+      val records: List[Record] = documents.map(RecordFormat[Document].to(_))
+      val source: Source[Record, NotUsed] = Source(records)
       val result: Future[Done] = source
         .runWith(AvroParquetSink(writer))
       // #init-sink

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
@@ -34,15 +34,10 @@ class AvroParquetSinkSpec
       //given
       val n: Int = 3
       val file: String = genFinalFile.sample.get
-      val records: List[GenericRecord] = genDocuments(n).sample.get.map(docToRecord)
-      val source: Source[GenericRecord, NotUsed] = // ???
-        Source(records)
+      val records: List[GenericRecord] = genDocuments(n).sample.get.map(docToGenericRecord)
+
       val writer = parquetWriter(file, conf, schema)
-      // #init-sink
-      val result: Future[Done] = source
-        .runWith(AvroParquetSink(writer))
-      // #init-sink
-      result.futureValue shouldBe Done
+      Source(records).runWith(AvroParquetSink(writer)).futureValue
 
       //when
       val parquetContent: List[GenericRecord] = fromParquet(file, conf)
@@ -57,11 +52,12 @@ class AvroParquetSinkSpec
       val n: Int = 3
       val file: String = genFinalFile.sample.get
       val documents: List[Document] = genDocuments(n).sample.get
-      val records: List[Record] = documents.map(format.to(_))
       // #init-sink
-      val source: Source[Record, NotUsed] = // ???
-        // #init-sink
-        Source(records)
+      val records: List[Record] = // ???
+        documents.map(format.to(_))
+      // #init-sink
+      val source: Source[Record, NotUsed] = Source(records)
+      // #init-sink
       val writer: ParquetWriter[Record] = avro4sWriter[Record](file, conf, schema)
       // #init-sink
       val result: Future[Done] = source

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
@@ -47,6 +47,8 @@ class AvroParquetSinkSpec
     }
 
     "create new parquet file from any subtype of `GenericRecord` " in assertAllStagesStopped {
+      import scala.language.higherKinds
+
       //given
       val n: Int = 3
       val file: String = genFinalFile.sample.get

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
@@ -4,8 +4,6 @@
 
 package docs.scaladsl
 
-import java.io.File
-
 import akka.actor.ActorSystem
 import akka.stream.alpakka.avroparquet.scaladsl.AvroParquetSink
 import akka.stream.scaladsl.Source
@@ -13,7 +11,6 @@ import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import org.scalatest.concurrent.ScalaFutures
 
-import scala.reflect.io.Directory
 import org.apache.avro.generic.GenericRecord
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
@@ -46,12 +43,6 @@ class AvroParquetSinkSpec
       parquetContent should contain theSameElementsAs records
     }
 
-  }
-
-  override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
-    val directory = new Directory(new File(folder))
-    directory.deleteRecursively()
   }
 
 }

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
@@ -35,7 +35,7 @@ class AvroParquetSourceSpec
       //given
       val n: Int = 4
       val file: String = genFinalFile.sample.get
-      val records: List[GenericRecord] = genDocuments(n).sample.get.map(docToRecord)
+      val records: List[GenericRecord] = genDocuments(n).sample.get.map(docToGenericRecord)
       Source(records)
         .toMat(AvroParquetSink(parquetWriter(file, conf, schema)))(Keep.right)
         .run()

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
@@ -4,12 +4,14 @@
 
 package docs.scaladsl
 
+import java.io.File
 import java.util.concurrent.TimeUnit
 
 import akka.stream.alpakka.avroparquet.scaladsl.{AvroParquetSink, AvroParquetSource}
 import akka.stream.scaladsl.{Keep, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.TestKit
 import akka.{Done, NotUsed}
 import org.apache.parquet.avro.AvroParquetWriter
 import org.apache.parquet.hadoop.ParquetWriter
@@ -18,6 +20,7 @@ import org.specs2.specification.{AfterAll, BeforeAll}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
+import scala.reflect.io.Directory
 
 //#init-reader
 import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
@@ -55,7 +58,11 @@ class AvroParquetSourceSpec extends Specification with AbstractAvroParquet with 
     }
 
   }
-
+  def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    val directory = new Directory(new File(folder))
+    directory.deleteRecursively()
+  }
   override def beforeAll(): Unit = {
     case class Document(id: String, body: String)
 

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
@@ -6,6 +6,7 @@ package docs.scaladsl
 
 import java.io.File
 
+import akka.actor.ActorSystem
 import akka.stream.alpakka.avroparquet.scaladsl.{AvroParquetSink, AvroParquetSource}
 import akka.stream.scaladsl.{Keep, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -22,7 +23,8 @@ import scala.concurrent.duration._
 import scala.reflect.io.Directory
 
 class AvroParquetSourceSpec
-    extends AnyWordSpecLike
+    extends TestKit(ActorSystem("SourceSpec"))
+    with AnyWordSpecLike
     with AbstractAvroParquet
     with Matchers
     with ScalaFutures

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
@@ -4,8 +4,6 @@
 
 package docs.scaladsl
 
-import java.io.File
-
 import akka.actor.ActorSystem
 import akka.stream.alpakka.avroparquet.scaladsl.{AvroParquetSink, AvroParquetSource}
 import akka.stream.scaladsl.{Keep, Source}
@@ -20,7 +18,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.concurrent.duration._
-import scala.reflect.io.Directory
 
 class AvroParquetSourceSpec
     extends TestKit(ActorSystem("SourceSpec"))

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
@@ -61,12 +61,12 @@ class AvroParquetSourceSpec
       val documents: List[Document] = genDocuments(n).sample.get
       val avroDocuments: List[Record] = documents.map(format.to(_))
       Source(avroDocuments)
-        .toMat(AvroParquetSink(avro4sWriter(file, conf, schema)))(Keep.right)
+        .toMat(AvroParquetSink(parquetWriter(file, conf, schema)))(Keep.right)
         .run()
         .futureValue
 
       //when
-      val reader: ParquetReader[GenericRecord] = parquetGReader(file, conf)
+      val reader: ParquetReader[GenericRecord] = parquetReader(file, conf)
       // #init-source
       val source: Source[GenericRecord, NotUsed] = AvroParquetSource(reader)
       // #init-source

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
@@ -56,10 +56,4 @@ class AvroParquetSourceSpec
 
   }
 
-  override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
-    val directory = new Directory(new File(folder))
-    directory.deleteRecursively()
-  }
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,11 @@ addCommandAlias("verifyCodeStyle", "headerCheck; verifyCodeFmt")
 lazy val amqp = alpakkaProject("amqp", "amqp", Dependencies.Amqp)
 
 lazy val avroparquet =
-  alpakkaProject("avroparquet", "avroparquet", Dependencies.AvroParquet, parallelExecution in Test := false)
+  alpakkaProject("avroparquet",
+                 "avroparquet",
+                 Dependencies.AvroParquet,
+                 crossScalaVersions -= Dependencies.Scala211,
+                 Test / parallelExecution := false)
 
 lazy val awslambda = alpakkaProject("awslambda",
                                     "aws.lambda",

--- a/docs/src/main/paradox/avroparquet.md
+++ b/docs/src/main/paradox/avroparquet.md
@@ -25,19 +25,11 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Source Initiation
 
-We will need an @apidoc[akka.actor.ActorSystem] and an @apidoc[akka.stream.Materializer].
-
-Scala
-: @@snip (/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala) { #init-system }
-
-Java
-: @@snip (/avroparquet/src/test/java/docs/javadsl/Examples.java) { #init-system }
-
 Sometimes it might be useful to use parquet file as stream Source. For this we will need to create `AvroParquetReader` 
 instance which produces Parquet `GenericRecord` instances.
  
 Scala
-: @@snip (/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala) { #init-reader } 
+: @@snip (/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala) { #prepare #init-reader }
 
 Java
 : @@snip (/avroparquet/src/test/java/docs/javadsl/Examples.java) { #init-reader }
@@ -57,7 +49,7 @@ Parquet files on HDFS (or any other distributed file system) and perform map-red
 For this we first of all need to create `AvroParquetWriter` instance which accepts `GenericRecord`.
  
 Scala
-: @@snip (/avroparquet/src/test/scala/docs/scaladsl//AvroParquetSinkSpec.scala) { #init-writer } 
+: @@snip (/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala) { #prepare #init-writer }
 
 Java
 : @@snip (/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java) { #init-writer }

--- a/docs/src/main/paradox/avroparquet.md
+++ b/docs/src/main/paradox/avroparquet.md
@@ -55,9 +55,13 @@ Java
 : @@snip (/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java) { #init-writer }
 
 After that, the AvroParquet Sink can already be used. 
+
+@@@ div { .group-scala }
+
 The below scala example demonstrates that *any* subtype of `GenericRecord` can be passed to the stream, in this case the one used is `com.sksamuel.avro4s.Record`, which it implements the `GenericRecord` avro interface.
-See [Avro4s](https://github.com/sksamuel/avro4s:) or [Avrohugger](https://github.com/julianpeeters/avrohugger:)
-) between other ways of generating these classes.
+See [Avro4s](https://github.com/sksamuel/avro4s) or [Avrohugger](https://github.com/julianpeeters/avrohugger) between other ways of generating these classes.
+
+@@@
  
 Scala
 : @@snip (/avroparquet/src/test/scala/docs/scaladsl//AvroParquetSinkSpec.scala) { #init-sink }
@@ -67,7 +71,7 @@ Java
 
 ## Flow Initiation
 
-The representation of a ParquetWriter as a Flow is also available to use as a streams flow stage, in which as well as per the other representations, it will expect subtypes of the Parquet `GenericRecord` type to be passed.
+The representation of a `ParquetWriter` as a Flow is also available to use as a streams flow stage, in which as well as per the other representations, it will expect subtypes of the Parquet `GenericRecord` type to be passed.
  In which as a result, writes into a Parquet file and return the same `GenericRecord`s. Such Flow stage can be easily created by using the `AvroParquetFlow` and providing an `AvroParquetWriter` instance as parameter.
 
 Scala

--- a/docs/src/main/paradox/avroparquet.md
+++ b/docs/src/main/paradox/avroparquet.md
@@ -60,7 +60,7 @@ See [Avro4s](https://github.com/sksamuel/avro4s:) or [Avrohugger](https://github
 ) between other ways of generating these classes.
  
 Scala
-: @@snip (/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala) { #init-sink }
+: @@snip (/avroparquet/src/test/scala/docs/scaladsl//AvroParquetSinkSpec.scala) { #init-sink }
 
 Java
 : @@snip (/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java) { #init-sink }

--- a/docs/src/main/paradox/avroparquet.md
+++ b/docs/src/main/paradox/avroparquet.md
@@ -26,15 +26,16 @@ The table below shows direct dependencies of this module and the second tab show
 ## Source Initiation
 
 Sometimes it might be useful to use parquet file as stream Source. For this we will need to create `AvroParquetReader` 
-instance which produces Parquet `GenericRecord` instances.
+instance which will produce records as a subtypes of `GenericRecord`, the abstract representation of a record in parquet.
  
 Scala
-: @@snip (/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala) { #prepare #init-reader }
+: @@snip (/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala) { #prepare-source #init-reader }
 
 Java
 : @@snip (/avroparquet/src/test/java/docs/javadsl/Examples.java) { #init-reader }
 
-After it, you can create your Source object which accepts instance of `AvroParquetReader` as parameter 
+After that, you can create the parquet Source from the initialisation of `AvroParquetReader`, this object requires an instance of 
+  a `org.apache.parquet.hadoop.ParquetReader` typed by a subtype of `GenericRecord`.
 
 Scala
 : @@snip (/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala) { #init-source }
@@ -44,29 +45,31 @@ Java
 
 ## Sink Initiation
 
-Sometimes it might be useful to use Parquet file as akka stream Sink. For an instance, if you need to store data on 
-Parquet files on HDFS (or any other distributed file system) and perform map-reduce jobs on it further. 
-For this we first of all need to create `AvroParquetWriter` instance which accepts `GenericRecord`.
+On the other hand, you can use `AvroParquetWriter`, as the akka streams Sink implementation for writing to parquet. 
+In that case, its initialisation would require an instance of `org.apache.parquet.hadoop.ParquetWriter`, it will also expect any subtype of `GenericRecord` to be passed.
  
 Scala
-: @@snip (/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala) { #prepare #init-writer }
+: @@snip (/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala) { #prepare-sink }
 
 Java
 : @@snip (/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java) { #init-writer }
 
-After it, you can create Sink which accepts instance of `AvroParquetWriter` as parameter. 
+After that, the AvroParquet Sink can already be used. [Akka HTTP](akka-http:)
+In order to demonstrate that *any* subtype of `GenericRecord` can be passed to the stream, the below Scala example 
+represents it by passing instances of `com.sksamuel.avro4s.Record`, which it is a type that implements the `GenericRecord` avro interface.
+See [Avro4s](https://github.com/sksamuel/avro4s:) or [Avrohugger](https://github.com/julianpeeters/avrohugger:)
+) between other ways of generating these classes.
  
 Scala
-: @@snip (/avroparquet/src/test/scala/docs/scaladsl//AvroParquetSinkSpec.scala) { #init-sink }
+: @@snip (/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala) { #init-sink }
 
 Java
 : @@snip (/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java) { #init-sink }
 
 ## Flow Initiation
 
-It might be useful to use ParquetWriter as the streams flow stage, which accepts Parquet `GenericRecord`, writes it to
-Parquet file, and returns the same `GenericRecords`. Such Flow stage can be easily created by creating `AvroParquetFlow`
-instance and providing `AvroParquetWriter` instance as parameter.
+The representation of a ParquetWriter as a Flow is also available to use as a streams flow stage, in which as well as per the other representations, it will expect subtypes of the Parquet `GenericRecord` type to be passed.
+ In which as a result, writes into a Parquet file and return the same `GenericRecord`s. Such Flow stage can be easily created by using the `AvroParquetFlow` and providing an `AvroParquetWriter` instance as parameter.
 
 Scala
 : @@snip (/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala) { #init-flow }

--- a/docs/src/main/paradox/avroparquet.md
+++ b/docs/src/main/paradox/avroparquet.md
@@ -26,7 +26,7 @@ The table below shows direct dependencies of this module and the second tab show
 ## Source Initiation
 
 Sometimes it might be useful to use parquet file as stream Source. For this we will need to create `AvroParquetReader` 
-instance which will produce records as a subtypes of `GenericRecord`, the abstract representation of a record in parquet.
+instance which will produce records as a subtypes of `GenericRecord`, the avro's record abstract representation.
  
 Scala
 : @@snip (/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala) { #prepare-source #init-reader }
@@ -54,9 +54,8 @@ Scala
 Java
 : @@snip (/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java) { #init-writer }
 
-After that, the AvroParquet Sink can already be used. [Akka HTTP](akka-http:)
-In order to demonstrate that *any* subtype of `GenericRecord` can be passed to the stream, the below Scala example 
-represents it by passing instances of `com.sksamuel.avro4s.Record`, which it is a type that implements the `GenericRecord` avro interface.
+After that, the AvroParquet Sink can already be used. 
+The below scala example demonstrates that *any* subtype of `GenericRecord` can be passed to the stream, in this case the one used is `com.sksamuel.avro4s.Record`, which it implements the `GenericRecord` avro interface.
 See [Avro4s](https://github.com/sksamuel/avro4s:) or [Avrohugger](https://github.com/julianpeeters/avrohugger:)
 ) between other ways of generating these classes.
  

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -183,6 +183,7 @@ object Dependencies {
         "org.apache.parquet" % "parquet-avro" % "1.10.0", //Apache2
         "org.apache.hadoop" % "hadoop-client" % "3.2.1" % Test exclude ("log4j", "log4j"), //Apache2
         "org.apache.hadoop" % "hadoop-common" % "3.2.1" % Test exclude ("log4j", "log4j"), //Apache2
+        "com.sksamuel.avro4s" %% "avro4s-core" % "3.0.0" % Test,
         "org.scalacheck" %% "scalacheck" % "1.14.1" % Test,
         "org.specs2" %% "specs2-core" % "4.8.0" % Test, //MIT like: https://github.com/etorreborre/specs2/blob/master/LICENSE.txt
         "org.slf4j" % "log4j-over-slf4j" % log4jOverSlf4jVersion % Test // MIT like: http://www.slf4j.org/license.html

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -180,12 +180,13 @@ object Dependencies {
 
   val AvroParquet = Seq(
     libraryDependencies ++= Seq(
-        "org.apache.parquet" % "parquet-avro" % "1.10.0", //Apache2
-        "org.apache.hadoop" % "hadoop-client" % "3.2.1" % Test exclude ("log4j", "log4j"), //Apache2
-        "org.apache.hadoop" % "hadoop-common" % "3.2.1" % Test exclude ("log4j", "log4j"), //Apache2
-        "org.specs2" %% "specs2-core" % "4.8.0" % Test, //MIT like: https://github.com/etorreborre/specs2/blob/master/LICENSE.txt
-        "org.slf4j" % "log4j-over-slf4j" % log4jOverSlf4jVersion % Test // MIT like: http://www.slf4j.org/license.html
-      )
+      "org.apache.parquet" % "parquet-avro" % "1.10.0", //Apache2
+      "org.apache.hadoop" % "hadoop-client" % "3.2.1" % Test exclude("log4j", "log4j"), //Apache2
+      "org.apache.hadoop" % "hadoop-common" % "3.2.1" % Test exclude("log4j", "log4j"), //Apache2
+      "org.scalacheck" %% "scalacheck" % "1.14.1" % Test,
+      "org.specs2" %% "specs2-core" % "4.8.0" % Test, //MIT like: https://github.com/etorreborre/specs2/blob/master/LICENSE.txt
+      "org.slf4j" % "log4j-over-slf4j" % log4jOverSlf4jVersion % Test // MIT like: http://www.slf4j.org/license.html
+    )
   )
 
   val Ftp = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -180,13 +180,13 @@ object Dependencies {
 
   val AvroParquet = Seq(
     libraryDependencies ++= Seq(
-      "org.apache.parquet" % "parquet-avro" % "1.10.0", //Apache2
-      "org.apache.hadoop" % "hadoop-client" % "3.2.1" % Test exclude("log4j", "log4j"), //Apache2
-      "org.apache.hadoop" % "hadoop-common" % "3.2.1" % Test exclude("log4j", "log4j"), //Apache2
-      "org.scalacheck" %% "scalacheck" % "1.14.1" % Test,
-      "org.specs2" %% "specs2-core" % "4.8.0" % Test, //MIT like: https://github.com/etorreborre/specs2/blob/master/LICENSE.txt
-      "org.slf4j" % "log4j-over-slf4j" % log4jOverSlf4jVersion % Test // MIT like: http://www.slf4j.org/license.html
-    )
+        "org.apache.parquet" % "parquet-avro" % "1.10.0", //Apache2
+        "org.apache.hadoop" % "hadoop-client" % "3.2.1" % Test exclude ("log4j", "log4j"), //Apache2
+        "org.apache.hadoop" % "hadoop-common" % "3.2.1" % Test exclude ("log4j", "log4j"), //Apache2
+        "org.scalacheck" %% "scalacheck" % "1.14.1" % Test,
+        "org.specs2" %% "specs2-core" % "4.8.0" % Test, //MIT like: https://github.com/etorreborre/specs2/blob/master/LICENSE.txt
+        "org.slf4j" % "log4j-over-slf4j" % log4jOverSlf4jVersion % Test // MIT like: http://www.slf4j.org/license.html
+      )
   )
 
   val Ftp = Seq(


### PR DESCRIPTION
Hello!
There is no issue related with this PR.

While looking at how to implement protobuf parquet connector, I realised that the current implementation of avroparquet was statically typead as `GenericRecord`, which for the Akka user is not nice.

On continuation with that the tests were simplified and improved by not just checking the number of records written but also the actual content of the file.