### PR TITLE
S3: Add some backoff delay to multipart upload retries for tests

### DIFF
--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -955,8 +955,8 @@ object S3WireMockBase {
     |  path-style-access = false
     |  endpoint-url = "http://localhost:$proxyPort"
     |  retry-settings {
-    |    min-backoff = 0s
-    |    max-backoff = 0s
+    |    min-backoff = 100ms
+    |    max-backoff = 300ms
     |  }
     |}
     """.stripMargin)


### PR DESCRIPTION
…to try and address intermittent failures (#2209).

No guarantees this will address the failures, but I can't replicate them locally, so will have to rely on Travis.