### PR TITLE
Build: Akka HTTP 10.2 in cron build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -348,6 +348,7 @@ lazy val docs = project
         "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.AkkaBinaryVersion}/%s",
         "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.AkkaBinaryVersion}",
         "javadoc.akka.base_url" -> s"https://doc.akka.io/japi/akka/${Dependencies.AkkaBinaryVersion}/",
+        "javadoc.akka.link_style" -> "direct",
         "extref.akka-http.base_url" -> s"https://doc.akka.io/docs/akka-http/${Dependencies.AkkaHttpBinaryVersion}/%s",
         "scaladoc.akka.http.base_url" -> s"https://doc.akka.io/api/akka-http/${Dependencies.AkkaHttpBinaryVersion}/",
         "javadoc.akka.http.base_url" -> s"https://doc.akka.io/japi/akka-http/${Dependencies.AkkaHttpBinaryVersion}/",

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -29,7 +29,7 @@ object Common extends AutoPlugin {
                             "Contributors",
                             "https://gitter.im/akka/dev",
                             url("https://github.com/akka/alpakka/graphs/contributors")),
-    licenses := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
+    licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
     description := "Alpakka is a Reactive Enterprise Integration library for Java and Scala, based on Reactive Streams and Akka.",
     fatalWarnings := true,
     mimaReportSignatureProblems := true
@@ -56,7 +56,7 @@ object Common extends AutoPlugin {
           case _ => Seq("-Xfuture", "-Yno-adapted-args")
         }),
       scalacOptions ++= (scalaVersion.value match {
-          case Dependencies.Scala212 if insideCI.value && fatalWarnings.value && !Dependencies.Nightly =>
+          case Dependencies.Scala212 if insideCI.value && fatalWarnings.value && !Dependencies.CronBuild =>
             Seq("-Xfatal-warnings")
           case _ => Seq.empty
         }),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,17 +3,17 @@ import Keys._
 
 object Dependencies {
 
-  val Nightly = sys.env.get("TRAVIS_EVENT_TYPE").contains("cron")
+  val CronBuild = sys.env.get("TRAVIS_EVENT_TYPE").contains("cron")
 
   val Scala211 = "2.11.12"
   val Scala212 = "2.12.10"
   val Scala213 = "2.13.1"
-  val ScalaVersions = Seq(Scala212, Scala211, Scala213).filterNot(_ == Scala211 && Nightly)
+  val ScalaVersions = Seq(Scala212, Scala211, Scala213).filterNot(_ == Scala211 && CronBuild)
 
   val Akka25Version = "2.5.31"
   val Akka26Version = "2.6.4"
-  val AkkaVersion = if (Nightly) Akka26Version else Akka25Version
-  val AkkaBinaryVersion = if (Nightly) "2.6" else "2.5"
+  val AkkaVersion = if (CronBuild) Akka26Version else Akka25Version
+  val AkkaBinaryVersion = if (CronBuild) "2.6" else "2.5"
 
   val InfluxDBJavaVersion = "2.15"
 
@@ -21,8 +21,10 @@ object Dependencies {
   val AwsSpiAkkaHttpVersion = "0.0.8"
   // Sync with plugins.sbt
   val AkkaGrpcBinaryVersion = "0.8"
-  val AkkaHttpVersion = "10.1.11"
-  val AkkaHttpBinaryVersion = "10.1"
+  val AkkaHttp101 = "10.1.11"
+  val AkkaHttp102 = "10.2.0-M1"
+  val AkkaHttpVersion = if (CronBuild) AkkaHttp102 else AkkaHttp101
+  val AkkaHttpBinaryVersion = if (CronBuild) "10.2" else "10.1"
   val mockitoVersion = "3.1.0"
 
   val CouchbaseVersion = "2.7.13"

--- a/sse/src/test/scala/docs/scaladsl/EventSourceSpec.scala
+++ b/sse/src/test/scala/docs/scaladsl/EventSourceSpec.scala
@@ -84,6 +84,7 @@ object EventSourceSpec {
     import Server._
     import context.dispatcher
 
+    private implicit val sys = context.system
     private implicit val mat = ActorMaterializer()
 
     context.system.scheduler.scheduleOnce(1.second, self, Bind)


### PR DESCRIPTION
Make the scheduled build use Akka 2.6 and Akka HTTP 10.2.

This required to provide an implicit actor system in the SSE tests, so that the `Route` to `Flow[...]` conversion would become applicable.

https://doc.akka.io//docs/akka-http/10.2/release-notes/10.2.x.html
