### PR TITLE
MQTT: avoid completing promise on reconnect

### DIFF
--- a/mqtt/src/main/scala/akka/stream/alpakka/mqtt/impl/MqttFlowStage.scala
+++ b/mqtt/src/main/scala/akka/stream/alpakka/mqtt/impl/MqttFlowStage.scala
@@ -94,11 +94,15 @@ abstract class MqttFlowStageLogic[I](in: Inlet[I],
   protected def handleDeliveryComplete(token: IMqttDeliveryToken): Unit = ()
 
   private val onSubscribe: AsyncCallback[Try[IMqttToken]] = getAsyncCallback[Try[IMqttToken]] { conn =>
-    subscriptionPromise.complete(conn.map(_ => {
-      log.debug("subscription established")
-      Done
-    }))
-    pull(in)
+    if (subscriptionPromise.isCompleted) {
+      log.debug("subscription re-established")
+    } else {
+      subscriptionPromise.complete(conn.map(_ => {
+        log.debug("subscription established")
+        Done
+      }))
+      pull(in)
+    }
   }
 
   private val onConnect: AsyncCallback[IMqttAsyncClient] =


### PR DESCRIPTION
The materialized subscription promise should not be completed again when a reconnect happens.

(I'm not sure yet why this problem didn't show earlier.)

References #2288