### PR TITLE
CSV: handle UTF-8 BOM correctly

### DIFF
--- a/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvParser.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvParser.scala
@@ -182,7 +182,7 @@ import scala.collection.mutable
   private[this] def checkForByteOrderMark(): Unit =
     if (buffer.length >= 2) {
       if (buffer.startsWith(ByteOrderMark.UTF_8)) {
-        advance(4)
+        advance(3)
         fieldStart = 3
       } else {
         if (buffer.startsWith(ByteOrderMark.UTF_16_LE)) {

--- a/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
@@ -321,6 +321,11 @@ class CsvParserSpec extends AnyWordSpec with Matchers with OptionValues with Log
       expectBsInOut(in, List("one", "two", "three"))
     }
 
+    "handle quote right after UTF-8 BOM" in {
+      val in = ByteOrderMark.UTF_8 ++ ByteString("\"one\",\"two\",\"three\"\n", StandardCharsets.UTF_8.name())
+      expectBsInOut(in, List("one", "two", "three"))
+    }
+
     "fail for UTF-16 LE BOM" in {
       val in = ByteOrderMark.UTF_16_LE ++ ByteString("one,two,three\n", StandardCharsets.UTF_16LE.name())
       a[UnsupportedCharsetException] should be thrownBy expectBsInOut(in, List("one", "two", "three"))


### PR DESCRIPTION
When the input to CSVParser.offer starts with a UTF-8 byte order marker, the cursor is advanced 4 places (but the size of the BOM is 3 bytes). This causes an edge case if the first value is quoted, where it gets wrapped in additional quotes:

```
      val in = ByteString("\"one\",\"two\",\"three\"\n", StandardCharsets.UTF_8.name())
      val inWithBom = ByteOrderMark.UTF_8 ++ in
      val parser = new CsvParser(',', '"', '\\', maximumLineLength)

      println("Without BOM")
      parser.offer(in)
      parser.poll(false).value.map(_.utf8String).foreach(s => println("- " + s))

      println("With BOM")
      parser.offer(inWithBom)
      parser.poll(false).value.map(_.utf8String).foreach(s => println("- " + s))
```

Output prior to this change (see the extra quotes around "one" in the second case):

```
Without BOM
- one
- two
- three
With BOM
- ﻿"one"
- two
- three
```