### PR TITLE
Slick/JDBC: Support `PreparedStatement` use in Java DSL

### DIFF
--- a/slick/src/main/scala/akka/stream/alpakka/slick/javadsl/Slick.scala
+++ b/slick/src/main/scala/akka/stream/alpakka/slick/javadsl/Slick.scala
@@ -4,20 +4,25 @@
 
 package akka.stream.alpakka.slick.javadsl
 
+import java.sql.Connection
+import java.sql.PreparedStatement
 import java.util.concurrent.CompletionStage
-import java.util.function.{BiFunction => JBiFunction, Function => JFunction}
+import java.util.function.{Function => JFunction}
+import java.util.function.{BiFunction => JBiFunction}
 
-import scala.compat.java8.FunctionConverters._
-import scala.compat.java8.FutureConverters._
 import akka.Done
 import akka.NotUsed
+import akka.japi.function.Function2
+import akka.stream.alpakka.slick.scaladsl.{Slick => ScalaSlick}
 import akka.stream.javadsl._
 import slick.dbio.DBIO
 import slick.jdbc.GetResult
 import slick.jdbc.SQLActionBuilder
 import slick.jdbc.SetParameter
-import akka.stream.alpakka.slick.scaladsl.{Slick => ScalaSlick}
+import slick.jdbc.SimpleJdbcAction
 
+import scala.compat.java8.FunctionConverters._
+import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext
 
 object Slick {
@@ -54,7 +59,7 @@ object Slick {
    *           those statements against the specified Slick database.
    *
    * @param session The database session to use.
-   * @param toStatement A function that creeates the SQL statement to
+   * @param toStatement A function that creates the SQL statement to
    *                    execute from the current element. Any DML or
    *                    DDL statement is acceptable.
    */
@@ -71,10 +76,27 @@ object Slick {
    *           those statements against the specified Slick database.
    *
    * @param session The database session to use.
+   * @param toStatement A function that creates the SQL statement to
+   *                    execute from the current element. Any DML or
+   *                    DDL statement is acceptable.
+   */
+  def flow[T](
+      session: SlickSession,
+      toStatement: Function2[T, Connection, PreparedStatement]
+  ): Flow[T, java.lang.Integer, NotUsed] =
+    flow(session, 1, toStatement)
+
+  /**
+   * Java API: creates a Flow that takes a stream of elements of
+   *           type T, transforms each element to a SQL statement
+   *           using the specified function, and then executes
+   *           those statements against the specified Slick database.
+   *
+   * @param session The database session to use.
    * @param parallelism How many parallel asynchronous streams should be
    *                    used to send statements to the database. Use a
    *                    value of 1 for sequential execution.
-   * @param toStatement A function that creeates the SQL statement to
+   * @param toStatement A function that creates the SQL statement to
    *                    execute from the current element. Any DML or
    *                    DDL statement is acceptable.
    */
@@ -85,7 +107,31 @@ object Slick {
   ): Flow[T, java.lang.Integer, NotUsed] =
     ScalaSlick
       .flow[T](parallelism, toDBIO(toStatement))(session)
-      .map(Int.box(_))
+      .map(Int.box)
+      .asJava
+
+  /**
+   * Java API: creates a Flow that takes a stream of elements of
+   *           type T, transforms each element to a SQL statement
+   *           using the specified function, and then executes
+   *           those statements against the specified Slick database.
+   *
+   * @param session The database session to use.
+   * @param parallelism How many parallel asynchronous streams should be
+   *                    used to send statements to the database. Use a
+   *                    value of 1 for sequential execution.
+   * @param toStatement A function that creates the SQL statement to
+   *                    execute from the current element. Any DML or
+   *                    DDL statement is acceptable.
+   */
+  def flow[T](
+      session: SlickSession,
+      parallelism: Int,
+      toStatement: Function2[T, Connection, PreparedStatement]
+  ): Flow[T, java.lang.Integer, NotUsed] =
+    ScalaSlick
+      .flow[T](parallelism, toDBIO(toStatement))(session)
+      .map(Int.box)
       .asJava
 
   /**
@@ -98,7 +144,7 @@ object Slick {
    * @param session The database session to use.
    * @param executionContext ExecutionContext used to run mapper function in.
    *                         E.g. the dispatcher of the ActorSystem.
-   * @param toStatement A function that creeates the SQL statement to
+   * @param toStatement A function that creates the SQL statement to
    *                    execute from the current element. Any DML or
    *                    DDL statement is acceptable.
    * @param mapper A function to create a result from the incoming element T
@@ -109,6 +155,30 @@ object Slick {
       executionContext: ExecutionContext,
       toStatement: JFunction[T, String],
       mapper: JBiFunction[T, java.lang.Integer, R]
+  ): Flow[T, R, NotUsed] =
+    flowWithPassThrough(session, executionContext, 1, toStatement, mapper)
+
+  /**
+   * Java API: creates a Flow that takes a stream of elements of
+   *           type T, transforms each element to a SQL statement
+   *           using the specified function, then executes
+   *           those statements against the specified Slick database
+   *           and allows to combine the statement result and element into a result type R.
+   *
+   * @param session The database session to use.
+   * @param executionContext ExecutionContext used to run mapper function in.
+   *                         E.g. the dispatcher of the ActorSystem.
+   * @param toStatement A function that creates the SQL statement to
+   *                    execute from the current element. Any DML or
+   *                    DDL statement is acceptable.
+   * @param mapper A function to create a result from the incoming element T
+   *               and the database statement result.
+   */
+  def flowWithPassThrough[T, R](
+      session: SlickSession,
+      executionContext: ExecutionContext,
+      toStatement: Function2[T, Connection, PreparedStatement],
+      mapper: Function2[T, java.lang.Integer, R]
   ): Flow[T, R, NotUsed] =
     flowWithPassThrough(session, executionContext, 1, toStatement, mapper)
 
@@ -147,13 +217,47 @@ object Slick {
       .asJava
 
   /**
+   * Java API: creates a Flow that takes a stream of elements of
+   *           type T, transforms each element to a SQL statement
+   *           using the specified function, then executes
+   *           those statements against the specified Slick database
+   *           and allows to combine the statement result and element into a result type R.
+   *
+   * @param session The database session to use.
+   * @param executionContext ExecutionContext used to run mapper function in.
+   *                         E.g. the dispatcher of the ActorSystem.
+   * @param parallelism How many parallel asynchronous streams should be
+   *                    used to send statements to the database. Use a
+   *                    value of 1 for sequential execution.
+   * @param toStatement A function that creates the SQL statement to
+   *                    execute from the current element. Any DML or
+   *                    DDL statement is acceptable.
+   * @param mapper A function to create a result from the incoming element T
+   *               and the database statement result.
+   */
+  def flowWithPassThrough[T, R](
+      session: SlickSession,
+      executionContext: ExecutionContext,
+      parallelism: Int,
+      toStatement: Function2[T, Connection, PreparedStatement],
+      mapper: Function2[T, java.lang.Integer, R]
+  ): Flow[T, R, NotUsed] =
+    ScalaSlick
+      .flowWithPassThrough[T, R](parallelism, (t: T) => {
+        toDBIO(toStatement)
+          .apply(t)
+          .map(count => mapper.apply(t, count))(executionContext)
+      })(session)
+      .asJava
+
+  /**
    * Java API: creates a Sink that takes a stream of elements of
    *           type T, transforms each element to a SQL statement
    *           using the specified function, and then executes
    *           those statements against the specified Slick database.
    *
    * @param session The database session to use.
-   * @param toStatement A function that creeates the SQL statement to
+   * @param toStatement A function that creates the SQL statement to
    *                    execute from the current element. Any DML or
    *                    DDL statement is acceptable.
    */
@@ -170,10 +274,27 @@ object Slick {
    *           those statements against the specified Slick database.
    *
    * @param session The database session to use.
+   * @param toStatement A function that creates the SQL statement to
+   *                    execute from the current element. Any DML or
+   *                    DDL statement is acceptable.
+   */
+  def sink[T](
+      session: SlickSession,
+      toStatement: Function2[T, Connection, PreparedStatement]
+  ): Sink[T, CompletionStage[Done]] =
+    sink(session, 1, toStatement)
+
+  /**
+   * Java API: creates a Sink that takes a stream of elements of
+   *           type T, transforms each element to a SQL statement
+   *           using the specified function, and then executes
+   *           those statements against the specified Slick database.
+   *
+   * @param session The database session to use.
    * @param parallelism How many parallel asynchronous streams should be
    *                    used to send statements to the database. Use a
    *                    value of 1 for sequential execution.
-   * @param toStatement A function that creeates the SQL statement to
+   * @param toStatement A function that creates the SQL statement to
    *                    execute from the current element. Any DML or
    *                    DDL statement is acceptable.
    */
@@ -181,6 +302,30 @@ object Slick {
       session: SlickSession,
       parallelism: Int,
       toStatement: JFunction[T, String]
+  ): Sink[T, CompletionStage[Done]] =
+    ScalaSlick
+      .sink[T](parallelism, toDBIO(toStatement))(session)
+      .mapMaterializedValue(_.toJava)
+      .asJava
+
+  /**
+   * Java API: creates a Sink that takes a stream of elements of
+   *           type T, transforms each element to a SQL statement
+   *           using the specified function, and then executes
+   *           those statements against the specified Slick database.
+   *
+   * @param session The database session to use.
+   * @param parallelism How many parallel asynchronous streams should be
+   *                    used to send statements to the database. Use a
+   *                    value of 1 for sequential execution.
+   * @param toStatement A function that creates the SQL statement to
+   *                    execute from the current element. Any DML or
+   *                    DDL statement is acceptable.
+   */
+  def sink[T](
+      session: SlickSession,
+      parallelism: Int,
+      toStatement: Function2[T, Connection, PreparedStatement]
   ): Sink[T, CompletionStage[Done]] =
     ScalaSlick
       .sink[T](parallelism, toDBIO(toStatement))(session)
@@ -220,5 +365,11 @@ object Slick {
 
   private def toDBIO[T](javaDml: JFunction[T, String]): T => DBIO[Int] = { t =>
     SQLActionBuilder(javaDml.asScala(t), SetParameter.SetUnit).asUpdate
+  }
+
+  private def toDBIO[T](javaDml: Function2[T, Connection, PreparedStatement]): T => DBIO[Int] = { t =>
+    SimpleJdbcAction { ctx =>
+      javaDml(t, ctx.connection).executeUpdate()
+    }
   }
 }

--- a/slick/src/test/java/docs/javadsl/DocSnippetFlow.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetFlow.java
@@ -4,18 +4,21 @@
 
 package docs.javadsl;
 
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 import akka.Done;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
+import akka.stream.alpakka.slick.javadsl.Slick;
+import akka.stream.alpakka.slick.javadsl.SlickSession;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
 
-import akka.stream.javadsl.*;
-import akka.stream.alpakka.slick.javadsl.*;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class DocSnippetFlow {
   public static void main(String[] args) throws Exception {
@@ -37,15 +40,17 @@ public class DocSnippetFlow {
     final CompletionStage<Done> done =
         Source.from(users)
             .via(
-                Slick.<User>flow(
+                Slick.flow(
                     session,
                     parallelism,
-                    (user) ->
-                        "INSERT INTO ALPAKKA_SLICK_JAVADSL_TEST_USERS VALUES ("
-                            + user.id
-                            + ", '"
-                            + user.name
-                            + "')"))
+                    (user, connection) -> {
+                      PreparedStatement statement =
+                          connection.prepareStatement(
+                              "INSERT INTO ALPAKKA_SLICK_JAVADSL_TEST_USERS VALUES (?, ?)");
+                      statement.setInt(1, user.id);
+                      statement.setString(2, user.name);
+                      return statement;
+                    }))
             .log("nr-of-updated-rows")
             .runWith(Sink.ignore(), materializer);
     // #flow-example

--- a/slick/src/test/java/docs/javadsl/DocSnippetSink.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetSink.java
@@ -4,18 +4,19 @@
 
 package docs.javadsl;
 
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 import akka.Done;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
+import akka.stream.alpakka.slick.javadsl.Slick;
+import akka.stream.alpakka.slick.javadsl.SlickSession;
+import akka.stream.javadsl.Source;
 
-import akka.stream.javadsl.*;
-import akka.stream.alpakka.slick.javadsl.*;
+import java.sql.PreparedStatement;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class DocSnippetSink {
   public static void main(String[] args) throws Exception {
@@ -38,12 +39,14 @@ public class DocSnippetSink {
                 Slick.<User>sink(
                     session,
                     // add an optional second argument to specify the parallelism factor (int)
-                    (user) ->
-                        "INSERT INTO ALPAKKA_SLICK_JAVADSL_TEST_USERS VALUES ("
-                            + user.id
-                            + ", '"
-                            + user.name
-                            + "')"),
+                    (user, connection) -> {
+                      PreparedStatement statement =
+                          connection.prepareStatement(
+                              "INSERT INTO ALPAKKA_SLICK_JAVADSL_TEST_USERS VALUES (?, ?)");
+                      statement.setInt(1, user.id);
+                      statement.setString(2, user.name);
+                      return statement;
+                    }),
                 materializer);
     // #sink-example
 

--- a/slick/src/test/java/docs/javadsl/SlickTest.java
+++ b/slick/src/test/java/docs/javadsl/SlickTest.java
@@ -7,6 +7,8 @@ package docs.javadsl;
 import akka.Done;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
+import akka.japi.function.Function2;
+import akka.japi.pf.PFBuilder;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.alpakka.slick.javadsl.Slick;
@@ -17,18 +19,29 @@ import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * This unit test is run using a local H2 database using `/tmp/alpakka-slick-h2-test` for temporary
@@ -58,6 +71,16 @@ public class SlickTest {
               + ", '"
               + user.name
               + "')";
+
+  private static final Function2<User, Connection, PreparedStatement> insertUserPS =
+      (user, connection) -> {
+        PreparedStatement statement =
+            connection.prepareStatement(
+                "INSERT INTO ALPAKKA_SLICK_JAVADSL_TEST_USERS VALUES (?, ?)");
+        statement.setInt(1, user.id);
+        statement.setString(2, user.name);
+        return statement;
+      };
 
   private static final String selectAllUsers =
       "SELECT ID, NAME FROM ALPAKKA_SLICK_JAVADSL_TEST_USERS";
@@ -92,133 +115,189 @@ public class SlickTest {
   }
 
   @Test
+  public void testSinkPSThatThrowException() {
+    final Sink<User, CompletionStage<Done>> slickSink =
+        Slick.sink(
+            session,
+            (__, connection) ->
+                connection.prepareStatement(
+                    "INSERT INTO ALPAKKA_SLICK_JAVADSL_TEST_USERS VALUES (?, ?)"));
+    assertThrows(
+        ExecutionException.class,
+        () ->
+            usersSource
+                .runWith(slickSink, materializer)
+                .toCompletableFuture()
+                .get(5, TimeUnit.SECONDS));
+  }
+
+  @Test
   public void testSinkWithoutParallelismAndReadBackWithSource() throws Exception {
     final Sink<User, CompletionStage<Done>> slickSink = Slick.sink(session, insertUser);
-    final CompletionStage<Done> insertionResultFuture =
-        usersSource.runWith(slickSink, materializer);
+    usersSource.runWith(slickSink, materializer).toCompletableFuture().get(5, TimeUnit.SECONDS);
 
-    insertionResultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+    assertEqualsUsers();
+  }
 
-    final Source<User, NotUsed> slickSource =
-        Slick.source(
-            session, selectAllUsers, (SlickRow row) -> new User(row.nextInt(), row.nextString()));
+  @Test
+  public void testSinkPSWithoutParallelismAndReadBackWithSource() throws Exception {
+    final Sink<User, CompletionStage<Done>> slickSink = Slick.sink(session, insertUserPS);
+    usersSource.runWith(slickSink, materializer).toCompletableFuture().get(5, TimeUnit.SECONDS);
 
-    final CompletionStage<List<User>> foundUsersFuture =
-        slickSource.runWith(Sink.seq(), materializer);
-    final Set<User> foundUsers =
-        new HashSet<>(foundUsersFuture.toCompletableFuture().get(3, TimeUnit.SECONDS));
-
-    assertEquals(foundUsers, users);
+    assertEqualsUsers();
   }
 
   @Test
   public void testSinkWithParallelismOf4AndReadBackWithSource() throws Exception {
     final Sink<User, CompletionStage<Done>> slickSink = Slick.sink(session, 4, insertUser);
-    final CompletionStage<Done> insertionResultFuture =
-        usersSource.runWith(slickSink, materializer);
+    usersSource.runWith(slickSink, materializer).toCompletableFuture().get(5, TimeUnit.SECONDS);
 
-    insertionResultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+    assertEqualsUsers();
+  }
 
-    final Source<User, NotUsed> slickSource =
-        Slick.source(
-            session, selectAllUsers, (SlickRow row) -> new User(row.nextInt(), row.nextString()));
+  @Test
+  public void testSinkPSWithParallelismOf4AndReadBackWithSource() throws Exception {
+    final Sink<User, CompletionStage<Done>> slickSink = Slick.sink(session, 4, insertUserPS);
+    usersSource.runWith(slickSink, materializer).toCompletableFuture().get(5, TimeUnit.SECONDS);
 
-    final CompletionStage<List<User>> foundUsersFuture =
-        slickSource.runWith(Sink.seq(), materializer);
-    final Set<User> foundUsers =
-        new HashSet<>(foundUsersFuture.toCompletableFuture().get(3, TimeUnit.SECONDS));
+    assertEqualsUsers();
+  }
 
-    assertEquals(foundUsers, users);
+  @Test
+  public void testFlowPSWithRecover() throws Exception {
+    final Flow<User, Integer, NotUsed> slickFlow =
+        Slick.<User>flow(
+                session,
+                (__, connection) ->
+                    connection.prepareStatement(
+                        "INSERT INTO ALPAKKA_SLICK_JAVADSL_TEST_USERS VALUES (?, ?)"))
+            .recover(
+                new PFBuilder<Throwable, Integer>().match(SQLException.class, (ex) -> -1).build());
+    final List<Integer> insertionResult =
+        usersSource
+            .via(slickFlow)
+            .runWith(Sink.seq(), materializer)
+            .toCompletableFuture()
+            .get(5, TimeUnit.SECONDS);
+
+    assertEquals(insertionResult.size(), 1);
+    assertEquals(insertionResult.get(0), Integer.valueOf(-1));
   }
 
   @Test
   public void testFlowWithoutParallelismAndReadBackWithSource() throws Exception {
     final Flow<User, Integer, NotUsed> slickFlow = Slick.flow(session, insertUser);
-    final CompletionStage<List<Integer>> insertionResultFuture =
-        usersSource.via(slickFlow).runWith(Sink.seq(), materializer);
     final List<Integer> insertionResult =
-        insertionResultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+        usersSource
+            .via(slickFlow)
+            .runWith(Sink.seq(), materializer)
+            .toCompletableFuture()
+            .get(5, TimeUnit.SECONDS);
 
     assertEquals(users.size(), insertionResult.size());
+    assertEqualsUsers();
+  }
 
-    final Source<User, NotUsed> slickSource =
-        Slick.source(
-            session, selectAllUsers, (SlickRow row) -> new User(row.nextInt(), row.nextString()));
+  @Test
+  public void testFlowPSWithoutParallelismAndReadBackWithSource() throws Exception {
+    final Flow<User, Integer, NotUsed> slickFlow = Slick.flow(session, insertUserPS);
+    final List<Integer> insertionResult =
+        usersSource
+            .via(slickFlow)
+            .runWith(Sink.seq(), materializer)
+            .toCompletableFuture()
+            .get(5, TimeUnit.SECONDS);
 
-    final CompletionStage<List<User>> foundUsersFuture =
-        slickSource.runWith(Sink.seq(), materializer);
-    final Set<User> foundUsers =
-        new HashSet<>(foundUsersFuture.toCompletableFuture().get(3, TimeUnit.SECONDS));
-
-    assertEquals(foundUsers, users);
+    assertEquals(users.size(), insertionResult.size());
+    assertEqualsUsers();
   }
 
   @Test
   public void testFlowWithParallelismOf4AndReadBackWithSource() throws Exception {
     final Flow<User, Integer, NotUsed> slickFlow = Slick.flow(session, 4, insertUser);
-    final CompletionStage<List<Integer>> insertionResultFuture =
-        usersSource.via(slickFlow).runWith(Sink.seq(), materializer);
     final List<Integer> insertionResult =
-        insertionResultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+        usersSource
+            .via(slickFlow)
+            .runWith(Sink.seq(), materializer)
+            .toCompletableFuture()
+            .get(5, TimeUnit.SECONDS);
 
     assertEquals(users.size(), insertionResult.size());
+    assertEqualsUsers();
+  }
 
-    final Source<User, NotUsed> slickSource =
-        Slick.source(
-            session, selectAllUsers, (SlickRow row) -> new User(row.nextInt(), row.nextString()));
+  @Test
+  public void testFlowPSWithParallelismOf4AndReadBackWithSource() throws Exception {
+    final Flow<User, Integer, NotUsed> slickFlow = Slick.flow(session, 4, insertUserPS);
+    final List<Integer> insertionResult =
+        usersSource
+            .via(slickFlow)
+            .runWith(Sink.seq(), materializer)
+            .toCompletableFuture()
+            .get(5, TimeUnit.SECONDS);
 
-    final CompletionStage<List<User>> foundUsersFuture =
-        slickSource.runWith(Sink.seq(), materializer);
-    final Set<User> foundUsers =
-        new HashSet<>(foundUsersFuture.toCompletableFuture().get(3, TimeUnit.SECONDS));
-
-    assertEquals(foundUsers, users);
+    assertEquals(users.size(), insertionResult.size());
+    assertEqualsUsers();
   }
 
   @Test
   public void testFlowWithPassThroughWithoutParallelismAndReadBackWithSource() throws Exception {
     final Flow<User, User, NotUsed> slickFlow =
         Slick.flowWithPassThrough(session, system.dispatcher(), insertUser, (user, i) -> user);
-    final CompletionStage<List<User>> insertionResultFuture =
-        usersSource.via(slickFlow).runWith(Sink.seq(), materializer);
     final List<User> insertedUsers =
-        insertionResultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+        usersSource
+            .via(slickFlow)
+            .runWith(Sink.seq(), materializer)
+            .toCompletableFuture()
+            .get(5, TimeUnit.SECONDS);
 
     assertEquals(SlickTest.users, new HashSet<>(insertedUsers));
+    assertEqualsUsers();
+  }
 
-    final Source<User, NotUsed> slickSource =
-        Slick.source(
-            session, selectAllUsers, (SlickRow row) -> new User(row.nextInt(), row.nextString()));
+  @Test
+  public void testFlowPSWithPassThroughWithoutParallelismAndReadBackWithSource() throws Exception {
+    final Flow<User, User, NotUsed> slickFlow =
+        Slick.flowWithPassThrough(session, system.dispatcher(), insertUserPS, (user, i) -> user);
+    final List<User> insertedUsers =
+        usersSource
+            .via(slickFlow)
+            .runWith(Sink.seq(), materializer)
+            .toCompletableFuture()
+            .get(5, TimeUnit.SECONDS);
 
-    final CompletionStage<List<User>> foundUsersFuture =
-        slickSource.runWith(Sink.seq(), materializer);
-    final Set<User> foundUsers =
-        new HashSet<>(foundUsersFuture.toCompletableFuture().get(3, TimeUnit.SECONDS));
-
-    assertEquals(foundUsers, SlickTest.users);
+    assertEquals(SlickTest.users, new HashSet<>(insertedUsers));
+    assertEqualsUsers();
   }
 
   @Test
   public void testFlowWithPassThroughWithParallelismOf4AndReadBackWithSource() throws Exception {
     final Flow<User, User, NotUsed> slickFlow =
         Slick.flowWithPassThrough(session, system.dispatcher(), 4, insertUser, (user, i) -> user);
-    final CompletionStage<List<User>> insertionResultFuture =
-        usersSource.via(slickFlow).runWith(Sink.seq(), materializer);
     final List<User> insertedUsers =
-        insertionResultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+        usersSource
+            .via(slickFlow)
+            .runWith(Sink.seq(), materializer)
+            .toCompletableFuture()
+            .get(5, TimeUnit.SECONDS);
 
     assertEquals(users, new HashSet<>(insertedUsers));
+    assertEqualsUsers();
+  }
 
-    final Source<User, NotUsed> slickSource =
-        Slick.source(
-            session, selectAllUsers, (SlickRow row) -> new User(row.nextInt(), row.nextString()));
+  @Test
+  public void testFlowPSWithPassThroughWithParallelismOf4AndReadBackWithSource() throws Exception {
+    final Flow<User, User, NotUsed> slickFlow =
+        Slick.flowWithPassThrough(session, system.dispatcher(), 4, insertUserPS, (user, i) -> user);
+    final List<User> insertedUsers =
+        usersSource
+            .via(slickFlow)
+            .runWith(Sink.seq(), materializer)
+            .toCompletableFuture()
+            .get(5, TimeUnit.SECONDS);
 
-    final CompletionStage<List<User>> foundUsersFuture =
-        slickSource.runWith(Sink.seq(), materializer);
-    final Set<User> foundUsers =
-        new HashSet<>(foundUsersFuture.toCompletableFuture().get(3, TimeUnit.SECONDS));
-
-    assertEquals(foundUsers, users);
+    assertEquals(users, new HashSet<>(insertedUsers));
+    assertEqualsUsers();
   }
 
   @Test
@@ -259,7 +338,10 @@ public class SlickTest {
     resultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
     assertEquals(users.size(), committedOffsets.size());
+    assertEqualsUsers();
+  }
 
+  private void assertEqualsUsers() throws Exception {
     final Source<User, NotUsed> slickSource =
         Slick.source(
             session, selectAllUsers, (SlickRow row) -> new User(row.nextInt(), row.nextString()));


### PR DESCRIPTION
Extend Java DSL for using `java.sql.PreparedStatement`

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #2247
