### PR TITLE
Allow LogRotatorSink be a Sink[T] instead of Sink[ByteString]

### DIFF
--- a/file/src/main/mima-filters/2.0.0-RC2.backwards.excludes/PR2323-log-rotator-sink.excludes
+++ b/file/src/main/mima-filters/2.0.0-RC2.backwards.excludes/PR2323-log-rotator-sink.excludes
@@ -1,0 +1,8 @@
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.file.scaladsl.LogRotatorSink.in")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.file.scaladsl.LogRotatorSink.shape")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.file.scaladsl.LogRotatorSink.this")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.alpakka.file.scaladsl.LogRotatorSink#Logic.checkTrigger")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.alpakka.file.scaladsl.LogRotatorSink#Logic.rotate")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.file.scaladsl.LogRotatorSink#Logic.sourceOut")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.file.scaladsl.LogRotatorSink#Logic.sourceOut_=")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.file.scaladsl.LogRotatorSink#Logic.triggerGenerator")

--- a/file/src/main/scala/akka/stream/alpakka/file/scaladsl/LogRotatorSink.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/scaladsl/LogRotatorSink.scala
@@ -47,7 +47,22 @@ object LogRotatorSink {
    * @tparam C criterion type (for files a `Path`)
    * @tparam R result type in materialized futures of `sinkFactory`
    **/
-  def withSinkFactory[T, C, R](
+  def withSinkFactory[C, R](
+      triggerGeneratorCreator: () => ByteString => Option[C],
+      sinkFactory: C => Sink[ByteString, Future[R]]
+  ): Sink[ByteString, Future[Done]] =
+    Sink.fromGraph(new LogRotatorSink[ByteString, C, R](triggerGeneratorCreator, sinkFactory))
+
+  /**
+   * Sink directing the incoming `T`s to a new `Sink` created by `sinkFactory` whenever `triggerGenerator` returns a value.
+   *
+   * @param triggerGeneratorCreator creates a function that triggers rotation by returning a value
+   * @param sinkFactory creates sinks for `T`s from the value returned by `triggerGenerator`
+   * @tparam T stream and sink data type
+   * @tparam C criterion type (for files a `Path`)
+   * @tparam R result type in materialized futures of `sinkFactory`
+   **/
+  def withTypedSinkFactory[T, C, R](
       triggerGeneratorCreator: () => T => Option[C],
       sinkFactory: C => Sink[T, Future[R]]
   ): Sink[T, Future[Done]] =

--- a/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
@@ -187,7 +187,7 @@ class LogRotatorSinkSpec
       }
 
       val timeBasedSink: Sink[(String, String), Future[Done]] =
-        LogRotatorSink.withSinkFactory(
+        LogRotatorSink.withTypedSinkFactory(
           streamBasedTriggerCreator,
           (path: Path) =>
             Flow[(String, String)]

--- a/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
@@ -170,6 +170,48 @@ class LogRotatorSinkSpec
 
     }
 
+    "work for stream-based rotation " in assertAllStagesStopped {
+      // #stream
+      val destinationDir = FileSystems.getDefault.getPath("/tmp")
+
+      val streamBasedTriggerCreator: () => ((String, String)) => Option[Path] = () => {
+        var currentFilename: Option[String] = None
+        (element: (String, String)) => {
+          if (currentFilename.contains(element._1)) {
+            None
+          } else {
+            currentFilename = Some(element._1)
+            Some(destinationDir.resolve(element._1))
+          }
+        }
+      }
+
+      val timeBasedSink: Sink[(String, String), Future[Done]] =
+        LogRotatorSink.withSinkFactory(
+          streamBasedTriggerCreator,
+          (path: Path) =>
+            Flow[(String, String)]
+              .map { case (_, data) => ByteString(data) }
+              .via(Compression.gzip)
+              .toMat(FileIO.toPath(path))(Keep.right)
+        )
+      // #stream
+
+      val timeBaseCompletion = Source(
+        immutable.Seq(
+          ("stream1", "test1"),
+          ("stream1", "test2"),
+          ("stream1", "test3"),
+          ("stream2", "test4"),
+          ("stream2", "test5"),
+          ("stream2", "test6")
+        )
+      ).runWith(timeBasedSink)
+
+      timeBaseCompletion.futureValue shouldBe Done
+
+    }
+
     "write lines to a single file" in assertAllStagesStopped {
       var files = Seq.empty[Path]
       val triggerFunctionCreator = () => {


### PR DESCRIPTION
The current implementation of `LogRotatorSink` works well for time-based rotation, if the time is the real time. It does not fit well, if the time to trigger on is contained in the stream itself, since the stream is already of type `ByteString`. You had to parse that `ByteString` to gain access to the time contained in the data (or anything else you would like to trigger on).

This PR slightly modifies `LogRotatorSink` to accept an additional type parameter `T`. The triggerGeneratorCreator function becomes `T => Option[C]`, the sinkFactory becomes `C => Sink[T, Future[R]]`. This allows to trigger on data contained in `T`, the sink also works on `T` and probably uses a transformer `T => ByteString`. For details, have a look at the new test in `LogRotatorSinkSpec`.