### PR TITLE
file/tar: Allow space as terminal character in tar header

### DIFF
--- a/file/src/main/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntry.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntry.scala
@@ -106,7 +106,7 @@ import akka.util.ByteString
 
   private def getString(bs: ByteString, from: Int, maxLength: Int) = {
     val dropped = bs.drop(from)
-    val f = Math.min(dropped.indexOf(0.toByte), maxLength)
+    val f = Math.min(dropped.indexWhere(b => b == 0.toByte || b == ' '.toByte), maxLength)
     dropped.take(f).utf8String
   }
 

--- a/file/src/test/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntrySpec.scala
+++ b/file/src/test/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntrySpec.scala
@@ -7,6 +7,7 @@ package akka.stream.alpakka.file.impl.archive
 import java.time.{Instant, LocalDateTime, ZoneId, ZonedDateTime}
 
 import akka.stream.alpakka.file.TarArchiveMetadata
+import akka.util.ByteString
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -24,5 +25,24 @@ class TarArchiveEntrySpec extends AnyFlatSpec with Matchers {
     parsed.filePath shouldBe filePathPrefix + "/" + filename
     parsed.size shouldBe size
     parsed.lastModification shouldBe lastModified
+  }
+
+  "Header parser" should "handle both space and null character as terminal" in {
+    val filePathPrefix = "dir1/dir2"
+    val filename = "thefile.txt"
+    val size = 100
+    val lastModified = Instant.from(ZonedDateTime.of(LocalDateTime.of(2020, 4, 11, 11, 34), ZoneId.of("CET")))
+    val data = TarArchiveMetadata(filePathPrefix, filename, size, lastModified)
+    val entry = new TarArchiveEntry(data)
+
+    val headerWithNull = entry.headerBytes
+    // Change terminal character after size and lastModified field to be space instead of null
+    val bytesWithSpace = headerWithNull.toArray.updated(135, ' '.toByte).updated(147, ' '.toByte)
+    val headerWithSpace = ByteString(bytesWithSpace)
+
+    val parsedNull = TarArchiveEntry.parse(headerWithNull)
+    val parsedSpace = TarArchiveEntry.parse(headerWithSpace)
+
+    parsedNull shouldBe parsedSpace
   }
 }


### PR DESCRIPTION
Fixes #2324
