### PR TITLE
[elasticsearch] Support `allow_explicit_index: false`

### DIFF
--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -123,6 +123,7 @@ Java
 | versionType         | None       | If set, `ElasticsearchSink` uses the chosen versionType to index documents. See [Version types](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types) for accepted settings. |
 | retryLogic          | No retries | See below |
 | apiVersion          | V5         | Currently supports `V5` and `V7` (see below) |
+| allowExplicitIndex  | True       | When set to False, the index name will be included in the URL instead of on each document (see below) | 
 
 #### Retry logic
 A bulk request might fail partially for some reason. To retry failed writes to Elasticsearch, a `RetryLogic` can be specified. 
@@ -151,6 +152,9 @@ To support writing to multiple versions of Elasticsearch, an `ApiVersion` can be
 This will be used to transform the bulk request into a format understood by the corresponding Elasticsearch server.
 Currently [`V5`](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-bulk.html#docs-bulk) and [`V7`](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/docs-bulk.html#docs-bulk) are supported specifically but this parameter does not need to match the server version exactly (for example, either `V5` or `V7` should work with Elasticsearch 6.x).
 
+### Allow explicit index
+
+When using the `_bulk` API, Elasticsearch will reject requests that have an explicit index in the request body if explicit index names are not allowed. See [URL-based access control](https://www.elastic.co/guide/en/elasticsearch/reference/current/url-access-control.html)
 
 ## Elasticsearch as Flow
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchWriteSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchWriteSettings.scala
@@ -61,7 +61,8 @@ object RetryWithBackoff {
 final class ElasticsearchWriteSettings private (val bufferSize: Int,
                                                 val retryLogic: RetryLogic,
                                                 val versionType: Option[String],
-                                                val apiVersion: ApiVersion) {
+                                                val apiVersion: ApiVersion,
+                                                val allowExplicitIndex: Boolean) {
 
   def withBufferSize(value: Int): ElasticsearchWriteSettings = copy(bufferSize = value)
 
@@ -73,18 +74,22 @@ final class ElasticsearchWriteSettings private (val bufferSize: Int,
   def withApiVersion(value: ApiVersion): ElasticsearchWriteSettings =
     if (apiVersion == value) this else copy(apiVersion = value)
 
+  def withAllowExplicitIndex(value: Boolean): ElasticsearchWriteSettings = copy(allowExplicitIndex = value)
+
   private def copy(bufferSize: Int = bufferSize,
                    retryLogic: RetryLogic = retryLogic,
                    versionType: Option[String] = versionType,
-                   apiVersion: ApiVersion = apiVersion): ElasticsearchWriteSettings =
-    new ElasticsearchWriteSettings(bufferSize, retryLogic, versionType, apiVersion)
+                   apiVersion: ApiVersion = apiVersion,
+                   allowExplicitIndex: Boolean = allowExplicitIndex): ElasticsearchWriteSettings =
+    new ElasticsearchWriteSettings(bufferSize, retryLogic, versionType, apiVersion, allowExplicitIndex)
 
   override def toString =
     "ElasticsearchWriteSettings(" +
     s"bufferSize=$bufferSize," +
     s"retryLogic=$retryLogic," +
     s"versionType=$versionType," +
-    s"apiVersion=$apiVersion)"
+    s"apiVersion=$apiVersion," +
+    s"allowExplicitIndex=$allowExplicitIndex)"
 
 }
 
@@ -92,7 +97,8 @@ object ElasticsearchWriteSettings {
   val Default = new ElasticsearchWriteSettings(bufferSize = 10,
                                                retryLogic = RetryNever,
                                                versionType = None,
-                                               apiVersion = ApiVersion.V5)
+                                               apiVersion = ApiVersion.V5,
+                                               allowExplicitIndex = true)
 
   /** Scala API */
   def apply(): ElasticsearchWriteSettings = Default

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
@@ -42,10 +42,10 @@ private[elasticsearch] final class ElasticsearchSimpleFlowStage[T, C](
     case ApiVersion.V5 =>
       require(_indexName != null, "You must define an index name")
       require(_typeName != null, "You must define a type name")
-      new RestBulkApiV5[T, C](_indexName, _typeName, settings.versionType, writer)
+      new RestBulkApiV5[T, C](_indexName, _typeName, settings.versionType, settings.allowExplicitIndex, writer)
     case ApiVersion.V7 =>
       require(_indexName != null, "You must define an index name")
-      new RestBulkApiV7[T, C](_indexName, settings.versionType, writer)
+      new RestBulkApiV7[T, C](_indexName, settings.versionType, settings.allowExplicitIndex, writer)
     case other => throw new IllegalArgumentException(s"API version $other is not supported")
   }
 
@@ -65,6 +65,7 @@ private[elasticsearch] final class ElasticsearchSimpleFlowStage[T, C](
     override def onPull(): Unit = tryPull()
 
     override def onPush(): Unit = {
+      val endpoint = if (settings.allowExplicitIndex) "/_bulk" else s"/${_indexName}/_bulk"
       val (messages, resultsPassthrough) = grab(in)
       inflight = true
       val json: String = restApi.toJson(messages)
@@ -74,7 +75,7 @@ private[elasticsearch] final class ElasticsearchSimpleFlowStage[T, C](
       // https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-low-usage-requests.html
       client.performRequestAsync(
         "POST",
-        "/_bulk",
+        endpoint,
         java.util.Collections.emptyMap[String, String](),
         new StringEntity(json, StandardCharsets.UTF_8),
         new ResponseListener() {

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApi.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApi.scala
@@ -48,4 +48,5 @@ private[impl] abstract class RestBulkApi[T, C] {
     case Delete => ""
   }
 
+  def constructSharedFields(message: WriteMessage[T, C]): Seq[(String, JsString)]
 }

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchConnectorBehaviour.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchConnectorBehaviour.scala
@@ -141,6 +141,20 @@ trait ElasticsearchConnectorBehaviour { this: AnyWordSpec with Matchers with Sca
       }
     }
 
+    "Sink Settings" should {
+      "copy explicit index name permission" in {
+        val sinkSettings =
+          ElasticsearchWriteSettings()
+            .withBufferSize(10)
+            .withVersionType("internal")
+            .withRetryLogic(RetryAtFixedRate(maxRetries = 5, retryInterval = 1.second))
+
+        val restrictiveCopy = sinkSettings.withAllowExplicitIndex(false)
+
+        restrictiveCopy.allowExplicitIndex shouldEqual false
+      }
+    }
+
     "Un-typed Elasticsearch connector" should {
       "consume and publish Json documents" in assertAllStagesStopped {
         val indexName = "sink2"


### PR DESCRIPTION
Purpose
---
Enables the use of the Elasticsearch Sink in non-default environments where url-based access control is performed.

This PR is an update of #1844 which seems to be abandoned.

References
---
References #1843 

Changes
---
`ElasticsearchWriteSettings`: Added an aditional setting `allowExplicitIndex`
`ElasticsearchSimpleFlowStage[T, C]`: The actual endpoint to which the _bulk request is determined based on the newly introduced `ElasticSearchWriteSetting.allowExplicitIndex` 
`RestBulkApi` and `RestBulkApiV5` and `RestBulkApiV7`: Support writing the shared fields to the API based on the `allowExplicitIndex` setting

Background Context
---
Current implementation of the Elastic search Sink will fail (requests rejected) if the cluster configuration does not hold the default setting for the rest.action.multi.allow_explicit_index property, which is common when url-based access control is performed (multi-tenancy)

These changes enabled the elasticsearch sink to work in these conditions, while preserving the current behaviour by default.