### PR TITLE
Kinesis: Construction safe API

### DIFF
--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/ShardIterator.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/ShardIterator.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.kinesis
+
+import java.time.Instant
+
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType
+
+sealed trait ShardIterator {
+  def timestamp: Option[Instant]
+  def startingSequenceNumber: Option[String]
+  def shardIteratorType: ShardIteratorType
+}
+
+object ShardIterator {
+  case object Latest extends ShardIterator {
+    override final val timestamp: Option[Instant] = None
+
+    override final val startingSequenceNumber: Option[String] = None
+
+    override final val shardIteratorType: ShardIteratorType = ShardIteratorType.LATEST
+  }
+  case object TrimHorizon extends ShardIterator {
+    override final val timestamp: Option[Instant] = None
+
+    override final val startingSequenceNumber: Option[String] = None
+
+    override final val shardIteratorType: ShardIteratorType = ShardIteratorType.TRIM_HORIZON
+  }
+  case class AtTimestamp private (value: Instant) extends ShardIterator {
+    override final val timestamp: Option[Instant] = Some(value)
+
+    override final val startingSequenceNumber: Option[String] = None
+
+    override final val shardIteratorType: ShardIteratorType = ShardIteratorType.AT_TIMESTAMP
+  }
+
+  case class AtSequenceNumber(sequenceNumber: String) extends ShardIterator {
+    override final val timestamp: Option[Instant] = None
+
+    override final val startingSequenceNumber: Option[String] = Some(sequenceNumber)
+
+    override final val shardIteratorType: ShardIteratorType = ShardIteratorType.AT_SEQUENCE_NUMBER
+  }
+  case class AfterSequenceNumber(sequenceNumber: String) extends ShardIterator {
+    override final val timestamp: Option[Instant] = None
+
+    override final val startingSequenceNumber: Option[String] = Some(sequenceNumber)
+
+    override final val shardIteratorType: ShardIteratorType = ShardIteratorType.AFTER_SEQUENCE_NUMBER
+  }
+
+  /**
+   * Java API
+   */
+  def latest(): ShardIterator = Latest
+
+  /**
+   * Java API
+   */
+  def trimHorizon(): ShardIterator = TrimHorizon
+
+  /**
+   * Java API
+   */
+  def atTimestamp(timestamp: Instant): ShardIterator = AtTimestamp(timestamp)
+
+  /**
+   * Java API
+   */
+  def atSequenceNumber(value: String): ShardIterator = AtSequenceNumber(value)
+
+  /**
+   * Java API
+   */
+  def afterSequenceNumber(value: String): ShardIterator = AfterSequenceNumber(value)
+}

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/ShardIterator.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/ShardIterator.scala
@@ -13,8 +13,8 @@ sealed trait ShardIterator {
   def startingSequenceNumber: Option[String]
   def shardIteratorType: ShardIteratorType
 }
-
 object ShardIterator {
+
   case object Latest extends ShardIterator {
     override final val timestamp: Option[Instant] = None
 
@@ -22,6 +22,7 @@ object ShardIterator {
 
     override final val shardIteratorType: ShardIteratorType = ShardIteratorType.LATEST
   }
+
   case object TrimHorizon extends ShardIterator {
     override final val timestamp: Option[Instant] = None
 
@@ -29,6 +30,7 @@ object ShardIterator {
 
     override final val shardIteratorType: ShardIteratorType = ShardIteratorType.TRIM_HORIZON
   }
+
   case class AtTimestamp private (value: Instant) extends ShardIterator {
     override final val timestamp: Option[Instant] = Some(value)
 
@@ -44,6 +46,7 @@ object ShardIterator {
 
     override final val shardIteratorType: ShardIteratorType = ShardIteratorType.AT_SEQUENCE_NUMBER
   }
+
   case class AfterSequenceNumber(sequenceNumber: String) extends ShardIterator {
     override final val timestamp: Option[Instant] = None
 
@@ -51,29 +54,40 @@ object ShardIterator {
 
     override final val shardIteratorType: ShardIteratorType = ShardIteratorType.AFTER_SEQUENCE_NUMBER
   }
+}
+
+/**
+ * Java API
+ */
+object ShardIterators {
 
   /**
    * Java API
    */
-  def latest(): ShardIterator = Latest
+  def latest(): ShardIterator =
+    ShardIterator.Latest
 
   /**
    * Java API
    */
-  def trimHorizon(): ShardIterator = TrimHorizon
+  def trimHorizon(): ShardIterator =
+    ShardIterator.TrimHorizon
 
   /**
    * Java API
    */
-  def atTimestamp(timestamp: Instant): ShardIterator = AtTimestamp(timestamp)
+  def atTimestamp(timestamp: Instant): ShardIterator =
+    ShardIterator.AtTimestamp(timestamp)
 
   /**
    * Java API
    */
-  def atSequenceNumber(value: String): ShardIterator = AtSequenceNumber(value)
+  def atSequenceNumber(value: String): ShardIterator =
+    ShardIterator.AtSequenceNumber(value)
 
   /**
    * Java API
    */
-  def afterSequenceNumber(value: String): ShardIterator = AfterSequenceNumber(value)
+  def afterSequenceNumber(value: String): ShardIterator =
+    ShardIterator.AfterSequenceNumber(value)
 }

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/ShardSettings.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/ShardSettings.scala
@@ -35,7 +35,6 @@ final class ShardSettings private (
 
   def withStreamName(value: String): ShardSettings = copy(streamName = value)
   def withShardId(value: String): ShardSettings = copy(shardId = value)
-  def withShardIteratorType(value: ShardIteratorType): ShardSettings = copy(shardIteratorType = value)
 
   def withShardIterator(shardIterator: ShardIterator): ShardSettings = copy(
     shardIteratorType = shardIterator.shardIteratorType,
@@ -44,20 +43,31 @@ final class ShardSettings private (
   )
 
   /**
-   * Sets `shardIteratorType` to `AT_SEQUENCE_NUMBER` and uses the given value as starting sequence number.
+   * @deprecated use `withShardIterator` passing a [[ShardIterator]] instead
+   */
+  def withShardIteratorType(value: ShardIteratorType): ShardSettings = copy(shardIteratorType = value)
+
+  /**
+   * @deprecated use `withShardIterator` with [[ShardIterator.AtSequenceNumber]]` instead.
+   *
+   * Sets shardIteratorType` to `AT_SEQUENCE_NUMBER` and uses the given value as starting sequence number.
    */
   def withStartingSequenceNumber(value: String): ShardSettings =
     copy(shardIteratorType = ShardIteratorType.AT_SEQUENCE_NUMBER, startingSequenceNumber = Option(value))
 
   /**
+   * @deprecated use `withShardIterator` with [[ShardIterator.AfterSequenceNumber]]` instead.
+   *
    * Sets `shardIteratorType` to `AFTER_SEQUENCE_NUMBER` and uses the given value as starting sequence number.
    */
   def withStartingAfterSequenceNumber(value: String): ShardSettings =
     copy(shardIteratorType = ShardIteratorType.AFTER_SEQUENCE_NUMBER, startingSequenceNumber = Option(value))
 
   /**
+   * @deprecated use `withShardIterator` with [[ShardIterator.AtTimestamp]]` instead.
+   *
    * Sets `shardIteratorType` to `AT_TIMESTAMP` and uses the given `Instant` as starting timestamp.
-   */
+   **/
   def withAtTimestamp(value: java.time.Instant): ShardSettings =
     copy(shardIteratorType = ShardIteratorType.AT_TIMESTAMP, atTimestamp = Option(value))
 

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/ShardSettings.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/ShardSettings.scala
@@ -37,6 +37,12 @@ final class ShardSettings private (
   def withShardId(value: String): ShardSettings = copy(shardId = value)
   def withShardIteratorType(value: ShardIteratorType): ShardSettings = copy(shardIteratorType = value)
 
+  def withShardIterator(shardIterator: ShardIterator): ShardSettings = copy(
+    shardIteratorType = shardIterator.shardIteratorType,
+    atTimestamp = shardIterator.timestamp,
+    startingSequenceNumber = shardIterator.startingSequenceNumber
+  )
+
   /**
    * Sets `shardIteratorType` to `AT_SEQUENCE_NUMBER` and uses the given value as starting sequence number.
    */
@@ -99,13 +105,18 @@ object ShardSettings {
    * Create settings using the default configuration
    */
   def apply(streamName: String, shardId: String): ShardSettings =
-    new ShardSettings(streamName,
-                      shardId,
-                      ShardIteratorType.LATEST,
-                      startingSequenceNumber = None,
-                      atTimestamp = None,
-                      refreshInterval = 1.second,
-                      limit = 500)
+    apply(streamName, shardId, ShardIterator.Latest)
+
+  def apply(streamName: String, shardId: String, shardIterator: ShardIterator): ShardSettings =
+    new ShardSettings(
+      streamName,
+      shardId,
+      shardIterator.shardIteratorType,
+      startingSequenceNumber = shardIterator.startingSequenceNumber,
+      atTimestamp = shardIterator.timestamp,
+      refreshInterval = 1.second,
+      limit = 500
+    )
 
   /**
    * Java API: Create settings using the default configuration

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/ShardSettings.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/ShardSettings.scala
@@ -45,29 +45,33 @@ final class ShardSettings private (
   /**
    * @deprecated use `withShardIterator` passing a [[ShardIterator]] instead
    */
+  @deprecated("use `withShardIterator` passing a `ShardIterator` instead", "2.0.1")
   def withShardIteratorType(value: ShardIteratorType): ShardSettings = copy(shardIteratorType = value)
 
   /**
-   * @deprecated use `withShardIterator` with [[ShardIterator.AtSequenceNumber]]` instead.
+   * @deprecated use `withShardIterator` with [[ShardIterator.AtSequenceNumber]] instead.
    *
    * Sets shardIteratorType` to `AT_SEQUENCE_NUMBER` and uses the given value as starting sequence number.
    */
+  @deprecated("use `withShardIterator` with `ShardIterator.AtSequenceNumber` instead", "2.0.1")
   def withStartingSequenceNumber(value: String): ShardSettings =
     copy(shardIteratorType = ShardIteratorType.AT_SEQUENCE_NUMBER, startingSequenceNumber = Option(value))
 
   /**
-   * @deprecated use `withShardIterator` with [[ShardIterator.AfterSequenceNumber]]` instead.
+   * @deprecated use `withShardIterator` with [[ShardIterator.AfterSequenceNumber]] instead.
    *
    * Sets `shardIteratorType` to `AFTER_SEQUENCE_NUMBER` and uses the given value as starting sequence number.
    */
+  @deprecated("use `withShardIterator` with `ShardIterator.AfterSequenceNumber` instead", "2.0.1")
   def withStartingAfterSequenceNumber(value: String): ShardSettings =
     copy(shardIteratorType = ShardIteratorType.AFTER_SEQUENCE_NUMBER, startingSequenceNumber = Option(value))
 
   /**
-   * @deprecated use `withShardIterator` with [[ShardIterator.AtTimestamp]]` instead.
+   * @deprecated use `withShardIterator` with [[ShardIterator.AtTimestamp]] instead.
    *
    * Sets `shardIteratorType` to `AT_TIMESTAMP` and uses the given `Instant` as starting timestamp.
-   **/
+   */
+  @deprecated("use `withShardIterator` with `ShardIterator.AtTimestamp` instead.", "2.0.1")
   def withAtTimestamp(value: java.time.Instant): ShardSettings =
     copy(shardIteratorType = ShardIteratorType.AT_TIMESTAMP, atTimestamp = Option(value))
 

--- a/kinesis/src/test/java/docs/javadsl/KinesisSnippets.java
+++ b/kinesis/src/test/java/docs/javadsl/KinesisSnippets.java
@@ -8,7 +8,7 @@ import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.alpakka.kinesis.KinesisFlowSettings;
-import akka.stream.alpakka.kinesis.ShardIterator;
+import akka.stream.alpakka.kinesis.ShardIterators;
 import akka.stream.alpakka.kinesis.ShardSettings;
 import akka.stream.alpakka.kinesis.javadsl.KinesisFlow;
 import akka.stream.alpakka.kinesis.javadsl.KinesisSink;
@@ -25,7 +25,6 @@ import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
 import software.amazon.awssdk.services.kinesis.model.PutRecordsResultEntry;
 import software.amazon.awssdk.services.kinesis.model.Record;
 // #source-settings
-import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
 // #source-settings
 
 import java.time.Duration;
@@ -56,7 +55,7 @@ public class KinesisSnippets {
         ShardSettings.create("streamName", "shard-id")
             .withRefreshInterval(Duration.ofSeconds(1))
             .withLimit(500)
-            .withShardIterator(ShardIterator.trimHorizon());
+            .withShardIterator(ShardIterators.trimHorizon());
     // #source-settings
 
     // #source-single

--- a/kinesis/src/test/java/docs/javadsl/KinesisSnippets.java
+++ b/kinesis/src/test/java/docs/javadsl/KinesisSnippets.java
@@ -8,6 +8,7 @@ import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.alpakka.kinesis.KinesisFlowSettings;
+import akka.stream.alpakka.kinesis.ShardIterator;
 import akka.stream.alpakka.kinesis.ShardSettings;
 import akka.stream.alpakka.kinesis.javadsl.KinesisFlow;
 import akka.stream.alpakka.kinesis.javadsl.KinesisSink;
@@ -55,7 +56,7 @@ public class KinesisSnippets {
         ShardSettings.create("streamName", "shard-id")
             .withRefreshInterval(Duration.ofSeconds(1))
             .withLimit(500)
-            .withShardIteratorType(ShardIteratorType.TRIM_HORIZON);
+            .withShardIterator(ShardIterator.trimHorizon());
     // #source-settings
 
     // #source-single

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSourceSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSourceSpec.scala
@@ -34,7 +34,7 @@ class KinesisSourceSpec extends AnyWordSpec with Matchers with KinesisMock with 
 
     val shardSettings =
       ShardSettings("stream_name", "shard-id")
-        .withShardIteratorType(ShardIteratorType.TRIM_HORIZON)
+        .withShardIterator(ShardIterator.TrimHorizon)
 
     "poll for records" in assertAllStagesStopped {
       new KinesisSpecContext with WithGetShardIteratorSuccess with WithGetRecordsSuccess {

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/ShardSettingsSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/ShardSettingsSpec.scala
@@ -49,5 +49,14 @@ class ShardSettingsSpec extends AnyWordSpec with Matchers with LogCapturing {
     "accept a valid limit" in {
       noException should be thrownBy baseSettings.withLimit(500)
     }
+
+    "accept all combinations of alterations with ShardIterator" in {
+      noException should be thrownBy baseSettings
+        .withShardIterator(ShardIterator.AtSequenceNumber("SQC"))
+        .withShardIterator(ShardIterator.AfterSequenceNumber("SQC"))
+        .withShardIterator(ShardIterator.AtTimestamp(Instant.EPOCH))
+        .withShardIterator(ShardIterator.Latest)
+        .withShardIterator(ShardIterator.TrimHorizon)
+    }
   }
 }

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/ShardSettingsSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/ShardSettingsSpec.scala
@@ -9,39 +9,10 @@ import java.time.Instant
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.must.Matchers
-import software.amazon.awssdk.services.kinesis.model.ShardIteratorType
 
 class ShardSettingsSpec extends AnyWordSpec with Matchers with LogCapturing {
   val baseSettings = ShardSettings("name", "shardid")
   "ShardSettings" must {
-    "require a timestamp for shard iterator type is AT_TIMESTAMP" in {
-      a[IllegalArgumentException] should be thrownBy baseSettings
-        .withShardIteratorType(ShardIteratorType.AT_TIMESTAMP)
-    }
-    "accept a valid timestamp for shard iterator type AT_TIMESTAMP" in {
-      noException should be thrownBy baseSettings
-        .withAtTimestamp(Instant.now())
-        .withShardIteratorType(ShardIteratorType.AT_TIMESTAMP)
-    }
-    "require a sequence number for iterator type AT_SEQUENCE_NUMBER" in {
-      a[IllegalArgumentException] should be thrownBy baseSettings
-        .withShardIteratorType(ShardIteratorType.AT_SEQUENCE_NUMBER)
-    }
-    "accept a valid sequence number for iterator type AT_SEQUENCE_NUMBER" in {
-      noException should be thrownBy baseSettings
-        .withStartingSequenceNumber("SQC")
-        .withShardIteratorType(ShardIteratorType.AT_SEQUENCE_NUMBER)
-    }
-    "require a sequence number for iterator type AFTER_SEQUENCE_NUMBER" in {
-      a[IllegalArgumentException] should be thrownBy baseSettings
-        .withStartingSequenceNumber(null)
-        .withShardIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER)
-    }
-    "accept a valid sequence number for iterator type AFTER_SEQUENCE_NUMBER" in {
-      noException should be thrownBy baseSettings
-        .withStartingSequenceNumber("SQC")
-        .withShardIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER)
-    }
     "require a valid limit" in {
       a[IllegalArgumentException] should be thrownBy baseSettings.withLimit(10001)
       a[IllegalArgumentException] should be thrownBy baseSettings.withLimit(-1)

--- a/kinesis/src/test/scala/docs/scaladsl/KinesisSnippets.scala
+++ b/kinesis/src/test/scala/docs/scaladsl/KinesisSnippets.scala
@@ -39,7 +39,6 @@ object KinesisSnippets {
   //#init-client
 
   //#source-settings
-  import software.amazon.awssdk.services.kinesis.model.ShardIteratorType
 
   val settings =
     ShardSettings(streamName = "myStreamName", shardId = "shard-id")

--- a/kinesis/src/test/scala/docs/scaladsl/KinesisSnippets.scala
+++ b/kinesis/src/test/scala/docs/scaladsl/KinesisSnippets.scala
@@ -9,7 +9,7 @@ import java.nio.ByteBuffer
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.alpakka.kinesis.scaladsl.{KinesisFlow, KinesisSink, KinesisSource}
-import akka.stream.alpakka.kinesis.{KinesisFlowSettings, ShardSettings}
+import akka.stream.alpakka.kinesis.{KinesisFlowSettings, ShardIterator, ShardSettings}
 import akka.stream.scaladsl.{Flow, FlowWithContext, Sink, Source}
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.util.ByteString
@@ -45,7 +45,7 @@ object KinesisSnippets {
     ShardSettings(streamName = "myStreamName", shardId = "shard-id")
       .withRefreshInterval(1.second)
       .withLimit(500)
-      .withShardIteratorType(ShardIteratorType.TRIM_HORIZON)
+      .withShardIterator(ShardIterator.TrimHorizon)
   //#source-settings
 
   //#source-single


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #2315 

I'd also suggest to mark the following methods as deprecated:
```scala
def withShardIteratorType
def withStartingSequenceNumber
def withStartingAfterSequenceNumber
def withAtTimestamp
```

Although technically the latter 3 are safe, it is not visible in their type that they are also changing the shard iterator type and I've observed people making the mistake of setting the shard iterator type first anyway  (including myself :P)

Please let me know what you think.

Thanks
