### PR TITLE
File: Fail LogRotatorSink on failures in the sinks

### DIFF
--- a/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
@@ -358,7 +358,7 @@ class LogRotatorSinkSpec
             sinkFactory = (_: Path) =>
               Flow[ByteString]
                 .map { data =>
-                  throw new IllegalArgumentException("The data is broken")
+                  if (data.utf8String == "test") throw new IllegalArgumentException("The data is broken")
                   data
                 }
                 .toMat(Sink.ignore)(Keep.right)

--- a/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
@@ -342,6 +342,45 @@ class LogRotatorSinkSpec
 
   }
 
+  "downstream fail on exception in sink" in assertAllStagesStopped {
+    val path = Files.createTempFile(fs.getPath("/"), "test", ".log")
+    val triggerFunctionCreator = () => {
+      (x: ByteString) => {
+        Option(path)
+      }
+    }
+    val (probe, completion) =
+      TestSource
+        .probe[ByteString]
+        .toMat(
+          LogRotatorSink.withSinkFactory(
+            triggerGeneratorCreator = triggerFunctionCreator,
+            sinkFactory = (_: Path) =>
+              Flow[ByteString]
+                .map { data =>
+                  throw new IllegalArgumentException("The data is broken")
+                  data
+                }
+                .toMat(Sink.ignore)(Keep.right)
+          )
+        )(Keep.both)
+        .run()
+
+    probe.sendNext(ByteString("test"))
+    probe.sendNext(ByteString("test"))
+    probe.expectCancellation()
+
+    val exception = intercept[Exception] {
+      Await.result(completion, 3.seconds)
+    }
+
+    exactly(
+      1,
+      List(exception, // Akka 2.5 throws nio exception directly
+           exception.getCause) // Akka 2.6 wraps nio exception in a akka.stream.IOOperationIncompleteException
+    ) shouldBe a[IllegalArgumentException]
+  }
+
   def readUpFilesAndSizesThenClean(files: Seq[Path]): (Seq[String], Seq[Long]) = {
     val (bytes, sizes) = readUpFileBytesAndSizesThenClean(files)
     (bytes.map(_.utf8String), sizes)


### PR DESCRIPTION
I would expect the stream to be terminated with an exception, if the sink created by `sinkFactory` of `LogRotatorSink.withSinkFactory` throws an exception. This is not the case. I added a test case in `LogRotatorSinkSpec` that demonstrates this.

The issue initially occured while trying to use `LogRotatorSink` together with `S3.multipartUpload`. My aws-config was not correct, leading to Exceptions being thrown in `S3.multipartUpload`-Sink, which never showed up and left the stream in a non-functional, but not terminated condition. I had to remove `LogRotatorSink` and use `S3.multipartUpload` directly to see those exceptions and have the stream terminated.
