### PR TITLE
AWS S3: parse error replies

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/S3Exception.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/S3Exception.scala
@@ -4,35 +4,73 @@
 
 package akka.stream.alpakka.s3
 
-import akka.http.scaladsl.model.StatusCode
+import akka.annotation.{DoNotInherit, InternalApi}
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 
 import scala.util.Try
 import scala.xml.{Elem, XML}
 
-class S3Exception(val code: String, val message: String, val requestId: String, val hostId: String)
+/**
+ * Represents AWS S3 error responses [[https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html]].
+ */
+@DoNotInherit
+class S3Exception @InternalApi private[s3] (val statusCode: StatusCode,
+                                            val code: String,
+                                            val message: String,
+                                            val requestId: String,
+                                            val resource: String)
     extends RuntimeException(message) {
 
-  def this(xmlResponse: Elem) =
-    this((xmlResponse \ "Code").text,
+  @deprecated("kept for binary compatiblity", "2.0.1")
+  private[s3] val hostId = ""
+
+  @deprecated("kept for binary compatiblity", "2.0.1")
+  private[s3] def this(code: String, message: String, requestId: String, resource: String) =
+    this(StatusCodes.NotFound, code, message, requestId, resource)
+
+  @deprecated("kept for binary compatiblity", "2.0.1")
+  private[s3] def this(xmlResponse: Elem) =
+    this(StatusCodes.NotFound,
+         (xmlResponse \ "Code").text,
          (xmlResponse \ "Message").text,
          (xmlResponse \ "RequestID").text,
          (xmlResponse \ "HostID").text)
 
-  def this(response: String) =
+  @deprecated("kept for binary compatiblity", "2.0.1")
+  private[s3] def this(response: String) =
     this(
       Try(XML.loadString(response)).getOrElse(
-        <Error><Code>-</Code><Message>{response}</Message><RequestID>-</RequestID><HostID>-</HostID></Error>
+        <Error><Code>-</Code><Message>{response}</Message><RequestId>-</RequestId><Resource>-</Resource></Error>
       )
     )
 
-  def this(response: String, code: StatusCode) =
+  @deprecated("kept for binary compatiblity", "2.0.1")
+  private[s3] def this(response: String, code: StatusCode) =
     this(
       Try(XML.loadString(response)).getOrElse(
-        <Error><Code>{code}</Code><Message>{response}</Message><RequestID>-</RequestID><HostID>-</HostID></Error>
+        <Error><Code>{code}</Code><Message>{response}</Message><RequestId>-</RequestId><Resource>-</Resource></Error>
       )
     )
 
   override def toString: String =
-    s"${super.toString} (Code: $code, RequestID: $requestId, HostID: $hostId)"
+    s"${super.toString} (Status code: $statusCode, Code: $code, RequestId: $requestId, Resource: $resource)"
 
+}
+
+object S3Exception {
+  def apply(response: String, statusCode: StatusCode): S3Exception = {
+    try {
+      val xmlResponse = XML.loadString(response)
+      new S3Exception(
+        statusCode,
+        (xmlResponse \ "Code").text,
+        (xmlResponse \ "Message").text,
+        (xmlResponse \ "RequestId").text,
+        (xmlResponse \ "Resource").text
+      )
+    } catch {
+      case e: Exception =>
+        new S3Exception(statusCode, statusCode.toString, response, "-", "-")
+    }
+  }
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -234,13 +234,18 @@ import scala.util.{Failure, Success, Try}
               Source.fromFuture(entity.discardBytes().future().map(_ => None))
             case HttpResponse(code, _, entity, _) =>
               Source.fromFuture {
-                Unmarshal(entity).to[String].map { err =>
-                  throw new S3Exception(err, code)
-                }
+                unmarshalError(code, entity)
               }
           }
       }
       .mapMaterializedValue(_ => NotUsed)
+
+  private def unmarshalError(code: StatusCode, entity: ResponseEntity)(implicit mat: Materializer) = {
+    import mat.executionContext
+    Unmarshal(entity).to[String].map { err =>
+      throw S3Exception(err, code)
+    }
+  }
 
   def deleteObject(s3Location: S3Location, versionId: Option[String], s3Headers: S3Headers): Source[Done, NotUsed] =
     Source
@@ -255,9 +260,7 @@ import scala.util.{Failure, Success, Try}
               Source.fromFuture(entity.discardBytes().future().map(_ => Done))
             case HttpResponse(code, _, entity, _) =>
               Source.fromFuture {
-                Unmarshal(entity).to[String].map { err =>
-                  throw new S3Exception(err, code)
-                }
+                unmarshalError(code, entity)
               }
           }
       }
@@ -301,9 +304,7 @@ import scala.util.{Failure, Success, Try}
               }
             case HttpResponse(code, _, entity, _) =>
               Source.fromFuture {
-                Unmarshal(entity).to[String].map { err =>
-                  throw new S3Exception(err, code)
-                }
+                unmarshalError(code, entity)
               }
           }
       }
@@ -400,17 +401,13 @@ import scala.util.{Failure, Success, Try}
       .mapMaterializedValue(_ => NotUsed)
 
   private def processBucketLifecycleResponse(response: HttpResponse, materializer: Materializer): Future[Done] = {
-    import materializer.executionContext
-
     implicit val mat: Materializer = materializer
 
     response match {
       case HttpResponse(status, _, entity, _) if status.isSuccess() =>
         entity.discardBytes().future()
       case HttpResponse(code, _, entity, _) =>
-        Unmarshal(entity).to[String].map { err =>
-          throw new S3Exception(err, code)
-        }
+        unmarshalError(code, entity)
     }
   }
 
@@ -434,9 +431,7 @@ import scala.util.{Failure, Success, Try}
               }
           )
       case HttpResponse(code, _, entity, _) =>
-        Unmarshal(entity).to[String].map { err =>
-          throw new S3Exception(err, code)
-        }
+        unmarshalError(code, entity)
     }
   }
 
@@ -471,9 +466,7 @@ import scala.util.{Failure, Success, Try}
             Source.fromFuture(Unmarshal(entity).to[MultipartUpload])
           case HttpResponse(code, _, entity, _) =>
             Source.fromFuture {
-              Unmarshal(entity).to[String].map { err =>
-                throw new S3Exception(err, code)
-              }
+              unmarshalError(code, entity)
             }
         }
       }
@@ -807,14 +800,11 @@ import scala.util.{Failure, Success, Try}
   private def entityForSuccess(
       resp: HttpResponse
   )(implicit mat: Materializer): Future[(ResponseEntity, Seq[HttpHeader])] = {
-    import mat.executionContext
     resp match {
       case HttpResponse(status, headers, entity, _) if status.isSuccess() && !status.isRedirection() =>
         Future.successful((entity, headers))
       case HttpResponse(code, _, entity, _) =>
-        Unmarshal(entity).to[String].map { err =>
-          throw new S3Exception(err, code)
-        }
+        unmarshalError(code, entity)
     }
   }
 
@@ -886,11 +876,7 @@ import scala.util.{Failure, Success, Try}
                 case OK =>
                   Unmarshal(entity).to[CopyPartResult].map(cp => SuccessfulUploadPart(upload, index, cp.eTag))
                 case statusCode: StatusCode =>
-                  Unmarshal(entity).to[String].map { err =>
-                    val response =
-                      Option(err).getOrElse(s"Failed to upload part into S3, status code was: $statusCode")
-                    throw new S3Exception(response, statusCode)
-                  }
+                  unmarshalError(statusCode, entity)
               }
 
             case (Failure(ex), multipartCopy) =>

--- a/s3/src/test/scala/akka/stream/alpakka/s3/S3ExceptionSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/S3ExceptionSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.s3
+
+import akka.http.scaladsl.model.StatusCodes
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+class S3ExceptionSpec extends AnyFlatSpecLike with Matchers {
+
+  "S3 exception" should "be parsed" in {
+    val e = S3Exception("Hej", StatusCodes.OK)
+    e.toString shouldBe "akka.stream.alpakka.s3.S3Exception: Hej (Status code: 200 OK, Code: 200 OK, RequestId: -, Resource: -)"
+  }
+
+  it should "parse AWS sample" in {
+    val s = """<?xml version="1.0" encoding="UTF-8"?>
+              |<Error>
+              |  <Code>NoSuchKey</Code>
+              |  <Message>The resource you requested does not exist</Message>
+              |  <Resource>/mybucket/myfoto.jpg</Resource>
+              |  <RequestId>4442587FB7D0A2F9</RequestId>
+              |</Error>""".stripMargin
+    val e = S3Exception(s, StatusCodes.NotFound)
+    e.code shouldBe "NoSuchKey"
+    e.message shouldBe "The resource you requested does not exist"
+    e.requestId shouldBe "4442587FB7D0A2F9"
+    e.resource shouldBe "/mybucket/myfoto.jpg"
+  }
+
+  it should "survive null" in {
+    val e = S3Exception(null, StatusCodes.NotFound)
+    e.toString shouldBe "akka.stream.alpakka.s3.S3Exception (Status code: 404 Not Found, Code: 404 Not Found, RequestId: -, Resource: -)"
+  }
+
+}

--- a/s3/src/test/scala/akka/stream/alpakka/s3/S3ExceptionSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/S3ExceptionSpec.scala
@@ -28,6 +28,7 @@ class S3ExceptionSpec extends AnyFlatSpecLike with Matchers {
     e.message shouldBe "The resource you requested does not exist"
     e.requestId shouldBe "4442587FB7D0A2F9"
     e.resource shouldBe "/mybucket/myfoto.jpg"
+    e.toString shouldBe "akka.stream.alpakka.s3.S3Exception: The resource you requested does not exist (Status code: 404 Not Found, Code: NoSuchKey, RequestId: 4442587FB7D0A2F9, Resource: /mybucket/myfoto.jpg)"
   }
 
   it should "survive null" in {


### PR DESCRIPTION
* Simplify construction of the exception when the XML can't be parsed.
* Always keep the HTTP status code.
* According to the [docs](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html) it should be `RequestId` not `RequestID` as the earlier code did.
* `HostID` doesn't exist anymore(?), but `Resource` is there

References #2310
