### PR TITLE
json-streaming: fix generated POM

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -298,7 +298,6 @@ object Dependencies {
 
   val JsonStreaming = Seq(
     libraryDependencies ++= Seq(
-        "com.github.jsurfer" % "jsurfer" % "1.6.0", // MIT,
         "com.github.jsurfer" % "jsurfer-jackson" % "1.6.0" // MIT
       ) ++ JacksonDatabindDependencies
   )


### PR DESCRIPTION
Removes the explicit dependency on `jsurfer`, which is of type `pom`, but is implicitly specified as being of type `jar` in the generated POM for `alpakka-json-streaming`, making the latter unusable from Maven (#2338).
