### PR TITLE
Update the elasticsearch-rest-client to 7.7.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,13 +74,13 @@ services:
     ports:
       - "8001:8000"
   elasticsearch6:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.10
     ports:
       - "9201:9200"
     environment:
       - "discovery.type=single-node"
   elasticsearch7:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.7.1
     ports:
       - "9202:9200"
     environment:

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTest.java
@@ -22,6 +22,8 @@ import org.apache.http.HttpHost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
 // #init-client
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 // #init-client
 import org.junit.*;
@@ -89,7 +91,7 @@ public class ElasticsearchTest {
 
   @Parameterized.AfterParam
   public static void afterParam() throws IOException {
-    client.performRequest("DELETE", "/_all");
+    client.performRequest(new Request("DELETE", "/_all"));
     client.close();
   }
 
@@ -112,17 +114,18 @@ public class ElasticsearchTest {
   }
 
   private static void flushAndRefresh(String indexName) throws IOException {
-    client.performRequest("POST", indexName + "/_flush");
-    client.performRequest("POST", indexName + "/_refresh");
+    client.performRequest(new Request("POST", indexName + "/_flush"));
+    client.performRequest(new Request("POST", indexName + "/_refresh"));
   }
 
   private static void register(String indexName, String title) throws IOException {
-    client.performRequest(
-        "POST",
-        indexName + "/_doc",
-        new HashMap<>(),
-        new StringEntity(String.format("{\"title\": \"%s\"}", title)),
-        new BasicHeader("Content-Type", "application/json"));
+    Request request = new Request("POST", indexName + "/_doc");
+    request.setEntity(new StringEntity(String.format("{\"title\": \"%s\"}", title)));
+    RequestOptions.Builder requestOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    requestOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(requestOptionsBuilder);
+
+    client.performRequest(request);
   }
 
   private void documentation() {

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
@@ -9,6 +9,7 @@ import akka.stream.alpakka.elasticsearch._
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.testkit.TestKit
+import org.elasticsearch.client.Request
 //#init-client
 import org.apache.http.HttpHost
 import org.elasticsearch.client.RestClient
@@ -39,8 +40,8 @@ class ElasticsearchSpec
   val clientV7 = RestClient.builder(new HttpHost("localhost", 9202)).build()
 
   override def afterAll() = {
-    client.performRequest("DELETE", "/_all")
-    clientV7.performRequest("DELETE", "/_all")
+    client.performRequest(new Request("DELETE", "/_all"))
+    clientV7.performRequest(new Request("DELETE", "/_all"))
     client.close()
     clientV7.close()
     TestKit.shutdownActorSystem(system)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -161,7 +161,7 @@ object Dependencies {
 
   val Elasticsearch = Seq(
     libraryDependencies ++= Seq(
-        "org.elasticsearch.client" % "elasticsearch-rest-client" % "6.3.1", // ApacheV2
+        "org.elasticsearch.client" % "elasticsearch-rest-client" % "7.7.1", // ApacheV2
         "io.spray" %% "spray-json" % "1.3.5", // ApacheV2
         "org.slf4j" % "jcl-over-slf4j" % jclOverSlf4jVersion % Test
       ) ++ JacksonDatabindDependencies


### PR DESCRIPTION
# Purpose

Update the elasticsearch-rest-client to the latest 7.x release

# References

This'll solve the method signature change introduces in elasticsearch-rest-client 6.4 as described in #2308

# Changes

- Updated all `performRequest` and `performRequestAsync` calls in both the source and tests
- Updated the ElasticSearch Docker images used in the `docker-compose.yml`

# Context

I've updated the elasticsearch-rest-client to the latest available version, being 7.7.1. I think there is no harm doing so since the ES low-level client in no way binds itself to a particular ES version.