### PR TITLE
AWS S3: Make BucketAccess a sealed trait

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
@@ -551,7 +551,7 @@ object ObjectMetadata {
  *
  * @see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketHEAD.html
  */
-sealed class BucketAccess
+sealed trait BucketAccess
 
 object BucketAccess {
   case object AccessDenied extends BucketAccess


### PR DESCRIPTION
So we know at compile time that it'll be one of those three cases, and that there's not a 4th `BucketAccess` case possible.