### PR TITLE
AMQP: Fixes handling null replyTo header in AmqpReplyToSinkStage

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpReplyToSinkStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpReplyToSinkStage.scala
@@ -62,7 +62,7 @@ private[amqp] final class AmqpReplyToSinkStage(settings: AmqpReplyToSinkSettings
           override def onPush(): Unit = {
             val elem = grab(in)
 
-            val replyTo = elem.properties.map(_.getReplyTo)
+            val replyTo = elem.properties.flatMap(properties => Option(properties.getReplyTo))
 
             if (replyTo.isDefined) {
               channel.basicPublish(


### PR DESCRIPTION
Fixes situation when `properties` of the message are present, but `replyTo` header in this properties is `null`. In that case `elem.properties.map(_.getReplyTo)` evaluated to `Some(null)` and sending message resulted with the error:
```
java.lang.IllegalStateException: Invalid configuration: 'routingKey' must be non-null.
	at com.rabbitmq.client.impl.AMQImpl$Basic$Publish.<init>(AMQImpl.java:2280)
	at com.rabbitmq.client.AMQP$Basic$Publish$Builder.build(AMQP.java:1219)
	at com.rabbitmq.client.impl.ChannelN.basicPublish(ChannelN.java:696)
	at com.rabbitmq.client.impl.recovery.AutorecoveringChannel.basicPublish(AutorecoveringChannel.java:202)
	at akka.stream.alpakka.amqp.impl.AmqpReplyToSinkStage$$anon$1$$anon$2.onPush(AmqpReplyToSinkStage.scala:74)
```
