### PR TITLE
BigQuery: re-implement splitter as stage

### DIFF
--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/impl/util/Delay.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/impl/util/Delay.scala
@@ -24,7 +24,7 @@ private[impl] object Delay {
     GraphDSL.create() { implicit builder =>
       import GraphDSL.Implicits._
 
-      val splitter = builder.add(Splitter[T](shouldDelay)())
+      val splitter = builder.add(Splitter[T](shouldDelay))
       val delayFlow =
         builder.add(DelayFlow[T](() => new FibonacciStrategy[T](delayUnit, maxDelay)))
       val merge = builder.add(Merge[T](2, eagerComplete = true))

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/impl/util/Splitter.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/impl/util/Splitter.scala
@@ -6,25 +6,53 @@ package akka.stream.alpakka.googlecloud.bigquery.impl.util
 
 import akka.NotUsed
 import akka.annotation.InternalApi
-import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL}
-import akka.stream.{Graph, UniformFanOutShape}
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.stream.{Attributes, Graph, Inlet, Outlet, UniformFanOutShape}
 
 @InternalApi
 private[impl] object Splitter {
-
-  def apply[T](out0Predicate: T => Boolean)(
-      out1Predicate: T => Boolean = (elem: T) => !out0Predicate(elem)
-  ): Graph[UniformFanOutShape[T, T], NotUsed] = GraphDSL.create() { implicit builder =>
-    import GraphDSL.Implicits._
-
-    val broadcast = builder.add(Broadcast[T](2, true))
-    val filterOut0 = builder.add(Flow[T].filter(out0Predicate(_)))
-    val filterOut1 = builder.add(Flow[T].filter(out1Predicate(_)))
-
-    broadcast.out(0) ~> filterOut0
-    broadcast.out(1) ~> filterOut1
-
-    UniformFanOutShape(broadcast.in, filterOut0.out, filterOut1.out)
+  def apply[T](out0Predicate: T => Boolean): Graph[UniformFanOutShape[T, T], NotUsed] = {
+    new Splitter[T](out0Predicate)
   }
 
+  private[impl] class Splitter[T](out0Predicate: T => Boolean) extends GraphStage[UniformFanOutShape[T, T]] {
+    val in: Inlet[T] = Inlet[T]("Splitter.in")
+    val out0: Outlet[T] = Outlet("Splitter.out0")
+    val out1: Outlet[T] = Outlet("Splitter.out1")
+    override val shape: UniformFanOutShape[T, T] = UniformFanOutShape(in, out0, out1)
+
+    override def createLogic(attr: Attributes): GraphStageLogic =
+      new GraphStageLogic(shape) {
+        var pulls = 0
+        def pullIfNeeded(): Unit = {
+          if (pulls == 2) {
+            pull(in)
+          }
+        }
+        setHandler(in, new InHandler {
+          override def onPush(): Unit = {
+            val e = grab(in)
+            if (out0Predicate(e)) {
+              push(out0, e)
+              pulls -= 1;
+            } else {
+              push(out1, e)
+              pulls -= 1;
+            }
+          }
+        })
+        setHandler(out0, new OutHandler {
+          override def onPull(): Unit = {
+            pulls += 1
+            pullIfNeeded()
+          }
+        })
+        setHandler(out1, new OutHandler {
+          override def onPull(): Unit = {
+            pulls += 1
+            pullIfNeeded()
+          }
+        })
+      }
+  }
 }

--- a/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/impl/util/SplitterSpec.scala
+++ b/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/impl/util/SplitterSpec.scala
@@ -33,7 +33,7 @@ class SplitterSpec
     RunnableGraph.fromGraph(GraphDSL.create(sink1, sink2)((_, _)) { implicit builder => (s1, s2) =>
       import GraphDSL.Implicits._
 
-      val splitter = builder.add(Splitter[Int](_ < 3)())
+      val splitter = builder.add(Splitter[Int](_ < 3))
 
       source ~> splitter.in
       splitter.out(0) ~> s1


### PR DESCRIPTION
Fixes #2379 
Fixes #2361 
Fixes #2378 

More info below the linked issues but tldr;

The BQ connector has a cycle in it, so the pull and close propagation are critical. The filter changes in 2.6.2 (akka/akka#28467) broke it, so the Splitter logic moved to a custom stage. This made the tests in earlier and later akka versions green too.

