### PR TITLE
Check client instance for nulls

### DIFF
--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchFlow.scala
@@ -233,6 +233,7 @@ object ElasticsearchFlow {
     override def convert(message: T): String = message.toJson.toString()
   }
 
+  @InternalApi
   private[scaladsl] def checkClient(client: RestClient): Unit =
     require(client != null, "The elasticsearch `RestClient` passed in may not be null.")
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchFlow.scala
@@ -223,6 +223,7 @@ object ElasticsearchFlow {
                                    settings: ElasticsearchWriteSettings,
                                    elasticsearchClient: RestClient,
                                    writer: MessageWriter[T]) = {
+    checkClient(elasticsearchClient)
     Flow.fromGraph {
       new impl.ElasticsearchSimpleFlowStage[T, C](indexName, typeName, elasticsearchClient, settings, writer)
     }
@@ -231,5 +232,8 @@ object ElasticsearchFlow {
   private final class SprayJsonWriter[T](implicit writer: JsonWriter[T]) extends MessageWriter[T] {
     override def convert(message: T): String = message.toJson.toString()
   }
+
+  private[scaladsl] def checkClient(client: RestClient): Unit =
+    require(client != null, "The elasticsearch `RestClient` passed in may not be null.")
 
 }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSource.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSource.scala
@@ -78,7 +78,8 @@ object ElasticsearchSource {
              searchParams: Map[String, String],
              settings: ElasticsearchSourceSettings)(
       implicit elasticsearchClient: RestClient
-  ): Source[ReadResult[JsObject], NotUsed] =
+  ): Source[ReadResult[JsObject], NotUsed] = {
+    ElasticsearchFlow.checkClient(elasticsearchClient)
     Source.fromGraph(
       new impl.ElasticsearchSourceStage(
         indexName,
@@ -89,6 +90,7 @@ object ElasticsearchSource {
         new SprayJsonReader[JsObject]()(DefaultJsonProtocol.RootJsObjectFormat)
       )
     )
+  }
 
   /**
    * Creates a [[akka.stream.scaladsl.Source]] from Elasticsearch that streams [[ReadResult]]s of type `T`
@@ -127,7 +129,8 @@ object ElasticsearchSource {
                settings: ElasticsearchSourceSettings)(
       implicit elasticsearchClient: RestClient,
       sprayJsonReader: JsonReader[T]
-  ): Source[ReadResult[T], NotUsed] =
+  ): Source[ReadResult[T], NotUsed] = {
+    ElasticsearchFlow.checkClient(elasticsearchClient)
     Source.fromGraph(
       new impl.ElasticsearchSourceStage(indexName,
                                         typeName,
@@ -136,6 +139,7 @@ object ElasticsearchSource {
                                         settings,
                                         new SprayJsonReader[T]()(sprayJsonReader))
     )
+  }
 
   private final class SprayJsonReader[T](implicit reader: JsonReader[T]) extends impl.MessageReader[T] {
 

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisFlow.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisFlow.scala
@@ -7,6 +7,7 @@ package akka.stream.alpakka.kinesis.scaladsl
 import java.nio.ByteBuffer
 
 import akka.NotUsed
+import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts.sameThreadExecutionContext
 import akka.stream.ThrottleMode
 import akka.stream.alpakka.kinesis.KinesisFlowSettings
@@ -102,6 +103,7 @@ object KinesisFlow {
       }
       .via(byPartitionAndData(streamName, settings))
 
+  @InternalApi
   private[scaladsl] def checkClient(kinesisClient: KinesisAsyncClient): Unit =
     require(kinesisClient != null, "The `KinesisAsyncClient` passed in may not be null.")
 

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisSource.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisSource.scala
@@ -17,8 +17,10 @@ object KinesisSource {
   /**
    * Read from one shard into a stream.
    */
-  def basic(shardSettings: ShardSettings, amazonKinesisAsync: KinesisAsyncClient): Source[Record, NotUsed] =
+  def basic(shardSettings: ShardSettings, amazonKinesisAsync: KinesisAsyncClient): Source[Record, NotUsed] = {
+    KinesisFlow.checkClient(amazonKinesisAsync)
     Source.fromGraph(new KinesisSourceStage(shardSettings, amazonKinesisAsync))
+  }
 
   /**
    * Read from multiple shards into a single stream.

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttActorSystemsSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttActorSystemsSpec.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package docs.scaladsl
 
 import akka.actor.typed.scaladsl.Behaviors

--- a/sns/src/main/scala/akka/stream/alpakka/sns/scaladsl/SnsPublisher.scala
+++ b/sns/src/main/scala/akka/stream/alpakka/sns/scaladsl/SnsPublisher.scala
@@ -44,9 +44,11 @@ object SnsPublisher {
    */
   def publishFlow(
       settings: SnsPublishSettings
-  )(implicit snsClient: SnsAsyncClient): Flow[PublishRequest, PublishResponse, NotUsed] =
+  )(implicit snsClient: SnsAsyncClient): Flow[PublishRequest, PublishResponse, NotUsed] = {
+    require(snsClient != null, "The `SnsAsyncClient` passed in may not be null.")
     Flow[PublishRequest]
       .mapAsyncUnordered(settings.concurrency)(snsClient.publish(_).toScala)
+  }
 
   /**
    * creates a [[akka.stream.scaladsl.Flow Flow]] to publish messages to SNS topics based on the message topic arn using an [[software.amazon.awssdk.services.sns.SnsAsyncClient SnsAsyncClient]]

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
@@ -26,7 +26,8 @@ object SqsSource {
   def apply(
       queueUrl: String,
       settings: SqsSourceSettings = SqsSourceSettings.Defaults
-  )(implicit sqsClient: SqsAsyncClient): Source[Message, NotUsed] =
+  )(implicit sqsClient: SqsAsyncClient): Source[Message, NotUsed] = {
+    SqsAckFlow.checkClient(sqsClient)
     Source
       .repeat {
         val requestBuilder =
@@ -48,6 +49,7 @@ object SqsSource {
       .takeWhile(messages => !settings.closeOnEmptyReceive || messages.nonEmpty)
       .mapConcat(identity)
       .buffer(settings.maxBufferSize, OverflowStrategy.backpressure)
+  }
 
   private def resolveHandler(parallelism: Int)(implicit sqsClient: SqsAsyncClient) =
     if (parallelism == 1) {


### PR DESCRIPTION
I got reports from users that ended up with an NPE without understanding where it came from.

This PR covers some random connectors which get a client instance passed (implicitly).