### PR TITLE
SQS tests: Remove tight requestNext timeout

### DIFF
--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceMockSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceMockSpec.scala
@@ -93,7 +93,7 @@ class SqsSourceMockSpec extends AnyFlatSpec with Matchers with DefaultTestContex
       i <- 1 to bufferToBatchRatio
       message <- defaultMessages
     } {
-      probe.requestNext(10.milliseconds) shouldEqual message
+      probe.requestNext() shouldEqual message
     }
     probe.cancel()
   }
@@ -141,7 +141,7 @@ class SqsSourceMockSpec extends AnyFlatSpec with Matchers with DefaultTestContex
         .withWaitTime(timeout)
     ).runWith(TestSink.probe[Message])
 
-    (1 to firstWithDataCount * 10).foreach(_ => probe.requestNext(10.milliseconds))
+    (1 to firstWithDataCount * 10).foreach(_ => probe.requestNext())
 
     verify(sqsClient, atMostTimes(firstWithDataCount + parallelism)).receiveMessage(any[ReceiveMessageRequest])
 


### PR DESCRIPTION
They don't really have a function here since requestNext returns as soon
as the expected object arrives

fixes #2389