### PR TITLE
S3: Add access-style property

### DIFF
--- a/s3/src/main/resources/reference.conf
+++ b/s3/src/main/resources/reference.conf
@@ -78,11 +78,22 @@ alpakka.s3 {
   # AWS S3 is going to retire path-style access, thus prefer the virtual-host-style access
   # https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
   #
+  # Also, prefer to use the newer access-style property.
+  #
   # Possible values:
   #  - false: use virtual-host style access
   #  - true: use legacy path-style access, warnings will be logged
   #  - force: use legacy path-style access, disable warnings
-  path-style-access = false
+  #  - empty, null or absent (default): use `access-style`, which in turn defaults to virtual-host style access
+  # path-style-access = false
+
+  # Which access style to use. Prefer to use this setting over path-style-access.
+  # Path-style access has been deprecated by Amazon and will not work on buckets created after September 30, 2020.
+  # For alternative S3 implementations (MinIO, Rados Gateway, etc.), path-style access may continue to be required.
+  # Possible values:
+  #  - virtual: virtual host-style access, i.e. https://<bucket name>.s3.amazonaws.com/file/inside/bucket
+  #  - path: path-style access, i.e. https://<region>.amazonaws.com/<bucket>/file/inside/bucket
+  access-style = virtual
 
   # Custom endpoint url, used for alternate s3 implementations
   # To enable virtual-host-style access with Alpakka S3 use the placeholder `{bucket}` in the URL

--- a/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
@@ -8,6 +8,7 @@ import java.util.{Objects, Optional}
 
 import akka.http.scaladsl.model.{DateTime, HttpHeader, IllegalUriException, Uri}
 import akka.http.scaladsl.model.headers._
+import akka.stream.alpakka.s3.AccessStyle.PathAccessStyle
 
 import scala.collection.immutable.Seq
 import scala.collection.immutable
@@ -580,7 +581,7 @@ object BucketAndKey {
   }
 
   private[s3] def validateBucketName(bucket: String, conf: S3Settings): Unit = {
-    if (conf.pathStyleAccess) {
+    if (conf.accessStyle == PathAccessStyle) {
       if (!pathStyleValid(bucket)) {
         throw IllegalUriException(
           "The bucket name contains sub-dir selection with `..`",

--- a/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
@@ -5,19 +5,21 @@
 package akka.stream.alpakka.s3
 
 import java.nio.file.{Path, Paths}
-import java.util.{Objects, Optional}
 import java.util.concurrent.TimeUnit
+import java.util.{Objects, Optional}
 
-import scala.util.Try
 import akka.actor.{ActorSystem, ClassicActorSystemProvider}
 import akka.http.scaladsl.model.Uri
-import software.amazon.awssdk.auth.credentials._
-import software.amazon.awssdk.regions.providers._
+import akka.stream.alpakka.s3.AccessStyle.{PathAccessStyle, VirtualHostAccessStyle}
 import com.typesafe.config.Config
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.regions.providers._
 
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration._
+import scala.util.Try
 
 final class Proxy private (
     val host: String,
@@ -212,12 +214,26 @@ object ApiVersion {
   def getListBucketVersion2: ListBucketVersion2 = ListBucketVersion2
 }
 
+sealed abstract class AccessStyle
+object AccessStyle {
+  sealed abstract class PathAccessStyle extends AccessStyle
+  case object PathAccessStyle extends PathAccessStyle
+
+  /** Java API */
+  def pathAccessStyle: PathAccessStyle = PathAccessStyle
+
+  sealed abstract class VirtualHostAccessStyle extends AccessStyle
+  case object VirtualHostAccessStyle extends VirtualHostAccessStyle
+
+  /** Java API */
+  def virtualHostAccessStyle: VirtualHostAccessStyle = VirtualHostAccessStyle
+}
+
 final class S3Settings private (
     val bufferType: BufferType,
     val credentialsProvider: AwsCredentialsProvider,
     val s3RegionProvider: AwsRegionProvider,
-    val pathStyleAccess: Boolean,
-    val pathStyleAccessWarning: Boolean,
+    val accessStyle: AccessStyle,
     val endpointUrl: Option[String],
     val listBucketApiVersion: ApiVersion,
     val forwardProxy: Option[ForwardProxy],
@@ -241,7 +257,12 @@ final class S3Settings private (
   def getS3RegionProvider: AwsRegionProvider = s3RegionProvider
 
   /** Java API */
-  def isPathStyleAccess: Boolean = pathStyleAccess
+  def isPathStyleAccess: Boolean = accessStyle == PathAccessStyle
+
+  def pathStyleAccess: Boolean = accessStyle == PathAccessStyle
+
+  @deprecated("This is no longer configurable.", since = "2.0.2")
+  def pathStyleAccessWarning: Boolean = true
 
   /** Java API */
   def getEndpointUrl: java.util.Optional[String] = endpointUrl.asJava
@@ -252,6 +273,9 @@ final class S3Settings private (
   /** Java API */
   def getForwardProxy: java.util.Optional[ForwardProxy] = forwardProxy.asJava
 
+  /** Java API */
+  def getAccessStyle: AccessStyle = accessStyle
+
   def withBufferType(value: BufferType): S3Settings = copy(bufferType = value)
 
   @deprecated("Please use endpointUrl instead", since = "1.0.1")
@@ -261,12 +285,12 @@ final class S3Settings private (
     copy(credentialsProvider = value)
   def withS3RegionProvider(value: AwsRegionProvider): S3Settings = copy(s3RegionProvider = value)
 
-  @deprecated(
-    "AWS S3 is going to retire path-style access https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/",
-    since = "2.0.0"
-  )
+  @deprecated("Please use accessStyle instead", since = "2.0.2")
   def withPathStyleAccess(value: Boolean): S3Settings =
-    if (pathStyleAccess == value) this else copy(pathStyleAccess = value)
+    if (isPathStyleAccess == value) this else copy(accessStyle = if (value) PathAccessStyle else VirtualHostAccessStyle)
+  def withAccessStyle(value: AccessStyle): S3Settings =
+    if (accessStyle == value) this else copy(accessStyle = value);
+
   def withEndpointUrl(value: String): S3Settings = copy(endpointUrl = Option(value))
   def withListBucketApiVersion(value: ApiVersion): S3Settings =
     copy(listBucketApiVersion = value)
@@ -281,7 +305,7 @@ final class S3Settings private (
       bufferType: BufferType = bufferType,
       credentialsProvider: AwsCredentialsProvider = credentialsProvider,
       s3RegionProvider: AwsRegionProvider = s3RegionProvider,
-      pathStyleAccess: Boolean = pathStyleAccess,
+      accessStyle: AccessStyle = accessStyle,
       endpointUrl: Option[String] = endpointUrl,
       listBucketApiVersion: ApiVersion = listBucketApiVersion,
       forwardProxy: Option[ForwardProxy] = forwardProxy,
@@ -291,8 +315,7 @@ final class S3Settings private (
     bufferType,
     credentialsProvider,
     s3RegionProvider,
-    pathStyleAccess,
-    pathStyleAccessWarning,
+    accessStyle,
     endpointUrl,
     listBucketApiVersion,
     forwardProxy,
@@ -305,8 +328,7 @@ final class S3Settings private (
     s"bufferType=$bufferType," +
     s"credentialsProvider=$credentialsProvider," +
     s"s3RegionProvider=$s3RegionProvider," +
-    s"pathStyleAccess=$pathStyleAccess," +
-    s"pathStyleAccessWarning=$pathStyleAccessWarning," +
+    s"accessStyle=$accessStyle," +
     s"endpointUrl=$endpointUrl," +
     s"listBucketApiVersion=$listBucketApiVersion," +
     s"forwardProxy=$forwardProxy," +
@@ -318,8 +340,7 @@ final class S3Settings private (
       java.util.Objects.equals(this.bufferType, that.bufferType) &&
       Objects.equals(this.credentialsProvider, that.credentialsProvider) &&
       Objects.equals(this.s3RegionProvider, that.s3RegionProvider) &&
-      Objects.equals(this.pathStyleAccess, that.pathStyleAccess) &&
-      Objects.equals(this.pathStyleAccessWarning, that.pathStyleAccessWarning) &&
+      Objects.equals(this.accessStyle, that.accessStyle) &&
       Objects.equals(this.endpointUrl, that.endpointUrl) &&
       Objects.equals(this.listBucketApiVersion, that.listBucketApiVersion) &&
       Objects.equals(this.forwardProxy, that.forwardProxy) &&
@@ -332,8 +353,7 @@ final class S3Settings private (
       bufferType,
       credentialsProvider,
       s3RegionProvider,
-      Boolean.box(pathStyleAccess),
-      Boolean.box(pathStyleAccessWarning),
+      accessStyle,
       endpointUrl,
       listBucketApiVersion,
       forwardProxy,
@@ -342,6 +362,7 @@ final class S3Settings private (
 }
 
 object S3Settings {
+  private final val log = LoggerFactory.getLogger(getClass)
   val ConfigPath = "alpakka.s3"
 
   /**
@@ -375,15 +396,46 @@ object S3Settings {
       if (c.hasPath("forward-proxy")) Some(ForwardProxy(c.getConfig("forward-proxy")))
       else None
 
-    val (pathStyleAccess, pathStyleAccessWarning) =
-      if (c.getString("path-style-access") == "force") (true, false)
-      else (c.getBoolean("path-style-access"), true)
+    if (c.hasPath("path-style-access"))
+      log.warn(
+        "The deprecated 'path-style-access' property was used to specify access style. Please use 'access-style' instead."
+      )
+
+    val deprecatedPathAccessStyleSetting = Try(c.getString("path-style-access")).toOption
+
+    val accessStyle = deprecatedPathAccessStyleSetting match {
+      case None | Some("") =>
+        c.getString("access-style") match {
+          case "virtual" => VirtualHostAccessStyle
+          case "path" => PathAccessStyle
+          case other =>
+            throw new IllegalArgumentException(s"'access-style' must be 'virtual' or 'path'. Got: [$other]")
+        }
+      case Some("true") | Some("force") => PathAccessStyle
+      case Some("false") => VirtualHostAccessStyle
+      case Some(other) =>
+        throw new IllegalArgumentException(
+          s"'path-style-access' must be 'false', 'true' or 'force'. Got: [$other]. Prefer using access-style instead."
+        )
+    }
 
     val endpointUrl = if (c.hasPath("endpoint-url")) {
       Option(c.getString("endpoint-url"))
     } else {
       None
     }.orElse(maybeProxy.map(p => s"${p.scheme}://${p.host}:${p.port}"))
+
+    if (endpointUrl.isEmpty && accessStyle == PathAccessStyle)
+      log.warn(
+        s"""It appears you are attempting to use AWS S3 with path-style access.
+          |Amazon does not support path-style access to buckets created after September 30, 2020;
+          |see (https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/).
+          |
+          |Enable virtual host-style access by unsetting `$ConfigPath.path-style-access`,
+          |and leaving `$ConfigPath.access-style` on the default `virtual`.
+          |
+          |If your S3 provider is not AWS, you need to set `$ConfigPath.endpoint-url`.""".stripMargin
+      )
 
     val regionProvider = {
       val regionProviderPath = "aws.region.provider"
@@ -450,8 +502,7 @@ object S3Settings {
       bufferType,
       credentialsProvider,
       regionProvider,
-      pathStyleAccess,
-      pathStyleAccessWarning,
+      accessStyle,
       endpointUrl,
       apiVersion,
       maybeForwardProxy,
@@ -479,8 +530,7 @@ object S3Settings {
     bufferType,
     credentialsProvider,
     s3RegionProvider,
-    pathStyleAccess,
-    pathStyleAccessWarning = true,
+    accessStyle = if (pathStyleAccess) PathAccessStyle else VirtualHostAccessStyle,
     endpointUrl,
     listBucketApiVersion,
     forwardProxy = None,
@@ -498,8 +548,7 @@ object S3Settings {
     bufferType,
     credentialsProvider,
     s3RegionProvider,
-    pathStyleAccess = false,
-    pathStyleAccessWarning = true,
+    accessStyle = VirtualHostAccessStyle,
     endpointUrl = None,
     listBucketApiVersion,
     forwardProxy = None,

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ExtSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ExtSpec.scala
@@ -5,12 +5,13 @@
 package akka.stream.alpakka.s3.scaladsl
 
 import akka.actor.ActorSystem
-import com.typesafe.config.ConfigFactory
+import akka.stream.alpakka.s3.AccessStyle.PathAccessStyle
 import akka.stream.alpakka.s3.S3Ext
-
-import scala.collection.JavaConverters._
+import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters._
 
 class S3ExtSpec extends AnyFlatSpecLike with Matchers {
   it should "reuse application config from actor system" in {
@@ -23,6 +24,6 @@ class S3ExtSpec extends AnyFlatSpecLike with Matchers {
     implicit val system = ActorSystem.create("s3", config)
     val ext = S3Ext(system)
     ext.settings.endpointUrl shouldBe Some("http://localhost:8001")
-    ext.settings.pathStyleAccess shouldBe true
+    ext.settings.accessStyle shouldBe PathAccessStyle
   }
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -6,6 +6,7 @@ package akka.stream.alpakka.s3.scaladsl
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
+import akka.stream.alpakka.s3.AccessStyle.PathAccessStyle
 import akka.stream.alpakka.s3.BucketAccess.{AccessGranted, NotExists}
 import akka.stream.alpakka.s3._
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
@@ -69,10 +70,9 @@ trait S3IntegrationSpec
   /** Hooks for Minio tests to overwrite the HTTP transport */
   def attributes(s3Settings: S3Settings): Attributes = Attributes.none
 
-  @com.github.ghik.silencer.silent("path-style access")
   def otherRegionSettingsPathStyleAccess =
     S3Settings()
-      .withPathStyleAccess(true)
+      .withAccessStyle(PathAccessStyle)
       .withS3RegionProvider(new AwsRegionProvider {
         val getRegion: Region = Region.EU_CENTRAL_1
       })
@@ -620,12 +620,11 @@ class MinioS3IntegrationSpec extends S3IntegrationSpec {
                                  |}
     """.stripMargin).withFallback(super.config())
 
-  @com.github.ghik.silencer.silent
   override def otherRegionSettingsPathStyleAccess =
     S3Settings()
       .withCredentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secret)))
       .withEndpointUrl(endpointUrlPathStyle)
-      .withPathStyleAccess(true)
+      .withAccessStyle(PathAccessStyle)
 
   override def invalidCredentials: S3Settings =
     S3Settings()


### PR DESCRIPTION
References #2171 . In the pull request https://github.com/akka/alpakka/pull/2193#issuecomment-686304485 it was noted that it would be better to have a separate `access-style` property instead of the current tripartite `path-style-access` one. This PR attempts to improve that situation.

With this change, `access-style` is the preferred way of setting the property, using either `path` or `virtual`.

If the old, deprecated `path-style-access` is used, that takes precedence, but a warning is logged to instruct the developer to change to the new property.

If the effective access style is `path`, and `endpoint-url` is not set (i.e. the S3 provider is AWS), one warning is issued. This is not configurable, but it shouldn't have to be, because using path-style access on AWS S3 is likely going to cause problems sooner or later.