### PR TITLE
S3: `text/event-stream` ContentType in multipart upload response

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
@@ -31,7 +31,7 @@ import scala.xml.NodeSeq
   }
 
   implicit val completeMultipartUploadResultUnmarshaller: FromEntityUnmarshaller[CompleteMultipartUploadResult] = {
-    nodeSeqUnmarshaller(MediaTypes.`application/xml` withCharset HttpCharsets.`UTF-8`) map {
+    nodeSeqUnmarshaller(MediaTypes.`application/xml` withCharset HttpCharsets.`UTF-8`, MediaTypes.`text/event-stream`) map {
       case NodeSeq.Empty => throw Unmarshaller.NoContentException
       case x =>
         CompleteMultipartUploadResult(

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/MarshallingSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/MarshallingSpec.scala
@@ -208,4 +208,25 @@ class MarshallingSpec(_system: ActorSystem)
                                                   "5b27a21a97fcf8a7004dd1d906e7a5ba")
   }
 
+  it should "parse CompleteMultipartUpload in event-stream" in {
+    val xmlString =
+      """
+        |<CompleteMultipartUploadResult>
+        |   <Location>some-location</Location>
+        |   <Bucket>some-bucket</Bucket>
+        |   <Key>some/key</Key>
+        |   <ETag>"5b27a21a97fcf8a7004dd1d906e7a5ba"</ETag>
+        |</CompleteMultipartUploadResult>
+      """.stripMargin
+
+    val entity = HttpEntity(MediaTypes.`text/event-stream`, xmlString)
+
+    val result = Marshalling.completeMultipartUploadResultUnmarshaller(entity)
+
+    result.futureValue shouldEqual CompleteMultipartUploadResult("some-location",
+                                                                 "some-bucket",
+                                                                 "some/key",
+                                                                 "5b27a21a97fcf8a7004dd1d906e7a5ba")
+  }
+
 }

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SlowMinioIntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SlowMinioIntegrationSpec.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.s3.scaladsl
+
+import java.time.{Duration, Instant}
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.MediaTypes
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.s3._
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
+import akka.stream.scaladsl.Source
+import akka.testkit.TestKit
+import akka.util.ByteString
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.{Await, ExecutionContextExecutor}
+import scala.concurrent.duration._
+
+/*
+ * Test performing a multipart upload against a slow minio instance.  When minio is responding to a
+ * CompleteMultipartUpload request that takes longer than 10 seconds to complete, it will set the ContentType header
+ * to be `text/event-stream` and inject spaces in the response to prevent the client connection from timing out
+ * (see https://github.com/minio/minio/blob/fbd1c5f51a900158013e8d8e4593d9ca898f8b7e/cmd/object-handlers.go#L2444-L2479)
+ *
+ * For this test, you need a local minio instance with i/o throttling enabled so that the CompleteMultipartUpload takes
+ * longer than 10 seconds to process.
+ * See `create-slow-minio.sh` for an example on how to setup minio with throttling.
+ *
+ * To run this test, first uncomment the @Ignore annotation, then run this command inside sbt:
+ * s3/testOnly *.S3SlowMinioIntegrationSpec
+ */
+@Ignore
+class S3SlowMinioIntegrationSpec
+    extends AnyFlatSpecLike
+    with BeforeAndAfterAll
+    with Matchers
+    with ScalaFutures
+    with OptionValues
+    with LogCapturing {
+
+  implicit val actorSystem: ActorSystem = ActorSystem(
+    "S3SlowMinioIntegrationSpec",
+    config().withFallback(ConfigFactory.load())
+  )
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+  implicit val ec: ExecutionContextExecutor = materializer.executionContext
+
+  val defaultBucket = "my-test-us-east-1"
+
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(90.seconds, 100.millis)
+
+  override protected def beforeAll(): Unit = {
+    Await.ready(S3.makeBucket(defaultBucket).recover { case _ => Done }, 10.seconds)
+  }
+  override protected def afterAll(): Unit = TestKit.shutdownActorSystem(actorSystem)
+
+  def config(): Config = {
+    val accessKey = "TESTKEY"
+    val secret = "TESTSECRET"
+    val endpointUrlPathStyle = "http://localhost:9001"
+
+    ConfigFactory.parseString(s"""
+         |alpakka.s3 {
+         |  aws {
+         |    credentials {
+         |      provider = static
+         |      access-key-id = $accessKey
+         |      secret-access-key = $secret
+         |    }
+         |    region {
+         |      provider = static
+         |      default-region = "us-east-1"
+         |    }
+         |  }
+         |  path-style-access = force
+         |  endpoint-url = "$endpointUrlPathStyle"
+         |}
+    """.stripMargin)
+  }
+
+  it should "have the default bucket" in {
+    S3.checkIfBucketExists(defaultBucket).futureValue shouldBe BucketAccess.AccessGranted
+  }
+
+  it should "upload huge multipart to a slow server" in {
+    val objectKey = "slow"
+    val hugeString = "0123456789abcdef" * 64 * 1024 * 11 // ~ 11mb
+
+    val result =
+      Source
+        .single(ByteString(hugeString))
+        .runWith {
+          S3.multipartUpload(defaultBucket, objectKey, MediaTypes.`application/octet-stream`)
+        }
+
+    val start = Instant.now()
+    val multipartUploadResult = result.futureValue
+    multipartUploadResult.bucket shouldBe defaultBucket
+    multipartUploadResult.key shouldBe objectKey
+    Duration.between(start, Instant.now()) should be > Duration.ofSeconds(12)
+  }
+}

--- a/scripts/create-slow-minio.sh
+++ b/scripts/create-slow-minio.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+##
+## Start a Minio instance with I/O throttling to simulate connecting to a busy/slow Minio server.
+## Used by the S3SlowMinioIntegrationSpec test
+##
+
+# Create a loopback device to throttle
+LO_FILE="/tmp/minio-loopback.img"
+LO_DEV=$(losetup -f)
+
+dd if=/dev/zero of="$LO_FILE" bs=100M count=50
+mkfs.ext4 "$LO_FILE"
+sudo losetup -P "$LO_DEV" "$LO_FILE"
+
+# Start Minio
+# - Use the local volume driver to mount /dev/loopX directly - this allows us to pass the correct device to
+#   device-write-bps for throttling. I wasn't able to get throttling to work with the usual -v/bind mounts
+# - Set CONFIG_BLK_CGROUP and CONFIG_BLK_DEV_THROTTLING to enable throttling, following this guide:
+#   https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/blkio-controller.html#throttling-upper-limit-policy
+# - MINIO_FS_OSYNC needs to be set so that Mionio fsyncs to the disk, and throttling can take effect
+docker run -i --rm \
+  --name minio \
+  --device "$LO_DEV" \
+  --device-read-bps "$LO_DEV":1mb --device-write-bps "$LO_DEV":1mb \
+  -e MINIO_ACCESS_KEY=TESTKEY -e MINIO_SECRET_KEY=TESTSECRET -e MINIO_DOMAIN=s3minio.alpakka -e MINIO_FS_OSYNC=true \
+  -e CONFIG_BLK_CGROUP=y -e CONFIG_BLK_DEV_THROTTLING=y \
+  --mount "type=volume,source=miniodata,target=/data,volume-driver=local,volume-opt=type=ext4,volume-opt=device=$LO_DEV" \
+  -p 9001:9000 \
+  minio/minio \
+  server /data
+
+# We can verify that the throttling is properly configured by running dd
+# This command should take about 5 seconds to write 5 x 1mb blocks to our disk throttled to 1mb/s throttle
+# docker exec minio sh -c "dd if=/dev/zero of=/data/test5 bs=1M count=5 conv=fsync"
+
+# Cleanup loopback device and image
+sudo losetup -d "$LO_DEV"
+rm "$LO_FILE"
+docker volume rm miniodata


### PR DESCRIPTION
* Add support for `text/event-stream` in CompleteMultipartUploadResultUnmarshaller
* Add a unit test for unmarshlling
* Add an integration test to reproduce the behviour using a throttled Minio instance. Since setting up the throttled minio instance requires some effort, the test must be run manually and is annotated with an `@Ignore`

fixes #2394
