### PR TITLE
docs: least Akka 2.6 version from the scheduled build

### DIFF
--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -14,7 +14,7 @@ The code in this documentation is compiled against:
 
 * Alpakka $project.version$ ([Github](https://github.com/akka/alpakka), [API docs](https://doc.akka.io/api/alpakka/current/akka/stream/alpakka/index.html))
 * Scala $scala.binary.version$ (all modules are available for Scala 2.13, and most are available for Scala 2.11)
-* Akka Streams $akka.version$ (all modules are compatible with Akka 2.6.5+, few require $akka26.version$) (@extref:[Reference](akka:stream/index.html), [Github](https://github.com/akka/akka))
+* Akka Streams $akka.version$ (all modules are compatible with Akka $akka26.version$+) (@extref:[Reference](akka:stream/index.html), [Github](https://github.com/akka/akka))
 * Akka Http $akka-http.version$ (@extref:[Reference](akka-http:), [Github](https://github.com/akka/akka-http))
 
 See @ref:[Alpakka versioning](other-docs/versioning.md) for more details.

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -14,7 +14,7 @@ The code in this documentation is compiled against:
 
 * Alpakka $project.version$ ([Github](https://github.com/akka/alpakka), [API docs](https://doc.akka.io/api/alpakka/current/akka/stream/alpakka/index.html))
 * Scala $scala.binary.version$ (all modules are available for Scala 2.13, and most are available for Scala 2.11)
-* Akka Streams $akka.version$ (all modules are compatible with Akka 2.6.0+, few require $akka26.version$) (@extref:[Reference](akka:stream/index.html), [Github](https://github.com/akka/akka))
+* Akka Streams $akka.version$ (all modules are compatible with Akka 2.6.5+, few require $akka26.version$) (@extref:[Reference](akka:stream/index.html), [Github](https://github.com/akka/akka))
 * Akka Http $akka-http.version$ (@extref:[Reference](akka-http:), [Github](https://github.com/akka/akka-http))
 
 See @ref:[Alpakka versioning](other-docs/versioning.md) for more details.


### PR DESCRIPTION
follow-up to #2393

Or should it say Akka 2.6.8 as that's what we validate in the scheduled build?