### PR TITLE
File: tar with directory support and EOF block detection

### DIFF
--- a/docs/src/main/paradox/file.md
+++ b/docs/src/main/paradox/file.md
@@ -191,7 +191,7 @@ Java
 Result of flow can be send to sink even before whole TAR file is created, so size of resulting TAR archive
 is not limited to memory size.
 
-This example usage shows packaging files from disk.
+This example usage shows packaging directories and files from disk.
 
 Scala
 : @@snip [snip](/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala) { #sample-tar }
@@ -212,7 +212,7 @@ Java
 
 @apidoc[Archive.tarReader()](Archive$) reads a stream of `ByteString`s as TAR format emitting the metadata entry and a `Source` for every file in the stream. It is essential to request all the emitted source's data, otherwise the stream will not reach the next file entry.
 
-The example below reads the incoming stream and stores all files in the local file system.
+The example below reads the incoming stream, creates directories and stores all files in the local file system.
 
 Scala
 : @@snip [snip](/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala) { #tar-reader }

--- a/file/src/main/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntry.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntry.scala
@@ -125,7 +125,7 @@ import akka.util.ByteString
                 fileNameLength + fileModeLength + ownerIdLength + groupIdLength + fileSizeLength,
                 lastModificationLength)
     val lastModification = Instant.ofEpochSecond(parseUnsignedLong(lastModificationString, 8))
-    val linkIndicator = {
+    val linkIndicatorByte = {
       val tmp = bs(
         fileNameLength + fileModeLength + ownerIdLength + groupIdLength + fileSizeLength +
         lastModificationLength + headerChecksumLength
@@ -138,7 +138,7 @@ import akka.util.ByteString
       lastModificationLength + headerChecksumLength + linkIndicatorLength + linkFileNameLength + ustarIndicatorLength + ustarVersionLength + ownerNameLength + groupNameLength + deviceMajorNumberLength + deviceMinorNumberLength,
       fileNamePrefixLength
     )
-    TarArchiveMetadata(fileNamePrefix, filename, size, lastModification, linkIndicator)
+    TarArchiveMetadata(fileNamePrefix, filename, size, lastModification, linkIndicatorByte)
   }
 
   private def getString(bs: ByteString, from: Int, maxLength: Int) = {
@@ -185,7 +185,7 @@ import akka.util.ByteString
 
     padded(
       fileNameBytes ++ fixedData1 ++ fileSizeBytes ++ lastModificationBytes ++ fixedData2 ++
-      ByteString(metadata.linkIndicator) ++ fixedData3 ++ fileNamePrefixBytes,
+      ByteString(metadata.linkIndicatorByte) ++ fixedData3 ++ fileNamePrefixBytes,
       headerLength
     )
   }

--- a/file/src/main/scala/akka/stream/alpakka/file/impl/archive/TarReaderStage.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/impl/archive/TarReaderStage.scala
@@ -81,9 +81,7 @@ private[file] class TarReaderStage
             // await flow demand
             setHandler(flowOut, new OutHandler {
               override def onPull(): Unit = {
-                val handler = pushSource(metadata, buffer)
-                log.debug(s"setting $handler")
-                setHandler(flowIn, handler)
+                setHandler(flowIn, pushSource(metadata, buffer))
               }
             })
             failOnFlowPush

--- a/file/src/main/scala/akka/stream/alpakka/file/model.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/model.scala
@@ -21,12 +21,16 @@ final class TarArchiveMetadata private (
     val filePathPrefix: Option[String],
     val filePathName: String,
     val size: Long,
-    val lastModification: Instant
+    val lastModification: Instant,
+    val linkIndicator: Byte
 ) {
   val filePath = filePathPrefix match {
     case None => filePathName
     case Some(prefix) => prefix + "/" + filePathName
   }
+
+  def isDirectory: Boolean =
+    linkIndicator == TarArchiveMetadata.linkIndicatorDirectory || filePathName.endsWith("/")
 
   override def equals(obj: Any): Boolean = {
     obj match {
@@ -34,22 +38,38 @@ final class TarArchiveMetadata private (
         this.filePathPrefix == that.filePathPrefix &&
         this.filePathName == that.filePathName &&
         this.size == that.size &&
-        this.lastModification == that.lastModification
+        this.lastModification == that.lastModification &&
+        this.linkIndicator == that.linkIndicator
       case _ => false
     }
   }
 
-  override def hashCode(): Int = Objects.hash(filePathPrefix, filePathName, Long.box(size), lastModification)
+  override def hashCode(): Int =
+    Objects.hash(filePathPrefix, filePathName, Long.box(size), lastModification, Byte.box(linkIndicator))
 
   override def toString: String =
     "TarArchiveMetadata(" +
     s"filePathPrefix=$filePathPrefix," +
     s"filePathName=$filePathName," +
     s"size=$size," +
-    s"lastModification=${lastModification})"
+    s"lastModification=$lastModification," +
+    s"linkIndicator=${linkIndicator.toChar})"
 }
 
 object TarArchiveMetadata {
+
+  /**
+   * Constants for the `linkIndicator` flag.
+   */
+  val linkIndicatorNormal: Byte = '0'
+  val linkIndicatorLink: Byte = '1'
+  val linkIndicatorSymLink: Byte = '2'
+  val linkIndicatorCharacterDevice: Byte = '3'
+  val linkIndicatorBlockDevice: Byte = '4'
+  val linkIndicatorDirectory: Byte = '5'
+  val linkIndicatorPipe: Byte = '6'
+  val linkIndicatorContiguousFile: Byte = '7'
+
   def apply(filePath: String, size: Long): TarArchiveMetadata = apply(filePath, size, Instant.now)
   def apply(filePath: String, size: Long, lastModification: Instant): TarArchiveMetadata = {
     val filePathSegments = filePath.lastIndexOf("/")
@@ -57,36 +77,71 @@ object TarArchiveMetadata {
       Some(filePath.substring(0, filePathSegments))
     } else None
     val filePathName = filePath.substring(filePathSegments + 1, filePath.length)
-    apply(filePathPrefix, filePathName, size, lastModification)
+    apply(filePathPrefix, filePathName, size, lastModification, linkIndicatorNormal)
   }
 
   def apply(filePathPrefix: String, filePathName: String, size: Long, lastModification: Instant): TarArchiveMetadata = {
-    apply(if (filePathPrefix.isEmpty) None else Some(filePathPrefix), filePathName, size, lastModification)
+    apply(if (filePathPrefix.isEmpty) None else Some(filePathPrefix),
+          filePathName,
+          size,
+          lastModification,
+          linkIndicatorNormal)
+  }
+
+  def apply(filePathPrefix: String,
+            filePathName: String,
+            size: Long,
+            lastModification: Instant,
+            linkIndicator: Byte): TarArchiveMetadata = {
+    apply(if (filePathPrefix.isEmpty) None else Some(filePathPrefix),
+          filePathName,
+          size,
+          lastModification,
+          linkIndicator)
   }
 
   private def apply(filePathPrefix: Option[String],
                     filePathName: String,
                     size: Long,
-                    lastModification: Instant): TarArchiveMetadata = {
+                    lastModification: Instant,
+                    linkIndicator: Byte): TarArchiveMetadata = {
     filePathPrefix.foreach { value =>
       require(
         value.length <= 154,
         "File path prefix must be between 1 and 154 characters long"
       )
     }
-    require(filePathName.length > 0 && filePathName.length <= 99,
-            "File path name must be between 1 and 99 characters long")
+    require(filePathName.length >= 0 && filePathName.length <= 99,
+            s"File path name must be between 0 and 99 characters long, was ${filePathName.length}")
 
     new TarArchiveMetadata(filePathPrefix,
                            filePathName,
                            size,
                            // tar timestamp granularity is in seconds
-                           lastModification.`with`(ChronoField.NANO_OF_SECOND, 0L))
+                           lastModification.`with`(ChronoField.NANO_OF_SECOND, 0L),
+                           linkIndicator)
   }
 
   def create(filePath: String, size: Long): TarArchiveMetadata = apply(filePath, size, Instant.now)
   def create(filePath: String, size: Long, lastModification: Instant): TarArchiveMetadata =
     apply(filePath, size, lastModification)
+  def create(filePathPrefix: String, filePathName: String, size: Long, lastModification: Instant): TarArchiveMetadata =
+    apply(filePathPrefix, filePathName, size, lastModification)
+
+  /**
+   * Create metadata for a directory entry.
+   */
+  def directory(filePathName: String): TarArchiveMetadata =
+    directory(filePathName, Instant.now())
+
+  /**
+   * Create metadata for a directory entry.
+   */
+  def directory(filePathName: String, lastModification: Instant): TarArchiveMetadata = {
+    val n = if (filePathName.endsWith("/")) filePathName else filePathName + "/"
+    apply(None, n, size = 0L, lastModification, linkIndicatorDirectory)
+  }
+
 }
 
 final class TarReaderException(msg: String) extends Exception(msg)

--- a/file/src/test/java/docs/javadsl/ArchiveTest.java
+++ b/file/src/test/java/docs/javadsl/ArchiveTest.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +38,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.*;
 
 public class ArchiveTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
@@ -106,7 +107,7 @@ public class ArchiveTest {
     ByteString resultFileContent = readFileAsByteString(Paths.get("logo.zip"));
     Map<String, ByteString> unzip = archiveHelper.unzip(resultFileContent);
 
-    assertEquals(inputFiles, unzip);
+    assertThat(inputFiles, is(unzip));
 
     // cleanup
     new File("logo.zip").delete();
@@ -135,14 +136,21 @@ public class ArchiveTest {
     // #sample-tar
     */
 
+    Instant lastModification = Instant.now();
     // #sample-tar
+    Pair<TarArchiveMetadata, Source<ByteString, NotUsed>> dir =
+        Pair.create(TarArchiveMetadata.directory("subdir", lastModification), Source.empty());
+
     Pair<TarArchiveMetadata, Source<ByteString, NotUsed>> pair1 =
-        Pair.create(TarArchiveMetadata.create("akka_full_color.svg", size1), source1);
+        Pair.create(
+            TarArchiveMetadata.create("subdir", "akka_full_color.svg", size1, lastModification),
+            source1);
     Pair<TarArchiveMetadata, Source<ByteString, NotUsed>> pair2 =
-        Pair.create(TarArchiveMetadata.create("akka_icon_reverse.svg", size2), source2);
+        Pair.create(
+            TarArchiveMetadata.create("akka_icon_reverse.svg", size2, lastModification), source2);
 
     Source<Pair<TarArchiveMetadata, Source<ByteString, NotUsed>>, NotUsed> source =
-        Source.from(Arrays.asList(pair1, pair2));
+        Source.from(Arrays.asList(dir, pair1, pair2));
 
     Sink<ByteString, CompletionStage<IOResult>> fileSink = FileIO.toPath(Paths.get("logo.tar"));
     CompletionStage<IOResult> ioResult = source.via(Archive.tar()).runWith(fileSink, mat);
@@ -168,9 +176,13 @@ public class ArchiveTest {
   @Test
   public void tarReader() throws Exception {
     ByteString tenDigits = ByteString.fromString("1234567890");
-    TarArchiveMetadata metadata1 = TarArchiveMetadata.create("dir/file1.txt", tenDigits.length());
+    TarArchiveMetadata metadata1 = TarArchiveMetadata.directory("dir/");
+    TarArchiveMetadata metadata2 = TarArchiveMetadata.create("dir/file1.txt", tenDigits.length());
     CompletionStage<ByteString> oneFileArchive =
-        Source.single(Pair.create(metadata1, Source.single(tenDigits)))
+        Source.from(
+                Arrays.asList(
+                    Pair.create(metadata1, Source.empty(ByteString.class)),
+                    Pair.create(metadata2, Source.single(tenDigits))))
             .via(Archive.tar())
             .runWith(Sink.fold(ByteString.emptyByteString(), ByteString::concat), mat);
 
@@ -188,22 +200,61 @@ public class ArchiveTest {
                 1,
                 pair -> {
                   TarArchiveMetadata metadata = pair.first();
-                  Source<ByteString, NotUsed> source = pair.second();
                   Path targetFile = target.resolve(metadata.filePath());
-                  // create the target directory
-                  return Source.single(targetFile.getParent())
-                      .via(Directory.mkdirs())
-                      .runWith(Sink.ignore(), mat)
-                      .thenCompose(
-                          done ->
-                              // stream the file contents to a local file
-                              source.runWith(FileIO.toPath(targetFile), mat));
+                  if (metadata.isDirectory()) {
+                    return Source.single(targetFile)
+                        .via(Directory.mkdirs())
+                        .runWith(Sink.ignore(), mat);
+                  } else {
+                    Source<ByteString, NotUsed> source = pair.second();
+                    // create the target directory
+                    return Source.single(targetFile.getParent())
+                        .via(Directory.mkdirs())
+                        .runWith(Sink.ignore(), mat)
+                        .thenCompose(
+                            done ->
+                                // stream the file contents to a local file
+                                source
+                                    .runWith(FileIO.toPath(targetFile), mat)
+                                    .thenApply(io -> Done.done()));
+                  }
                 })
             .runWith(Sink.ignore(), mat);
     // #tar-reader
     assertThat(tar.toCompletableFuture().get(2, TimeUnit.SECONDS), is(Done.done()));
     File file = target.resolve("dir/file1.txt").toFile();
-    assertTrue(file.exists());
+    assertThat(file.exists(), is(true));
+  }
+
+  @Test
+  public void tarReaderWithEofBlocks() throws Exception {
+    ByteString tenDigits = ByteString.fromString("1234567890");
+    TarArchiveMetadata metadata1 = TarArchiveMetadata.create("file5.txt", tenDigits.length());
+    CompletionStage<ByteString> oneFileArchive =
+        Source.single(Pair.create(metadata1, Source.single(tenDigits)))
+            .via(Archive.tar())
+            // tar standard suggests two empty 512 byte blocks as EOF marker
+            .concat(Source.single(ByteString.fromArray(new byte[1024])))
+            .runWith(Sink.fold(ByteString.emptyByteString(), ByteString::concat), mat);
+
+    Source<ByteString, NotUsed> bytesSource = Source.fromCompletionStage(oneFileArchive);
+    Path target = Files.createTempDirectory("alpakka-tar-");
+
+    CompletionStage<Done> tar =
+        bytesSource
+            .via(Archive.tarReader())
+            .mapAsync(
+                1,
+                pair -> {
+                  TarArchiveMetadata metadata = pair.first();
+                  Source<ByteString, NotUsed> source = pair.second();
+                  Path targetFile = target.resolve(metadata.filePath());
+                  return source.runWith(FileIO.toPath(targetFile), mat);
+                })
+            .runWith(Sink.ignore(), mat);
+    assertThat(tar.toCompletableFuture().get(2, TimeUnit.SECONDS), is(Done.done()));
+    File file = target.resolve("file5.txt").toFile();
+    assertThat(file.exists(), is(true));
   }
 
   @After

--- a/file/src/test/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntrySpec.scala
+++ b/file/src/test/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntrySpec.scala
@@ -17,7 +17,8 @@ class TarArchiveEntrySpec extends AnyFlatSpec with Matchers {
     val filename = "thefile.txt"
     val size = 100
     val lastModified = Instant.from(ZonedDateTime.of(LocalDateTime.of(2020, 4, 11, 11, 34), ZoneId.of("CET")))
-    val data = TarArchiveMetadata(filePathPrefix, filename, size, lastModified)
+    val data =
+      TarArchiveMetadata(filePathPrefix, filename, size, lastModified, TarArchiveMetadata.linkIndicatorDirectory)
     val entry = new TarArchiveEntry(data)
     val header = entry.headerBytes
 
@@ -25,6 +26,7 @@ class TarArchiveEntrySpec extends AnyFlatSpec with Matchers {
     parsed.filePath shouldBe filePathPrefix + "/" + filename
     parsed.size shouldBe size
     parsed.lastModification shouldBe lastModified
+    parsed.isDirectory shouldBe true
   }
 
   "Header parser" should "handle both space and null character as terminal" in {
@@ -32,7 +34,7 @@ class TarArchiveEntrySpec extends AnyFlatSpec with Matchers {
     val filename = "thefile.txt"
     val size = 100
     val lastModified = Instant.from(ZonedDateTime.of(LocalDateTime.of(2020, 4, 11, 11, 34), ZoneId.of("CET")))
-    val data = TarArchiveMetadata(filePathPrefix, filename, size, lastModified)
+    val data = TarArchiveMetadata(filePathPrefix, filename, size, lastModified, TarArchiveMetadata.linkIndicatorNormal)
     val entry = new TarArchiveEntry(data)
 
     val headerWithNull = entry.headerBytes

--- a/file/src/test/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlowTest.scala
+++ b/file/src/test/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlowTest.scala
@@ -23,7 +23,7 @@ class ZipArchiveFlowTest
   implicit val mat = ActorMaterializer()
 
   "ZipArchiveFlowStage" when {
-    "steam ends" should {
+    "stream ends" should {
       "emit element only when downstream requests" in {
         val (upstream, downstream) =
           TestSource


### PR DESCRIPTION
* Support directory entries in tar files (writing and reading)
* Accept closing EOF marker blocks of 512 0-bytes

The somewhat loose tar standard allows for more variants than Alpakka File can handle. This adds support for the "link indicator" flag, which also indicates directory entries.

Tar recommends files end with two 512 byte blocks of 0-bytes. This makes Alpakka File handle those and read to the end of the incoming streams.