### PR TITLE
Less use of deprecated APIs in Java code

### DIFF
--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectionProvidersTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectionProvidersTest.java
@@ -5,7 +5,11 @@
 package akka.stream.alpakka.amqp.javadsl;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import akka.stream.alpakka.amqp.*;
 import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;

--- a/aws-event-bridge/src/test/java/docs/javadsl/EventBridgePublisherTest.java
+++ b/aws-event-bridge/src/test/java/docs/javadsl/EventBridgePublisherTest.java
@@ -32,7 +32,7 @@ import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsResponse;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.*;
 
 import java.util.Collections;

--- a/build.sbt
+++ b/build.sbt
@@ -131,11 +131,7 @@ lazy val csvBench = internalProject("csv-bench")
 
 lazy val dynamodb = alpakkaProject("dynamodb", "aws.dynamodb", Dependencies.DynamoDB)
 
-lazy val elasticsearch = alpakkaProject(
-  "elasticsearch",
-  "elasticsearch",
-  Dependencies.Elasticsearch
-)
+lazy val elasticsearch = alpakkaProject("elasticsearch", "elasticsearch", Dependencies.Elasticsearch)
 
 // The name 'file' is taken by `sbt.file`, hence 'files'
 lazy val files = alpakkaProject("file", "file", Dependencies.File)
@@ -194,7 +190,8 @@ lazy val googleCloudPubSubGrpc = alpakkaProject(
       "-P:silencer:pathFilters=akka-grpc/main",
       "-P:silencer:pathFilters=akka-grpc/test"
     ),
-  crossScalaVersions --= Seq(Dependencies.Scala211) // 2.11 is not supported since Akka gRPC 0.6
+  compile / javacOptions := (compile / javacOptions).value.filterNot(_ == "-Xlint:deprecation"),
+  crossScalaVersions --= Seq(Dependencies.Scala211)
 ).enablePlugins(AkkaGrpcPlugin)
 
 lazy val googleCloudStorage =
@@ -203,12 +200,7 @@ lazy val googleCloudStorage =
                  Dependencies.GoogleStorage,
                  crossScalaVersions -= Dependencies.Scala211)
 
-lazy val googleFcm = alpakkaProject(
-  "google-fcm",
-  "google.firebase.fcm",
-  Dependencies.GoogleFcm,
-  Test / fork := true
-)
+lazy val googleFcm = alpakkaProject("google-fcm", "google.firebase.fcm", Dependencies.GoogleFcm, Test / fork := true)
 
 lazy val hbase = alpakkaProject("hbase", "hbase", Dependencies.HBase, Test / fork := true)
 
@@ -228,21 +220,15 @@ lazy val ironmq = alpakkaProject(
   crossScalaVersions -= Dependencies.Scala211 // hseeberger/akka-http-json does not support Scala 2.11 anymore
 )
 
-lazy val jms =
-  alpakkaProject("jms", "jms", Dependencies.Jms, fatalWarnings := false)
+lazy val jms = alpakkaProject("jms", "jms", Dependencies.Jms)
 
 lazy val jsonStreaming = alpakkaProject("json-streaming", "json.streaming", Dependencies.JsonStreaming)
 
-lazy val kinesis = alpakkaProject(
-  "kinesis",
-  "aws.kinesis",
-  Dependencies.Kinesis
-)
+lazy val kinesis = alpakkaProject("kinesis", "aws.kinesis", Dependencies.Kinesis)
 
 lazy val kudu = alpakkaProject("kudu", "kudu", Dependencies.Kudu, fork in Test := false)
 
-lazy val mongodb =
-  alpakkaProject("mongodb", "mongodb", Dependencies.MongoDb)
+lazy val mongodb = alpakkaProject("mongodb", "mongodb", Dependencies.MongoDb)
 
 lazy val mqtt = alpakkaProject("mqtt", "mqtt", Dependencies.Mqtt)
 
@@ -262,13 +248,13 @@ lazy val reference = internalProject("reference", Dependencies.Reference)
 
 lazy val s3 = alpakkaProject("s3", "aws.s3", Dependencies.S3)
 
-lazy val pravega =
-  alpakkaProject("pravega",
-                 "pravega",
-                 Dependencies.Pravega,
-                 Test / fork := true,
-                 crossScalaVersions -= Dependencies.Scala211 // 2.11 SAM issue for java API.
-  )
+lazy val pravega = alpakkaProject(
+  "pravega",
+  "pravega",
+  Dependencies.Pravega,
+  Test / fork := true,
+  crossScalaVersions -= Dependencies.Scala211 // 2.11 SAM issue for java API.
+)
 
 lazy val springWeb = alpakkaProject("spring-web", "spring.web", Dependencies.SpringWeb)
 
@@ -276,22 +262,13 @@ lazy val simpleCodecs = alpakkaProject("simple-codecs", "simplecodecs")
 
 lazy val slick = alpakkaProject("slick", "slick", Dependencies.Slick)
 
-lazy val eventbridge =
-  alpakkaProject("aws-event-bridge", "aws.eventbridge", Dependencies.Eventbridge)
+lazy val eventbridge = alpakkaProject("aws-event-bridge", "aws.eventbridge", Dependencies.Eventbridge)
 
-lazy val sns = alpakkaProject(
-  "sns",
-  "aws.sns",
-  Dependencies.Sns
-)
+lazy val sns = alpakkaProject("sns", "aws.sns", Dependencies.Sns)
 
 lazy val solr = alpakkaProject("solr", "solr", Dependencies.Solr)
 
-lazy val sqs = alpakkaProject(
-  "sqs",
-  "aws.sqs",
-  Dependencies.Sqs
-)
+lazy val sqs = alpakkaProject("sqs", "aws.sqs", Dependencies.Sqs)
 
 lazy val sse = alpakkaProject("sse", "sse", Dependencies.Sse)
 
@@ -299,11 +276,7 @@ lazy val text = alpakkaProject("text", "text")
 
 lazy val udp = alpakkaProject("udp", "udp")
 
-lazy val unixdomainsocket = alpakkaProject(
-  "unix-domain-socket",
-  "unixdomainsocket",
-  Dependencies.UnixDomainSocket
-)
+lazy val unixdomainsocket = alpakkaProject("unix-domain-socket", "unixdomainsocket", Dependencies.UnixDomainSocket)
 
 lazy val xml = alpakkaProject("xml", "xml", Dependencies.Xml)
 

--- a/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
+++ b/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
@@ -4,7 +4,6 @@
 
 package docs.javadsl;
 
-import akka.Done;
 import akka.actor.ActorSystem;
 import akka.stream.Materializer;
 // #deleteWithResult
@@ -69,7 +68,11 @@ import static com.couchbase.client.java.query.dsl.Expression.*;
 import scala.concurrent.duration.FiniteDuration;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class CouchbaseExamplesTest {
 

--- a/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
+++ b/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
@@ -27,21 +27,19 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DiscoveryTest {
 
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem actorSystem;
-  private static Materializer materializer;
   private static final String bucketName = "akka";
 
   @BeforeClass
   public static void beforeAll() {
     Config config = ConfigFactory.parseResources("discovery.conf");
     actorSystem = ActorSystem.create("DiscoveryTest", config);
-    materializer = ActorMaterializer.create(actorSystem);
   }
 
   @AfterClass

--- a/csv/src/test/java/docs/javadsl/CsvFormattingTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvFormattingTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CsvFormattingTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/csv/src/test/java/docs/javadsl/CsvParsingTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvParsingTest.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class CsvParsingTest {

--- a/csv/src/test/java/docs/javadsl/CsvToMapTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvToMapTest.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CsvToMapTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
@@ -19,7 +19,7 @@ import akka.stream.{ActorMaterializer, IOResult, Materializer}
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -35,6 +35,7 @@ class TarArchiveSpec
     with ScalaFutures
     with BeforeAndAfterAll
     with LogCapturing
+    with Eventually
     with IntegrationPatience {
 
   implicit val mat: Materializer = ActorMaterializer()
@@ -204,7 +205,9 @@ class TarArchiveSpec
       // #tar-reader
       tar.futureValue shouldBe Done
       val file: File = target.resolve("dir/file1.txt").toFile
-      file.exists() shouldBe true
+      eventually {
+        file.exists() shouldBe true
+      }
     }
 
     "emit empty file" in {

--- a/ftp/src/test/java/docs/javadsl/FtpWritingTest.java
+++ b/ftp/src/test/java/docs/javadsl/FtpWritingTest.java
@@ -30,11 +30,12 @@ import akka.stream.Materializer;
 import akka.testkit.javadsl.TestKit;
 import org.junit.*;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FtpWritingTest extends BaseFtpSupport {
 

--- a/google-cloud-storage/src/test/java/docs/javadsl/GCStorageTest.java
+++ b/google-cloud-storage/src/test/java/docs/javadsl/GCStorageTest.java
@@ -28,7 +28,9 @@ import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class GCStorageTest extends GCStorageWiremockBase {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/jms/src/test/java/docs/javadsl/JmsSettingsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsSettingsTest.java
@@ -14,8 +14,8 @@ import org.junit.Test;
 import java.time.Duration;
 
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 // #retry-settings #send-retry-settings
 import com.typesafe.config.Config;

--- a/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
@@ -539,7 +539,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val completionFuture: Future[Done] = Source(msgsIn).runWith(jmsSink)
       completionFuture.futureValue shouldBe Done
       // make sure connection was closed
-      connectionFactory.cachedConnection shouldBe 'closed
+      eventually { connectionFactory.cachedConnection shouldBe Symbol("closed") }
     }
 
     "sink exceptional completion" in withConnectionFactory() { connFactory =>
@@ -557,7 +557,7 @@ class JmsConnectorsSpec extends JmsSpec {
 
       completionFuture.failed.futureValue shouldBe a[RuntimeException]
       // make sure connection was closed
-      eventually { connectionFactory.cachedConnection shouldBe 'closed }
+      eventually { connectionFactory.cachedConnection shouldBe Symbol("closed") }
     }
 
     "producer disconnect exceptional completion" in withServer() { server =>
@@ -591,7 +591,7 @@ class JmsConnectorsSpec extends JmsSpec {
       // - not yet initialized before broker stop, or
       // - closed on broker stop (if preStart came first).
       if (connectionFactory.cachedConnection != null) {
-        connectionFactory.cachedConnection shouldBe 'closed
+        connectionFactory.cachedConnection shouldBe Symbol("closed")
       }
     }
 

--- a/json-streaming/src/test/java/docs/javadsl/JsonReaderUsageTest.java
+++ b/json-streaming/src/test/java/docs/javadsl/JsonReaderUsageTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.CoreMatchers.hasItems;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class JsonReaderUsageTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/kudu/src/test/java/docs/javadsl/KuduTableTest.java
+++ b/kudu/src/test/java/docs/javadsl/KuduTableTest.java
@@ -29,7 +29,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -9,10 +9,9 @@ import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.japi.JavaPartialFunction;
 import akka.japi.Pair;
-import akka.stream.ActorMaterializer;
 import akka.stream.KillSwitches;
-import akka.stream.Materializer;
 import akka.stream.OverflowStrategy;
+import akka.stream.SystemMaterializer;
 import akka.stream.UniqueKillSwitch;
 import akka.stream.alpakka.mqtt.streaming.Command;
 import akka.stream.alpakka.mqtt.streaming.ConnAck;
@@ -68,19 +67,15 @@ public class MqttFlowTest {
   private static int TIMEOUT_SECONDS = 5;
 
   private static ActorSystem system;
-  private static Materializer materializer;
 
-  private static Pair<ActorSystem, Materializer> setupMaterializer() {
+  private static ActorSystem setupSystem() {
     final ActorSystem system = ActorSystem.create("MqttFlowTest");
-    final Materializer materializer = ActorMaterializer.create(system);
-    return Pair.create(system, materializer);
+    return system;
   }
 
   @BeforeClass
   public static void setup() {
-    final Pair<ActorSystem, Materializer> sysmat = setupMaterializer();
-    system = sysmat.first();
-    materializer = sysmat.second();
+    system = setupSystem();
   }
 
   @AfterClass
@@ -90,7 +85,7 @@ public class MqttFlowTest {
 
   @After
   public void assertStageStopping() {
-    StreamTestKit.assertAllStagesStopped(materializer);
+    StreamTestKit.assertAllStagesStopped(SystemMaterializer.get(system).materializer());
   }
 
   @Test
@@ -124,7 +119,7 @@ public class MqttFlowTest {
                   }
                 })
             .toMat(Sink.head(), Keep.both())
-            .run(materializer);
+            .run(system);
 
     SourceQueueWithComplete<Command<Object>> commands = run.first();
     commands.offer(new Command<>(new Connect(clientId, ConnectFlags.CleanSession())));
@@ -184,7 +179,7 @@ public class MqttFlowTest {
                           Source.<Command<Object>>queue(2, OverflowStrategy.dropHead())
                               .via(mqttFlow)
                               .toMat(BroadcastHub.of(DecodeErrorOrEvent.classOf()), Keep.both())
-                              .run(materializer);
+                              .run(system);
 
                   SourceQueueWithComplete<Command<Object>> queue = run.first();
                   Source<DecodeErrorOrEvent<Object>, NotUsed> source = run.second();
@@ -225,7 +220,7 @@ public class MqttFlowTest {
                           } // Ignore everything else
                         }
                       },
-                      materializer);
+                      system);
 
                   return source;
                 });
@@ -233,7 +228,7 @@ public class MqttFlowTest {
 
     // #run-streaming-bind-flow
     Pair<CompletionStage<Tcp.ServerBinding>, UniqueKillSwitch> bindingAndSwitch =
-        bindSource.viaMat(KillSwitches.single(), Keep.both()).to(Sink.ignore()).run(materializer);
+        bindSource.viaMat(KillSwitches.single(), Keep.both()).to(Sink.ignore()).run(system);
 
     CompletionStage<Tcp.ServerBinding> bound = bindingAndSwitch.first();
     UniqueKillSwitch server = bindingAndSwitch.second();
@@ -262,7 +257,7 @@ public class MqttFlowTest {
                   }
                 })
             .toMat(Sink.head(), Keep.both())
-            .run(materializer);
+            .run(system);
 
     SourceQueueWithComplete<Command<Object>> commands = run.first();
     commands.offer(new Command<>(new Connect(clientId, ConnectFlags.None())));

--- a/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -44,7 +44,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MqttSourceTest {
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -94,7 +94,8 @@ object Common extends AutoPlugin {
         }),
       Compile / doc / scalacOptions -= "-Xfatal-warnings",
       compile / javacOptions ++= Seq(
-          "-Xlint:unchecked"
+          "-Xlint:unchecked",
+          "-Xlint:deprecation"
         ),
       compile / javacOptions ++= (scalaVersion.value match {
           case Dependencies.Scala212 if insideCI.value && fatalWarnings.value => Seq("-Werror")

--- a/simple-codecs/src/test/java/docs/javadsl/RecordIOFramingTest.java
+++ b/simple-codecs/src/test/java/docs/javadsl/RecordIOFramingTest.java
@@ -16,8 +16,8 @@ import akka.util.ByteString;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.Test;
-import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;

--- a/slick/src/test/java/docs/javadsl/SlickTest.java
+++ b/slick/src/test/java/docs/javadsl/SlickTest.java
@@ -171,8 +171,7 @@ public class SlickTest {
                 (__, connection) ->
                     connection.prepareStatement(
                         "INSERT INTO ALPAKKA_SLICK_JAVADSL_TEST_USERS VALUES (?, ?)"))
-            .recover(
-                new PFBuilder<Throwable, Integer>().match(SQLException.class, (ex) -> -1).build());
+            .recoverWithRetries(1, SQLException.class, () -> Source.single(-1));
     final List<Integer> insertionResult =
         usersSource
             .via(slickFlow)

--- a/sns/src/test/java/docs/javadsl/SnsPublisherTest.java
+++ b/sns/src/test/java/docs/javadsl/SnsPublisherTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest;
 import software.amazon.awssdk.services.sns.model.PublishRequest;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.CoreMatchers.*;
 
 import java.util.concurrent.CompletionStage;

--- a/text/src/test/java/docs/javadsl/CharsetCodingFlowsDoc.java
+++ b/text/src/test/java/docs/javadsl/CharsetCodingFlowsDoc.java
@@ -34,7 +34,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class CharsetCodingFlowsDoc {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/xml/src/test/java/docs/javadsl/XmlParsingTest.java
+++ b/xml/src/test/java/docs/javadsl/XmlParsingTest.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class XmlParsingTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();


### PR DESCRIPTION
tests: use Hamcrest's assertThat 
JMS tests: expect connection to be closed eventually 
File tests: Check that the file exists, eventually on Travis 
Slick test: recover -> recoverWithRetries

A part of #2410