### PR TITLE
CI: allow Java warnings in the schdeduled build

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -98,7 +98,8 @@ object Common extends AutoPlugin {
           "-Xlint:deprecation"
         ),
       compile / javacOptions ++= (scalaVersion.value match {
-          case Dependencies.Scala212 if insideCI.value && fatalWarnings.value => Seq("-Werror")
+          case Dependencies.Scala212 if insideCI.value && fatalWarnings.value && !Dependencies.CronBuild =>
+            Seq("-Werror")
           case _ => Seq.empty
         }),
       autoAPIMappings := true,


### PR DESCRIPTION
Since enabling more Java warnings in #2413 the scheduled build, which runs on JKD11, failed.
This allows warnings in the scheduled build, just as Scala warnings are allowed.
