### PR TITLE
Catch and fix more warnings in Java sources

### DIFF
--- a/aws-event-bridge/src/test/java/docs/javadsl/EventBridgePublisherTest.java
+++ b/aws-event-bridge/src/test/java/docs/javadsl/EventBridgePublisherTest.java
@@ -67,8 +67,6 @@ public class EventBridgePublisherTest {
         eventBridgeClient
             .createEventBus(
                 CreateEventBusRequest.builder()
-                    .build()
-                    .builder()
                     .name("alpakka-java-eventbus-" + UUID.randomUUID().toString())
                     .build())
             .get()

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTest.java
@@ -709,13 +709,14 @@ public class ElasticsearchTest {
     String doc = "dummy-doc";
 
     // #custom-index-name-example
-    WriteMessage msg = WriteMessage.createIndexMessage(doc).withIndexName("my-index");
+    WriteMessage<String, NotUsed> msg =
+        WriteMessage.createIndexMessage(doc).withIndexName("my-index");
     // #custom-index-name-example
 
     // #custom-metadata-example
     Map<String, String> metadata = new HashMap<>();
     metadata.put("pipeline", "myPipeline");
-    WriteMessage msgWithMetadata =
+    WriteMessage<String, NotUsed> msgWithMetadata =
         WriteMessage.createIndexMessage(doc).withCustomMetadata(metadata);
     // #custom-metadata-example
   }

--- a/file/src/main/java/akka/stream/alpakka/file/impl/DirectoryChangesSource.java
+++ b/file/src/main/java/akka/stream/alpakka/file/impl/DirectoryChangesSource.java
@@ -219,10 +219,9 @@ public final class DirectoryChangesSource<T> extends GraphStage<SourceShape<T>> 
    *     there was no changes, if the JDK implementation is slow, it will not help lowering this
    * @param maxBufferSize Maximum number of buffered directory changes before the stage fails
    */
-  @SuppressWarnings("unchecked")
   public static Source<Pair<Path, DirectoryChange>, NotUsed> create(
       Path directoryPath, FiniteDuration pollInterval, int maxBufferSize) {
     return Source.fromGraph(
-        new DirectoryChangesSource(directoryPath, pollInterval, maxBufferSize, Pair::apply));
+        new DirectoryChangesSource<>(directoryPath, pollInterval, maxBufferSize, Pair::apply));
   }
 }

--- a/file/src/main/java/akka/stream/alpakka/file/javadsl/DirectoryChangesSource.java
+++ b/file/src/main/java/akka/stream/alpakka/file/javadsl/DirectoryChangesSource.java
@@ -26,11 +26,10 @@ public final class DirectoryChangesSource {
    *     there was no changes, if the JDK implementation is slow, it will not help lowering this
    * @param maxBufferSize Maximum number of buffered directory changes before the stage fails
    */
-  @SuppressWarnings("unchecked")
   public static Source<Pair<Path, DirectoryChange>, NotUsed> create(
       Path directoryPath, java.time.Duration pollInterval, int maxBufferSize) {
     return Source.fromGraph(
-        new akka.stream.alpakka.file.impl.DirectoryChangesSource(
+        new akka.stream.alpakka.file.impl.DirectoryChangesSource<>(
             directoryPath,
             JavaDurationConverters.asFiniteDuration(pollInterval),
             maxBufferSize,

--- a/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
@@ -54,6 +54,8 @@ import static org.junit.Assert.fail;
 
 final class DummyJavaTests implements java.io.Serializable {
 
+  private static final long serialVersionUID = 1234567L;
+
   private final String value;
 
   DummyJavaTests(String value) {

--- a/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
+++ b/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
@@ -350,10 +350,7 @@ public class OrientDbTest {
               db.setDatabaseOwner(new OObjectDatabaseTx(db));
               ODatabaseRecordThreadLocal.instance().set(db);
               messages.stream()
-                  .forEach(
-                      message -> {
-                        commitToKafka.accept(((KafkaOffset) message.passThrough()));
-                      });
+                  .forEach(message -> commitToKafka.accept(message.passThrough()));
               return NotUsed.getInstance();
             })
         .runWith(Sink.seq(), materializer)

--- a/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
+++ b/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
@@ -349,8 +349,7 @@ public class OrientDbTest {
               ODatabaseDocumentTx db = oDatabase.acquire();
               db.setDatabaseOwner(new OObjectDatabaseTx(db));
               ODatabaseRecordThreadLocal.instance().set(db);
-              messages.stream()
-                  .forEach(message -> commitToKafka.accept(message.passThrough()));
+              messages.stream().forEach(message -> commitToKafka.accept(message.passThrough()));
               return NotUsed.getInstance();
             })
         .runWith(Sink.seq(), materializer)

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -94,8 +94,20 @@ object Common extends AutoPlugin {
         }),
       Compile / doc / scalacOptions -= "-Xfatal-warnings",
       compile / javacOptions ++= Seq(
+          "-Xlint:cast",
+          "-Xlint:deprecation",
+          "-Xlint:dep-ann",
+          "-Xlint:empty",
+          "-Xlint:fallthrough",
+          "-Xlint:finally",
+          "-Xlint:overloads",
+          "-Xlint:overrides",
+          "-Xlint:rawtypes",
+          "-Xlint:removal",
+          "-Xlint:static",
+          "-Xlint:try",
           "-Xlint:unchecked",
-          "-Xlint:deprecation"
+          "-Xlint:varargs"
         ),
       compile / javacOptions ++= (scalaVersion.value match {
           case Dependencies.Scala212 if insideCI.value && fatalWarnings.value && !Dependencies.CronBuild =>

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -103,7 +103,7 @@ object Common extends AutoPlugin {
           "-Xlint:overloads",
           "-Xlint:overrides",
           "-Xlint:rawtypes",
-          "-Xlint:removal",
+          // JDK 11 "-Xlint:removal",
           "-Xlint:static",
           "-Xlint:try",
           "-Xlint:unchecked",


### PR DESCRIPTION
Enable more Java linting flags and﻿fix a few warnings detected by it.
