### PR TITLE
Google Cloud Pub/Sub gRPC: align the gRPC auth version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -232,7 +232,9 @@ object Dependencies {
     libraryDependencies ++= Seq(
         // https://github.com/googleapis/java-pubsub/tree/master/proto-google-cloud-pubsub-v1/
         "com.google.api.grpc" % "grpc-google-cloud-pubsub-v1" % "1.85.1" % "protobuf-src", // ApacheV2
-        "io.grpc" % "grpc-auth" % "1.29.0", // ApacheV2
+        // Align with the version from the Akka gRPC plugin
+        // https://doc.akka.io/docs/akka-grpc/current/server/walkthrough.html#dependencies
+        "io.grpc" % "grpc-auth" % "1.30.0", // ApacheV2
         "com.google.auth" % "google-auth-library-oauth2-http" % "0.20.0", // BSD 3-clause
         // pull in Akka Discovery for our Akka version
         "com.typesafe.akka" %% "akka-discovery" % AkkaVersion


### PR DESCRIPTION
Align io.grpc grpc-auth version with the versions brought in by Akka gRPC.
https://doc.akka.io/docs/akka-grpc/1.0.0/server/walkthrough.html#dependencies
﻿
