### PR TITLE
Google Pub/Sub: lock emulator version to 313.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       - ./geode/scripts/:/scripts/
     command: /scripts/geode.sh
   gcloud-pubsub-emulator:
-    image: google/cloud-sdk:latest
+    image: google/cloud-sdk:313.0.1
     ports:
       - "8538:8538"
     command: gcloud beta emulators pubsub start --project=alpakka --host-port=0.0.0.0:8538


### PR DESCRIPTION
Select the former version of the gcloud docker image as all Pub/Sub tests started failing.

Refs #2448﻿
