### PR TITLE
Google FCM: Forward proxy

### DIFF
--- a/google-fcm/src/main/mima-filters/2.0.x.backwards.excludes
+++ b/google-fcm/src/main/mima-filters/2.0.x.backwards.excludes
@@ -1,0 +1,2 @@
+# change to private constructor
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.google.firebase.fcm.FcmSettings.this")

--- a/google-fcm/src/main/resources/reference.conf
+++ b/google-fcm/src/main/resources/reference.conf
@@ -1,0 +1,14 @@
+alpakka.google.fcm {
+  # An address of a proxy that will be used for all connections using HTTP CONNECT tunnel.
+  # forward-proxy {
+  #   host = "proxy"
+  #   port = 8080
+  #   credentials {
+  #     username = "username"
+  #     password = "password"
+  #   }
+  #   trustPem {
+  #     pemPath = "/path/to/file.pem"
+  #   }
+  # }
+}

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/FcmSettings.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/FcmSettings.scala
@@ -4,12 +4,17 @@
 
 package akka.stream.alpakka.google.firebase.fcm
 
+import java.util.Objects
+
+import scala.compat.java8.OptionConverters._
+
 final class FcmSettings private (
     val clientEmail: String,
     val privateKey: String,
     val projectId: String,
     val isTest: Boolean,
-    val maxConcurrentConnections: Int
+    val maxConcurrentConnections: Int,
+    val forwardProxy: Option[ForwardProxy] = Option.empty
 ) {
 
   def withClientEmail(value: String): FcmSettings = copy(clientEmail = value)
@@ -17,23 +22,179 @@ final class FcmSettings private (
   def withProjectId(value: String): FcmSettings = copy(projectId = value)
   def withIsTest(value: Boolean): FcmSettings = if (isTest == value) this else copy(isTest = value)
   def withMaxConcurrentConnections(value: Int): FcmSettings = copy(maxConcurrentConnections = value)
+  def withForwardProxy(value: ForwardProxy): FcmSettings = copy(forwardProxy = Option(value))
 
   private def copy(
       clientEmail: String = clientEmail,
       privateKey: String = privateKey,
       projectId: String = projectId,
       isTest: Boolean = isTest,
-      maxConcurrentConnections: Int = maxConcurrentConnections
+      maxConcurrentConnections: Int = maxConcurrentConnections,
+      forwardProxy: Option[ForwardProxy] = forwardProxy
   ): FcmSettings =
     new FcmSettings(clientEmail = clientEmail,
                     privateKey = privateKey,
                     projectId = projectId,
                     isTest = isTest,
-                    maxConcurrentConnections = maxConcurrentConnections)
+                    maxConcurrentConnections = maxConcurrentConnections,
+                    forwardProxy = forwardProxy)
 
   override def toString =
-    s"""FcmFlowConfig(clientEmail=$clientEmail,projectId=$projectId,isTest=$isTest,maxConcurrentConnections=$maxConcurrentConnections)"""
+    s"""FcmFlowConfig(clientEmail=$clientEmail,projectId=$projectId,isTest=$isTest,maxConcurrentConnections=$maxConcurrentConnections,forwardProxy=$forwardProxy)"""
 
+}
+
+object ForwardProxyTrustPem {
+
+  /** Scala API */
+  def apply(pemPath: String): ForwardProxyTrustPem =
+    new ForwardProxyTrustPem(pemPath)
+
+  /** Java API */
+  def create(pemPath: String): ForwardProxyTrustPem =
+    apply(pemPath)
+
+}
+
+final class ForwardProxyTrustPem private (val pemPath: String) {
+
+  def getPemPath: String = pemPath
+
+  override def toString: String =
+    "ForwardProxyTrustPem(" +
+    s"pemPath=$pemPath," +
+    ")"
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ForwardProxyTrustPem =>
+      Objects.equals(this.pemPath, that.pemPath)
+    case _ => false
+  }
+
+  override def hashCode(): Int =
+    Objects.hash(pemPath)
+
+}
+
+object ForwardProxyCredentials {
+
+  /** Scala API */
+  def apply(username: String, password: String): ForwardProxyCredentials =
+    new ForwardProxyCredentials(username, password)
+
+  /** Java API */
+  def create(username: String, password: String): ForwardProxyCredentials =
+    apply(username, password)
+
+}
+
+final class ForwardProxyCredentials private (val username: String, val password: String) {
+
+  /** Java API */
+  def getUsername: String = username
+
+  /** Java API */
+  def getPassword: String = password
+
+  def withUsername(username: String) = copy(username = username)
+  def withPassword(password: String) = copy(password = password)
+
+  private def copy(username: String = username, password: String = password) =
+    new ForwardProxyCredentials(username, password)
+
+  override def toString =
+    "ForwardProxyCredentials(" +
+    s"username=$username," +
+    s"password=******" +
+    ")"
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ForwardProxyCredentials =>
+      Objects.equals(this.username, that.username) &&
+      Objects.equals(this.password, that.password)
+    case _ => false
+  }
+
+  override def hashCode(): Int =
+    Objects.hash(username, password)
+
+}
+
+object ForwardProxy {
+
+  /** Scala API */
+  def apply(host: String, port: Int) =
+    new ForwardProxy(host, port, Option.empty, Option.empty)
+
+  def apply(host: String, port: Int, credentials: Option[ForwardProxyCredentials]) =
+    new ForwardProxy(host, port, credentials, Option.empty)
+
+  def apply(host: String,
+            port: Int,
+            credentials: Option[ForwardProxyCredentials],
+            trustPem: Option[ForwardProxyTrustPem]) =
+    new ForwardProxy(host, port, credentials, trustPem)
+
+  /** Java API */
+  def create(host: String, port: Int) =
+    apply(host, port)
+
+  def create(host: String, port: Int, credentials: Option[ForwardProxyCredentials]) =
+    apply(host, port, credentials)
+
+  def create(host: String,
+             port: Int,
+             credentials: Option[ForwardProxyCredentials],
+             trustPem: Option[ForwardProxyTrustPem]) =
+    apply(host, port, credentials, trustPem)
+
+}
+
+final class ForwardProxy private (val host: String,
+                                  val port: Int,
+                                  val credentials: Option[ForwardProxyCredentials],
+                                  val trustPem: Option[ForwardProxyTrustPem]) {
+
+  /** Java API */
+  def getHost: String = host
+
+  /** Java API */
+  def getPort: Int = port
+
+  /** Java API */
+  def getCredentials: java.util.Optional[ForwardProxyCredentials] = credentials.asJava
+
+  def getForwardProxyTrustPem: java.util.Optional[ForwardProxyTrustPem] = trustPem.asJava
+
+  def withHost(host: String) = copy(host = host)
+  def withPort(port: Int) = copy(port = port)
+  def withCredentials(credentials: ForwardProxyCredentials) = copy(credentials = Option(credentials))
+
+  private def copy(host: String = host,
+                   port: Int = port,
+                   credentials: Option[ForwardProxyCredentials] = credentials,
+                   trustPem: Option[ForwardProxyTrustPem] = trustPem) =
+    new ForwardProxy(host, port, credentials, trustPem)
+
+  override def toString =
+    "ForwardProxy(" +
+    s"host=$host," +
+    s"port=$port," +
+    s"credentials=$credentials," +
+    s"trustPem=$trustPem" +
+    ")"
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ForwardProxy =>
+      Objects.equals(this.host, that.host) &&
+      Objects.equals(this.port, that.port) &&
+      Objects.equals(this.credentials, that.credentials) &&
+      Objects.equals(this.trustPem, that.trustPem)
+    case _ => false
+  }
+
+  override def hashCode(): Int =
+    Objects.hash(host, Int.box(port), credentials)
 }
 
 object FcmSettings {
@@ -51,16 +212,26 @@ object FcmSettings {
     maxConcurrentConnections = 100
   )
 
-  /** Java API */
-  def create(
+  def apply(
       clientEmail: String,
       privateKey: String,
-      projectId: String
+      projectId: String,
+      forwardProxy: ForwardProxy
   ): FcmSettings = new FcmSettings(
     clientEmail,
     privateKey,
     projectId,
     isTest = false,
-    maxConcurrentConnections = 100
+    maxConcurrentConnections = 100,
+    forwardProxy = Option(forwardProxy)
   )
+
+  /** Java API */
+  def create(clientEmail: String, privateKey: String, projectId: String): FcmSettings = {
+    apply(clientEmail, privateKey, projectId)
+  }
+
+  def create(clientEmail: String, privateKey: String, projectId: String, forwardProxy: ForwardProxy): FcmSettings = {
+    apply(clientEmail, privateKey, projectId, forwardProxy)
+  }
 }

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/ForwardProxyHttpsContext.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/ForwardProxyHttpsContext.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm
+
+import java.io.FileInputStream
+import java.security.KeyStore
+import java.security.cert.{CertificateFactory, X509Certificate}
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.{Http, HttpsConnectionContext}
+import javax.net.ssl.{SSLContext, TrustManagerFactory}
+
+private[fcm] object ForwardProxyHttpsContext {
+
+  val SSL = "SSL"
+  val X509 = "X509"
+
+  implicit class ForwardProxyHttpsContext(forwardProxy: ForwardProxy) {
+
+    def httpsContext(system: ActorSystem) = {
+      forwardProxy.trustPem match {
+        case Some(trustPem) => createHttpsContext(trustPem)
+        case None => defaultHttpsContext(system)
+      }
+    }
+  }
+
+  private def defaultHttpsContext(implicit system: ActorSystem) = {
+    Http().createDefaultClientHttpsContext()
+  }
+
+  private def createHttpsContext(trustPem: ForwardProxyTrustPem) = {
+    val certificate = x509Certificate(trustPem)
+    val sslContext = SSLContext.getInstance(SSL)
+
+    val alias = certificate.getIssuerDN.getName
+    val trustStore = KeyStore.getInstance(KeyStore.getDefaultType)
+    trustStore.load(null, null)
+    trustStore.setCertificateEntry(alias, certificate)
+
+    val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+    tmf.init(trustStore)
+    val trustManagers = tmf.getTrustManagers
+    sslContext.init(null, trustManagers, null)
+    new HttpsConnectionContext(sslContext)
+  }
+
+  private def x509Certificate(trustPem: ForwardProxyTrustPem) = {
+    val stream = new FileInputStream(trustPem.pemPath)
+    var result: X509Certificate = null
+    try result = CertificateFactory.getInstance(X509).generateCertificate(stream).asInstanceOf[X509Certificate]
+    finally if (stream != null) stream.close()
+    result
+  }
+
+}

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/ForwardProxyPoolSettings.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/ForwardProxyPoolSettings.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.google.firebase.fcm
+
+import java.net.InetSocketAddress
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.ClientTransport
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import akka.http.scaladsl.settings.{ClientConnectionSettings, ConnectionPoolSettings}
+
+private[fcm] object ForwardProxyPoolSettings {
+
+  implicit class ForwardProxyPoolSettings(forwardProxy: ForwardProxy) {
+
+    def poolSettings(system: ActorSystem) = {
+      val address = InetSocketAddress.createUnresolved(forwardProxy.host, forwardProxy.port)
+      val transport = forwardProxy.credentials.fold(ClientTransport.httpsProxy(address))(
+        c => ClientTransport.httpsProxy(address, BasicHttpCredentials(c.username, c.password))
+      )
+
+      ConnectionPoolSettings(system)
+        .withConnectionSettings(
+          ClientConnectionSettings(system)
+            .withTransport(transport)
+        )
+    }
+  }
+
+}

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmFlows.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmFlows.scala
@@ -23,13 +23,15 @@ private[fcm] object FcmFlows {
       .setup { (materializer, _) =>
         import materializer.executionContext
         val http = Http()(materializer.system)
-        val session: GoogleSession = new GoogleSession(conf.clientEmail, conf.privateKey, new GoogleTokenApi(http))
+        val session: GoogleSession = new GoogleSession(conf.clientEmail,
+                                                       conf.privateKey,
+                                                       new GoogleTokenApi(http, materializer.system, conf.forwardProxy))
         Flow[(FcmNotification, T)]
           .mapAsync(conf.maxConcurrentConnections)(
             in =>
               session.getToken()(materializer).flatMap { token =>
                 sender
-                  .send(conf.projectId, token, http, FcmSend(conf.isTest, in._1))(materializer)
+                  .send(conf, token, http, FcmSend(conf.isTest, in._1), materializer.system)(materializer)
                   .zip(Future.successful(in._2))
               }
           )
@@ -41,13 +43,15 @@ private[fcm] object FcmFlows {
       .setup { (materializer, _) =>
         import materializer.executionContext
         val http = Http()(materializer.system)
-        val session: GoogleSession = new GoogleSession(conf.clientEmail, conf.privateKey, new GoogleTokenApi(http))
+        val session: GoogleSession = new GoogleSession(conf.clientEmail,
+                                                       conf.privateKey,
+                                                       new GoogleTokenApi(http, materializer.system, conf.forwardProxy))
         val sender: FcmSender = new FcmSender()
         Flow[FcmNotification]
           .mapAsync(conf.maxConcurrentConnections)(
             in =>
               session.getToken()(materializer).flatMap { token =>
-                sender.send(conf.projectId, token, http, FcmSend(conf.isTest, in))(materializer)
+                sender.send(conf, token, http, FcmSend(conf.isTest, in), materializer.system)(materializer)
               }
           )
       }

--- a/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmSender.scala
+++ b/google-fcm/src/main/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmSender.scala
@@ -4,13 +4,16 @@
 
 package akka.stream.alpakka.google.firebase.fcm.impl
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.HttpExt
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
-import akka.stream.alpakka.google.firebase.fcm.{FcmErrorResponse, FcmResponse, FcmSuccessResponse}
+import akka.stream.alpakka.google.firebase.fcm.{FcmErrorResponse, FcmResponse, FcmSettings, FcmSuccessResponse}
 import akka.annotation.InternalApi
+import akka.stream.alpakka.google.firebase.fcm.ForwardProxyHttpsContext.ForwardProxyHttpsContext
+import akka.stream.alpakka.google.firebase.fcm.ForwardProxyPoolSettings.ForwardProxyPoolSettings
 import spray.json._
 
 import scala.collection.immutable
@@ -23,19 +26,35 @@ import scala.concurrent.{ExecutionContext, Future}
 private[fcm] class FcmSender {
   import FcmJsonSupport._
 
-  def send(projectId: String, token: String, http: HttpExt, fcmSend: FcmSend)(
+  def send(conf: FcmSettings, token: String, http: HttpExt, fcmSend: FcmSend, system: ActorSystem)(
       implicit materializer: Materializer
   ): Future[FcmResponse] = {
+    val projectId = conf.projectId
+    val forwardProxy = conf.forwardProxy
     val url = s"https://fcm.googleapis.com/v1/projects/$projectId/messages:send"
 
-    val response = http.singleRequest(
-      HttpRequest(
-        HttpMethods.POST,
-        url,
-        immutable.Seq(Authorization(OAuth2BearerToken(token))),
-        HttpEntity(ContentTypes.`application/json`, fcmSend.toJson.compactPrint)
-      )
-    )
+    val response = forwardProxy match {
+      case Some(fp) =>
+        http.singleRequest(
+          HttpRequest(
+            HttpMethods.POST,
+            url,
+            immutable.Seq(Authorization(OAuth2BearerToken(token))),
+            HttpEntity(ContentTypes.`application/json`, fcmSend.toJson.compactPrint)
+          ),
+          connectionContext = fp.httpsContext(system),
+          settings = fp.poolSettings(system)
+        )
+      case None =>
+        http.singleRequest(
+          HttpRequest(
+            HttpMethods.POST,
+            url,
+            immutable.Seq(Authorization(OAuth2BearerToken(token))),
+            HttpEntity(ContentTypes.`application/json`, fcmSend.toJson.compactPrint)
+          )
+        )
+    }
     parse(response)
   }
 

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmSenderSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/FcmSenderSpec.scala
@@ -11,8 +11,7 @@ import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.http.scaladsl.{HttpExt, HttpsConnectionContext}
 import akka.stream.ActorMaterializer
-import akka.stream.alpakka.google.firebase.fcm.{FcmErrorResponse, FcmSuccessResponse}
-import akka.stream.alpakka.google.firebase.fcm.FcmNotification
+import akka.stream.alpakka.google.firebase.fcm.{FcmErrorResponse, FcmNotification, FcmSettings, FcmSuccessResponse}
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.mockito.ArgumentCaptor
@@ -48,6 +47,8 @@ class FcmSenderSpec
 
   implicit val materializer = ActorMaterializer()
 
+  implicit val conf = FcmSettings.create("test-XXX@test-XXXXX.iam.gserviceaccount.com", "RSA KEY", "projectId")
+
   "FcmSender" should {
 
     "call the api as the docs want to" in {
@@ -62,7 +63,7 @@ class FcmSenderSpec
         Future.successful(HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, """{"name": ""}""")))
       )
 
-      Await.result(sender.send("projectId", "token", http, FcmSend(false, FcmNotification.empty)),
+      Await.result(sender.send(conf, "token", http, FcmSend(false, FcmNotification.empty), system),
                    defaultPatience.timeout)
 
       val captor: ArgumentCaptor[HttpRequest] = ArgumentCaptor.forClass(classOf[HttpRequest])
@@ -90,7 +91,7 @@ class FcmSenderSpec
       )
 
       sender
-        .send("projectId", "token", http, FcmSend(false, FcmNotification.empty))
+        .send(conf, "token", http, FcmSend(false, FcmNotification.empty), system)
         .futureValue shouldBe FcmSuccessResponse("test")
     }
 
@@ -110,7 +111,7 @@ class FcmSenderSpec
       )
 
       sender
-        .send("projectId", "token", http, FcmSend(false, FcmNotification.empty))
+        .send(conf, "token", http, FcmSend(false, FcmNotification.empty), system)
         .futureValue shouldBe FcmErrorResponse(
         """{"name":"test"}"""
       )

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleTokenApiSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/impl/GoogleTokenApiSpec.scala
@@ -93,7 +93,7 @@ class GoogleTokenApiSpec
         )
       )
 
-      val api = new GoogleTokenApi(http)
+      val api = new GoogleTokenApi(http, system, Option.empty)
       Await.result(api.getAccessToken("email", privateKey), defaultPatience.timeout)
 
       val captor: ArgumentCaptor[HttpRequest] = ArgumentCaptor.forClass(classOf[HttpRequest])
@@ -131,7 +131,7 @@ class GoogleTokenApiSpec
         )
       )
 
-      val api = new GoogleTokenApi(http)
+      val api = new GoogleTokenApi(http, system, Option.empty)
       api.getAccessToken("email", privateKey).futureValue should matchPattern {
         case AccessTokenExpiry("token", exp) if exp > (System.currentTimeMillis / 1000L + 3000L) =>
       }


### PR DESCRIPTION
### Purpose

Akka HTTP has support for forward proxies via its [Pluggable Client Transports](https://doc.akka.io/docs/akka-http/current/client-side/client-transport.html). The functionality is used in this update in order to support forward proxies when integrating with Google FCM.

### References
### Changes
### Background Context