### PR TITLE
Google Pub-Sub: Switch to older emulator image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       - ./geode/scripts/:/scripts/
     command: /scripts/geode.sh
   gcloud-pubsub-emulator:
-    image: google/cloud-sdk:313.0.1
+    image: google/cloud-sdk:311.0.0
     ports:
       - "8538:8538"
     command: gcloud beta emulators pubsub start --project=alpakka --host-port=0.0.0.0:8538


### PR DESCRIPTION
The last successful CRON build was 26/9, this is the most
recent tag that was uploaded before that date.