### PR TITLE
Require Akka 2.6 (drop Akka 2.5)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,8 +79,6 @@ lazy val alpakka = project
         .filterNot(_.data.getAbsolutePath.contains("guava-28.1-android.jar"))
         .filterNot(_.data.getAbsolutePath.contains("commons-net-3.1.jar"))
         .filterNot(_.data.getAbsolutePath.contains("protobuf-java-2.6.1.jar"))
-        // Some projects require (and introduce) Akka 2.6:
-        .filterNot(_.data.getAbsolutePath.contains(s"akka-stream_2.12-${Dependencies.Akka25Version}.jar"))
     },
     ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(`doc-examples`,
                                                                              csvBench,
@@ -194,9 +192,7 @@ lazy val googleCloudPubSubGrpc = alpakkaProject(
 ).enablePlugins(AkkaGrpcPlugin)
 
 lazy val googleCloudStorage =
-  alpakkaProject("google-cloud-storage",
-                 "google.cloud.storage",
-                 Dependencies.GoogleStorage)
+  alpakkaProject("google-cloud-storage", "google.cloud.storage", Dependencies.GoogleStorage)
 
 lazy val googleFcm = alpakkaProject("google-fcm", "google.firebase.fcm", Dependencies.GoogleFcm, Test / fork := true)
 
@@ -204,10 +200,7 @@ lazy val hbase = alpakkaProject("hbase", "hbase", Dependencies.HBase, Test / for
 
 lazy val hdfs = alpakkaProject("hdfs", "hdfs", Dependencies.Hdfs)
 
-lazy val influxdb = alpakkaProject("influxdb",
-                                   "influxdb",
-                                   Dependencies.InfluxDB,
-                                   fatalWarnings := false)
+lazy val influxdb = alpakkaProject("influxdb", "influxdb", Dependencies.InfluxDB, fatalWarnings := false)
 
 lazy val ironmq = alpakkaProject(
   "ironmq",
@@ -228,9 +221,7 @@ lazy val mongodb = alpakkaProject("mongodb", "mongodb", Dependencies.MongoDb)
 
 lazy val mqtt = alpakkaProject("mqtt", "mqtt", Dependencies.Mqtt)
 
-lazy val mqttStreaming = alpakkaProject("mqtt-streaming",
-                                        "mqttStreaming",
-                                        Dependencies.MqttStreaming)
+lazy val mqttStreaming = alpakkaProject("mqtt-streaming", "mqttStreaming", Dependencies.MqttStreaming)
 lazy val mqttStreamingBench = internalProject("mqtt-streaming-bench")
   .enablePlugins(JmhPlugin)
   .dependsOn(mqtt, mqttStreaming)
@@ -294,7 +285,6 @@ lazy val docs = project
     Paradox / siteSubdirName := s"docs/alpakka/${projectInfoVersion.value}",
     paradoxProperties ++= Map(
         "akka.version" -> Dependencies.AkkaVersion,
-        "akka26.version" -> Dependencies.Akka26Version,
         "akka-http.version" -> Dependencies.AkkaHttpVersion,
         "hadoop.version" -> Dependencies.HadoopVersion,
         "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.AkkaBinaryVersion}/%s",

--- a/docs/src/main/paradox/mqtt-streaming.md
+++ b/docs/src/main/paradox/mqtt-streaming.md
@@ -29,7 +29,7 @@ Alpakka MQTT Streaming implements the [MQTT 3.1.1](https://docs.oasis-open.org/m
   artifact=akka-stream-alpakka-mqtt-streaming_$scala.binary.version$
   version=$project.version$
   symbol2=AkkaVersion
-  value2=$akka26.version$
+  value2=$akka.version$
   group2=com.typesafe.akka
   artifact2=akka-stream_$scala.binary.version$
   version2=AkkaVersion
@@ -41,12 +41,6 @@ Alpakka MQTT Streaming implements the [MQTT 3.1.1](https://docs.oasis-open.org/m
 The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.
 
 @@dependencies { projectId="mqtt-streaming" }
-
-@@@ note
-
-Unlike most Alpakka modules, mqtt-streaming requires at least Akka $akka26.version$.
-
-@@@
 
 ## Flow through a client session
 

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -13,9 +13,9 @@ There are a few blog posts and presentations about Alpakka out there, we've @ref
 The code in this documentation is compiled against:
 
 * Alpakka $project.version$ ([Github](https://github.com/akka/alpakka), [API docs](https://doc.akka.io/api/alpakka/current/akka/stream/alpakka/index.html))
-* Scala $scala.binary.version$ (all modules are available for Scala 2.13, and most are available for Scala 2.11)
-* Akka Streams $akka.version$ (all modules are compatible with Akka $akka26.version$+) (@extref:[Reference](akka:stream/index.html), [Github](https://github.com/akka/akka))
-* Akka Http $akka-http.version$ (@extref:[Reference](akka-http:), [Github](https://github.com/akka/akka-http))
+* Scala $scala.binary.version$ (all modules are available for Scala 2.13)
+* Akka Streams $akka.version$+ (@extref:[Reference](akka:stream/index.html), [Github](https://github.com/akka/akka))
+* Akka HTTP $akka-http.version$+ (@extref:[Reference](akka-http:), [Github](https://github.com/akka/akka-http))
 
 See @ref:[Alpakka versioning](other-docs/versioning.md) for more details.
 

--- a/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/grpc/javadsl/GooglePubSub.scala
@@ -128,9 +128,7 @@ object GooglePubSub {
       .mapMaterializedValue(flattenCs(_))
 
   private def flattenCs[T](f: CompletionStage[_ <: CompletionStage[T]]): CompletionStage[T] =
-    f.thenCompose(new java.util.function.Function[CompletionStage[T], CompletionStage[T]] {
-      override def apply(t: CompletionStage[T]): CompletionStage[T] = t
-    })
+    f.thenCompose((t: CompletionStage[T]) => t)
 
   private def publisher(mat: ActorMaterializer, attr: Attributes) =
     attr

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -31,7 +31,9 @@ object Common extends AutoPlugin {
                             url("https://github.com/akka/alpakka/graphs/contributors")),
     licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
     description := "Alpakka is a Reactive Enterprise Integration library for Java and Scala, based on Reactive Streams and Akka.",
-    fatalWarnings := true,
+    // TODO https://github.com/akka/alpakka/issues/2456
+    // fatalWarnings := true,
+    fatalWarnings := false,
     mimaReportSignatureProblems := true
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,10 +9,8 @@ object Dependencies {
   val Scala213 = "2.13.3" // update even 2 places in .travis.yml
   val ScalaVersions = Seq(Scala212, Scala213)
 
-  val Akka25Version = "2.5.31"
-  val Akka26Version = "2.6.8"
-  val AkkaVersion = if (CronBuild) Akka26Version else Akka25Version
-  val AkkaBinaryVersion = if (CronBuild) "2.6" else "2.5"
+  val AkkaVersion = "2.6.10"
+  val AkkaBinaryVersion = "2.6"
 
   val InfluxDBJavaVersion = "2.15"
 
@@ -354,10 +352,10 @@ object Dependencies {
 
   val MqttStreaming = Seq(
     libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-actor-typed" % Akka26Version, // ApacheV2
-        "com.typesafe.akka" %% "akka-actor-testkit-typed" % Akka26Version % Test, // ApacheV2
-        "com.typesafe.akka" %% "akka-stream-typed" % Akka26Version, // ApacheV2
-        "com.typesafe.akka" %% "akka-stream-testkit" % Akka26Version % Test // ApacheV2
+        "com.typesafe.akka" %% "akka-actor-typed" % AkkaVersion, // ApacheV2
+        "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test, // ApacheV2
+        "com.typesafe.akka" %% "akka-stream-typed" % AkkaVersion, // ApacheV2
+        "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test // ApacheV2
       )
   )
 

--- a/text/src/main/scala/akka/stream/alpakka/text/javadsl/TextFlow.scala
+++ b/text/src/main/scala/akka/stream/alpakka/text/javadsl/TextFlow.scala
@@ -7,7 +7,6 @@ package akka.stream.alpakka.text.javadsl
 import java.nio.charset.Charset
 
 import akka.NotUsed
-import akka.japi.function
 import akka.stream.alpakka.text.impl.{CharsetDecodingFlow, CharsetTranscodingFlow}
 import akka.stream.javadsl.Flow
 import akka.util.ByteString
@@ -30,9 +29,7 @@ object TextFlow {
    * Decodes a stream of bytes into a stream of characters, using the supplied charset.
    */
   def encoding(outgoing: Charset): Flow[String, ByteString, NotUsed] =
-    Flow.fromFunction(new function.Function[String, ByteString] {
-      override def apply(s: String): ByteString = ByteString.fromString(s, outgoing)
-    })
+    Flow.fromFunction((s: String) => ByteString.fromString(s, outgoing))
 
   /**
    * Translates a stream of bytes from one character encoding into another.


### PR DESCRIPTION
Set Akka 2.6.10 as the only Akka version used in Alpakka.


To allow the deprecation warnings in CI, `fatalWarnings` is now `false` by default. https://github.com/akka/alpakka/issues/2456

References #2054 