### PR TITLE
CSV: remove materializer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,7 +121,7 @@ lazy val cassandra =
 lazy val couchbase =
   alpakkaProject("couchbase", "couchbase", Dependencies.Couchbase, whitesourceGroup := Whitesource.Group.Supported)
 
-lazy val csv = alpakkaProject("csv", "csv", whitesourceGroup := Whitesource.Group.Supported, fatalWarnings := false)
+lazy val csv = alpakkaProject("csv", "csv", whitesourceGroup := Whitesource.Group.Supported, fatalWarnings := true)
 
 lazy val csvBench = internalProject("csv-bench")
   .dependsOn(csv)

--- a/build.sbt
+++ b/build.sbt
@@ -121,7 +121,7 @@ lazy val cassandra =
 lazy val couchbase =
   alpakkaProject("couchbase", "couchbase", Dependencies.Couchbase, whitesourceGroup := Whitesource.Group.Supported)
 
-lazy val csv = alpakkaProject("csv", "csv", whitesourceGroup := Whitesource.Group.Supported)
+lazy val csv = alpakkaProject("csv", "csv", whitesourceGroup := Whitesource.Group.Supported, fatalWarnings := false)
 
 lazy val csvBench = internalProject("csv-bench")
   .dependsOn(csv)

--- a/csv/src/test/java/docs/javadsl/CsvFormattingTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvFormattingTest.java
@@ -5,8 +5,7 @@
 package docs.javadsl;
 
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
+import akka.stream.SystemMaterializer;
 // #import
 import akka.stream.alpakka.csv.javadsl.CsvFormatting;
 import akka.stream.alpakka.csv.javadsl.CsvQuotingStyle;
@@ -38,7 +37,6 @@ public class CsvFormattingTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
-  private static Materializer materializer;
 
   public void documentation() {
     char delimiter = CsvFormatting.COMMA;
@@ -69,7 +67,7 @@ public class CsvFormattingTest {
         // #formatting
         Source.single(Arrays.asList("one", "two", "three"))
             .via(CsvFormatting.format())
-            .runWith(Sink.head(), materializer);
+            .runWith(Sink.head(), system);
     // #formatting
     ByteString result = completionStage.toCompletableFuture().get(1, TimeUnit.SECONDS);
     assertThat(result.utf8String(), equalTo("one,two,three\r\n"));
@@ -78,7 +76,6 @@ public class CsvFormattingTest {
   @BeforeClass
   public static void setup() throws Exception {
     system = ActorSystem.create();
-    materializer = ActorMaterializer.create(system);
   }
 
   @AfterClass
@@ -88,6 +85,6 @@ public class CsvFormattingTest {
 
   @After
   public void checkForStageLeaks() {
-    StreamTestKit.assertAllStagesStopped(materializer);
+    StreamTestKit.assertAllStagesStopped(SystemMaterializer.get(system).materializer());
   }
 }

--- a/csv/src/test/java/docs/javadsl/CsvToMapTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvToMapTest.java
@@ -5,8 +5,7 @@
 package docs.javadsl;
 
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
+import akka.stream.SystemMaterializer;
 // #import
 import akka.stream.alpakka.csv.javadsl.CsvParsing;
 import akka.stream.alpakka.csv.javadsl.CsvToMap;
@@ -34,7 +33,6 @@ public class CsvToMapTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
-  private static Materializer materializer;
 
   public void documentation() {
     // #flow-type
@@ -64,7 +62,7 @@ public class CsvToMapTest {
         Source.single(ByteString.fromString("eins,zwei,drei\n1,2,3"))
             .via(CsvParsing.lineScanner())
             .via(CsvToMap.toMap(StandardCharsets.UTF_8))
-            .runWith(Sink.head(), materializer);
+            .runWith(Sink.head(), system);
     // #header-line
     Map<String, ByteString> map = completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
     // #header-line
@@ -84,7 +82,7 @@ public class CsvToMapTest {
         Source.single(ByteString.fromString("eins,zwei,drei\n1,2,3"))
             .via(CsvParsing.lineScanner())
             .via(CsvToMap.toMapAsStrings(StandardCharsets.UTF_8))
-            .runWith(Sink.head(), materializer);
+            .runWith(Sink.head(), system);
     // #header-line
     Map<String, String> map = completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
     // #header-line
@@ -103,7 +101,7 @@ public class CsvToMapTest {
         Source.single(ByteString.fromString("1,2,3"))
             .via(CsvParsing.lineScanner())
             .via(CsvToMap.withHeaders("eins", "zwei", "drei"))
-            .runWith(Sink.head(), materializer);
+            .runWith(Sink.head(), system);
     // #column-names
     Map<String, ByteString> map = completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
     // #column-names
@@ -123,7 +121,7 @@ public class CsvToMapTest {
         Source.single(ByteString.fromString("1,2,3"))
             .via(CsvParsing.lineScanner())
             .via(CsvToMap.withHeadersAsStrings(StandardCharsets.UTF_8, "eins", "zwei", "drei"))
-            .runWith(Sink.head(), materializer);
+            .runWith(Sink.head(), system);
     // #column-names
     Map<String, String> map = completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
     // #column-names
@@ -137,7 +135,6 @@ public class CsvToMapTest {
   @BeforeClass
   public static void setup() throws Exception {
     system = ActorSystem.create();
-    materializer = ActorMaterializer.create(system);
   }
 
   @AfterClass
@@ -147,6 +144,6 @@ public class CsvToMapTest {
 
   @After
   public void checkForStageLeaks() {
-    StreamTestKit.assertAllStagesStopped(materializer);
+    StreamTestKit.assertAllStagesStopped(SystemMaterializer.get(system).materializer());
   }
 }

--- a/csv/src/test/scala/docs/scaladsl/CsvSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvSpec.scala
@@ -5,7 +5,6 @@
 package docs.scaladsl
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.scalatest.concurrent.ScalaFutures
@@ -22,7 +21,6 @@ abstract class CsvSpec
     with LogCapturing {
 
   implicit val system = ActorSystem(this.getClass.getSimpleName)
-  implicit val materializer = ActorMaterializer()
 
   override protected def afterAll(): Unit =
     TestKit.shutdownActorSystem(system)


### PR DESCRIPTION
Update the CSV tests to pass the actor system instead of an explicit materializer.

References #2054, #2468 
