### PR TITLE
Pravega: Re-factor tests

### DIFF
--- a/pravega/src/main/scala/akka/stream/alpakka/pravega/PravegaSettings.scala
+++ b/pravega/src/main/scala/akka/stream/alpakka/pravega/PravegaSettings.scala
@@ -127,6 +127,13 @@ object ReaderSettingsBuilder {
     apply(actorSystem)
 
   /**
+   * Java API: Create settings from a configuration with the same layout as
+   * * the default configuration `akka.alpakka.pravega.reader`.
+   */
+  def create[Message](config: Config): ReaderSettingsBuilder =
+    apply(config)
+
+  /**
    * Create settings from a configuration with the same layout as
    * the default configuration `akka.alpakka.pravega.reader`.
    */

--- a/pravega/src/test/java/akka/stream/alpakka/pravega/PravegaAkkaTestCaseSupport.java
+++ b/pravega/src/test/java/akka/stream/alpakka/pravega/PravegaAkkaTestCaseSupport.java
@@ -5,8 +5,6 @@
 package akka.stream.alpakka.pravega;
 
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import docs.javadsl.PravegaBaseTestCase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,10 +13,8 @@ public class PravegaAkkaTestCaseSupport {
 
   protected static final Logger LOGGER = LoggerFactory.getLogger(PravegaBaseTestCase.class);
   protected static ActorSystem system;
-  protected static Materializer materializer;
 
   public static void init() {
     system = ActorSystem.create();
-    materializer = ActorMaterializer.create(system);
   }
 }

--- a/pravega/src/test/java/akka/stream/alpakka/pravega/PravegaGraphTestCase.java
+++ b/pravega/src/test/java/akka/stream/alpakka/pravega/PravegaGraphTestCase.java
@@ -5,9 +5,9 @@
 package akka.stream.alpakka.pravega;
 
 import akka.Done;
-import akka.japi.function.Function2;
 import akka.stream.javadsl.Source;
 
+import com.typesafe.config.ConfigFactory;
 import docs.javadsl.PravegaBaseTestCase;
 import io.pravega.client.stream.impl.JavaSerializer;
 import org.junit.Assert;
@@ -28,20 +28,34 @@ import java.util.concurrent.*;
 
 public class PravegaGraphTestCase extends PravegaBaseTestCase {
 
-  private WriterSettings<String> writerSettings =
-      WriterSettingsBuilder.<String>create(system).withSerializer(new JavaSerializer<>());
-
-  private WriterSettings<String> writerSettingsWithRoutingKey =
-      WriterSettingsBuilder.<String>create(system)
-          .withKeyExtractor((String str) -> str.substring(0, 1))
-          .withSerializer(new JavaSerializer<>());
-
-  private ReaderSettings<String> readerSettings =
-      ReaderSettingsBuilder.create(system).withSerializer(new JavaSerializer<>());
+  private long timeoutSeconds = 10;
 
   @Test
   public void infiniteSourceTest()
       throws ExecutionException, InterruptedException, TimeoutException {
+
+    String group = newGroup();
+    String scope = newScope();
+    String streamName = newStreamName();
+
+    WriterSettings<String> writerSettings =
+        WriterSettingsBuilder.<String>create(system).withSerializer(new JavaSerializer<>());
+
+    WriterSettings<String> writerSettingsWithRoutingKey =
+        WriterSettingsBuilder.<String>create(system)
+            .withKeyExtractor((String str) -> str.substring(0, 1))
+            .withSerializer(new JavaSerializer<>());
+
+    ReaderSettings<String> readerSettings =
+        ReaderSettingsBuilder.create(
+                system
+                    .settings()
+                    .config()
+                    .getConfig(ReaderSettingsBuilder.configPath())
+                    .withFallback(ConfigFactory.parseString("group-name = " + group)))
+            .withSerializer(new JavaSerializer<>());
+
+    createStream(scope, streamName);
 
     final List<String> events = Arrays.asList("One", "Two", "Three");
 
@@ -49,15 +63,15 @@ public class PravegaGraphTestCase extends PravegaBaseTestCase {
         Pravega.sink(scope, streamName, writerSettings);
 
     CompletionStage<Done> doneWithRouting =
-        Source.from(events).toMat(sinkWithRouting, Keep.right()).run(materializer);
+        Source.from(events).toMat(sinkWithRouting, Keep.right()).run(system);
 
     Sink<String, CompletionStage<Done>> sink =
         Pravega.sink(scope, streamName, writerSettingsWithRoutingKey);
 
-    CompletionStage<Done> done = Source.from(events).toMat(sink, Keep.right()).run(materializer);
+    CompletionStage<Done> done = Source.from(events).toMat(sink, Keep.right()).run(system);
 
     CompletableFuture.allOf(done.toCompletableFuture(), doneWithRouting.toCompletableFuture())
-        .get();
+        .get(timeoutSeconds, TimeUnit.SECONDS);
 
     CompletableFuture<Boolean> countTo200 = new CompletableFuture<>();
 
@@ -73,14 +87,14 @@ public class PravegaGraphTestCase extends PravegaBaseTestCase {
                       return acc - 1;
                     }),
                 Keep.both())
-            .run(materializer);
+            .run(system);
 
-    countTo200.get(10, TimeUnit.SECONDS);
+    countTo200.get(timeoutSeconds, TimeUnit.SECONDS);
 
     LOGGER.info("Die, die by my hand.");
     pair.first().shutdown();
 
-    Integer result = pair.second().toCompletableFuture().get();
+    Integer result = pair.second().toCompletableFuture().get(timeoutSeconds, TimeUnit.SECONDS);
     Assert.assertTrue("Read 6 events", result == 0);
   }
 }

--- a/pravega/src/test/java/docs/javadsl/PravegaBaseTestCase.java
+++ b/pravega/src/test/java/docs/javadsl/PravegaBaseTestCase.java
@@ -25,21 +25,24 @@ import io.pravega.client.stream.StreamConfiguration;
 
 public abstract class PravegaBaseTestCase extends PravegaAkkaTestCaseSupport {
 
-  protected ReaderSettings<String> settings =
-      ReaderSettingsBuilder.apply(system)
-          .withGroupName("javaGroupName")
-          .withSerializer(new UTF8StringSerializer());
+  protected String newGroup() {
+    return "java-test-group-" + UUID.randomUUID().toString();
+  }
 
-  protected final String scope = "java-test-scope-" + UUID.randomUUID().toString();
+  protected String newScope() {
+    return "java-test-scope-" + UUID.randomUUID().toString();
+  }
 
-  protected final String streamName = "java-test-topic-" + UUID.randomUUID().toString();
+  protected String newStreamName() {
+    return "java-test-topic-" + UUID.randomUUID().toString();
+  }
 
   @BeforeClass
   public static void setup() {
     init();
   }
 
-  public PravegaBaseTestCase() {
+  public void createStream(String scope, String streamName) {
     StreamManager streamManager = StreamManager.create(URI.create("tcp://localhost:9090"));
 
     if (streamManager.createScope(scope)) LOGGER.info("Created scope [{}]", scope);

--- a/pravega/src/test/java/docs/javadsl/PravegaReadWriteDocs.java
+++ b/pravega/src/test/java/docs/javadsl/PravegaReadWriteDocs.java
@@ -32,7 +32,7 @@ public class PravegaReadWriteDocs extends PravegaAkkaTestCaseSupport {
         Pravega.sink("an_existing_scope", "an_existing_scope", writerSettings);
 
     CompletionStage<Done> doneWithRouting =
-        Source.from(Arrays.asList("One", "Two", "Three")).runWith(sinkWithRouting, materializer);
+        Source.from(Arrays.asList("One", "Two", "Three")).runWith(sinkWithRouting, system);
 
     // #writing
 
@@ -40,7 +40,7 @@ public class PravegaReadWriteDocs extends PravegaAkkaTestCaseSupport {
     CompletionStage<Done> fut =
         Pravega.<String>source("an_existing_scope", "an_existing_scope", readerSettings)
             .to(Sink.foreach(e -> processMessage(e.message())))
-            .run(materializer);
+            .run(system);
     // #reading
 
   }

--- a/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaBaseSpec.scala
+++ b/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaBaseSpec.scala
@@ -7,11 +7,8 @@ package akka.stream.alpakka.pravega
 import java.net.URI
 import java.util.UUID
 
-import akka.stream.{ActorMaterializer, Materializer}
-
 import io.pravega.client.admin.StreamManager
 import io.pravega.client.stream.{ScalingPolicy, StreamConfiguration}
-
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -20,14 +17,11 @@ import org.slf4j.LoggerFactory
 abstract class PravegaBaseSpec extends AnyWordSpec with PravegaAkkaSpecSupport with ScalaFutures with Matchers {
   val logger = LoggerFactory.getLogger(this.getClass())
 
-  implicit val mat: Materializer = ActorMaterializer()
+  def newGroupName() = "scala-test-group-" + UUID.randomUUID().toString
+  def newScope() = "scala-test-scope-" + UUID.randomUUID().toString
+  def newStreamName() = "scala-test-stream-" + UUID.randomUUID().toString
 
-  final val groupName = "scala-test-group"
-
-  final val scope = "scala-test-scope-" + UUID.randomUUID().toString
-  final val streamName = "scala-test-stream-" + UUID.randomUUID().toString
-
-  override def beforeAll(): Unit = {
+  def createStream(scope: String, streamName: String) = {
     val streamManager = StreamManager.create(URI.create("tcp://localhost:9090"))
     if (streamManager.createScope(scope))
       logger.info(s"Created scope [$scope].")
@@ -42,5 +36,4 @@ abstract class PravegaBaseSpec extends AnyWordSpec with PravegaAkkaSpecSupport w
 
     streamManager.close()
   }
-
 }

--- a/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaGraphSpec.scala
+++ b/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaGraphSpec.scala
@@ -6,43 +6,57 @@ package akka.stream.alpakka.pravega
 
 import akka.stream.KillSwitches
 import akka.stream.alpakka.pravega.scaladsl.Pravega
-
+import akka.stream.alpakka.testkit.scaladsl.Repeated
 import akka.stream.scaladsl.{Keep, Sink, Source}
+import com.typesafe.config.ConfigFactory
 import io.pravega.client.stream.impl.UTF8StringSerializer
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Promise}
 
-class PravegaGraphSpec extends PravegaBaseSpec {
+class PravegaGraphSpec extends PravegaBaseSpec with Repeated {
 
   val serializer = new UTF8StringSerializer
-
-  implicit val readerSettings = ReaderSettingsBuilder(system)
-    .withSerializer(serializer)
-
-  implicit val writerSettings = WriterSettingsBuilder(system)
-    .withSerializer(serializer)
-
-  val writerSettingsWithRoutingKey = WriterSettingsBuilder(system)
-    .withKeyExtractor((str: String) => str.substring(0, 2))
-    .withSerializer(serializer)
-
   val nEvent = 500
+  val timeout = 10.seconds
 
   "Pravega connector" should {
 
     "runs sources" in {
 
+      val group = newGroupName()
+      val scope = newScope()
+      val stream = newStreamName()
+
+      implicit val readerSettings = ReaderSettingsBuilder(
+        system.settings.config
+          .getConfig(ReaderSettingsBuilder.configPath)
+          .withFallback(ConfigFactory.parseString(s"group-name = $group"))
+      ).withSerializer(serializer)
+
+      implicit val writerSettings = WriterSettingsBuilder(system)
+        .withSerializer(serializer)
+
+      val writerSettingsWithRoutingKey = WriterSettingsBuilder(system)
+        .withKeyExtractor((str: String) => str.substring(0, 2))
+        .withSerializer(serializer)
+
+      createStream(scope, stream)
+
       logger.info("start source")
 
       // #writing
-      Source(1 to nEvent)
+      val done = Source(1 to nEvent)
         .map(i => f"$i%02d_event")
-        .runWith(Pravega.sink(scope, streamName))
+        .runWith(Pravega.sink(scope, stream))
 
-      Source(1 to nEvent)
+      Await.ready(done, timeout)
+
+      val doneWithRoutingKey = Source(1 to nEvent)
         .map(i => f"$i%02d_event")
-        .runWith(Pravega.sink(scope, streamName)(writerSettingsWithRoutingKey))
+        .runWith(Pravega.sink(scope, stream)(writerSettingsWithRoutingKey))
+
+      Await.ready(doneWithRoutingKey, timeout)
 
       // #writing
 
@@ -51,7 +65,7 @@ class PravegaGraphSpec extends PravegaBaseSpec {
       // #reading
 
       val (kill, fut) = Pravega
-        .source(scope, streamName)
+        .source(scope, stream)
         .viaMat(KillSwitches.single)(Keep.right)
         .toMat(Sink.fold(nEvent * 2) { (acc, _) =>
           if (acc == 1)
@@ -62,7 +76,7 @@ class PravegaGraphSpec extends PravegaBaseSpec {
 
       // #reading
 
-      Await.ready(finishReading.future, 10.seconds)
+      Await.ready(finishReading.future, timeout)
 
       logger.debug("Die, die by my hand.")
       kill.shutdown()


### PR DESCRIPTION
Initially I was only attempting to recreate #2453. I noticed when I ran the same test twice I received a timeout on the same Future as #2453.  I added some explicit timeouts to the data population code and got a little carried away.

* Always use unique group, scope, and stream name per test
* Java API: overload to load `ReaderBasicSettings` from supplied config
* Remove usages of Materializer
