### PR TITLE
Text: Adapt to Akka 2.6

### DIFF
--- a/text/src/test/java/docs/javadsl/CharsetCodingFlowsDoc.java
+++ b/text/src/test/java/docs/javadsl/CharsetCodingFlowsDoc.java
@@ -5,8 +5,6 @@
 package docs.javadsl;
 
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 
 // #encoding
 import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
@@ -41,7 +39,6 @@ public class CharsetCodingFlowsDoc {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final ActorSystem system = ActorSystem.create();
-  private static final Materializer materializer = ActorMaterializer.create(system);
 
   @AfterClass
   public static void afterAll() {
@@ -66,7 +63,7 @@ public class CharsetCodingFlowsDoc {
         stringSource
             .via(TextFlow.encoding(StandardCharsets.US_ASCII))
             .intersperse(ByteString.fromString("\n"))
-            .runWith(FileIO.toPath(targetFile), materializer);
+            .runWith(FileIO.toPath(targetFile), system);
     // #encoding
     IOResult result = streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS);
     assertTrue(result.wasSuccessful());
@@ -83,7 +80,7 @@ public class CharsetCodingFlowsDoc {
         // #decoding
         byteStringSource
             .via(TextFlow.decoding(StandardCharsets.UTF_16))
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
     // #decoding
     List<String> result = streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS);
     assertEquals(Arrays.asList("äåûßêëé"), result);
@@ -102,7 +99,7 @@ public class CharsetCodingFlowsDoc {
         // #transcoding
         byteStringSource
             .via(TextFlow.transcoding(StandardCharsets.UTF_16, StandardCharsets.UTF_8))
-            .runWith(FileIO.toPath(targetFile), materializer);
+            .runWith(FileIO.toPath(targetFile), system);
     // #transcoding
     IOResult result = streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS);
     assertTrue(result.wasSuccessful());

--- a/text/src/test/scala/akka/stream/alpakka/text/scaladsl/CharsetCodingFlowsSpec.scala
+++ b/text/src/test/scala/akka/stream/alpakka/text/scaladsl/CharsetCodingFlowsSpec.scala
@@ -7,23 +7,21 @@ package akka.stream.alpakka.text.scaladsl
 import java.nio.charset.{Charset, StandardCharsets, UnmappableCharacterException}
 import java.nio.file.Paths
 
-import akka.Done
 import akka.actor.ActorSystem
+import akka.stream.IOResult
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
-import akka.stream.{ActorMaterializer, IOResult, Materializer}
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.{BeforeAndAfterAll, RecoverMethods}
 
 import scala.collection.immutable
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContextExecutor, Future}
-import scala.util.Success
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpecLike
 
 class CharsetCodingFlowsSpec
     extends TestKit(ActorSystem("charset"))
@@ -34,7 +32,6 @@ class CharsetCodingFlowsSpec
     with RecoverMethods
     with LogCapturing {
 
-  private implicit val mat: Materializer = ActorMaterializer()
   private implicit val executionContext: ExecutionContextExecutor = system.dispatcher
 
   val multiByteChars = "äåû經濟商行政管理总局التجارى"
@@ -77,7 +74,7 @@ class CharsetCodingFlowsSpec
           .via(TextFlow.encoding(StandardCharsets.US_ASCII))
           .intersperse(ByteString("\n"))
           .runWith(FileIO.toPath(targetFile))
-      result.futureValue.status should be(Success(Done))
+      result.futureValue.count should be > 50L
     }
   }
 
@@ -114,7 +111,7 @@ class CharsetCodingFlowsSpec
         byteStringSource
           .via(TextFlow.transcoding(StandardCharsets.UTF_16, StandardCharsets.UTF_8))
           .runWith(FileIO.toPath(targetFile))
-      result.futureValue.status should be(Success(Done))
+      result.futureValue.count should be > 5L
     }
 
     def verifyTranscoding(charsetIn: Charset, charsetOut: Charset, value: String) = {

--- a/text/src/test/scala/docs/scaladsl/CharsetCodingFlowsDoc.scala
+++ b/text/src/test/scala/docs/scaladsl/CharsetCodingFlowsDoc.scala
@@ -6,21 +6,19 @@ package docs.scaladsl
 
 import java.nio.file.Paths
 
-import akka.Done
 import akka.actor.ActorSystem
+import akka.stream.IOResult
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.{ActorMaterializer, IOResult, Materializer}
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.{BeforeAndAfterAll, RecoverMethods}
 
 import scala.collection.immutable
 import scala.concurrent.Future
-import scala.util.Success
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpecLike
 
 class CharsetCodingFlowsDoc
     extends TestKit(ActorSystem("charset"))
@@ -31,8 +29,6 @@ class CharsetCodingFlowsDoc
     with RecoverMethods
     with LogCapturing {
 
-  private implicit val mat: Materializer = ActorMaterializer()
-
   val multiByteChars = "äåû經濟商行政管理总局التجارى"
 
   "Encoding" should {
@@ -41,6 +37,7 @@ class CharsetCodingFlowsDoc
       // format: off
       // #encoding
       import java.nio.charset.StandardCharsets
+
       import akka.stream.alpakka.text.scaladsl.TextFlow
       import akka.stream.scaladsl.FileIO
 
@@ -60,7 +57,7 @@ class CharsetCodingFlowsDoc
         .intersperse(ByteString("\n"))
         .runWith(FileIO.toPath(targetFile))
       // #encoding
-      result.futureValue.status should be(Success(Done))
+      result.futureValue.count should be > 50L
       // format: on
     }
   }
@@ -70,6 +67,7 @@ class CharsetCodingFlowsDoc
       // format: off
       // #decoding
       import java.nio.charset.StandardCharsets
+
       import akka.stream.alpakka.text.scaladsl.TextFlow
 
       // #decoding
@@ -97,8 +95,9 @@ class CharsetCodingFlowsDoc
       // format: off
       // #transcoding
       import java.nio.charset.StandardCharsets
-      import akka.stream.scaladsl.FileIO
+
       import akka.stream.alpakka.text.scaladsl.TextFlow
+      import akka.stream.scaladsl.FileIO
 
       // #transcoding
       val utf16bytes = ByteString("äåûßêëé", StandardCharsets.UTF_16)
@@ -115,7 +114,7 @@ class CharsetCodingFlowsDoc
         .via(TextFlow.transcoding(StandardCharsets.UTF_16, StandardCharsets.UTF_8))
         .runWith(FileIO.toPath(targetFile))
       // #transcoding
-      result.futureValue.status should be(Success(Done))
+      result.futureValue.count should be > 5L
       // format: on
     }
 


### PR DESCRIPTION
Fixes #2503 

(doesn't enable fatal warnings as that triggers a total rebuild of Alpakka, I'll spare that until we have merged a few)﻿
