### PR TITLE
SQS: Akka 2.6; proper Http client pool shutdown in tests

### DIFF
--- a/docs/src/main/paradox/sqs.md
+++ b/docs/src/main/paradox/sqs.md
@@ -38,7 +38,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Setup
 
-Prepare an @apidoc[akka.actor.ActorSystem] and a @apidoc[Materializer].
+Prepare an @apidoc[akka.actor.ActorSystem].
 
 Scala
 : @@snip [snip](/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala) { #init-mat }
@@ -47,7 +47,7 @@ Java
 : @@snip [snip](/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/BaseSqsTest.java) { #init-mat }
 
 
-This connector requires an implicit @javadoc[SqsAsyncClient](software.amazon.awssdk.services.sqs.SqsAsyncClient) instance to communicate with AWS SQS.
+This connector requires an @scala[implicit] @javadoc[SqsAsyncClient](software.amazon.awssdk.services.sqs.SqsAsyncClient) instance to communicate with AWS SQS.
 
 It is your code's responsibility to call `close` to free any resources held by the client. In this example it will be called when the actor system is terminated.
 

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/impl/BalancingMapAsync.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/impl/BalancingMapAsync.scala
@@ -19,19 +19,13 @@ import scala.util.{Failure, Success}
 
 /**
  * Internal API.
- *
- * Imported from `akka.stream.impl` for Akka 2.5/2.6 cross-compilation.
  */
 @InternalApi private[impl] object BufferImpl {
   val FixedQueueSize = 128
   val FixedQueueMask = 127
 
-  def apply[T](size: Int, materializer: Materializer): Buffer[T] =
-    materializer match {
-      case m: ActorMaterializer =>
-        apply(size, m.settings.maxFixedBufferSize)
-      case _ => apply(size, 1000000000)
-    }
+  def apply[T](size: Int, effectiveAttributes: Attributes): Buffer[T] =
+    apply(size, effectiveAttributes.mandatoryAttribute[ActorAttributes.MaxFixedBufferSize].size)
 
   private def apply[T](size: Int, max: Int): Buffer[T] =
     if (size < FixedQueueSize || size < max) FixedSizeBuffer(size)
@@ -75,7 +69,7 @@ import scala.util.{Failure, Success}
           }
       )
 
-      override def preStart(): Unit = buffer = BufferImpl(parallelism, materializer)
+      override def preStart(): Unit = buffer = BufferImpl(parallelism, inheritedAttributes)
 
       override def onPull(): Unit = pushNextIfPossible()
 

--- a/sqs/src/test/java/docs/javadsl/SqsAckTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsAckTest.java
@@ -84,7 +84,7 @@ public class SqsAckTest extends BaseSqsTest {
         // #ack
         source
             .map(m -> MessageAction.delete(m))
-            .runWith(SqsAckSink.create(queueUrl, SqsAckSettings.create(), awsClient), materializer);
+            .runWith(SqsAckSink.create(queueUrl, SqsAckSettings.create(), awsClient), system);
     // #ack
 
     done.toCompletableFuture().get(1, TimeUnit.SECONDS);
@@ -107,7 +107,7 @@ public class SqsAckTest extends BaseSqsTest {
         source
             .map(m -> MessageAction.delete(m))
             .via(SqsAckFlow.create(queueUrl, SqsAckSettings.create(), awsClient))
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
     // #flow-ack
 
     List<SqsAckResult> results = stage.toCompletableFuture().get(1, TimeUnit.SECONDS);
@@ -139,7 +139,7 @@ public class SqsAckTest extends BaseSqsTest {
         // #requeue
         source
             .map(m -> MessageAction.changeMessageVisibility(m, 12))
-            .runWith(SqsAckSink.create(queueUrl, SqsAckSettings.create(), awsClient), materializer);
+            .runWith(SqsAckSink.create(queueUrl, SqsAckSettings.create(), awsClient), system);
     // #requeue
     done.toCompletableFuture().get(1, TimeUnit.SECONDS);
 
@@ -160,7 +160,7 @@ public class SqsAckTest extends BaseSqsTest {
         source
             .map(m -> MessageAction.ignore(m))
             .via(SqsAckFlow.create(queueUrl, SqsAckSettings.create(), awsClient))
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
     // #ignore
 
     List<SqsAckResult> results = stage.toCompletableFuture().get(1, TimeUnit.SECONDS);
@@ -196,7 +196,7 @@ public class SqsAckTest extends BaseSqsTest {
         source
             .map(m -> MessageAction.delete(m))
             .via(SqsAckFlow.grouped(queueUrl, SqsAckGroupedSettings.create(), awsClient))
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
 
     // #batch-ack
 
@@ -241,7 +241,7 @@ public class SqsAckTest extends BaseSqsTest {
         source
             .map(m -> MessageAction.changeMessageVisibility(m, 5))
             .via(SqsAckFlow.grouped(queueUrl, SqsAckGroupedSettings.create(), awsClient))
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
     // #batch-requeue
 
     List<SqsAckResultEntry> results = stage.toCompletableFuture().get(1, TimeUnit.SECONDS);
@@ -274,7 +274,7 @@ public class SqsAckTest extends BaseSqsTest {
         source
             .map(m -> MessageAction.ignore(m))
             .via(SqsAckFlow.grouped(queueUrl, SqsAckGroupedSettings.create(), awsClient))
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
     // #batch-ignore
 
     List<SqsAckResultEntry> results = stage.toCompletableFuture().get(1, TimeUnit.SECONDS);

--- a/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
@@ -64,8 +64,7 @@ public class SqsPublishTest extends BaseSqsTest {
         // #run-string
         Source.single("alpakka")
             .runWith(
-                SqsPublishSink.create(queueUrl, SqsPublishSettings.create(), sqsClient),
-                materializer);
+                SqsPublishSink.create(queueUrl, SqsPublishSettings.create(), sqsClient), system);
     // #run-string
     done.toCompletableFuture().get(10, TimeUnit.SECONDS);
 
@@ -89,7 +88,7 @@ public class SqsPublishTest extends BaseSqsTest {
         Source.single(SendMessageRequest.builder().messageBody("alpakka").build())
             .runWith(
                 SqsPublishSink.messageSink(queueUrl, SqsPublishSettings.create(), sqsClient),
-                materializer);
+                system);
 
     // #run-send-request
     done.toCompletableFuture().get(10, TimeUnit.SECONDS);
@@ -113,8 +112,7 @@ public class SqsPublishTest extends BaseSqsTest {
         // for dynamic SQS queues
         Source.single(
                 SendMessageRequest.builder().messageBody("alpakka").queueUrl(queueUrl).build())
-            .runWith(
-                SqsPublishSink.messageSink(SqsPublishSettings.create(), sqsClient), materializer);
+            .runWith(SqsPublishSink.messageSink(SqsPublishSettings.create(), sqsClient), system);
     // #run-send-request
     done.toCompletableFuture().get(10, TimeUnit.SECONDS);
 
@@ -136,7 +134,7 @@ public class SqsPublishTest extends BaseSqsTest {
         // for fix SQS queue
         Source.single(SendMessageRequest.builder().messageBody("alpakka-flow").build())
             .via(SqsPublishFlow.create(queueUrl, SqsPublishSettings.create(), sqsClient))
-            .runWith(Sink.head(), materializer);
+            .runWith(Sink.head(), system);
 
     // #flow
     SqsPublishResult result = done.toCompletableFuture().get(10, TimeUnit.SECONDS);
@@ -161,7 +159,7 @@ public class SqsPublishTest extends BaseSqsTest {
         Source.single(
                 SendMessageRequest.builder().messageBody("alpakka-flow").queueUrl(queueUrl).build())
             .via(SqsPublishFlow.create(SqsPublishSettings.create(), sqsClient))
-            .runWith(Sink.head(), materializer);
+            .runWith(Sink.head(), system);
     // #flow
     SqsPublishResult result = done.toCompletableFuture().get(10, TimeUnit.SECONDS);
     assertEquals(toMd5("alpakka-flow"), result.result().md5OfMessageBody());
@@ -189,7 +187,7 @@ public class SqsPublishTest extends BaseSqsTest {
         Source.from(messagesToSend)
             .runWith(
                 SqsPublishSink.grouped(queueUrl, SqsPublishGroupedSettings.create(), sqsClient),
-                materializer);
+                system);
     // #group
     done.toCompletableFuture().get(10, TimeUnit.SECONDS);
 
@@ -224,7 +222,7 @@ public class SqsPublishTest extends BaseSqsTest {
         Source.single(messagesToSend)
             .runWith(
                 SqsPublishSink.batch(queueUrl, SqsPublishBatchSettings.create(), sqsClient),
-                materializer);
+                system);
     // #batch-string
     done.toCompletableFuture().get(10, TimeUnit.SECONDS);
 
@@ -253,7 +251,7 @@ public class SqsPublishTest extends BaseSqsTest {
             .runWith(
                 SqsPublishSink.batchedMessageSink(
                     queueUrl, SqsPublishBatchSettings.create(), sqsClient),
-                materializer);
+                system);
     // #batch-send-request
     done.toCompletableFuture().get(10, TimeUnit.SECONDS);
 
@@ -279,7 +277,7 @@ public class SqsPublishTest extends BaseSqsTest {
     CompletionStage<List<SqsPublishResultEntry>> stage =
         Source.from(messagesToSend)
             .via(SqsPublishFlow.grouped(queueUrl, SqsPublishGroupedSettings.create(), sqsClient))
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
 
     List<SqsPublishResultEntry> results = stage.toCompletableFuture().get(10, TimeUnit.SECONDS);
     assertEquals(10, results.size());
@@ -314,7 +312,7 @@ public class SqsPublishTest extends BaseSqsTest {
         Source.single(messagesToSend)
             .via(SqsPublishFlow.batch(queueUrl, SqsPublishBatchSettings.create(), sqsClient))
             .mapConcat(x -> x)
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
 
     List<SqsPublishResultEntry> results = new ArrayList<>();
 
@@ -345,7 +343,7 @@ public class SqsPublishTest extends BaseSqsTest {
     CompletionStage<SqsPublishResult> stage =
         Source.single(SendMessageRequest.builder().messageBody("alpakka-flow").build())
             .via(SqsPublishFlow.create(queueUrl, SqsPublishSettings.create(), sqsClient))
-            .runWith(Sink.head(), materializer);
+            .runWith(Sink.head(), system);
 
     SqsPublishResult result = stage.toCompletableFuture().get(10, TimeUnit.SECONDS);
     assertEquals(toMd5("alpakka-flow"), result.result().md5OfMessageBody());

--- a/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
@@ -51,9 +51,7 @@ public class SqsSourceTest extends BaseSqsTest {
                         .messageBody("alpakka-" + i)
                         .build())
             .grouped(10)
-            .runWith(
-                SqsPublishSink.batchedMessageSink(queueUrl, batchSettings, sqsClient),
-                materializer);
+            .runWith(SqsPublishSink.batchedMessageSink(queueUrl, batchSettings, sqsClient), system);
 
     produced.toCompletableFuture().get(2, TimeUnit.SECONDS);
 
@@ -65,7 +63,7 @@ public class SqsSourceTest extends BaseSqsTest {
                     .withCloseOnEmptyReceive(true)
                     .withWaitTime(Duration.ofMillis(10)),
                 sqsClient)
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
     // #run
 
     assertEquals(100, messages.toCompletableFuture().get(20, TimeUnit.SECONDS).size());
@@ -122,7 +120,7 @@ public class SqsSourceTest extends BaseSqsTest {
         SqsSource.create(
                 queueUrl, SqsSourceSettings.create().withWaitTimeSeconds(0), customSqsClient)
             .map(Message::body)
-            .runWith(Sink.head(), materializer);
+            .runWith(Sink.head(), system);
 
     assertEquals("alpakka", cs.toCompletableFuture().get(20, TimeUnit.SECONDS));
   }


### PR DESCRIPTION
References #2500﻿
