### PR TITLE
Elasticsearch: Make V7 the default version

### DIFF
--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -122,7 +122,7 @@ Java
 | bufferSize             | 10             | `ElasticsearchSource` retrieves messages from Elasticsearch by scroll scan. This buffer size is used as the scroll size. | 
 | includeDocumentVersion | false          | Tell Elasticsearch to return the documents `_version` property with the search results. See [Version](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html) and [Optimistic Concurrenct Control](https://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html) to know about this property. |
 | scrollDuration         | 5 min          | `ElasticsearchSource`  retrieves messages from Elasticsearch by scroll scan. This parameter is used as a scroll value. See [Time units](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units) for supported units.                |
-| apiVersion             | V5             | Currently supports `V5` and `V7` (see below) |
+| apiVersion             | V7             | Currently supports `V5` and `V7` (see below) |
 
 ### Sink and flow configuration
 
@@ -140,7 +140,7 @@ Java
 | bufferSize          | 10         | Flow and Sink batch messages to bulk requests when back-pressure applies.                              |
 | versionType         | None       | If set, `ElasticsearchSink` uses the chosen versionType to index documents. See [Version types](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types) for accepted settings. |
 | retryLogic          | No retries | See below |
-| apiVersion          | V5         | Currently supports `V5` and `V7` (see below) |
+| apiVersion          | V7         | Currently supports `V5` and `V7` (see below) |
 | allowExplicitIndex  | True       | When set to False, the index name will be included in the URL instead of on each document (see below) | 
 
 #### Retry logic

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSourceSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchSourceSettings.scala
@@ -77,7 +77,7 @@ object ElasticsearchSourceSettings {
                                     10,
                                     includeDocumentVersion = false,
                                     FiniteDuration(5, TimeUnit.MINUTES),
-                                    ApiVersion.V5)
+                                    ApiVersion.V7)
 
   /** Java API */
   def create(connection: ElasticsearchConnectionSettings): ElasticsearchSourceSettings =
@@ -85,5 +85,5 @@ object ElasticsearchSourceSettings {
                                     10,
                                     includeDocumentVersion = false,
                                     FiniteDuration(5, TimeUnit.MINUTES),
-                                    ApiVersion.V5)
+                                    ApiVersion.V7)
 }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchWriteSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchWriteSettings.scala
@@ -103,9 +103,9 @@ object ElasticsearchWriteSettings {
 
   /** Scala API */
   def apply(connection: ElasticsearchConnectionSettings): ElasticsearchWriteSettings =
-    new ElasticsearchWriteSettings(connection, 10, RetryNever, None, ApiVersion.V5, allowExplicitIndex = true)
+    new ElasticsearchWriteSettings(connection, 10, RetryNever, None, ApiVersion.V7, allowExplicitIndex = true)
 
   /** Java API */
   def create(connection: ElasticsearchConnectionSettings): ElasticsearchWriteSettings =
-    new ElasticsearchWriteSettings(connection, 10, RetryNever, None, ApiVersion.V5, allowExplicitIndex = true)
+    new ElasticsearchWriteSettings(connection, 10, RetryNever, None, ApiVersion.V7, allowExplicitIndex = true)
 }

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStageTest.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStageTest.scala
@@ -30,7 +30,7 @@ class ElasticsearchSimpleFlowStageTest
 
   val writer: StringMessageWriter = StringMessageWriter.getInstance
   val settings: ElasticsearchWriteSettings = ElasticsearchWriteSettings(
-    ElasticsearchConnectionSettings("http://localhost:9201")
+    ElasticsearchConnectionSettings("http://localhost:9202")
   )
   val dummyMessages: (immutable.Seq[WriteMessage[String, NotUsed]], immutable.Seq[WriteResult[String, NotUsed]]) = (
     immutable.Seq(
@@ -49,7 +49,7 @@ class ElasticsearchSimpleFlowStageTest
             .probe[(immutable.Seq[WriteMessage[String, NotUsed]], immutable.Seq[WriteResult[String, NotUsed]])]
             .via(
               new impl.ElasticsearchSimpleFlowStage[String, NotUsed](
-                ElasticsearchParams.V5("es-simple-flow-index", "_doc"),
+                ElasticsearchParams.V7("es-simple-flow-index"),
                 settings,
                 writer
               )


### PR DESCRIPTION
PR to change the default Elasticsearch version from V5 to V7. Change impacts the default used by both the `ElasticsearchSourceSettings` and `ElasticsearchWriteSettings`