### PR TITLE
Ftp 2541 incorrect credentials should complete with a failed future

### DIFF
--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
@@ -6,7 +6,6 @@ package akka.stream.alpakka.ftp
 package impl
 
 import akka.annotation.InternalApi
-import net.schmizz.sshj.userauth.UserAuthException
 import org.apache.commons.net.ftp.{FTP, FTPClient}
 
 import scala.util.Try
@@ -38,7 +37,7 @@ private[ftp] trait FtpOperations extends CommonFtpOperations { _: FtpLike[FTPCli
       connectionSettings.credentials.password
     )
     if (ftpClient.getReplyCode == 530) {
-      throw new UserAuthException(
+      throw new FtpAuthenticationException(
         s"unable to login to host=[${connectionSettings.host}], port=${connectionSettings.port} ${connectionSettings.proxy
           .fold("")("proxy=" + _.toString)}"
       )

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
@@ -6,7 +6,6 @@ package akka.stream.alpakka.ftp
 package impl
 
 import akka.annotation.InternalApi
-import javax.security.auth.login.FailedLoginException
 import net.schmizz.sshj.userauth.UserAuthException
 import org.apache.commons.net.ftp.{FTP, FTPClient}
 

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
@@ -6,6 +6,8 @@ package akka.stream.alpakka.ftp
 package impl
 
 import akka.annotation.InternalApi
+import javax.security.auth.login.FailedLoginException
+import net.schmizz.sshj.userauth.UserAuthException
 import org.apache.commons.net.ftp.{FTP, FTPClient}
 
 import scala.util.Try
@@ -36,6 +38,12 @@ private[ftp] trait FtpOperations extends CommonFtpOperations { _: FtpLike[FTPCli
       connectionSettings.credentials.username,
       connectionSettings.credentials.password
     )
+    if (ftpClient.getReplyCode == 530) {
+      throw new UserAuthException(
+        s"unable to login to host=[${connectionSettings.host}], port=${connectionSettings.port} ${connectionSettings.proxy
+          .fold("")("proxy=" + _.toString)}"
+      )
+    }
 
     if (connectionSettings.binary) {
       ftpClient.setFileType(FTP.BINARY_FILE_TYPE)

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
@@ -5,8 +5,7 @@
 package akka.stream.alpakka.ftp.impl
 
 import akka.annotation.InternalApi
-import akka.stream.alpakka.ftp.FtpsSettings
-import net.schmizz.sshj.userauth.UserAuthException
+import akka.stream.alpakka.ftp.{FtpAuthenticationException, FtpsSettings}
 import org.apache.commons.net.ftp.{FTP, FTPSClient}
 
 import scala.util.Try
@@ -31,7 +30,7 @@ private[ftp] trait FtpsOperations extends CommonFtpOperations {
         connectionSettings.credentials.password
       )
       if (ftpClient.getReplyCode == 530) {
-        throw new UserAuthException(
+        throw new FtpAuthenticationException(
           s"unable to login to host=[${connectionSettings.host}], port=${connectionSettings.port} ${connectionSettings.proxy
             .fold("")("proxy=" + _.toString)}"
         )

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.ftp.impl
 
 import akka.annotation.InternalApi
 import akka.stream.alpakka.ftp.FtpsSettings
-import javax.security.auth.login.FailedLoginException
+import net.schmizz.sshj.userauth.UserAuthException
 import org.apache.commons.net.ftp.{FTP, FTPSClient}
 
 import scala.util.Try
@@ -31,7 +31,7 @@ private[ftp] trait FtpsOperations extends CommonFtpOperations {
         connectionSettings.credentials.password
       )
       if (ftpClient.getReplyCode == 530) {
-        throw new FailedLoginException(
+        throw new UserAuthException(
           s"unable to login to host=[${connectionSettings.host}], port=${connectionSettings.port} ${connectionSettings.proxy
             .fold("")("proxy=" + _.toString)}"
         )

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -37,7 +37,7 @@ final case class FtpFile(
  * Common remote file settings.
  */
 @DoNotInherit
-sealed abstract class RemoteFileSettings {
+abstract sealed class RemoteFileSettings {
   def host: InetAddress
   def port: Int
   def credentials: FtpCredentials
@@ -47,7 +47,7 @@ sealed abstract class RemoteFileSettings {
  * Common settings for FTP and FTPs.
  */
 @DoNotInherit
-sealed abstract class FtpFileSettings extends RemoteFileSettings {
+abstract sealed class FtpFileSettings extends RemoteFileSettings {
   def binary: Boolean // BINARY or ASCII (default)
   def passiveMode: Boolean
 }
@@ -78,7 +78,8 @@ final class FtpSettings private (
   def withPort(value: Int): FtpSettings = copy(port = value)
   def withCredentials(value: FtpCredentials): FtpSettings = copy(credentials = value)
   def withBinary(value: Boolean): FtpSettings = if (binary == value) this else copy(binary = value)
-  def withPassiveMode(value: Boolean): FtpSettings = if (passiveMode == value) this else copy(passiveMode = value)
+  def withPassiveMode(value: Boolean): FtpSettings =
+    if (passiveMode == value) this else copy(passiveMode = value)
   def withProxy(value: Proxy): FtpSettings = copy(proxy = Some(value))
 
   /**
@@ -92,7 +93,9 @@ final class FtpSettings private (
    * Java API:
    * Sets the configure connection callback.
    */
-  def withConfigureConnectionConsumer(configureConnection: java.util.function.Consumer[FTPClient]): FtpSettings =
+  def withConfigureConnectionConsumer(
+      configureConnection: java.util.function.Consumer[FTPClient]
+  ): FtpSettings =
     copy(configureConnection = configureConnection.accept)
 
   private def copy(
@@ -133,9 +136,7 @@ object FtpSettings {
   final val DefaultFtpPort = 21
 
   /** Scala API */
-  def apply(
-      host: java.net.InetAddress
-  ): FtpSettings = new FtpSettings(
+  def apply(host: java.net.InetAddress): FtpSettings = new FtpSettings(
     host,
     port = DefaultFtpPort,
     credentials = FtpCredentials.AnonFtpCredentials,
@@ -146,9 +147,7 @@ object FtpSettings {
   )
 
   /** Java API */
-  def create(
-      host: java.net.InetAddress
-  ): FtpSettings = apply(
+  def create(host: java.net.InetAddress): FtpSettings = apply(
     host
   )
 }
@@ -179,20 +178,24 @@ final class FtpsSettings private (
   def withPort(value: Int): FtpsSettings = copy(port = value)
   def withCredentials(value: FtpCredentials): FtpsSettings = copy(credentials = value)
   def withBinary(value: Boolean): FtpsSettings = if (binary == value) this else copy(binary = value)
-  def withPassiveMode(value: Boolean): FtpsSettings = if (passiveMode == value) this else copy(passiveMode = value)
+  def withPassiveMode(value: Boolean): FtpsSettings =
+    if (passiveMode == value) this else copy(passiveMode = value)
   def withProxy(value: Proxy): FtpsSettings = copy(proxy = Some(value))
 
   /**
    * Scala API:
    * Sets the configure connection callback.
    */
-  def withConfigureConnection(value: FTPSClient => Unit): FtpsSettings = copy(configureConnection = value)
+  def withConfigureConnection(value: FTPSClient => Unit): FtpsSettings =
+    copy(configureConnection = value)
 
   /**
    * Java API:
    * Sets the configure connection callback.
    */
-  def withConfigureConnectionConsumer(configureConnection: java.util.function.Consumer[FTPSClient]): FtpsSettings =
+  def withConfigureConnectionConsumer(
+      configureConnection: java.util.function.Consumer[FTPSClient]
+  ): FtpsSettings =
     copy(configureConnection = configureConnection.accept)
 
   private def copy(
@@ -233,9 +236,7 @@ object FtpsSettings {
   final val DefaultFtpsPort = 2222
 
   /** Scala API */
-  def apply(
-      host: java.net.InetAddress
-  ): FtpsSettings = new FtpsSettings(
+  def apply(host: java.net.InetAddress): FtpsSettings = new FtpsSettings(
     host,
     DefaultFtpsPort,
     FtpCredentials.AnonFtpCredentials,
@@ -246,9 +247,7 @@ object FtpsSettings {
   )
 
   /** Java API */
-  def create(
-      host: java.net.InetAddress
-  ): FtpsSettings = apply(
+  def create(host: java.net.InetAddress): FtpsSettings = apply(
     host
   )
 }
@@ -321,9 +320,7 @@ object SftpSettings {
   final val DefaultSftpPort = 22
 
   /** Scala API */
-  def apply(
-      host: java.net.InetAddress
-  ): SftpSettings = new SftpSettings(
+  def apply(host: java.net.InetAddress): SftpSettings = new SftpSettings(
     host,
     DefaultSftpPort,
     FtpCredentials.AnonFtpCredentials,
@@ -334,9 +331,7 @@ object SftpSettings {
   )
 
   /** Java API */
-  def create(
-      host: java.net.InetAddress
-  ): SftpSettings = apply(
+  def create(host: java.net.InetAddress): SftpSettings = apply(
     host
   )
 }
@@ -344,7 +339,7 @@ object SftpSettings {
 /**
  * FTP credentials
  */
-sealed abstract class FtpCredentials {
+abstract sealed class FtpCredentials {
   def username: String
   def password: String
 }
@@ -373,9 +368,12 @@ object FtpCredentials {
    * @param username the username
    * @param password the password
    */
-  final class NonAnonFtpCredentials @InternalApi private[FtpCredentials] (val username: String, val password: String)
-      extends FtpCredentials {
-    override def toString = s"FtpCredentials(username=$username,password.nonEmpty=${password.nonEmpty})"
+  final class NonAnonFtpCredentials @InternalApi private[FtpCredentials] (
+      val username: String,
+      val password: String
+  ) extends FtpCredentials {
+    override def toString =
+      s"FtpCredentials(username=$username,password.nonEmpty=${password.nonEmpty})"
   }
 
   /** Create username/password credentials. */
@@ -386,7 +384,7 @@ object FtpCredentials {
 /**
  * SFTP identity details
  */
-sealed abstract class SftpIdentity {
+abstract sealed class SftpIdentity {
   type KeyType
   val privateKey: KeyType
   val privateKeyFilePassphrase: Option[Array[Byte]]
@@ -411,7 +409,10 @@ object SftpIdentity {
    * @param privateKey private key value to use when connecting
    * @param privateKeyFilePassphrase password to use to decrypt private key
    */
-  def createRawSftpIdentity(privateKey: Array[Byte], privateKeyFilePassphrase: Array[Byte]): RawKeySftpIdentity =
+  def createRawSftpIdentity(
+      privateKey: Array[Byte],
+      privateKeyFilePassphrase: Array[Byte]
+  ): RawKeySftpIdentity =
     new RawKeySftpIdentity(privateKey, Some(privateKeyFilePassphrase))
 
   /**
@@ -442,7 +443,10 @@ object SftpIdentity {
    * @param privateKey private key file to use when connecting
    * @param privateKeyFilePassphrase password to use to decrypt private key file
    */
-  def createFileSftpIdentity(privateKey: String, privateKeyFilePassphrase: Array[Byte]): KeyFileSftpIdentity =
+  def createFileSftpIdentity(
+      privateKey: String,
+      privateKeyFilePassphrase: Array[Byte]
+  ): KeyFileSftpIdentity =
     new KeyFileSftpIdentity(privateKey, Some(privateKeyFilePassphrase))
 }
 
@@ -511,3 +515,5 @@ final class KeyFileSftpIdentity @InternalApi private[ftp] (
   )
 
 }
+
+final class FtpAuthenticationException(msg: String) extends IllegalArgumentException(msg)

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/BaseFtpSupport.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/BaseFtpSupport.java
@@ -12,7 +12,6 @@ public class BaseFtpSupport extends BaseSupportImpl {
   private final Path ROOT_DIR = Paths.get("tmp/home");
   public final String HOSTNAME = "localhost";
   public final int PORT = 21000;
-  public final FtpCredentials CREDENTIALS = FtpCredentials.create("username", "userpass");
 
   @Override
   public Path getRootDir() {

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/BaseSftpSupport.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/BaseSftpSupport.java
@@ -14,7 +14,6 @@ public class BaseSftpSupport extends BaseSupportImpl {
   private final Path ROOT_DIR = Paths.get("tmp/home");
   final String HOSTNAME = "localhost";
   final int PORT = 2222;
-  final FtpCredentials CREDENTIALS = FtpCredentials.create("username", "userpass");
   // Issue: the root folder of the sftp server is not writable so tests must happen inside a
   // sub-folder
   final String ROOT_PATH = "upload/";

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/BaseSupportImpl.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/BaseSupportImpl.java
@@ -18,6 +18,8 @@ public abstract class BaseSupportImpl implements BaseSupport, AkkaSupport {
 
   private ActorSystem system = ActorSystem.create("alpakka-ftp");
   private Materializer materializer = ActorMaterializer.create(system);
+  public final FtpCredentials CREDENTIALS = FtpCredentials.create("username", "userpass");
+  public final FtpCredentials WRONG_CREDENTIALS = FtpCredentials.create("username", "qwerty");
 
   private String loremIpsum =
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent auctor imperdiet "

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
@@ -15,25 +15,40 @@ import java.net.InetAddress
 
 trait BaseFtpSpec extends BaseFtpSupport with BaseSpec {
 
-  val settings = FtpSettings(
-    InetAddress.getByName(HOSTNAME)
-  ).withPort(PORT)
-    .withCredentials(CREDENTIALS)
-    .withBinary(true)
-    .withPassiveMode(true)
+  private def createSettings(credentials: FtpCredentials): FtpSettings =
+    FtpSettings(
+      InetAddress.getByName(HOSTNAME)
+    ).withPort(PORT)
+      .withCredentials(credentials)
+      .withBinary(true)
+      .withPassiveMode(true)
+
+  val settings = createSettings(CREDENTIALS)
+  val wrongSettings = createSettings(WRONG_CREDENTIALS)
+
+  protected def listFilesWithWrongCredentials(basePath: String): Source[FtpFile, NotUsed] =
+    Ftp.ls(basePath, wrongSettings)
 
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =
     Ftp.ls(basePath, settings)
 
-  protected def listFilesWithFilter(basePath: String,
-                                    branchSelector: FtpFile => Boolean,
-                                    emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed] =
+  protected def listFilesWithFilter(
+      basePath: String,
+      branchSelector: FtpFile => Boolean,
+      emitTraversedDirectories: Boolean = false
+  ): Source[FtpFile, NotUsed] =
     Ftp.ls(basePath, settings, branchSelector, emitTraversedDirectories)
 
-  protected def retrieveFromPath(path: String, fromRoot: Boolean = false): Source[ByteString, Future[IOResult]] =
+  protected def retrieveFromPath(
+      path: String,
+      fromRoot: Boolean = false
+  ): Source[ByteString, Future[IOResult]] =
     Ftp.fromPath(path, settings)
 
-  protected def retrieveFromPathWithOffset(path: String, offset: Long): Source[ByteString, Future[IOResult]] =
+  protected def retrieveFromPathWithOffset(
+      path: String,
+      offset: Long
+  ): Source[ByteString, Future[IOResult]] =
     Ftp.fromPath(path, settings, 8192, offset)
 
   protected def storeToPath(path: String, append: Boolean): Sink[ByteString, Future[IOResult]] =

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
@@ -15,25 +15,40 @@ import scala.concurrent.Future
 
 trait BaseFtpsSpec extends BaseFtpSupport with BaseSpec {
 
-  val settings = FtpsSettings(
-    InetAddress.getByName(HOSTNAME)
-  ).withPort(PORT)
-    .withCredentials(CREDENTIALS)
-    .withBinary(true)
-    .withPassiveMode(true)
+  private def createSettings(credentials: FtpCredentials): FtpsSettings =
+    FtpsSettings(
+      InetAddress.getByName(HOSTNAME)
+    ).withPort(PORT)
+      .withCredentials(credentials)
+      .withBinary(true)
+      .withPassiveMode(true)
+
+  val settings = createSettings(CREDENTIALS)
+  val wrongSettings = createSettings(WRONG_CREDENTIALS)
+
+  protected def listFilesWithWrongCredentials(basePath: String): Source[FtpFile, NotUsed] =
+    Ftps.ls(basePath, wrongSettings)
 
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =
     Ftps.ls(basePath, settings)
 
-  protected def listFilesWithFilter(basePath: String,
-                                    branchSelector: FtpFile => Boolean,
-                                    emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
+  protected def listFilesWithFilter(
+      basePath: String,
+      branchSelector: FtpFile => Boolean,
+      emitTraversedDirectories: Boolean
+  ): Source[FtpFile, NotUsed] =
     Ftps.ls(basePath, settings, branchSelector, emitTraversedDirectories)
 
-  protected def retrieveFromPath(path: String, fromRoot: Boolean = false): Source[ByteString, Future[IOResult]] =
+  protected def retrieveFromPath(
+      path: String,
+      fromRoot: Boolean = false
+  ): Source[ByteString, Future[IOResult]] =
     Ftps.fromPath(path, settings)
 
-  protected def retrieveFromPathWithOffset(path: String, offset: Long): Source[ByteString, Future[IOResult]] =
+  protected def retrieveFromPathWithOffset(
+      path: String,
+      offset: Long
+  ): Source[ByteString, Future[IOResult]] =
     Ftps.fromPath(path, settings, 8192, offset)
 
   protected def storeToPath(path: String, append: Boolean): Sink[ByteString, Future[IOResult]] =

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
@@ -15,26 +15,41 @@ import scala.concurrent.Future
 
 trait BaseSftpSpec extends BaseSftpSupport with BaseSpec {
 
-  val settings = SftpSettings(
-    InetAddress.getByName(HOSTNAME)
-  ).withPort(PORT)
-    .withCredentials(CREDENTIALS)
-    .withStrictHostKeyChecking(false)
+  private def createSettings(credentials: FtpCredentials): SftpSettings =
+    SftpSettings(
+      InetAddress.getByName(HOSTNAME)
+    ).withPort(PORT)
+      .withCredentials(credentials)
+      .withStrictHostKeyChecking(false)
+
+  val settings = createSettings(CREDENTIALS)
+  val wrongSettings = createSettings(WRONG_CREDENTIALS)
+
+  protected def listFilesWithWrongCredentials(basePath: String): Source[FtpFile, NotUsed] =
+    Sftp.ls(ROOT_PATH + basePath, wrongSettings)
 
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed] =
     Sftp.ls(ROOT_PATH + basePath, settings)
 
-  protected def listFilesWithFilter(basePath: String,
-                                    branchSelector: FtpFile => Boolean,
-                                    emitTraversedDirectories: Boolean): Source[FtpFile, NotUsed] =
+  protected def listFilesWithFilter(
+      basePath: String,
+      branchSelector: FtpFile => Boolean,
+      emitTraversedDirectories: Boolean
+  ): Source[FtpFile, NotUsed] =
     Sftp.ls(ROOT_PATH + basePath, settings, branchSelector, emitTraversedDirectories)
 
-  protected def retrieveFromPath(path: String, fromRoot: Boolean = false): Source[ByteString, Future[IOResult]] = {
+  protected def retrieveFromPath(
+      path: String,
+      fromRoot: Boolean = false
+  ): Source[ByteString, Future[IOResult]] = {
     val finalPath = if (fromRoot) path else ROOT_PATH + path
     Sftp.fromPath(finalPath, settings)
   }
 
-  protected def retrieveFromPathWithOffset(path: String, offset: Long): Source[ByteString, Future[IOResult]] =
+  protected def retrieveFromPathWithOffset(
+      path: String,
+      offset: Long
+  ): Source[ByteString, Future[IOResult]] =
     Sftp.fromPath(ROOT_PATH + path, settings, 8192, offset)
 
   protected def storeToPath(path: String, append: Boolean): Sink[ByteString, Future[IOResult]] =

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
@@ -30,15 +30,25 @@ trait BaseSpec
     with BaseSupport
     with LogCapturing { this: TestSuite =>
 
+  protected def listFilesWithWrongCredentials(basePath: String): Source[FtpFile, NotUsed]
+
   protected def listFiles(basePath: String): Source[FtpFile, NotUsed]
 
-  protected def listFilesWithFilter(basePath: String,
-                                    branchSelector: FtpFile => Boolean,
-                                    emitTraversedDirectories: Boolean = false): Source[FtpFile, NotUsed]
+  protected def listFilesWithFilter(
+      basePath: String,
+      branchSelector: FtpFile => Boolean,
+      emitTraversedDirectories: Boolean = false
+  ): Source[FtpFile, NotUsed]
 
-  protected def retrieveFromPath(path: String, fromRoot: Boolean = false): Source[ByteString, Future[IOResult]]
+  protected def retrieveFromPath(
+      path: String,
+      fromRoot: Boolean = false
+  ): Source[ByteString, Future[IOResult]]
 
-  protected def retrieveFromPathWithOffset(path: String, offset: Long): Source[ByteString, Future[IOResult]]
+  protected def retrieveFromPathWithOffset(
+      path: String,
+      offset: Long
+  ): Source[ByteString, Future[IOResult]]
 
   protected def storeToPath(path: String, append: Boolean): Sink[ByteString, Future[IOResult]]
 
@@ -60,7 +70,7 @@ trait BaseSpec
   // Allows to run tests n times in a row with a command line argument, useful for debugging sporadic failures
   // e.g. ftp/testOnly *.FtpsStageSpec -- -Dtimes=20
   // https://gist.github.com/dwickern/6ba9c5c505d2325d3737ace059302922
-  protected abstract override def runTest(testName: String, args: Args): Status = {
+  override abstract protected def runTest(testName: String, args: Args): Status = {
     def run0(times: Int): Status = {
       val status = super.runTest(testName, args)
       if (times <= 1) status else status.thenRun(run0(times - 1))

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -17,7 +17,6 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
 import akka.util.ByteString
-import net.schmizz.sshj.userauth.UserAuthException
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Seconds, Span}
 
@@ -85,7 +84,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
         .run()
         .failed
         .map { ex =>
-          ex shouldBe a[UserAuthException]
+          ex shouldBe a[FtpAuthenticationException]
         }
     }
 

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -17,6 +17,8 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
 import akka.util.ByteString
+import javax.security.auth.login.FailedLoginException
+import org.scalatest.Succeeded
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Seconds, Span}
 
@@ -51,7 +53,8 @@ final class KeyFileSftpSourceSpec extends BaseSftpSpec with CommonFtpStageSpec {
     .withCredentials(FtpCredentials.create("username", "wrong password"))
     .withStrictHostKeyChecking(false)
     .withSftpIdentity(
-      SftpIdentity.createFileSftpIdentity(getClientPrivateKeyFile.getPath, ClientPrivateKeyPassphrase)
+      SftpIdentity
+        .createFileSftpIdentity(getClientPrivateKeyFile.getPath, ClientPrivateKeyPassphrase)
     )
 }
 
@@ -63,7 +66,8 @@ final class StrictHostCheckingSftpSourceSpec extends BaseSftpSpec with CommonFtp
     .withStrictHostKeyChecking(true)
     .withKnownHosts(getKnownHostsFile.getPath)
     .withSftpIdentity(
-      SftpIdentity.createFileSftpIdentity(getClientPrivateKeyFile.getPath, ClientPrivateKeyPassphrase)
+      SftpIdentity
+        .createFileSftpIdentity(getClientPrivateKeyFile.getPath, ClientPrivateKeyPassphrase)
     )
 }
 
@@ -75,6 +79,15 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
     PatienceConfig(timeout = Span(30, Seconds), interval = Span(600, Millis))
 
   "FtpBrowserSource" should {
+    "complete with a failed Future, when the credentials supplied were wrong" in {
+      an[Exception] should be thrownBy {
+        listFilesWithWrongCredentials("")
+          .toMat(Sink.seq)(Keep.right)
+          .run()
+          .futureValue
+      }
+    }
+
     "list all files from root" in assertAllStagesStopped {
       val basePath = ""
       generateFiles(30, 10, basePath)
@@ -107,7 +120,9 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
       val basePath = "/foo"
       generateFiles(30, 10, basePath)
       val probe =
-        listFilesWithFilter(basePath, f => f.name.contains("1")).toMat(TestSink.probe)(Keep.right).run()
+        listFilesWithFilter(basePath, f => f.name.contains("1"))
+          .toMat(TestSink.probe)(Keep.right)
+          .run()
       probe.request(40).expectNextN(21) // 9 files in root, 2 directories, 10 files in dir_1
       probe.expectComplete()
 
@@ -196,7 +211,8 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
       val offset = 1000010L
       Random.nextBytes(fileContents)
       putFileOnFtpWithContents(fileName, fileContents)
-      val (result, probe) = retrieveFromPathWithOffset(s"/$fileName", offset).toMat(TestSink.probe)(Keep.both).run()
+      val (result, probe) =
+        retrieveFromPathWithOffset(s"/$fileName", offset).toMat(TestSink.probe)(Keep.both).run()
       probe.request(1000).expectNextOrComplete()
 
       val expectedNumOfBytes = fileContents.length - offset
@@ -229,7 +245,10 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
         val fileName = "sample_io_" + Instant.now().getNano
         List(true, false).foreach { mode =>
           val result =
-            Source.single(ByteString(getDefaultContent)).runWith(storeToPath(s"/$fileName", mode)).futureValue
+            Source
+              .single(ByteString(getDefaultContent))
+              .runWith(storeToPath(s"/$fileName", mode))
+              .futureValue
 
           val expectedNumOfBytes = getDefaultContent.getBytes().length
           result shouldBe IOResult.createSuccessful(expectedNumOfBytes)
@@ -252,7 +271,10 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
         putFileOnFtp(fileName)
 
         val result =
-          Source.single(ByteString(reversedLoremIpsum)).runWith(storeToPath(s"/$fileName", append = false)).futureValue
+          Source
+            .single(ByteString(reversedLoremIpsum))
+            .runWith(storeToPath(s"/$fileName", append = false))
+            .futureValue
 
         result shouldBe IOResult.createSuccessful(expectedNumOfBytes)
 
@@ -268,7 +290,10 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
         putFileOnFtp(fileName)
 
         val result =
-          Source.single(ByteString(reversedLoremIpsum)).runWith(storeToPath(s"/$fileName", append = true)).futureValue
+          Source
+            .single(ByteString(reversedLoremIpsum))
+            .runWith(storeToPath(s"/$fileName", append = true))
+            .futureValue
 
         result shouldBe IOResult.createSuccessful(expectedNumOfBytes)
 
@@ -432,8 +457,11 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
 
       Await.result(res, Duration(1, TimeUnit.MINUTES))
 
-      val listing = listFilesWithFilter(basePath = "/", branchSelector = _ => true, emitTraversedDirectories = true)
-        .runWith(Sink.seq)
+      val listing = listFilesWithFilter(
+        basePath = "/",
+        branchSelector = _ => true,
+        emitTraversedDirectories = true
+      ).runWith(Sink.seq)
 
       val listingRes: immutable.Seq[FtpFile] = Await.result(listing, Duration(1, TimeUnit.MINUTES))
 
@@ -458,18 +486,24 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
 
       Await.result(res, Duration(1, TimeUnit.MINUTES))
 
-      val listing = listFilesWithFilter(basePath = "/", branchSelector = _ => true, emitTraversedDirectories = true)
-        .runWith(Sink.seq)
+      val listing = listFilesWithFilter(
+        basePath = "/",
+        branchSelector = _ => true,
+        emitTraversedDirectories = true
+      ).runWith(Sink.seq)
 
       val listingRes: immutable.Seq[FtpFile] = Await.result(listing, Duration(1, TimeUnit.MINUTES))
 
       listingRes.map(_.name) should contain allElementsOf Seq(name)
 
-      val listingOnlyInnerDir = listFilesWithFilter(basePath = innerDirPath,
-                                                    branchSelector = _ => true,
-                                                    emitTraversedDirectories = true).runWith(Sink.seq)
+      val listingOnlyInnerDir = listFilesWithFilter(
+        basePath = innerDirPath,
+        branchSelector = _ => true,
+        emitTraversedDirectories = true
+      ).runWith(Sink.seq)
 
-      val listingInnerDirRes: immutable.Seq[FtpFile] = Await.result(listingOnlyInnerDir, Duration(1, TimeUnit.MINUTES))
+      val listingInnerDirRes: immutable.Seq[FtpFile] =
+        Await.result(listingOnlyInnerDir, Duration(1, TimeUnit.MINUTES))
 
       listingInnerDirRes.map(_.name) should contain allElementsOf Seq(innerDirName)
 


### PR DESCRIPTION
This PR addresses issue https://github.com/akka/alpakka/issues/2541: when wrong credentials are being used to connect to a FTP server, the materialized Future will be completed with a failure containing a `UserAuthException`.

While `UserAuthException` belongs to `sshj` project, thus not really 100% appropriate for `FtpsOperations` and `FtpOperations` (it's only thrown by `SftpOperations`), I believe it looks more consistent from an user perspective rather than throwing for example a `javax.security.auth.login.FailedLoginException` for the Ftp/Ftps cases and a `UserAuthException` in case of `Sftp`.