### PR TITLE
jms-testkit 0.4.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -302,7 +302,7 @@ object Dependencies {
         "com.ibm.mq" % "com.ibm.mq.allclient" % "9.2.0.0" % Test, // IBM International Program License Agreement https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/maven/licenses/L-APIG-AZYF2E/LI_en.html
         "org.apache.activemq" % "activemq-broker" % "5.16.0" % Test, // ApacheV2
         "org.apache.activemq" % "activemq-client" % "5.16.0" % Test, // ApacheV2
-        "io.github.sullis" %% "jms-testkit" % "0.2.8" % Test // ApacheV2
+        "io.github.sullis" %% "jms-testkit" % "0.4.1" % Test // ApacheV2
       ) ++ Mockito,
     // Having JBoss as a first resolver is a workaround for https://github.com/coursier/coursier/issues/200
     externalResolvers := ("jboss" at "https://repository.jboss.org/nexus/content/groups/public") +: externalResolvers.value


### PR DESCRIPTION
This version of jms-testkit has been cross-compiled
for Scala 2.11, Scala 2,12, Scala 2.13, and Scala 3.0.0-M3

https://github.com/sullis/jms-testkit/commits/master


<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->

