### PR TITLE
GCS: Allow adding custom metadata for resumable uploads

### DIFF
--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/javadsl/GCStorage.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/javadsl/GCStorage.scala
@@ -16,6 +16,7 @@ import akka.stream.{Attributes, Materializer}
 import akka.util.ByteString
 import akka.{Done, NotUsed}
 
+import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 
@@ -232,6 +233,38 @@ object GCStorage {
                    data: Source[ByteString, _],
                    contentType: ContentType): Source[StorageObject, NotUsed] =
     GCStorageStream.putObject(bucket, objectName, data.asScala, contentType.asInstanceOf[ScalaContentType]).asJava
+
+  /**
+   * Uploads object by making multiple requests
+   *
+   * @see https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload
+   *
+   * @param bucket the bucket name
+   * @param objectName the object name
+   * @param contentType `ContentType`
+   * @param chunkSize the size of the request sent to google cloud storage in bytes, must be a multiple of 256KB
+   * @param metadata custom metadata for the object
+   * @return a `Sink` that accepts `ByteString`'s and materializes to a `Future` of `StorageObject`
+   */
+  def resumableUpload(bucket: String,
+                      objectName: String,
+                      contentType: ContentType,
+                      chunkSize: java.lang.Integer,
+                      metadata: java.util.Map[String, String]): Sink[ByteString, CompletionStage[StorageObject]] = {
+    assert(
+      (chunkSize >= (256 * 1024)) && (chunkSize % (256 * 1024) == 0),
+      "Chunk size must be a multiple of 256KB"
+    )
+
+    GCStorageStream
+      .resumableUpload(bucket,
+                       objectName,
+                       contentType.asInstanceOf[ScalaContentType],
+                       chunkSize,
+                       Some(metadata.asScala.toMap))
+      .asJava
+      .mapMaterializedValue(func(_.toJava))
+  }
 
   /**
    * Uploads object by making multiple requests

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/scaladsl/GCStorage.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/scaladsl/GCStorage.scala
@@ -226,13 +226,8 @@ object GCStorage {
                       objectName: String,
                       contentType: ContentType,
                       chunkSize: Int,
-                      metadata: Map[String, String]): Sink[ByteString, Future[StorageObject]] = {
-    assert(
-      (chunkSize >= (256 * 1024)) && (chunkSize % (256 * 1024) == 0),
-      "Chunk size must be a multiple of 256KB"
-    )
-    GCStorageStream.resumableUpload(bucket, objectName, contentType, chunkSize, Some(metadata))
-  }
+                      metadata: Map[String, String]): Sink[ByteString, Future[StorageObject]] =
+    resumableUpload(bucket, objectName, contentType, chunkSize, Some(metadata))
 
   /**
    * Uploads object by making multiple requests
@@ -248,12 +243,19 @@ object GCStorage {
   def resumableUpload(bucket: String,
                       objectName: String,
                       contentType: ContentType,
-                      chunkSize: Int): Sink[ByteString, Future[StorageObject]] = {
+                      chunkSize: Int): Sink[ByteString, Future[StorageObject]] =
+    resumableUpload(bucket, objectName, contentType, chunkSize, metadata = None)
+
+  private def resumableUpload(bucket: String,
+                              objectName: String,
+                              contentType: ContentType,
+                              chunkSize: Int,
+                              metadata: Option[Map[String, String]]): Sink[ByteString, Future[StorageObject]] = {
     assert(
       (chunkSize >= (256 * 1024)) && (chunkSize % (256 * 1024) == 0),
       "Chunk size must be a multiple of 256KB"
     )
-    GCStorageStream.resumableUpload(bucket, objectName, contentType, chunkSize)
+    GCStorageStream.resumableUpload(bucket, objectName, contentType, chunkSize, metadata)
   }
 
   /**

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/scaladsl/GCStorage.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/scaladsl/GCStorage.scala
@@ -219,6 +219,30 @@ object GCStorage {
    * @param objectName the object name
    * @param contentType `ContentType`
    * @param chunkSize the size of the request sent to google cloud storage in bytes, must be a multiple of 256KB
+   * @param metadata custom metadata for the object
+   * @return a `Sink` that accepts `ByteString`'s and materializes to a `Future` of `StorageObject`
+   */
+  def resumableUpload(bucket: String,
+                      objectName: String,
+                      contentType: ContentType,
+                      chunkSize: Int,
+                      metadata: Map[String, String]): Sink[ByteString, Future[StorageObject]] = {
+    assert(
+      (chunkSize >= (256 * 1024)) && (chunkSize % (256 * 1024) == 0),
+      "Chunk size must be a multiple of 256KB"
+    )
+    GCStorageStream.resumableUpload(bucket, objectName, contentType, chunkSize, Some(metadata))
+  }
+
+  /**
+   * Uploads object by making multiple requests
+   *
+   * @see https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload
+   *
+   * @param bucket the bucket name
+   * @param objectName the object name
+   * @param contentType `ContentType`
+   * @param chunkSize the size of the request sent to google cloud storage in bytes, must be a multiple of 256KB
    * @return a `Sink` that accepts `ByteString`'s and materializes to a `Future` of `StorageObject`
    */
   def resumableUpload(bucket: String,

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
@@ -236,8 +236,10 @@ class GCStorageStreamIntegrationSpec
 
     "provide a sink to stream data to gcs" ignore {
       val fileName = testFileName("big-streaming-file")
+      val meta = Map("meta-key-1" -> "value-1")
+
       val sink =
-        GCStorageStream.resumableUpload(bucket, fileName, ContentTypes.`text/plain(UTF-8)`, 4 * 256 * 1024)
+        GCStorageStream.resumableUpload(bucket, fileName, ContentTypes.`text/plain(UTF-8)`, 4 * 256 * 1024, Some(meta))
 
       val res = Source
         .fromIterator(
@@ -251,6 +253,7 @@ class GCStorageStreamIntegrationSpec
       val so = res.futureValue
       so.name shouldBe fileName
       so.size shouldBe 12345670
+      so.metadata shouldBe Some(meta)
     }
 
     "rewrite file from source to destination path" ignore {

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/scaladsl/GCStorageWiremockBase.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/scaladsl/GCStorageWiremockBase.scala
@@ -14,6 +14,8 @@ import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, matching, url
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.github.tomakehurst.wiremock.stubbing.Scenario
 import com.typesafe.config.ConfigFactory
+import spray.json.DefaultJsonProtocol.{mapFormat, StringJsonFormat}
+import spray.json.enrichAny
 
 import scala.util.Random
 
@@ -33,8 +35,10 @@ abstract class GCStorageWiremockBase(_system: ActorSystem, _wireMockServer: Wire
   val fileName = "file1.txt"
   val generation = 1543055053992769L
 
-  def storageObjectJson(generation: Long = 1543055053992768L,
-                        metadata: (String, String) = "countryOfOrigin" -> "United Kingdom"): String =
+  def storageObjectJson(
+      generation: Long = 1543055053992768L,
+      metadata: Map[String, String] = Map("countryOfOrigin" -> "United Kingdom")
+  ): String =
     s"""
        |{
        |  "etag":"CMDm8oLo7N4CEAE=",
@@ -65,7 +69,7 @@ abstract class GCStorageWiremockBase(_system: ActorSystem, _wireMockServer: Wire
        |  "componentCount": 2,
        |  "customTime": "2020-09-17T11:09:21.039Z",
        |  "kmsKeyName": "projects/my-gcs-project/keys",
-       |  "metadata": {"${metadata._1}": "${metadata._2}"},
+       |  "metadata": ${metadata.toJson.compactPrint},
        |  "customerEncryption": {"encryptionAlgorithm": "AES256", "keySha256": "encryption-key-sha256"},
        |  "owner": {"entity": "project-owners-123412341234", "entityId": "790607247"},
        |  "acl": [{ "kind": "storage#objectAccessControl", "id": "my-bucket/test-acl/1463505795940000", "selfLink": "https://www.googleapis.com/storage/v1/b/my-bucket/o/test-acl", "bucket": "my-bucket", "object": "test-acl", "generation": "1463505795940000", "entity": "some-entity", "role": "OWNER", "email": "owner@google.com", "entityId": "790607247", "domain": "my-domain", "projectTeam": { "projectNumber": "57959400", "team": "management" }, "etag": "R2OZrfQiij=" }]
@@ -718,7 +722,7 @@ abstract class GCStorageWiremockBase(_system: ActorSystem, _wireMockServer: Wire
   def mockLargeFileUpload(firstChunkContent: String,
                           secondChunkContent: String,
                           chunkSize: Int,
-                          metadata: Option[(String, String)]): Unit = {
+                          metadata: Option[Map[String, String]] = None): Unit = {
     val uploadId = "uploadId"
 
     val noMeta =
@@ -736,12 +740,11 @@ abstract class GCStorageWiremockBase(_system: ActorSystem, _wireMockServer: Wire
             .withStatus(200)
         )
     mock.register(
-      metadata.fold(noMeta) {
-        case (key, value) =>
-          val metaString = s"""{"$key":"$value"}"""
-          noMeta
-            .withRequestBody(WireMock.equalTo(metaString))
-            .withHeader("Content-Length", WireMock.equalTo(metaString.length.toString))
+      metadata.fold(noMeta) { m =>
+        val metaString = m.toJson.compactPrint
+        noMeta
+          .withRequestBody(WireMock.equalTo(metaString))
+          .withHeader("Content-Length", WireMock.equalTo(metaString.length.toString))
       }
     )
 

--- a/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSinkSpec.scala
+++ b/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSinkSpec.scala
@@ -42,12 +42,15 @@ class GCStorageSinkSpec
     val chunkSize = 256 * 1024
     val firstChunkContent = Random.alphanumeric.take(chunkSize).mkString
     val secondChunkContent = Random.alphanumeric.take(chunkSize).mkString
+    val metaKey = Random.alphanumeric.take(5).mkString
+    val metaValue = Random.alphanumeric.take(5).mkString
+    val metadata = Map(metaKey -> metaValue)
 
-    mockLargeFileUpload(firstChunkContent, secondChunkContent, chunkSize)
+    mockLargeFileUpload(firstChunkContent, secondChunkContent, chunkSize, Some(metaKey -> metaValue))
 
     //#upload
     val sink =
-      GCStorage.resumableUpload(bucketName, fileName, ContentTypes.`text/plain(UTF-8)`, chunkSize)
+      GCStorage.resumableUpload(bucketName, fileName, ContentTypes.`text/plain(UTF-8)`, chunkSize, metadata)
 
     val source = Source(
       List(ByteString(firstChunkContent), ByteString(secondChunkContent))
@@ -61,6 +64,7 @@ class GCStorageSinkSpec
 
     storageObject.name shouldBe fileName
     storageObject.bucket shouldBe bucketName
+    storageObject.metadata shouldBe Some(metadata)
   }
 
   "fail with error when large file upload fails" in {

--- a/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSinkSpec.scala
+++ b/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSinkSpec.scala
@@ -42,11 +42,9 @@ class GCStorageSinkSpec
     val chunkSize = 256 * 1024
     val firstChunkContent = Random.alphanumeric.take(chunkSize).mkString
     val secondChunkContent = Random.alphanumeric.take(chunkSize).mkString
-    val metaKey = Random.alphanumeric.take(5).mkString
-    val metaValue = Random.alphanumeric.take(5).mkString
-    val metadata = Map(metaKey -> metaValue)
+    val metadata = Map(Random.alphanumeric.take(5).mkString -> Random.alphanumeric.take(5).mkString)
 
-    mockLargeFileUpload(firstChunkContent, secondChunkContent, chunkSize, Some(metaKey -> metaValue))
+    mockLargeFileUpload(firstChunkContent, secondChunkContent, chunkSize, Some(metadata))
 
     //#upload
     val sink =


### PR DESCRIPTION
Pretty self explanatory, metadata is currently part of StorageObjects but wasn't able to be added on upload.

I wasn't sure which combination of overloaded functions/default args to add, so for now I've just added an additional overloaded function for where chunkSize is already set.

I didn't add it for the `simpleUpload` case as it [seems to be quite messy to upload a single file with metadata](https://cloud.google.com/storage/docs/uploading-objects), so I felt it best to leave until someone had a use case for that