### PR TITLE
CSV: Include values when headers and data length are different

### DIFF
--- a/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvToMapStage.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvToMapStage.scala
@@ -15,7 +15,6 @@ import scala.collection.immutable
 
 /**
  * Internal API: Converts incoming [[List[ByteString]]] to [[Map[String, ByteString]]].
- * If the header values are shorter than the data (or vice-versa) placeholder elements are used to extend the shorter collection to the length of the longer.
  *
  * @see akka.stream.alpakka.csv.impl.CsvToMapJavaStage
  * @param columnNames If given, these names are used as map keys; if not first stream element is used

--- a/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
@@ -30,10 +30,7 @@ object CsvToMap {
    */
   def toMapAsStrings(charset: Charset = StandardCharsets.UTF_8): Flow[List[ByteString], Map[String, String], NotUsed] =
     Flow.fromGraph(
-      new CsvToMapAsStringsStage(columnNames = None,
-                                 charset,
-                                 includeEmptyFields = false,
-                                 headerPlaceholder = Option.empty)
+      new CsvToMapAsStringsStage(columnNames = None, charset, combineAll = false, headerPlaceholder = Option.empty)
     )
 
   /**
@@ -65,10 +62,7 @@ object CsvToMap {
       headerPlaceholder: Option[String] = None
   ): Flow[List[ByteString], Map[String, String], NotUsed] =
     Flow.fromGraph(
-      new CsvToMapAsStringsStage(columnNames = None,
-                                 charset,
-                                 includeEmptyFields = true,
-                                 headerPlaceholder = headerPlaceholder)
+      new CsvToMapAsStringsStage(columnNames = None, charset, combineAll = true, headerPlaceholder = headerPlaceholder)
     )
 
   /**
@@ -95,9 +89,6 @@ object CsvToMap {
       headers: String*
   ): Flow[List[ByteString], Map[String, String], NotUsed] =
     Flow.fromGraph(
-      new CsvToMapAsStringsStage(Some(headers.toList),
-                                 charset,
-                                 includeEmptyFields = false,
-                                 headerPlaceholder = Option.empty)
+      new CsvToMapAsStringsStage(Some(headers.toList), charset, combineAll = false, headerPlaceholder = Option.empty)
     )
 }

--- a/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
@@ -38,8 +38,7 @@ object CsvToMap {
    * element's values as keys.
    * If the header values are shorter than the data (or vice-versa) placeholder elements are used to extend the shorter collection to the length of the longer.
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
-   * @paramheaderPlaceholder
-   *placeholder used when there are more headers than data.
+   * @param headerPlaceholder placeholder used when there are more headers than data.
    */
   def toMapCombineAll(
       charset: Charset = StandardCharsets.UTF_8,
@@ -54,8 +53,7 @@ object CsvToMap {
    * element's values as keys.
    * If the header values are shorter than the data (or vice-versa) placeholder elements are used to extend the shorter collection to the length of the longer.
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
-   * @paramheaderPlaceholder
-   *placeholder used when there are more headers than data.
+   * @param headerPlaceholder placeholder used when there are more headers than data.
    */
   def toMapAsStringsCombineAll(
       charset: Charset = StandardCharsets.UTF_8,

--- a/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
@@ -19,7 +19,9 @@ object CsvToMap {
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
    */
   def toMap(charset: Charset = StandardCharsets.UTF_8): Flow[List[ByteString], Map[String, ByteString], NotUsed] =
-    Flow.fromGraph(new CsvToMapStage(columnNames = None, charset))
+    Flow.fromGraph(
+      new CsvToMapStage(columnNames = None, charset, combineAll = false, headerPlaceholder = Option.empty)
+    )
 
   /**
    * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String keys and values using the stream's first
@@ -27,7 +29,47 @@ object CsvToMap {
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
    */
   def toMapAsStrings(charset: Charset = StandardCharsets.UTF_8): Flow[List[ByteString], Map[String, String], NotUsed] =
-    Flow.fromGraph(new CsvToMapAsStringsStage(columnNames = None, charset))
+    Flow.fromGraph(
+      new CsvToMapAsStringsStage(columnNames = None,
+                                 charset,
+                                 includeEmptyFields = false,
+                                 headerPlaceholder = Option.empty)
+    )
+
+  /**
+   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String and ByteString using the stream's first
+   * element's values as keys.
+   * If the header values are shorter than the data (or vice-versa) placeholder elements are used to extend the shorter collection to the length of the longer.
+   * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
+   * @paramheaderPlaceholder
+   *placeholder used when there are more headers than data.
+   */
+  def toMapCombineAll(
+      charset: Charset = StandardCharsets.UTF_8,
+      headerPlaceholder: Option[String] = None
+  ): Flow[List[ByteString], Map[String, ByteString], NotUsed] =
+    Flow.fromGraph(
+      new CsvToMapStage(columnNames = None, charset, combineAll = true, headerPlaceholder = headerPlaceholder)
+    )
+
+  /**
+   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String keys and values using the stream's first
+   * element's values as keys.
+   * If the header values are shorter than the data (or vice-versa) placeholder elements are used to extend the shorter collection to the length of the longer.
+   * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
+   * @paramheaderPlaceholder
+   *placeholder used when there are more headers than data.
+   */
+  def toMapAsStringsCombineAll(
+      charset: Charset = StandardCharsets.UTF_8,
+      headerPlaceholder: Option[String] = None
+  ): Flow[List[ByteString], Map[String, String], NotUsed] =
+    Flow.fromGraph(
+      new CsvToMapAsStringsStage(columnNames = None,
+                                 charset,
+                                 includeEmptyFields = true,
+                                 headerPlaceholder = headerPlaceholder)
+    )
 
   /**
    * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String and ByteString using the given headers
@@ -35,7 +77,12 @@ object CsvToMap {
    * @param headers column names to be used as map keys
    */
   def withHeaders(headers: String*): Flow[List[ByteString], Map[String, ByteString], NotUsed] =
-    Flow.fromGraph(new CsvToMapStage(Some(headers.toList), StandardCharsets.UTF_8))
+    Flow.fromGraph(
+      new CsvToMapStage(Some(headers.toList),
+                        StandardCharsets.UTF_8,
+                        combineAll = false,
+                        headerPlaceholder = Option.empty)
+    )
 
   /**
    * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String keys and values using the given headers
@@ -47,5 +94,10 @@ object CsvToMap {
       charset: Charset,
       headers: String*
   ): Flow[List[ByteString], Map[String, String], NotUsed] =
-    Flow.fromGraph(new CsvToMapAsStringsStage(Some(headers.toList), charset))
+    Flow.fromGraph(
+      new CsvToMapAsStringsStage(Some(headers.toList),
+                                 charset,
+                                 includeEmptyFields = false,
+                                 headerPlaceholder = Option.empty)
+    )
 }

--- a/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
@@ -179,7 +179,7 @@ class CsvParsingSpec extends CsvSpec {
         FileIO
           .fromPath(Paths.get("csv/src/test/resources/correctness.csv"))
           .via(CsvParsing.lineScanner())
-          .via(CsvToMap.toMapCombineAll())
+          .via(CsvToMap.toMap())
           .map(_.mapValues(_.utf8String).toIndexedSeq)
           .runWith(Sink.seq)
       val res = fut.futureValue

--- a/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
@@ -179,7 +179,7 @@ class CsvParsingSpec extends CsvSpec {
         FileIO
           .fromPath(Paths.get("csv/src/test/resources/correctness.csv"))
           .via(CsvParsing.lineScanner())
-          .via(CsvToMap.toMap())
+          .via(CsvToMap.toMapCombineAll())
           .map(_.mapValues(_.utf8String).toIndexedSeq)
           .runWith(Sink.seq)
       val res = fut.futureValue

--- a/csv/src/test/scala/docs/scaladsl/CsvToMapSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvToMapSpec.scala
@@ -21,7 +21,7 @@ class CsvToMapSpec extends CsvSpec {
 
     // keep values as ByteString
     val flow1: Flow[List[ByteString], Map[String, ByteString], NotUsed]
-      = CsvToMap.toMap()
+      = CsvToMap.toMapCombineAll()
 
     val flow2: Flow[List[ByteString], Map[String, ByteString], NotUsed]
       = CsvToMap.toMap(StandardCharsets.UTF_8)
@@ -35,6 +35,11 @@ class CsvToMapSpec extends CsvSpec {
 
     val flow5: Flow[List[ByteString], Map[String, String], NotUsed]
     = CsvToMap.withHeadersAsStrings(StandardCharsets.UTF_8, "column1", "column2", "column3")
+
+
+    // values as String (decode ByteString)
+    val flow6: Flow[List[ByteString], Map[String, String], NotUsed]
+    = CsvToMap.toMapAsStringsCombineAll(StandardCharsets.UTF_8, Option.empty)
     // #flow-type
     // format: on
 
@@ -43,6 +48,7 @@ class CsvToMapSpec extends CsvSpec {
     Source.single(List(ByteString("a"), ByteString("b"))).via(flow3).runWith(Sink.ignore)
     Source.single(List(ByteString("a"), ByteString("b"))).via(flow4).runWith(Sink.ignore)
     Source.single(List(ByteString("a"), ByteString("b"))).via(flow5).runWith(Sink.ignore)
+    Source.single(List(ByteString("a"), ByteString("b"))).via(flow6).runWith(Sink.ignore)
   }
 
   "CSV to Map" should {
@@ -189,5 +195,207 @@ class CsvToMapSpec extends CsvSpec {
       // #column-names
     }
 
+    "parse header and decode data line. Be OK with more headers column than data (including the header in the result)" in assertAllStagesStopped {
+      // #header-line
+      import akka.stream.alpakka.csv.scaladsl.{CsvParsing, CsvToMap}
+
+      // #header-line
+      val future =
+        // format: off
+      // #header-line
+      // values as ByteString
+        Source
+          .single(ByteString(
+            """eins,zwei,drei,vier,fünt
+              |11,12,13
+              |21,22,23
+              |""".stripMargin))
+          .via(CsvParsing.lineScanner())
+          .via(CsvToMap.toMapAsStringsCombineAll(headerPlaceholder = Option.empty))
+          .runWith(Sink.seq)
+      // #header-line
+      // format: on
+      val result = future.futureValue
+      // #header-line
+
+      result should be(
+        Seq(
+          Map("eins" -> "11", "zwei" -> "12", "drei" -> "13", "vier" -> "", "fünt" -> ""),
+          Map("eins" -> "21", "zwei" -> "22", "drei" -> "23", "vier" -> "", "fünt" -> "")
+        )
+      )
+      // #header-line
+    }
+
+    "parse header and decode data line. Be OK when there are more data than header column, set a default header in the result" in assertAllStagesStopped {
+      // #header-line
+      import akka.stream.alpakka.csv.scaladsl.{CsvParsing, CsvToMap}
+
+      // #header-line
+      val future =
+        // format: off
+      // #header-line
+      // values as ByteString
+        Source
+          .single(ByteString(
+            """eins,zwei,drei
+              |11,12,13,14
+              |21,22,23
+              |""".stripMargin))
+          .via(CsvParsing.lineScanner())
+          .via(CsvToMap.toMapAsStringsCombineAll(headerPlaceholder = Option.empty))
+          .runWith(Sink.seq)
+      // #header-line
+      // format: on
+      val result = future.futureValue
+      // #header-line
+
+      result should be(
+        Seq(
+          Map("eins" -> "11", "zwei" -> "12", "drei" -> "13", "Missing Header" -> "14"),
+          Map("eins" -> "21", "zwei" -> "22", "drei" -> "23")
+        )
+      )
+      // #header-line
+    }
+
+    "parse header and decode data line. Be OK when there are more data than header column, set the user configured header in the result" in assertAllStagesStopped {
+      // #header-line
+      import akka.stream.alpakka.csv.scaladsl.{CsvParsing, CsvToMap}
+
+      // #header-line
+      val future =
+        // format: off
+      // #header-line
+      // values as ByteString
+        Source
+          .single(ByteString(
+            """eins,zwei
+              |11,12,13
+              |21,22,
+              |""".stripMargin))
+          .via(CsvParsing.lineScanner())
+          .via(CsvToMap.toMapAsStringsCombineAll(headerPlaceholder = Option("drei")))
+          .runWith(Sink.seq)
+      // #header-line
+      // format: on
+      val result = future.futureValue
+      // #header-line
+
+      result should be(
+        Seq(
+          Map("eins" -> "11", "zwei" -> "12", "drei" -> "13"),
+          Map("eins" -> "21", "zwei" -> "22", "drei" -> "")
+        )
+      )
+      // #header-line
+    }
+  }
+
+  "be OK with more headers column than data (including the header in the result)" in assertAllStagesStopped {
+    // #header-line
+    import akka.stream.alpakka.csv.scaladsl.{CsvParsing, CsvToMap}
+
+    // #header-line
+    val future =
+      // format: off
+    // #header-line
+    // values as ByteString
+      Source
+        .single(ByteString(
+          """eins,zwei,drei,vier,fünt
+            |11,12,13
+            |21,22,23
+            |""".stripMargin))
+        .via(CsvParsing.lineScanner())
+        .via(CsvToMap.toMapCombineAll(headerPlaceholder = Option.empty))
+        .runWith(Sink.seq)
+    // #header-line
+    // format: on
+    val result = future.futureValue
+    // #header-line
+
+    result should be(
+      Seq(
+        Map("eins" -> ByteString("11"),
+            "zwei" -> ByteString("12"),
+            "drei" -> ByteString("13"),
+            "vier" -> ByteString(""),
+            "fünt" -> ByteString("")),
+        Map("eins" -> ByteString("21"),
+            "zwei" -> ByteString("22"),
+            "drei" -> ByteString("23"),
+            "vier" -> ByteString(""),
+            "fünt" -> ByteString(""))
+      )
+    )
+    // #header-line
+  }
+
+  "be OK when there are more data than header column, set a default header in the result" in assertAllStagesStopped {
+    // #header-line
+    import akka.stream.alpakka.csv.scaladsl.{CsvParsing, CsvToMap}
+
+    // #header-line
+    val future =
+      // format: off
+    // #header-line
+    // values as ByteString
+      Source
+        .single(ByteString(
+          """eins,zwei,drei
+            |11,12,13,14
+            |21,22,23
+            |""".stripMargin))
+        .via(CsvParsing.lineScanner())
+        .via(CsvToMap.toMapCombineAll(headerPlaceholder = Option.empty))
+        .runWith(Sink.seq)
+    // #header-line
+    // format: on
+    val result = future.futureValue
+    // #header-line
+
+    result should be(
+      Seq(
+        Map("eins" -> ByteString("11"),
+            "zwei" -> ByteString("12"),
+            "drei" -> ByteString("13"),
+            "Missing Header" -> ByteString("14")),
+        Map("eins" -> ByteString("21"), "zwei" -> ByteString("22"), "drei" -> ByteString("23"))
+      )
+    )
+    // #header-line
+  }
+
+  "be OK when there are more data than header column, set the user configured header in the result" in assertAllStagesStopped {
+    // #header-line
+    import akka.stream.alpakka.csv.scaladsl.{CsvParsing, CsvToMap}
+
+    // #header-line
+    val future =
+      // format: off
+    // #header-line
+    // values as ByteString
+      Source
+        .single(ByteString(
+          """eins,zwei
+            |11,12,13
+            |21,22,
+            |""".stripMargin))
+        .via(CsvParsing.lineScanner())
+        .via(CsvToMap.toMapCombineAll(headerPlaceholder = Option("drei")))
+        .runWith(Sink.seq)
+    // #header-line
+    // format: on
+    val result = future.futureValue
+    // #header-line
+
+    result should be(
+      Seq(
+        Map("eins" -> ByteString("11"), "zwei" -> ByteString("12"), "drei" -> ByteString("13")),
+        Map("eins" -> ByteString("21"), "zwei" -> ByteString("22"), "drei" -> ByteString(""))
+      )
+    )
+    // #header-line
   }
 }

--- a/csv/src/test/scala/docs/scaladsl/CsvToMapSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvToMapSpec.scala
@@ -21,7 +21,7 @@ class CsvToMapSpec extends CsvSpec {
 
     // keep values as ByteString
     val flow1: Flow[List[ByteString], Map[String, ByteString], NotUsed]
-      = CsvToMap.toMapCombineAll()
+      = CsvToMap.toMap()
 
     val flow2: Flow[List[ByteString], Map[String, ByteString], NotUsed]
       = CsvToMap.toMap(StandardCharsets.UTF_8)


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->

This PR adds a couple of function that basically allows the user to include the empty fields (using some placeholders) in cases where there are more headers than data (or vice-versa) in the csv being transformed to a Map.

Examples:
 1. When there are more data than headers
```csv
eins,zwei
11,12,13
```
maps to
```scala
Map("eins" -> "11", "zwei" -> "12", "Missing header" -> "13" 
```
The "Missing header" value is the default one, the user has the option to pass a custom value for this placeholder.

2. When there are more headers than data
```csv
eins,zwei,drei,vier,fünt
11,12,13
```
maps to
```scala
Map("eins" -> "11", "zwei" -> "12", "dreir" -> "13", "vier" -> "", "fünt" -> "")
```

This would be helpful, especially in the second case, when I want to keep the headers even when I don't have values associated with them.

