### PR TITLE
CSV: Use placeholders when header and data length differs

### DIFF
--- a/csv/src/main/java/akka/stream/alpakka/csv/javadsl/CsvToMap.java
+++ b/csv/src/main/java/akka/stream/alpakka/csv/javadsl/CsvToMap.java
@@ -35,7 +35,8 @@ public class CsvToMap {
    */
   public static Flow<Collection<ByteString>, Map<String, ByteString>, ?> toMap(Charset charset) {
     return Flow.fromGraph(
-        new CsvToMapJavaStage(Optional.empty(), charset, false, Optional.empty()));
+        new CsvToMapJavaStage(
+            Optional.empty(), charset, false, Optional.empty(), Optional.empty()));
   }
 
   /**
@@ -47,7 +48,8 @@ public class CsvToMap {
   public static Flow<Collection<ByteString>, Map<String, String>, ?> toMapAsStrings(
       Charset charset) {
     return Flow.fromGraph(
-        new CsvToMapAsStringsJavaStage(Optional.empty(), charset, false, Optional.empty()));
+        new CsvToMapAsStringsJavaStage(
+            Optional.empty(), charset, false, Optional.empty(), Optional.empty()));
   }
 
   /**
@@ -58,12 +60,16 @@ public class CsvToMap {
    *
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]],
    *     defaults to UTF-8
+   * @param customFieldValuePlaceHolder placeholder used when there data than headers.
    * @param headerPlaceholder placeholder used when there are more headers than data.
    */
   public static Flow<Collection<ByteString>, Map<String, ByteString>, ?> toMapCombineAll(
-      Charset charset, Optional<String> headerPlaceholder) {
+      Charset charset,
+      Optional<ByteString> customFieldValuePlaceHolder,
+      Optional<String> headerPlaceholder) {
     return Flow.fromGraph(
-        new CsvToMapJavaStage(Optional.empty(), charset, true, headerPlaceholder));
+        new CsvToMapJavaStage(
+            Optional.empty(), charset, true, customFieldValuePlaceHolder, headerPlaceholder));
   }
 
   /**
@@ -74,12 +80,16 @@ public class CsvToMap {
    *
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]],
    *     defaults to UTF-8
+   * @param customFieldValuePlaceHolder placeholder used when there data than headers.
    * @param headerPlaceholder placeholder used when there are more headers than data.
    */
   public static Flow<Collection<ByteString>, Map<String, String>, ?> toMapAsStringsCombineAll(
-      Charset charset, Optional<String> headerPlaceholder) {
+      Charset charset,
+      Optional<String> customFieldValuePlaceHolder,
+      Optional<String> headerPlaceholder) {
     return Flow.fromGraph(
-        new CsvToMapAsStringsJavaStage(Optional.empty(), charset, true, headerPlaceholder));
+        new CsvToMapAsStringsJavaStage(
+            Optional.empty(), charset, true, customFieldValuePlaceHolder, headerPlaceholder));
   }
 
   /**
@@ -92,7 +102,11 @@ public class CsvToMap {
       String... headers) {
     return Flow.fromGraph(
         new CsvToMapJavaStage(
-            Optional.of(Arrays.asList(headers)), StandardCharsets.UTF_8, false, Optional.empty()));
+            Optional.of(Arrays.asList(headers)),
+            StandardCharsets.UTF_8,
+            false,
+            Optional.empty(),
+            Optional.empty()));
   }
 
   /**
@@ -105,6 +119,10 @@ public class CsvToMap {
       Charset charset, String... headers) {
     return Flow.fromGraph(
         new CsvToMapAsStringsJavaStage(
-            Optional.of(Arrays.asList(headers)), charset, false, Optional.empty()));
+            Optional.of(Arrays.asList(headers)),
+            charset,
+            false,
+            Optional.empty(),
+            Optional.empty()));
   }
 }

--- a/csv/src/main/java/akka/stream/alpakka/csv/javadsl/CsvToMap.java
+++ b/csv/src/main/java/akka/stream/alpakka/csv/javadsl/CsvToMap.java
@@ -34,7 +34,8 @@ public class CsvToMap {
    * @param charset the charset to decode {@link ByteString} to {@link String}
    */
   public static Flow<Collection<ByteString>, Map<String, ByteString>, ?> toMap(Charset charset) {
-    return Flow.fromGraph(new CsvToMapJavaStage(Optional.empty(), charset));
+    return Flow.fromGraph(
+        new CsvToMapJavaStage(Optional.empty(), charset, false, Optional.empty()));
   }
 
   /**
@@ -45,7 +46,40 @@ public class CsvToMap {
    */
   public static Flow<Collection<ByteString>, Map<String, String>, ?> toMapAsStrings(
       Charset charset) {
-    return Flow.fromGraph(new CsvToMapAsStringsJavaStage(Optional.empty(), charset));
+    return Flow.fromGraph(
+        new CsvToMapAsStringsJavaStage(Optional.empty(), charset, false, Optional.empty()));
+  }
+
+  /**
+   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String and
+   * ByteString using the stream's first element's values as keys. If the header values are shorter
+   * than the data (or vice-versa) placeholder elements are used to extend the shorter collection to
+   * the length of the longer.
+   *
+   * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]],
+   *     defaults to UTF-8
+   * @param headerPlaceholder placeholder used when there are more headers than data.
+   */
+  public static Flow<Collection<ByteString>, Map<String, ByteString>, ?> toMapCombineAll(
+      Charset charset, Optional<String> headerPlaceholder) {
+    return Flow.fromGraph(
+        new CsvToMapJavaStage(Optional.empty(), charset, true, headerPlaceholder));
+  }
+
+  /**
+   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String keys
+   * and values using the stream's first element's values as keys. If the header values are shorter
+   * than the data (or vice-versa) placeholder elements are used to extend the shorter collection to
+   * the length of the longer.
+   *
+   * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]],
+   *     defaults to UTF-8
+   * @param headerPlaceholder placeholder used when there are more headers than data.
+   */
+  public static Flow<Collection<ByteString>, Map<String, String>, ?> toMapAsStringsCombineAll(
+      Charset charset, Optional<String> headerPlaceholder) {
+    return Flow.fromGraph(
+        new CsvToMapAsStringsJavaStage(Optional.empty(), charset, true, headerPlaceholder));
   }
 
   /**
@@ -57,7 +91,8 @@ public class CsvToMap {
   public static Flow<Collection<ByteString>, Map<String, ByteString>, ?> withHeaders(
       String... headers) {
     return Flow.fromGraph(
-        new CsvToMapJavaStage(Optional.of(Arrays.asList(headers)), StandardCharsets.UTF_8));
+        new CsvToMapJavaStage(
+            Optional.of(Arrays.asList(headers)), StandardCharsets.UTF_8, false, Optional.empty()));
   }
 
   /**
@@ -69,6 +104,7 @@ public class CsvToMap {
   public static Flow<Collection<ByteString>, Map<String, String>, ?> withHeadersAsStrings(
       Charset charset, String... headers) {
     return Flow.fromGraph(
-        new CsvToMapAsStringsJavaStage(Optional.of(Arrays.asList(headers)), charset));
+        new CsvToMapAsStringsJavaStage(
+            Optional.of(Arrays.asList(headers)), charset, false, Optional.empty()));
   }
 }

--- a/csv/src/main/java/akka/stream/alpakka/csv/javadsl/CsvToMap.java
+++ b/csv/src/main/java/akka/stream/alpakka/csv/javadsl/CsvToMap.java
@@ -53,13 +53,12 @@ public class CsvToMap {
   }
 
   /**
-   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String and
-   * ByteString using the stream's first element's values as keys. If the header values are shorter
-   * than the data (or vice-versa) placeholder elements are used to extend the shorter collection to
-   * the length of the longer.
+   * A flow translating incoming {@link Collection<ByteString>} to a {@link Map<String, ByteString>}
+   * using the stream's first element's values as keys. If the header values are shorter than the
+   * data (or vice-versa) placeholder elements are used to extend the shorter collection to the
+   * length of the longer.
    *
-   * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]],
-   *     defaults to UTF-8
+   * @param charset the charset to decode {@link ByteString} to {@link String}, defaults to UTF-8
    * @param customFieldValuePlaceholder placeholder used when there are more data than headers.
    * @param headerPlaceholder placeholder used when there are more headers than data.
    */
@@ -73,13 +72,12 @@ public class CsvToMap {
   }
 
   /**
-   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String keys
-   * and values using the stream's first element's values as keys. If the header values are shorter
-   * than the data (or vice-versa) placeholder elements are used to extend the shorter collection to
-   * the length of the longer.
+   * A flow translating incoming {@link Collection<ByteString>} to a {@link Map<String, ByteString>}
+   * using the stream's first element's values as keys. If the header values are shorter than the
+   * data (or vice-versa) placeholder elements are used to extend the shorter collection to the
+   * length of the longer.
    *
-   * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]],
-   *     defaults to UTF-8
+   * @param charset the charset to decode {@link ByteString} to {@link String}, defaults to UTF-8
    * @param customFieldValuePlaceholder placeholder used when there are more data than headers.
    * @param headerPlaceholder placeholder used when there are more headers than data.
    */

--- a/csv/src/main/java/akka/stream/alpakka/csv/javadsl/CsvToMap.java
+++ b/csv/src/main/java/akka/stream/alpakka/csv/javadsl/CsvToMap.java
@@ -60,16 +60,16 @@ public class CsvToMap {
    *
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]],
    *     defaults to UTF-8
-   * @param customFieldValuePlaceHolder placeholder used when there data than headers.
+   * @param customFieldValuePlaceholder placeholder used when there are more data than headers.
    * @param headerPlaceholder placeholder used when there are more headers than data.
    */
   public static Flow<Collection<ByteString>, Map<String, ByteString>, ?> toMapCombineAll(
       Charset charset,
-      Optional<ByteString> customFieldValuePlaceHolder,
+      Optional<ByteString> customFieldValuePlaceholder,
       Optional<String> headerPlaceholder) {
     return Flow.fromGraph(
         new CsvToMapJavaStage(
-            Optional.empty(), charset, true, customFieldValuePlaceHolder, headerPlaceholder));
+            Optional.empty(), charset, true, customFieldValuePlaceholder, headerPlaceholder));
   }
 
   /**
@@ -80,16 +80,16 @@ public class CsvToMap {
    *
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]],
    *     defaults to UTF-8
-   * @param customFieldValuePlaceHolder placeholder used when there data than headers.
+   * @param customFieldValuePlaceholder placeholder used when there are more data than headers.
    * @param headerPlaceholder placeholder used when there are more headers than data.
    */
   public static Flow<Collection<ByteString>, Map<String, String>, ?> toMapAsStringsCombineAll(
       Charset charset,
-      Optional<String> customFieldValuePlaceHolder,
+      Optional<String> customFieldValuePlaceholder,
       Optional<String> headerPlaceholder) {
     return Flow.fromGraph(
         new CsvToMapAsStringsJavaStage(
-            Optional.empty(), charset, true, customFieldValuePlaceHolder, headerPlaceholder));
+            Optional.empty(), charset, true, customFieldValuePlaceholder, headerPlaceholder));
   }
 
   /**

--- a/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvToMapJavaStage.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvToMapJavaStage.scala
@@ -16,12 +16,15 @@ import akka.util.ByteString
  * Internal Java API: Converts incoming {@link Collection}<{@link ByteString}> to {@link java.util.Map}<String, ByteString>.
  *
  * @param columnNames If given, these names are used as map keys; if not first stream element is used
- * @param charset     Character set used to convert header line ByteString to String
+ * @param charset Character set used to convert header line ByteString to String
+ * @param combineAll If true, placeholder elements will be used to extend the shorter collection to the length of the longer.
+ * @param customFieldValuePlaceholder placeholder used when there are more data than headers.
+ * @param headerPlaceholder placeholder used when there are more headers than data.
  */
 @InternalApi private[csv] abstract class CsvToMapJavaStageBase[V](columnNames: ju.Optional[ju.Collection[String]],
                                                                   charset: Charset,
                                                                   combineAll: Boolean,
-                                                                  customFieldValuePlaceHolder: ju.Optional[V],
+                                                                  customFieldValuePlaceholder: ju.Optional[V],
                                                                   headerPlaceholder: ju.Optional[String])
     extends GraphStage[FlowShape[ju.Collection[ByteString], ju.Map[String, V]]] {
 
@@ -93,7 +96,7 @@ import akka.util.ByteString
             if (colIter.hasNext) {
               map.put(hIter.next(), colIter.next())
             } else {
-              map.put(hIter.next(), customFieldValuePlaceHolder.orElse(fieldValuePlaceholder))
+              map.put(hIter.next(), customFieldValuePlaceholder.orElse(fieldValuePlaceholder))
             }
           }
         } else if (elem.size() > headers.get.size()) {
@@ -125,12 +128,12 @@ import akka.util.ByteString
 @InternalApi private[csv] class CsvToMapJavaStage(columnNames: ju.Optional[ju.Collection[String]],
                                                   charset: Charset,
                                                   combineAll: Boolean,
-                                                  customFieldValuePlaceHolder: ju.Optional[ByteString],
+                                                  customFieldValuePlaceholder: ju.Optional[ByteString],
                                                   headerPlaceholder: ju.Optional[String])
     extends CsvToMapJavaStageBase[ByteString](columnNames,
                                               charset,
                                               combineAll,
-                                              customFieldValuePlaceHolder,
+                                              customFieldValuePlaceholder,
                                               headerPlaceholder) {
 
   override val fieldValuePlaceholder: ByteString = ByteString("")
@@ -145,12 +148,12 @@ import akka.util.ByteString
 @InternalApi private[csv] class CsvToMapAsStringsJavaStage(columnNames: ju.Optional[ju.Collection[String]],
                                                            charset: Charset,
                                                            combineAll: Boolean,
-                                                           customFieldValuePlaceHolder: ju.Optional[String],
+                                                           customFieldValuePlaceholder: ju.Optional[String],
                                                            headerPlaceholder: ju.Optional[String])
     extends CsvToMapJavaStageBase[String](columnNames,
                                           charset,
                                           combineAll,
-                                          customFieldValuePlaceHolder,
+                                          customFieldValuePlaceholder,
                                           headerPlaceholder) {
 
   override val fieldValuePlaceholder: String = ""

--- a/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvToMapStage.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvToMapStage.scala
@@ -15,20 +15,28 @@ import scala.collection.immutable
 
 /**
  * Internal API: Converts incoming [[List[ByteString]]] to [[Map[String, ByteString]]].
- * @see akka.stream.alpakka.csv.impl.CsvToMapJavaStage
  *
+ * @see akka.stream.alpakka.csv.impl.CsvToMapJavaStage
  * @param columnNames If given, these names are used as map keys; if not first stream element is used
  * @param charset Character set used to convert header line ByteString to String
+ * @param combineAll If true, placeholder elements will be used to extend the shorter collection to the length of the longer.
+ * @param headerPlaceholder placeholder used when there are more headers than data.
  */
 @InternalApi private[csv] abstract class CsvToMapStageBase[V](columnNames: Option[immutable.Seq[String]],
-                                                              charset: Charset)
+                                                              charset: Charset,
+                                                              combineAll: Boolean,
+                                                              headerPlaceholder: Option[String])
     extends GraphStage[FlowShape[immutable.Seq[ByteString], Map[String, V]]] {
 
   override protected def initialAttributes: Attributes = Attributes.name("CsvToMap")
 
+  private type Headers = Option[Seq[String]]
+
   private val in = Inlet[immutable.Seq[ByteString]]("CsvToMap.in")
   private val out = Outlet[Map[String, V]]("CsvToMap.out")
   override val shape = FlowShape.of(in, out)
+
+  val fieldValuePlaceholder: V
 
   protected def transformElements(elements: immutable.Seq[ByteString]): immutable.Seq[V]
 
@@ -40,9 +48,22 @@ import scala.collection.immutable
 
       override def onPush(): Unit = {
         val elem = grab(in)
+        if (combineAll) {
+          val combine: Headers => Map[String, V] = headers =>
+            headers.get
+              .zipAll(transformElements(elem),
+                      headerPlaceholder.fold("Missing Header")(identity),
+                      fieldValuePlaceholder)
+              .toMap
+          process(elem, combine)
+        } else {
+          process(elem, headers => headers.get.zip(transformElements(elem)).toMap)
+        }
+      }
+
+      private def process(elem: immutable.Seq[ByteString], combine: Headers => Map[String, V]): Unit = {
         if (headers.isDefined) {
-          val map = headers.get.zip(transformElements(elem)).toMap
-          push(out, map)
+          push(out, combine(headers))
         } else {
           headers = Some(elem.map(_.decodeString(charset)))
           pull(in)
@@ -56,17 +77,27 @@ import scala.collection.immutable
 /**
  * Internal API
  */
-@InternalApi private[csv] class CsvToMapStage(columnNames: Option[immutable.Seq[String]], charset: Charset)
-    extends CsvToMapStageBase[ByteString](columnNames, charset) {
+@InternalApi private[csv] class CsvToMapStage(columnNames: Option[immutable.Seq[String]],
+                                              charset: Charset,
+                                              combineAll: Boolean,
+                                              headerPlaceholder: Option[String])
+    extends CsvToMapStageBase[ByteString](columnNames, charset, combineAll, headerPlaceholder) {
+  override val fieldValuePlaceholder: ByteString = ByteString("")
 
   override protected def transformElements(elements: immutable.Seq[ByteString]): immutable.Seq[ByteString] = elements
+
 }
 
 /**
  * Internal API
  */
-@InternalApi private[csv] class CsvToMapAsStringsStage(columnNames: Option[immutable.Seq[String]], charset: Charset)
-    extends CsvToMapStageBase[String](columnNames, charset) {
+@InternalApi private[csv] class CsvToMapAsStringsStage(columnNames: Option[immutable.Seq[String]],
+                                                       charset: Charset,
+                                                       combineAll: Boolean,
+                                                       headerPlaceholder: Option[String])
+    extends CsvToMapStageBase[String](columnNames, charset, combineAll, headerPlaceholder) {
+
+  override val fieldValuePlaceholder: String = ""
 
   override protected def transformElements(elements: immutable.Seq[ByteString]): immutable.Seq[String] =
     elements.map(_.decodeString(charset))

--- a/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvToMapStage.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/impl/CsvToMapStage.scala
@@ -19,12 +19,13 @@ import scala.collection.immutable
  * @param columnNames If given, these names are used as map keys; if not first stream element is used
  * @param charset Character set used to convert header line ByteString to String
  * @param combineAll If true, placeholder elements will be used to extend the shorter collection to the length of the longer.
+ * @param customFieldValuePlaceholder placeholder used when there are more data than headers.
  * @param headerPlaceholder placeholder used when there are more headers than data.
  */
 @InternalApi private[csv] abstract class CsvToMapStageBase[V](columnNames: Option[immutable.Seq[String]],
                                                               charset: Charset,
                                                               combineAll: Boolean,
-                                                              customFieldValuePlaceHolder: Option[V],
+                                                              customFieldValuePlaceholder: Option[V],
                                                               headerPlaceholder: Option[String])
     extends GraphStage[FlowShape[immutable.Seq[ByteString], Map[String, V]]] {
 
@@ -71,7 +72,7 @@ import scala.collection.immutable
     val combined = headers.get
       .zipAll(transformElements(elem),
               headerPlaceholder.getOrElse("MissingHeader"),
-              customFieldValuePlaceHolder.getOrElse(fieldValuePlaceholder))
+              customFieldValuePlaceholder.getOrElse(fieldValuePlaceholder))
     val filtering: String => Boolean = key =>
       headerPlaceholder.map(_.equalsIgnoreCase(key)).fold(key.equalsIgnoreCase("MissingHeader"))(identity)
     val missingHeadersContent =
@@ -102,12 +103,12 @@ import scala.collection.immutable
 @InternalApi private[csv] class CsvToMapStage(columnNames: Option[immutable.Seq[String]],
                                               charset: Charset,
                                               combineAll: Boolean,
-                                              customFieldValuePlaceHolder: Option[ByteString],
+                                              customFieldValuePlaceholder: Option[ByteString],
                                               headerPlaceholder: Option[String])
     extends CsvToMapStageBase[ByteString](columnNames,
                                           charset,
                                           combineAll,
-                                          customFieldValuePlaceHolder,
+                                          customFieldValuePlaceholder,
                                           headerPlaceholder) {
 
   override val fieldValuePlaceholder: ByteString = ByteString("")
@@ -122,9 +123,9 @@ import scala.collection.immutable
 @InternalApi private[csv] class CsvToMapAsStringsStage(columnNames: Option[immutable.Seq[String]],
                                                        charset: Charset,
                                                        combineAll: Boolean,
-                                                       customFieldValuePlaceHolder: Option[String],
+                                                       customFieldValuePlaceholder: Option[String],
                                                        headerPlaceholder: Option[String])
-    extends CsvToMapStageBase[String](columnNames, charset, combineAll, customFieldValuePlaceHolder, headerPlaceholder) {
+    extends CsvToMapStageBase[String](columnNames, charset, combineAll, customFieldValuePlaceholder, headerPlaceholder) {
 
   override val fieldValuePlaceholder: String = ""
 

--- a/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
@@ -23,7 +23,7 @@ object CsvToMap {
       new CsvToMapStage(columnNames = None,
                         charset,
                         combineAll = false,
-                        customFieldValuePlaceHolder = Option.empty,
+                        customFieldValuePlaceholder = Option.empty,
                         headerPlaceholder = Option.empty)
     )
 
@@ -37,7 +37,7 @@ object CsvToMap {
       new CsvToMapAsStringsStage(columnNames = None,
                                  charset,
                                  combineAll = false,
-                                 customFieldValuePlaceHolder = Option.empty,
+                                 customFieldValuePlaceholder = Option.empty,
                                  headerPlaceholder = Option.empty)
     )
 
@@ -46,7 +46,7 @@ object CsvToMap {
    * element's values as keys.
    * If the header values are shorter than the data (or vice-versa) placeholder elements are used to extend the shorter collection to the length of the longer.
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
-   * @param customFieldValuePlaceholder placeholder used when there data than headers.
+   * @param customFieldValuePlaceholder placeholder used when there is more data than headers.
    * @param headerPlaceholder placeholder used when there are more headers than data.
    */
   def toMapCombineAll(
@@ -58,7 +58,7 @@ object CsvToMap {
       new CsvToMapStage(columnNames = None,
                         charset,
                         combineAll = true,
-                        customFieldValuePlaceHolder = customFieldValuePlaceholder,
+                        customFieldValuePlaceholder = customFieldValuePlaceholder,
                         headerPlaceholder = headerPlaceholder)
     )
 
@@ -67,7 +67,7 @@ object CsvToMap {
    * element's values as keys.
    * If the header values are shorter than the data (or vice-versa) placeholder elements are used to extend the shorter collection to the length of the longer.
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
-   * @param customFieldValuePlaceholder placeholder used when there data than headers.
+   * @param customFieldValuePlaceholder placeholder used when there is more data than headers.
    * @param headerPlaceholder placeholder used when there are more headers than data.
    */
   def toMapAsStringsCombineAll(
@@ -79,7 +79,7 @@ object CsvToMap {
       new CsvToMapAsStringsStage(columnNames = None,
                                  charset,
                                  combineAll = true,
-                                 customFieldValuePlaceHolder = customFieldValuePlaceholder,
+                                 customFieldValuePlaceholder = customFieldValuePlaceholder,
                                  headerPlaceholder = headerPlaceholder)
     )
 
@@ -93,7 +93,7 @@ object CsvToMap {
       new CsvToMapStage(Some(headers.toList),
                         StandardCharsets.UTF_8,
                         combineAll = false,
-                        customFieldValuePlaceHolder = Option.empty,
+                        customFieldValuePlaceholder = Option.empty,
                         headerPlaceholder = Option.empty)
     )
 
@@ -111,7 +111,7 @@ object CsvToMap {
       new CsvToMapAsStringsStage(Some(headers.toList),
                                  charset,
                                  combineAll = false,
-                                 customFieldValuePlaceHolder = Option.empty,
+                                 customFieldValuePlaceholder = Option.empty,
                                  headerPlaceholder = Option.empty)
     )
 }

--- a/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
@@ -20,7 +20,11 @@ object CsvToMap {
    */
   def toMap(charset: Charset = StandardCharsets.UTF_8): Flow[List[ByteString], Map[String, ByteString], NotUsed] =
     Flow.fromGraph(
-      new CsvToMapStage(columnNames = None, charset, combineAll = false, headerPlaceholder = Option.empty)
+      new CsvToMapStage(columnNames = None,
+                        charset,
+                        combineAll = false,
+                        customFieldValuePlaceHolder = Option.empty,
+                        headerPlaceholder = Option.empty)
     )
 
   /**
@@ -30,7 +34,11 @@ object CsvToMap {
    */
   def toMapAsStrings(charset: Charset = StandardCharsets.UTF_8): Flow[List[ByteString], Map[String, String], NotUsed] =
     Flow.fromGraph(
-      new CsvToMapAsStringsStage(columnNames = None, charset, combineAll = false, headerPlaceholder = Option.empty)
+      new CsvToMapAsStringsStage(columnNames = None,
+                                 charset,
+                                 combineAll = false,
+                                 customFieldValuePlaceHolder = Option.empty,
+                                 headerPlaceholder = Option.empty)
     )
 
   /**
@@ -38,14 +46,20 @@ object CsvToMap {
    * element's values as keys.
    * If the header values are shorter than the data (or vice-versa) placeholder elements are used to extend the shorter collection to the length of the longer.
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
+   * @param customFieldValuePlaceholder placeholder used when there data than headers.
    * @param headerPlaceholder placeholder used when there are more headers than data.
    */
   def toMapCombineAll(
       charset: Charset = StandardCharsets.UTF_8,
+      customFieldValuePlaceholder: Option[ByteString] = None,
       headerPlaceholder: Option[String] = None
   ): Flow[List[ByteString], Map[String, ByteString], NotUsed] =
     Flow.fromGraph(
-      new CsvToMapStage(columnNames = None, charset, combineAll = true, headerPlaceholder = headerPlaceholder)
+      new CsvToMapStage(columnNames = None,
+                        charset,
+                        combineAll = true,
+                        customFieldValuePlaceHolder = customFieldValuePlaceholder,
+                        headerPlaceholder = headerPlaceholder)
     )
 
   /**
@@ -53,14 +67,20 @@ object CsvToMap {
    * element's values as keys.
    * If the header values are shorter than the data (or vice-versa) placeholder elements are used to extend the shorter collection to the length of the longer.
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
+   * @param customFieldValuePlaceholder placeholder used when there data than headers.
    * @param headerPlaceholder placeholder used when there are more headers than data.
    */
   def toMapAsStringsCombineAll(
       charset: Charset = StandardCharsets.UTF_8,
+      customFieldValuePlaceholder: Option[String] = None,
       headerPlaceholder: Option[String] = None
   ): Flow[List[ByteString], Map[String, String], NotUsed] =
     Flow.fromGraph(
-      new CsvToMapAsStringsStage(columnNames = None, charset, combineAll = true, headerPlaceholder = headerPlaceholder)
+      new CsvToMapAsStringsStage(columnNames = None,
+                                 charset,
+                                 combineAll = true,
+                                 customFieldValuePlaceHolder = customFieldValuePlaceholder,
+                                 headerPlaceholder = headerPlaceholder)
     )
 
   /**
@@ -73,6 +93,7 @@ object CsvToMap {
       new CsvToMapStage(Some(headers.toList),
                         StandardCharsets.UTF_8,
                         combineAll = false,
+                        customFieldValuePlaceHolder = Option.empty,
                         headerPlaceholder = Option.empty)
     )
 
@@ -87,6 +108,10 @@ object CsvToMap {
       headers: String*
   ): Flow[List[ByteString], Map[String, String], NotUsed] =
     Flow.fromGraph(
-      new CsvToMapAsStringsStage(Some(headers.toList), charset, combineAll = false, headerPlaceholder = Option.empty)
+      new CsvToMapAsStringsStage(Some(headers.toList),
+                                 charset,
+                                 combineAll = false,
+                                 customFieldValuePlaceHolder = Option.empty,
+                                 headerPlaceholder = Option.empty)
     )
 }

--- a/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
@@ -42,9 +42,9 @@ object CsvToMap {
     )
 
   /**
-   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String and ByteString using the stream's first
-   * element's values as keys.
-   * If the header values are shorter than the data (or vice-versa) placeholder elements are used to extend the shorter collection to the length of the longer.
+   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String and ByteString
+   * using the stream's first element's values as keys. If the header values are shorter than the data (or vice-versa)
+   * placeholder elements are used to extend the shorter collection to the length of the longer.
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
    * @param customFieldValuePlaceholder placeholder used when there is more data than headers.
    * @param headerPlaceholder placeholder used when there are more headers than data.
@@ -63,9 +63,9 @@ object CsvToMap {
     )
 
   /**
-   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String keys and values using the stream's first
-   * element's values as keys.
-   * If the header values are shorter than the data (or vice-versa) placeholder elements are used to extend the shorter collection to the length of the longer.
+   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String keys and values
+   * using the stream's first element's values as keys. If the header values are shorter than the data (or vice-versa)
+   * placeholder elements are used to extend the shorter collection to the length of the longer.
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
    * @param customFieldValuePlaceholder placeholder used when there is more data than headers.
    * @param headerPlaceholder placeholder used when there are more headers than data.

--- a/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
+++ b/csv/src/main/scala/akka/stream/alpakka/csv/scaladsl/CsvToMap.scala
@@ -19,7 +19,9 @@ object CsvToMap {
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
    */
   def toMap(charset: Charset = StandardCharsets.UTF_8): Flow[List[ByteString], Map[String, ByteString], NotUsed] =
-    Flow.fromGraph(new CsvToMapStage(columnNames = None, charset))
+    Flow.fromGraph(
+      new CsvToMapStage(columnNames = None, charset, combineAll = false, headerPlaceholder = Option.empty)
+    )
 
   /**
    * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String keys and values using the stream's first
@@ -27,7 +29,39 @@ object CsvToMap {
    * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
    */
   def toMapAsStrings(charset: Charset = StandardCharsets.UTF_8): Flow[List[ByteString], Map[String, String], NotUsed] =
-    Flow.fromGraph(new CsvToMapAsStringsStage(columnNames = None, charset))
+    Flow.fromGraph(
+      new CsvToMapAsStringsStage(columnNames = None, charset, combineAll = false, headerPlaceholder = Option.empty)
+    )
+
+  /**
+   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String and ByteString using the stream's first
+   * element's values as keys.
+   * If the header values are shorter than the data (or vice-versa) placeholder elements are used to extend the shorter collection to the length of the longer.
+   * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
+   * @param headerPlaceholder placeholder used when there are more headers than data.
+   */
+  def toMapCombineAll(
+      charset: Charset = StandardCharsets.UTF_8,
+      headerPlaceholder: Option[String] = None
+  ): Flow[List[ByteString], Map[String, ByteString], NotUsed] =
+    Flow.fromGraph(
+      new CsvToMapStage(columnNames = None, charset, combineAll = true, headerPlaceholder = headerPlaceholder)
+    )
+
+  /**
+   * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String keys and values using the stream's first
+   * element's values as keys.
+   * If the header values are shorter than the data (or vice-versa) placeholder elements are used to extend the shorter collection to the length of the longer.
+   * @param charset the charset to decode [[akka.util.ByteString]] to [[scala.Predef.String]], defaults to UTF-8
+   * @param headerPlaceholder placeholder used when there are more headers than data.
+   */
+  def toMapAsStringsCombineAll(
+      charset: Charset = StandardCharsets.UTF_8,
+      headerPlaceholder: Option[String] = None
+  ): Flow[List[ByteString], Map[String, String], NotUsed] =
+    Flow.fromGraph(
+      new CsvToMapAsStringsStage(columnNames = None, charset, combineAll = true, headerPlaceholder = headerPlaceholder)
+    )
 
   /**
    * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String and ByteString using the given headers
@@ -35,7 +69,12 @@ object CsvToMap {
    * @param headers column names to be used as map keys
    */
   def withHeaders(headers: String*): Flow[List[ByteString], Map[String, ByteString], NotUsed] =
-    Flow.fromGraph(new CsvToMapStage(Some(headers.toList), StandardCharsets.UTF_8))
+    Flow.fromGraph(
+      new CsvToMapStage(Some(headers.toList),
+                        StandardCharsets.UTF_8,
+                        combineAll = false,
+                        headerPlaceholder = Option.empty)
+    )
 
   /**
    * A flow translating incoming [[scala.List]] of [[akka.util.ByteString]] to a map of String keys and values using the given headers
@@ -47,5 +86,7 @@ object CsvToMap {
       charset: Charset,
       headers: String*
   ): Flow[List[ByteString], Map[String, String], NotUsed] =
-    Flow.fromGraph(new CsvToMapAsStringsStage(Some(headers.toList), charset))
+    Flow.fromGraph(
+      new CsvToMapAsStringsStage(Some(headers.toList), charset, combineAll = false, headerPlaceholder = Option.empty)
+    )
 }

--- a/csv/src/test/java/docs/javadsl/CsvToMapTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvToMapTest.java
@@ -23,6 +23,7 @@ import org.junit.*;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
@@ -51,6 +52,10 @@ public class CsvToMapTest {
 
     Flow<Collection<ByteString>, Map<String, String>, ?> flow5 =
         CsvToMap.withHeadersAsStrings(StandardCharsets.UTF_8, "column1", "column2", "column3");
+
+    // values as String (decode ByteString)
+    Flow<Collection<ByteString>, Map<String, String>, ?> flow6 =
+        CsvToMap.toMapAsStringsCombineAll(StandardCharsets.UTF_8, Optional.empty());
     // #flow-type
   }
 
@@ -130,6 +135,140 @@ public class CsvToMapTest {
     assertThat(map.get("zwei"), equalTo("2"));
     assertThat(map.get("drei"), equalTo("3"));
     // #column-names
+  }
+
+  @Test
+  public void givenMoreHeadersThanDataShouldBecomeMapKeysAndStringValues() throws Exception {
+    CompletionStage<Map<String, String>> completionStage =
+        // #column-names
+
+        // values as String
+        Source.single(ByteString.fromString("eins,zwei,drei,vier,fünt\n1,2,3"))
+            .via(CsvParsing.lineScanner())
+            .via(CsvToMap.toMapAsStringsCombineAll(StandardCharsets.UTF_8, Optional.empty()))
+            .runWith(Sink.head(), system);
+    // #column-names
+    Map<String, String> map = completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+    // #column-names
+
+    assertThat(map.get("eins"), equalTo("1"));
+    assertThat(map.get("zwei"), equalTo("2"));
+    assertThat(map.get("drei"), equalTo("3"));
+    assertThat(map.get("vier"), equalTo(""));
+    assertThat(map.get("fünt"), equalTo(""));
+    // #column-names
+  }
+
+  @Test
+  public void givenMoreDataThanHeadersShouldBecomeMapKeysAndStringValues() throws Exception {
+    CompletionStage<Map<String, String>> completionStage =
+        // #column-names
+
+        // values as String
+        Source.single(ByteString.fromString("eins,zwei,drei\n1,2,3,4,5"))
+            .via(CsvParsing.lineScanner())
+            .via(CsvToMap.toMapAsStringsCombineAll(StandardCharsets.UTF_8, Optional.empty()))
+            .runWith(Sink.head(), system);
+    // #column-names
+    Map<String, String> map = completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+    // #column-names
+
+    assertThat(map.get("eins"), equalTo("1"));
+    assertThat(map.get("zwei"), equalTo("2"));
+    assertThat(map.get("drei"), equalTo("3"));
+    assertThat(map.get("MissingHeader0"), equalTo("4"));
+    assertThat(map.get("MissingHeader1"), equalTo("5"));
+    // #column-names
+  }
+
+  @Test
+  public void
+      givenMoreDataThanHeadersAndACustomHeaderValueHeadersShouldBecomeMapKeysAndStringValues()
+          throws Exception {
+    CompletionStage<Map<String, String>> completionStage =
+        // #column-names
+
+        // values as String
+        Source.single(ByteString.fromString("eins,zwei,drei\n1,2,3,4,5"))
+            .via(CsvParsing.lineScanner())
+            .via(
+                CsvToMap.toMapAsStringsCombineAll(
+                    StandardCharsets.UTF_8, Optional.of("MyCustomHeader")))
+            .runWith(Sink.head(), system);
+    // #column-names
+    Map<String, String> map = completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+    // #column-names
+
+    assertThat(map.get("eins"), equalTo("1"));
+    assertThat(map.get("zwei"), equalTo("2"));
+    assertThat(map.get("drei"), equalTo("3"));
+    assertThat(map.get("MyCustomHeader0"), equalTo("4"));
+    assertThat(map.get("MyCustomHeader1"), equalTo("5"));
+    // #column-names
+  }
+
+  @Test
+  public void parsedLineShouldBecomeMapKeysWhenMoreDataThanHeaders() throws Exception {
+    CompletionStage<Map<String, ByteString>> completionStage =
+        // #header-line
+        // values as ByteString
+        Source.single(ByteString.fromString("eins,zwei,drei\n1,2,3,4,5"))
+            .via(CsvParsing.lineScanner())
+            .via(CsvToMap.toMapCombineAll(StandardCharsets.UTF_8, Optional.empty()))
+            .runWith(Sink.head(), system);
+    // #header-line
+    Map<String, ByteString> map = completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+    // #header-line
+
+    assertThat(map.get("eins"), equalTo(ByteString.fromString("1")));
+    assertThat(map.get("zwei"), equalTo(ByteString.fromString("2")));
+    assertThat(map.get("drei"), equalTo(ByteString.fromString("3")));
+    assertThat(map.get("MissingHeader0"), equalTo(ByteString.fromString("4")));
+    assertThat(map.get("MissingHeader1"), equalTo(ByteString.fromString("5")));
+    // #header-line
+  }
+
+  @Test
+  public void parsedLineShouldBecomeMapKeysWhenMoreHeadersThanData() throws Exception {
+    CompletionStage<Map<String, ByteString>> completionStage =
+        // #header-line
+        // values as ByteString
+        Source.single(ByteString.fromString("eins,zwei,drei,vier,fünt\n1,2,3"))
+            .via(CsvParsing.lineScanner())
+            .via(CsvToMap.toMapCombineAll(StandardCharsets.UTF_8, Optional.empty()))
+            .runWith(Sink.head(), system);
+    // #header-line
+    Map<String, ByteString> map = completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+    // #header-line
+
+    assertThat(map.get("eins"), equalTo(ByteString.fromString("1")));
+    assertThat(map.get("zwei"), equalTo(ByteString.fromString("2")));
+    assertThat(map.get("drei"), equalTo(ByteString.fromString("3")));
+    assertThat(map.get("vier"), equalTo(ByteString.fromString("")));
+    assertThat(map.get("fünt"), equalTo(ByteString.fromString("")));
+    // #header-line
+  }
+
+  @Test
+  public void parsedLineShouldBecomeMapKeysWhenMoreHeadersThanDataAndACustomHeaderIsDefined()
+      throws Exception {
+    CompletionStage<Map<String, ByteString>> completionStage =
+        // #header-line
+        // values as ByteString
+        Source.single(ByteString.fromString("eins,zwei,drei\n1,2,3,4,5"))
+            .via(CsvParsing.lineScanner())
+            .via(CsvToMap.toMapCombineAll(StandardCharsets.UTF_8, Optional.of("MyCustomHeader")))
+            .runWith(Sink.head(), system);
+    // #header-line
+    Map<String, ByteString> map = completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+    // #header-line
+
+    assertThat(map.get("eins"), equalTo(ByteString.fromString("1")));
+    assertThat(map.get("zwei"), equalTo(ByteString.fromString("2")));
+    assertThat(map.get("drei"), equalTo(ByteString.fromString("3")));
+    assertThat(map.get("MyCustomHeader0"), equalTo(ByteString.fromString("4")));
+    assertThat(map.get("MyCustomHeader1"), equalTo(ByteString.fromString("5")));
+    // #header-line
   }
 
   @BeforeClass

--- a/csv/src/test/scala/docs/scaladsl/CsvToMapSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvToMapSpec.scala
@@ -252,7 +252,7 @@ class CsvToMapSpec extends CsvSpec {
 
       result should be(
         Seq(
-          Map("eins" -> "11", "zwei" -> "12", "drei" -> "13", "Missing Header" -> "14"),
+          Map("eins" -> "11", "zwei" -> "12", "drei" -> "13", "MissingHeader0" -> "14"),
           Map("eins" -> "21", "zwei" -> "22", "drei" -> "23")
         )
       )
@@ -275,7 +275,7 @@ class CsvToMapSpec extends CsvSpec {
               |21,22,
               |""".stripMargin))
           .via(CsvParsing.lineScanner())
-          .via(CsvToMap.toMapAsStringsCombineAll(headerPlaceholder = Option("drei")))
+          .via(CsvToMap.toMapAsStringsCombineAll(headerPlaceholder = Option("MyCustomHeader")))
           .runWith(Sink.seq)
       // #header-line
       // format: on
@@ -284,8 +284,8 @@ class CsvToMapSpec extends CsvSpec {
 
       result should be(
         Seq(
-          Map("eins" -> "11", "zwei" -> "12", "drei" -> "13"),
-          Map("eins" -> "21", "zwei" -> "22", "drei" -> "")
+          Map("eins" -> "11", "zwei" -> "12", "MyCustomHeader0" -> "13"),
+          Map("eins" -> "21", "zwei" -> "22", "MyCustomHeader0" -> "")
         )
       )
       // #header-line
@@ -344,7 +344,7 @@ class CsvToMapSpec extends CsvSpec {
       Source
         .single(ByteString(
           """eins,zwei,drei
-            |11,12,13,14
+            |11,12,13,14,15
             |21,22,23
             |""".stripMargin))
         .via(CsvParsing.lineScanner())
@@ -360,7 +360,8 @@ class CsvToMapSpec extends CsvSpec {
         Map("eins" -> ByteString("11"),
             "zwei" -> ByteString("12"),
             "drei" -> ByteString("13"),
-            "Missing Header" -> ByteString("14")),
+            "MissingHeader0" -> ByteString("14"),
+            "MissingHeader1" -> ByteString("15")),
         Map("eins" -> ByteString("21"), "zwei" -> ByteString("22"), "drei" -> ByteString("23"))
       )
     )
@@ -383,7 +384,7 @@ class CsvToMapSpec extends CsvSpec {
             |21,22,
             |""".stripMargin))
         .via(CsvParsing.lineScanner())
-        .via(CsvToMap.toMapCombineAll(headerPlaceholder = Option("drei")))
+        .via(CsvToMap.toMapCombineAll(headerPlaceholder = Option("MyCustomHeader")))
         .runWith(Sink.seq)
     // #header-line
     // format: on
@@ -392,8 +393,8 @@ class CsvToMapSpec extends CsvSpec {
 
     result should be(
       Seq(
-        Map("eins" -> ByteString("11"), "zwei" -> ByteString("12"), "drei" -> ByteString("13")),
-        Map("eins" -> ByteString("21"), "zwei" -> ByteString("22"), "drei" -> ByteString(""))
+        Map("eins" -> ByteString("11"), "zwei" -> ByteString("12"), "MyCustomHeader0" -> ByteString("13")),
+        Map("eins" -> ByteString("21"), "zwei" -> ByteString("22"), "MyCustomHeader0" -> ByteString(""))
       )
     )
     // #header-line

--- a/csv/src/test/scala/docs/scaladsl/CsvToMapSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvToMapSpec.scala
@@ -204,15 +204,14 @@ class CsvToMapSpec extends CsvSpec {
         // format: off
       // #header-line
       // values as ByteString
-        Source
-          .single(ByteString(
-            """eins,zwei,drei,vier,fünt
-              |11,12,13
-              |21,22,23
-              |""".stripMargin))
-          .via(CsvParsing.lineScanner())
-          .via(CsvToMap.toMapAsStringsCombineAll(headerPlaceholder = Option.empty))
-          .runWith(Sink.seq)
+      Source
+        .single(ByteString("""eins,zwei,drei,vier,fünt
+                              |11,12,13
+                              |21,22,23
+                              |""".stripMargin))
+        .via(CsvParsing.lineScanner())
+        .via(CsvToMap.toMapAsStringsCombineAll(headerPlaceholder = Option.empty))
+        .runWith(Sink.seq)
       // #header-line
       // format: on
       val result = future.futureValue
@@ -236,15 +235,14 @@ class CsvToMapSpec extends CsvSpec {
         // format: off
       // #header-line
       // values as ByteString
-        Source
-          .single(ByteString(
-            """eins,zwei,drei
-              |11,12,13,14
-              |21,22,23
-              |""".stripMargin))
-          .via(CsvParsing.lineScanner())
-          .via(CsvToMap.toMapAsStringsCombineAll(headerPlaceholder = Option.empty))
-          .runWith(Sink.seq)
+      Source
+        .single(ByteString("""eins,zwei,drei
+                              |11,12,13,14
+                              |21,22,23
+                              |""".stripMargin))
+        .via(CsvParsing.lineScanner())
+        .via(CsvToMap.toMapAsStringsCombineAll(headerPlaceholder = Option.empty))
+        .runWith(Sink.seq)
       // #header-line
       // format: on
       val result = future.futureValue
@@ -268,15 +266,14 @@ class CsvToMapSpec extends CsvSpec {
         // format: off
       // #header-line
       // values as ByteString
-        Source
-          .single(ByteString(
-            """eins,zwei
-              |11,12,13
-              |21,22,
-              |""".stripMargin))
-          .via(CsvParsing.lineScanner())
-          .via(CsvToMap.toMapAsStringsCombineAll(headerPlaceholder = Option("MyCustomHeader")))
-          .runWith(Sink.seq)
+      Source
+        .single(ByteString("""eins,zwei
+                              |11,12,13
+                              |21,22,
+                              |""".stripMargin))
+        .via(CsvParsing.lineScanner())
+        .via(CsvToMap.toMapAsStringsCombineAll(headerPlaceholder = Option("MyCustomHeader")))
+        .runWith(Sink.seq)
       // #header-line
       // format: on
       val result = future.futureValue
@@ -300,15 +297,14 @@ class CsvToMapSpec extends CsvSpec {
         // format: off
         // #header-line
         // values as ByteString
-          Source
-            .single(ByteString(
-              """eins,zwei,drei,fünt
-                |11,12,13
-                |21,22,23
-                |""".stripMargin))
-            .via(CsvParsing.lineScanner())
-            .via(CsvToMap.toMapAsStringsCombineAll(customFieldValuePlaceholder = Option("missing")))
-            .runWith(Sink.seq)
+        Source
+          .single(ByteString("""eins,zwei,drei,fünt
+                                |11,12,13
+                                |21,22,23
+                                |""".stripMargin))
+          .via(CsvParsing.lineScanner())
+          .via(CsvToMap.toMapAsStringsCombineAll(customFieldValuePlaceholder = Option("missing")))
+          .runWith(Sink.seq)
         // #header-line
         // format: on
       val result = future.futureValue
@@ -333,15 +329,14 @@ class CsvToMapSpec extends CsvSpec {
       // format: off
     // #header-line
     // values as ByteString
-      Source
-        .single(ByteString(
-          """eins,zwei,drei,vier,fünt
-            |11,12,13
-            |21,22,23
-            |""".stripMargin))
-        .via(CsvParsing.lineScanner())
-        .via(CsvToMap.toMapCombineAll(headerPlaceholder = Option.empty))
-        .runWith(Sink.seq)
+    Source
+      .single(ByteString("""eins,zwei,drei,vier,fünt
+                            |11,12,13
+                            |21,22,23
+                            |""".stripMargin))
+      .via(CsvParsing.lineScanner())
+      .via(CsvToMap.toMapCombineAll(headerPlaceholder = Option.empty))
+      .runWith(Sink.seq)
     // #header-line
     // format: on
     val result = future.futureValue
@@ -374,14 +369,13 @@ class CsvToMapSpec extends CsvSpec {
     // #header-line
     // values as ByteString
       Source
-        .single(ByteString(
-          """eins,zwei,drei
-            |11,12,13,14,15
-            |21,22,23
-            |""".stripMargin))
-        .via(CsvParsing.lineScanner())
-        .via(CsvToMap.toMapCombineAll(headerPlaceholder = Option.empty))
-        .runWith(Sink.seq)
+      .single(ByteString("""eins,zwei,drei
+                            |11,12,13,14,15
+                            |21,22,23
+                            |""".stripMargin))
+      .via(CsvParsing.lineScanner())
+      .via(CsvToMap.toMapCombineAll(headerPlaceholder = Option.empty))
+      .runWith(Sink.seq)
     // #header-line
     // format: on
     val result = future.futureValue
@@ -410,14 +404,13 @@ class CsvToMapSpec extends CsvSpec {
     // #header-line
     // values as ByteString
       Source
-        .single(ByteString(
-          """eins,zwei
-            |11,12,13
-            |21,22,
-            |""".stripMargin))
-        .via(CsvParsing.lineScanner())
-        .via(CsvToMap.toMapCombineAll(headerPlaceholder = Option("MyCustomHeader")))
-        .runWith(Sink.seq)
+      .single(ByteString("""eins,zwei
+                            |11,12,13
+                            |21,22,
+                            |""".stripMargin))
+      .via(CsvParsing.lineScanner())
+      .via(CsvToMap.toMapCombineAll(headerPlaceholder = Option("MyCustomHeader")))
+      .runWith(Sink.seq)
     // #header-line
     // format: on
     val result = future.futureValue
@@ -441,15 +434,14 @@ class CsvToMapSpec extends CsvSpec {
       // format: off
       // #header-line
       // values as ByteString
-        Source
-          .single(ByteString(
-            """eins,zwei,drei,fünt
-              |11,12,13
-              |21,22,
-              |""".stripMargin))
-          .via(CsvParsing.lineScanner())
-          .via(CsvToMap.toMapCombineAll(headerPlaceholder = Option("MyCustomHeader"), customFieldValuePlaceholder = Option(ByteString("missing"))))
-          .runWith(Sink.seq)
+      Source
+        .single(ByteString("""eins,zwei,drei,fünt
+                              |11,12,13
+                              |21,22,
+                              |""".stripMargin))
+        .via(CsvParsing.lineScanner())
+        .via(CsvToMap.toMapCombineAll(headerPlaceholder = Option("MyCustomHeader"), customFieldValuePlaceholder = Option(ByteString("missing"))))
+        .runWith(Sink.seq)
       // #header-line
       // format: on
     val result = future.futureValue


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->

This PR adds a couple of function that basically allows the user to include the empty fields (using some placeholders) in cases where there are more headers than data (or vice-versa) in the csv being transformed to a Map.

Examples:
 1. When there are more data than headers
```csv
eins,zwei
11,12,13
```
maps to
```scala
Map("eins" -> "11", "zwei" -> "12", "Missing header" -> "13")
```
The "Missing header" value is the default one, the user has the option to pass a custom value for this placeholder.

2. When there are more headers than data
```csv
eins,zwei,drei,vier,fünt
11,12,13
```
maps to
```scala
Map("eins" -> "11", "zwei" -> "12", "dreir" -> "13", "vier" -> "", "fünt" -> "")
```

This would be helpful, especially in the second case, when I want to keep the headers even when I don't have values associated with them.

