### PR TITLE
Slick: Add note about enabling streaming with PostgreSQL (#1128)

### DIFF
--- a/docs/src/main/paradox/slick.md
+++ b/docs/src/main/paradox/slick.md
@@ -110,6 +110,18 @@ Java
 
 The Slick connector allows you to perform a SQL query and expose the resulting stream of results as an Akka Streams `Source[T]`. Where `T` is any type that can be constructed using a database row.
 
+@@@ warning
+Some database systems, such as PostgreSQL, require session parameters to be set in a certain way to support streaming without caching all data at once in memory on the client side, see [Slick documentation](https://scala-slick.org/doc/3.2.0/dbio.html#streaming).
+```scala
+// Example for PostgreSQL:
+query.result.withStatementParameters(
+  rsType = ResultSetType.ForwardOnly,
+  rsConcurrency = ResultSetConcurrency.ReadOnly,
+  fetchSize = 128, // not to be left at default value (0)
+).transactionally
+```
+@@@
+
 ### Plain SQL queries
 
 Both the Scala and Java DSLs support the use of @extref[plain SQL queries](slick:concepts.html#plain-sql-statements).


### PR DESCRIPTION
Some additional parameters need to be set to stream some databases such as PostgreSQL

I got the surprise of my application loading my whole database in-memory while I was thinking I was streaming it, so I think it's worth highlighting this.

References https://github.com/akka/alpakka/issues/1128
