### PR TITLE
File: LogRotatorSink fix completition

### DIFF
--- a/file/src/main/mima-filters/2.0.0-RC2.backwards.excludes/PR2559-log-rotator-sink.excludes
+++ b/file/src/main/mima-filters/2.0.0-RC2.backwards.excludes/PR2559-log-rotator-sink.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.file.scaladsl.LogRotatorSink#Logic.this")


### PR DESCRIPTION
issue come up with; https://discuss.lightbend.com/t/writing-element-each-to-its-own-file-problem-on-last-element/7696 also #2553

I need some help, bcs I see something really odd! I will write down the context to get faster to the point;

The logRotator is a custom sink stage. When it gets an element, it runs a function, and if the input function returns with a Some, creates a new subSink, and send the element to that sink.

The current problem appears when the subsink is still initializing (not consuming the dangling data) while the input gets an `onUpstreamFinish`. At this point the stage completes without giving down the last element to the last sink.

My idea was to simply override the input handler when the rotation happens and we still waiting to the data to be consumed by the new subsink, and when we are going back to the normal operation we complete the stage (if it should be completed).

And I get a timeout exception... So started to paint with `println`s the whole code to find out what is actually happening, and I think even if the input handler overrides the `onUpstreamFinish` somehow the `postStop` called.

What am I missing? With an overridden `onUpstreamFinish` the stage should wait until I manually call the `completeStage()` as I know. How can I debug this further?

Test output:
```
rotate
s
pull with dangling
normal
rotate
s
f
pull with dangling
normal
rotate
delayedfinish
postStopFinish
s
f
```
This means that after the rotate, the rotated input handler called with the delayed finish, then somehow the postStop, and after these the new sink starts, and the old finishes. The new sink never finished, so the promise never succeeds.

