### PR TITLE
FTP: Enable SFTP connector to issue more than one unconfirmed read request

### DIFF
--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -55,8 +55,8 @@ Java
 : @@snip [snip](/ftp/src/test/java/docs/javadsl/ConfigureCustomSSHClient.java) { #configure-custom-ssh-client }
 
 ### Improving SFTP throughput
-For SFTP connection allowing more than one unconfirmed read request to be sent by the client you can use `withMaxUnconfirmedReads` on @scaladoc[SftpSettings](akka.stream.alpakka.ftp.SftpSettings)  
-Command-line `sftp` uses a value of 64 by default.  This can significantly improve throughput by reducing the impact of latency.
+For SFTP connections allowing more than one unconfirmed read request to be sent by the client you can use `withMaxUnconfirmedReads` on @scaladoc[SftpSettings](akka.stream.alpakka.ftp.SftpSettings)  
+The command-line tool `sftp` uses a value of `64` by default.  This can significantly improve throughput by reducing the impact of latency.
 
 Scala
 : @@snip [snip](/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala) { #retrieving-with-unconfirmed-reads }

--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -54,6 +54,16 @@ Scala
 Java
 : @@snip [snip](/ftp/src/test/java/docs/javadsl/ConfigureCustomSSHClient.java) { #configure-custom-ssh-client }
 
+### Improving SFTP throughput
+For SFTP connection allowing more than one unconfirmed read request to be sent by the client you can use `withMaxUnconfirmedReads` on @scaladoc[SftpSettings](akka.stream.alpakka.ftp.SftpSettings)  
+Command-line `sftp` uses a value of 64 by default.  This can significantly improve throughput by reducing the impact of latency.
+
+Scala
+: @@snip [snip](/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala) { #retrieving-with-unconfirmed-reads }
+
+Java
+: @@snip [snip](/ftp/src/test/java/docs/javadsl/SftpRetrievingExample.java) { #retrieving-with-unconfirmed-reads }
+
 ## Traversing a remote FTP folder recursively
 
 In order to traverse a remote folder recursively, you need to use the `ls` method in the FTP API:

--- a/ftp/src/main/mima-filters/2.0.2.backwards.excludes
+++ b/ftp/src/main/mima-filters/2.0.2.backwards.excludes
@@ -1,0 +1,3 @@
+# Allow change to SFTPSettings
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.ftp.SftpSettings.this")
+

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
@@ -55,9 +55,20 @@ protected[ftp] trait RetrieveOffset { _: FtpLike[_, _] =>
  * INTERNAL API
  */
 @InternalApi
+protected[ftp] trait UnconfirmedReads { _: FtpLike[_, _] =>
+
+  def retrieveFileInputStream(name: String, handler: Handler, offset: Long, maxUnconfirmedReads: Int): Try[InputStream]
+
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
 object FtpLike {
   // type class instances
   implicit val ftpLikeInstance = new FtpLike[FTPClient, FtpSettings] with RetrieveOffset with FtpOperations
   implicit val ftpsLikeInstance = new FtpLike[FTPSClient, FtpsSettings] with RetrieveOffset with FtpsOperations
-  implicit val sFtpLikeInstance = new FtpLike[SSHClient, SftpSettings] with RetrieveOffset with SftpOperations
+  implicit val sFtpLikeInstance =
+    new FtpLike[SSHClient, SftpSettings] with RetrieveOffset with SftpOperations with UnconfirmedReads
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -262,6 +262,7 @@ object FtpsSettings {
  * @param knownHosts known hosts file to be used when connecting
  * @param sftpIdentity private/public key config to use when connecting
  * @param proxy An optional proxy to use when connecting with these settings
+ * @param maxUnconfirmedReads determines the number of read requests sent in parallel, disabled if set to <=1
  */
 final class SftpSettings private (
     val host: java.net.InetAddress,
@@ -270,7 +271,8 @@ final class SftpSettings private (
     val strictHostKeyChecking: Boolean,
     val knownHosts: Option[String],
     val sftpIdentity: Option[SftpIdentity],
-    val proxy: Option[Proxy]
+    val proxy: Option[Proxy],
+    val maxUnconfirmedReads: Int = 1
 ) extends RemoteFileSettings {
 
   def withHost(value: java.net.InetAddress): SftpSettings = copy(host = value)
@@ -281,6 +283,7 @@ final class SftpSettings private (
   def withKnownHosts(value: String): SftpSettings = copy(knownHosts = Option(value))
   def withSftpIdentity(value: SftpIdentity): SftpSettings = copy(sftpIdentity = Option(value))
   def withProxy(value: Proxy): SftpSettings = copy(proxy = Some(value))
+  def withMaxUnconfirmedReads(value: Int): SftpSettings = copy(maxUnconfirmedReads = value)
 
   private def copy(
       host: java.net.InetAddress = host,
@@ -289,7 +292,8 @@ final class SftpSettings private (
       strictHostKeyChecking: Boolean = strictHostKeyChecking,
       knownHosts: Option[String] = knownHosts,
       sftpIdentity: Option[SftpIdentity] = sftpIdentity,
-      proxy: Option[Proxy] = proxy
+      proxy: Option[Proxy] = proxy,
+      maxUnconfirmedReads: Int = maxUnconfirmedReads
   ): SftpSettings = new SftpSettings(
     host = host,
     port = port,
@@ -297,7 +301,8 @@ final class SftpSettings private (
     strictHostKeyChecking = strictHostKeyChecking,
     knownHosts = knownHosts,
     sftpIdentity = sftpIdentity,
-    proxy = proxy
+    proxy = proxy,
+    maxUnconfirmedReads = maxUnconfirmedReads
   )
 
   override def toString =
@@ -308,7 +313,8 @@ final class SftpSettings private (
     s"strictHostKeyChecking=$strictHostKeyChecking," +
     s"knownHosts=$knownHosts," +
     s"sftpIdentity=$sftpIdentity," +
-    s"proxy=$proxy)"
+    s"proxy=$proxy," +
+    s"maxUnconfirmedReads=$maxUnconfirmedReads)"
 }
 
 /**
@@ -327,7 +333,8 @@ object SftpSettings {
     strictHostKeyChecking = true,
     knownHosts = None,
     sftpIdentity = None,
-    proxy = None
+    proxy = None,
+    maxUnconfirmedReads = 1
   )
 
   /** Java API */

--- a/ftp/src/test/java/docs/javadsl/SftpRetrievingExample.java
+++ b/ftp/src/test/java/docs/javadsl/SftpRetrievingExample.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.javadsl;
+
+// #retrieving-with-unconfirmed-reads
+
+import akka.stream.IOResult;
+import akka.stream.alpakka.ftp.FtpSettings;
+import akka.stream.alpakka.ftp.javadsl.Sftp;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+
+import java.util.concurrent.CompletionStage;
+
+public class SftpRetrievingExample {
+
+  public Source<ByteString, CompletionStage<IOResult>> retrieveFromPath(
+      String path, SftpSettings settings) throws Exception {
+    return Sftp.fromPath(path, settings.withMaxUnconfirmedReads(64));
+  }
+}
+// #retrieving-with-unconfirmed-reads

--- a/ftp/src/test/java/docs/javadsl/SftpRetrievingExample.java
+++ b/ftp/src/test/java/docs/javadsl/SftpRetrievingExample.java
@@ -7,7 +7,7 @@ package docs.javadsl;
 // #retrieving-with-unconfirmed-reads
 
 import akka.stream.IOResult;
-import akka.stream.alpakka.ftp.FtpSettings;
+import akka.stream.alpakka.ftp.SftpSettings;
 import akka.stream.alpakka.ftp.javadsl.Sftp;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -69,6 +69,20 @@ final class StrictHostCheckingSftpSourceSpec extends BaseSftpSpec with CommonFtp
     )
 }
 
+final class UnconfirmedReadsSftpSourceSpec extends BaseSftpSpec with CommonFtpStageSpec {
+  override val settings = SftpSettings(
+    InetAddress.getByName(HOSTNAME)
+  ).withPort(PORT)
+    .withCredentials(FtpCredentials.create("username", "wrong password"))
+    .withStrictHostKeyChecking(true)
+    .withKnownHosts(getKnownHostsFile.getPath)
+    .withSftpIdentity(
+      SftpIdentity
+        .createFileSftpIdentity(getClientPrivateKeyFile.getPath, ClientPrivateKeyPassphrase)
+    )
+    .withMaxUnconfirmedReads(8)
+}
+
 trait CommonFtpStageSpec extends BaseSpec with Eventually {
 
   implicit val system = getSystem

--- a/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala
+++ b/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala
@@ -44,6 +44,21 @@ object scalaExamples {
     //#retrieving
   }
 
+  object retrievingUnconfirmedReads {
+    //#retrieving-with-unconfirmed-reads
+    import akka.stream.IOResult
+    import akka.stream.alpakka.ftp.scaladsl.Sftp
+    import akka.stream.scaladsl.Source
+    import akka.util.ByteString
+
+    import scala.concurrent.Future
+
+    def retrieveFromPath(path: String, settings: SftpSettings): Source[ByteString, Future[IOResult]] =
+      Sftp.fromPath(path, settings.withMaxUnconfirmedReads(64))
+
+    //#retrieving-with-unconfirmed-reads
+  }
+
   object removing {
     //#removing
     import akka.stream.IOResult

--- a/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala
+++ b/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala
@@ -3,7 +3,7 @@
  */
 
 package docs.scaladsl
-import akka.stream.alpakka.ftp.{FtpFile, FtpSettings}
+import akka.stream.alpakka.ftp.{FtpFile, FtpSettings, SftpSettings}
 
 object scalaExamples {
 


### PR DESCRIPTION
Fixes: #2557

This change allows the SFTP connector to send multiple parallel read requests to an SFTP server, significantly improving throughput.

A new API has been added to `SftpSettings` - `withMaxUnconfirmedReads(value: Int)`.  When this value is >=2 it will result in the SFTP client sending the corresponding number of read requests to the server without waiting synchronously on an ACK for each one.  This significantly improves performance and is particularly important for connections with higher latency.

The timings below show the time taken in milliseconds to download a 1GB file at various latencies between an Alpakka SFTP client and an openssh SFTP server.

```
0ms
64 reads: 32683ms
32 reads: 35815ms
16 reads: 35298ms
8 reads: 38902ms


20ms
64 reads: 42407ms
32 reads: 48456ms
16 reads: 52239ms
8 reads: 87970ms


40ms
64 reads: 47277ms
32 reads: 53954ms
16 reads: 88914ms
8 reads: 161923ms


60ms
64 reads: 66015ms
32 reads: 73512ms
16 reads: 127010ms
8 reads: 236830ms


80ms
64 reads: 91981ms
32 reads: 96287ms
16 reads: 166619ms
8 reads: 309943ms


100ms
64 reads: 94496ms
32 reads: 116160ms
16 reads: 206884ms
8 reads: 384467ms
```
