### PR TITLE
Kinesis and solr Akka 2.6 updates and other things

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -267,7 +267,7 @@ lazy val eventbridge =
 
 lazy val sns = alpakkaProject("sns", "aws.sns", Dependencies.Sns)
 
-lazy val solr = alpakkaProject("solr", "solr", Dependencies.Solr)
+lazy val solr = alpakkaProject("solr", "solr", Dependencies.Solr, fatalWarnings := true)
 
 lazy val sqs = alpakkaProject("sqs", "aws.sqs", Dependencies.Sqs)
 

--- a/build.sbt
+++ b/build.sbt
@@ -223,7 +223,7 @@ lazy val jms = alpakkaProject("jms", "jms", Dependencies.Jms, fatalWarnings := t
 
 lazy val jsonStreaming = alpakkaProject("json-streaming", "json.streaming", Dependencies.JsonStreaming)
 
-lazy val kinesis = alpakkaProject("kinesis", "aws.kinesis", Dependencies.Kinesis)
+lazy val kinesis = alpakkaProject("kinesis", "aws.kinesis", Dependencies.Kinesis, fatalWarnings := true)
 
 lazy val kudu = alpakkaProject("kudu", "kudu", Dependencies.Kudu, fork in Test := false)
 

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/impl/KinesisSchedulerSourceStage.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/impl/KinesisSchedulerSourceStage.scala
@@ -83,7 +83,7 @@ private[kinesis] class KinesisSchedulerSourceStage(
       callback.invoke(NewRecord(record))
     }
     override def onPull(): Unit = awaitingRecords(Pump)
-    override def onDownstreamFinish(): Unit = awaitingRecords(Complete)
+    override def onDownstreamFinish(cause: Throwable): Unit = awaitingRecords(Complete)
     @tailrec
     private def awaitingRecords(in: Command): Unit = in match {
       case NewRecord(record) =>

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisSchedulerSource.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisSchedulerSource.scala
@@ -37,7 +37,7 @@ object KinesisSchedulerSource {
       settings: KinesisSchedulerSourceSettings
   ): Source[CommittableRecord, Future[Scheduler]] =
     Source
-      .setup { (mat, _) =>
+      .fromMaterializer { (mat, _) =>
         import mat.executionContext
         Source
           .fromGraph(new KinesisSchedulerSourceStage(settings, schedulerBuilder))

--- a/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/KinesisTest.java
+++ b/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/KinesisTest.java
@@ -67,21 +67,17 @@ public class KinesisTest {
     when(amazonKinesisAsync.getShardIterator((GetShardIteratorRequest) any()))
         .thenAnswer(
             (Answer)
-                invocation -> {
-                  return CompletableFuture.completedFuture(
-                      GetShardIteratorResponse.builder().build());
-                });
+                invocation -> CompletableFuture.completedFuture(
+                      GetShardIteratorResponse.builder().build()));
 
     when(amazonKinesisAsync.getRecords((GetRecordsRequest) any()))
         .thenAnswer(
             (Answer)
-                invocation -> {
-                  return CompletableFuture.completedFuture(
+                invocation -> CompletableFuture.completedFuture(
                       GetRecordsResponse.builder()
                           .records(Record.builder().sequenceNumber("1").build())
                           .nextShardIterator("iter")
-                          .build());
-                });
+                          .build()));
 
     final Source<Record, NotUsed> source = KinesisSource.basic(settings, amazonKinesisAsync);
     final CompletionStage<Record> record = source.runWith(Sink.head(), system);

--- a/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/KinesisTest.java
+++ b/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/KinesisTest.java
@@ -67,17 +67,18 @@ public class KinesisTest {
     when(amazonKinesisAsync.getShardIterator((GetShardIteratorRequest) any()))
         .thenAnswer(
             (Answer)
-                invocation -> CompletableFuture.completedFuture(
-                      GetShardIteratorResponse.builder().build()));
+                invocation ->
+                    CompletableFuture.completedFuture(GetShardIteratorResponse.builder().build()));
 
     when(amazonKinesisAsync.getRecords((GetRecordsRequest) any()))
         .thenAnswer(
             (Answer)
-                invocation -> CompletableFuture.completedFuture(
-                      GetRecordsResponse.builder()
-                          .records(Record.builder().sequenceNumber("1").build())
-                          .nextShardIterator("iter")
-                          .build()));
+                invocation ->
+                    CompletableFuture.completedFuture(
+                        GetRecordsResponse.builder()
+                            .records(Record.builder().sequenceNumber("1").build())
+                            .nextShardIterator("iter")
+                            .build()));
 
     final Source<Record, NotUsed> source = KinesisSource.basic(settings, amazonKinesisAsync);
     final CompletionStage<Record> record = source.runWith(Sink.head(), system);

--- a/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/KinesisTest.java
+++ b/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/KinesisTest.java
@@ -6,8 +6,6 @@ package akka.stream.alpakka.kinesis.javadsl;
 
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.japi.Pair;
-import akka.stream.ActorMaterializer;
 import akka.stream.alpakka.kinesis.ShardSettings;
 import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
@@ -32,7 +30,6 @@ public class KinesisTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
-  private static ActorMaterializer materializer;
   private static ShardSettings settings;
   private static KinesisAsyncClient amazonKinesisAsync;
 
@@ -42,7 +39,6 @@ public class KinesisTest {
     System.setProperty("aws.secretKey", "someSecretKey");
 
     system = ActorSystem.create();
-    materializer = ActorMaterializer.create(system);
 
     settings = ShardSettings.create("my-stream", "shard-id");
     amazonKinesisAsync = mock(KinesisAsyncClient.class);
@@ -88,7 +84,7 @@ public class KinesisTest {
                 });
 
     final Source<Record, NotUsed> source = KinesisSource.basic(settings, amazonKinesisAsync);
-    final CompletionStage<Record> record = source.runWith(Sink.head(), materializer);
+    final CompletionStage<Record> record = source.runWith(Sink.head(), system);
 
     assertEquals("1", record.toCompletableFuture().get(10, TimeUnit.SECONDS).sequenceNumber());
   }

--- a/kinesis/src/test/java/docs/javadsl/KinesisFirehoseSnippets.java
+++ b/kinesis/src/test/java/docs/javadsl/KinesisFirehoseSnippets.java
@@ -6,7 +6,6 @@ package docs.javadsl;
 
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
 import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseFlowSettings;
 import akka.stream.alpakka.kinesisfirehose.javadsl.KinesisFirehoseFlow;
 import akka.stream.alpakka.kinesisfirehose.javadsl.KinesisFirehoseSink;
@@ -25,7 +24,6 @@ public class KinesisFirehoseSnippets {
     // #init-client
 
     final ActorSystem system = ActorSystem.create();
-    final ActorMaterializer materializer = ActorMaterializer.create(system);
 
     final software.amazon.awssdk.services.firehose.FirehoseAsyncClient amazonFirehoseAsync =
         FirehoseAsyncClient.builder()

--- a/kinesis/src/test/java/docs/javadsl/KinesisSnippets.java
+++ b/kinesis/src/test/java/docs/javadsl/KinesisSnippets.java
@@ -6,7 +6,6 @@ package docs.javadsl;
 
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
 import akka.stream.alpakka.kinesis.KinesisFlowSettings;
 import akka.stream.alpakka.kinesis.ShardIterators;
 import akka.stream.alpakka.kinesis.ShardSettings;
@@ -37,7 +36,6 @@ public class KinesisSnippets {
     // #init-client
 
     final ActorSystem system = ActorSystem.create();
-    final ActorMaterializer materializer = ActorMaterializer.create(system);
 
     final software.amazon.awssdk.services.kinesis.KinesisAsyncClient amazonKinesisAsync =
         KinesisAsyncClient.builder()

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/DefaultTestContext.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/DefaultTestContext.scala
@@ -7,7 +7,6 @@ package akka.stream.alpakka.kinesis
 import java.util.concurrent.{Executors, TimeoutException}
 
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, Materializer}
 import com.typesafe.config.ConfigFactory
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
@@ -24,7 +23,6 @@ trait DefaultTestContext extends BeforeAndAfterAll with BeforeAndAfterEach with 
     akka.stream.materializer.max-input-buffer-size = 1
   """)
   )
-  implicit protected val materializer: Materializer = ActorMaterializer()
   private val threadPool = Executors.newFixedThreadPool(10)
   implicit protected val executionContext: ExecutionContextExecutor =
     ExecutionContext.fromExecutor(threadPool)

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisMock.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisMock.scala
@@ -5,7 +5,6 @@
 package akka.stream.alpakka.kinesis
 
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, Materializer}
 import org.mockito.Mockito.reset
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 import org.scalatestplus.mockito.MockitoSugar
@@ -17,7 +16,6 @@ import scala.concurrent.duration._
 trait KinesisMock extends BeforeAndAfterAll with BeforeAndAfterEach with MockitoSugar { this: Suite =>
 
   implicit protected val system: ActorSystem = ActorSystem()
-  implicit protected val materializer: Materializer = ActorMaterializer()
   implicit protected val amazonKinesisAsync: KinesisAsyncClient = mock[KinesisAsyncClient]
 
   override protected def beforeEach(): Unit =

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseMock.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseMock.scala
@@ -5,7 +5,6 @@
 package akka.stream.alpakka.kinesisfirehose
 
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, Materializer}
 import org.mockito.Mockito.reset
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 import org.scalatestplus.mockito.MockitoSugar
@@ -17,7 +16,6 @@ import scala.concurrent.duration._
 trait KinesisFirehoseMock extends BeforeAndAfterAll with BeforeAndAfterEach with MockitoSugar { this: Suite =>
 
   implicit protected val system: ActorSystem = ActorSystem()
-  implicit protected val materializer: Materializer = ActorMaterializer()
   implicit protected val amazonKinesisFirehoseAsync: FirehoseAsyncClient = mock[FirehoseAsyncClient]
 
   override protected def beforeEach(): Unit =

--- a/kinesis/src/test/scala/docs/scaladsl/KclSnippets.scala
+++ b/kinesis/src/test/scala/docs/scaladsl/KclSnippets.scala
@@ -7,10 +7,9 @@ package docs.scaladsl
 import java.util.UUID
 
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.Sink
-import akka.stream.{ActorMaterializer, Materializer}
-import akka.stream.alpakka.kinesis.{KinesisSchedulerCheckpointSettings, KinesisSchedulerSourceSettings}
 import akka.stream.alpakka.kinesis.scaladsl.KinesisSchedulerSource
+import akka.stream.alpakka.kinesis.{KinesisSchedulerCheckpointSettings, KinesisSchedulerSourceSettings}
+import akka.stream.scaladsl.Sink
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
@@ -25,7 +24,6 @@ class KclSnippets {
 
   //#init-system
   implicit val system: ActorSystem = ActorSystem()
-  implicit val materializer: Materializer = ActorMaterializer()
   //#init-system
 
   //#init-clients

--- a/kinesis/src/test/scala/docs/scaladsl/KinesisFirehoseSnippets.scala
+++ b/kinesis/src/test/scala/docs/scaladsl/KinesisFirehoseSnippets.scala
@@ -9,7 +9,6 @@ import akka.actor.ActorSystem
 import akka.stream.alpakka.kinesisfirehose.KinesisFirehoseFlowSettings
 import akka.stream.alpakka.kinesisfirehose.scaladsl.{KinesisFirehoseFlow, KinesisFirehoseSink}
 import akka.stream.scaladsl.{Flow, Sink}
-import akka.stream.{ActorMaterializer, Materializer}
 import software.amazon.awssdk.services.firehose.model.{PutRecordBatchResponseEntry, Record}
 
 object KinesisFirehoseSnippets {
@@ -19,7 +18,6 @@ object KinesisFirehoseSnippets {
   import software.amazon.awssdk.services.firehose.FirehoseAsyncClient
 
   implicit val system: ActorSystem = ActorSystem()
-  implicit val materializer: Materializer = ActorMaterializer()
 
   implicit val amazonKinesisFirehoseAsync: software.amazon.awssdk.services.firehose.FirehoseAsyncClient =
     FirehoseAsyncClient

--- a/kinesis/src/test/scala/docs/scaladsl/KinesisSnippets.scala
+++ b/kinesis/src/test/scala/docs/scaladsl/KinesisSnippets.scala
@@ -11,7 +11,6 @@ import akka.actor.ActorSystem
 import akka.stream.alpakka.kinesis.scaladsl.{KinesisFlow, KinesisSink, KinesisSource}
 import akka.stream.alpakka.kinesis.{KinesisFlowSettings, ShardIterator, ShardSettings}
 import akka.stream.scaladsl.{Flow, FlowWithContext, Sink, Source}
-import akka.stream.{ActorMaterializer, Materializer}
 import akka.util.ByteString
 import software.amazon.awssdk.services.kinesis.model.{PutRecordsRequestEntry, PutRecordsResultEntry, Record}
 
@@ -24,7 +23,6 @@ object KinesisSnippets {
   import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 
   implicit val system: ActorSystem = ActorSystem()
-  implicit val materializer: Materializer = ActorMaterializer()
 
   implicit val amazonKinesisAsync: software.amazon.awssdk.services.kinesis.KinesisAsyncClient =
     KinesisAsyncClient

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,12 +14,12 @@ object Dependencies {
 
   val InfluxDBJavaVersion = "2.15"
 
-  val AwsSdk2Version = "2.11.14"
+  val AwsSdk2Version = "2.15.82"
   val AwsSpiAkkaHttpVersion = "0.0.11"
   // Sync with plugins.sbt
   val AkkaGrpcBinaryVersion = "1.0"
-  val AkkaHttp101 = "10.1.11"
-  val AkkaHttp102 = "10.2.0"
+  val AkkaHttp101 = "10.1.13"
+  val AkkaHttp102 = "10.2.3"
   val AkkaHttpVersion = if (CronBuild) AkkaHttp102 else AkkaHttp101
   val AkkaHttpBinaryVersion = if (CronBuild) "10.2" else "10.1"
   val ScalaTestVersion = "3.2.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -321,7 +321,7 @@ object Dependencies {
       ) ++ Seq(
         "software.amazon.awssdk" % "kinesis" % AwsSdk2Version, // ApacheV2
         "software.amazon.awssdk" % "firehose" % AwsSdk2Version, // ApacheV2
-        "software.amazon.kinesis" % "amazon-kinesis-client" % "2.2.7" // ApacheV2
+        "software.amazon.kinesis" % "amazon-kinesis-client" % "2.3.3" // ApacheV2
       ).map(
         _.excludeAll(
           ExclusionRule("software.amazon.awssdk", "apache-client"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,12 +14,12 @@ object Dependencies {
 
   val InfluxDBJavaVersion = "2.15"
 
-  val AwsSdk2Version = "2.15.82"
+  val AwsSdk2Version = "2.11.14"
   val AwsSpiAkkaHttpVersion = "0.0.11"
   // Sync with plugins.sbt
   val AkkaGrpcBinaryVersion = "1.0"
-  val AkkaHttp101 = "10.1.13"
-  val AkkaHttp102 = "10.2.3"
+  val AkkaHttp101 = "10.1.11"
+  val AkkaHttp102 = "10.2.0"
   val AkkaHttpVersion = if (CronBuild) AkkaHttp102 else AkkaHttp101
   val AkkaHttpBinaryVersion = if (CronBuild) "10.2" else "10.1"
   val ScalaTestVersion = "3.2.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val InfluxDBJavaVersion = "2.15"
 
   val AwsSdk2Version = "2.11.14"
-  val AwsSpiAkkaHttpVersion = "0.0.10"
+  val AwsSpiAkkaHttpVersion = "0.0.11"
   // Sync with plugins.sbt
   val AkkaGrpcBinaryVersion = "1.0"
   val AkkaHttp101 = "10.1.11"

--- a/solr/src/test/java/docs/javadsl/SolrTest.java
+++ b/solr/src/test/java/docs/javadsl/SolrTest.java
@@ -7,7 +7,6 @@ package docs.javadsl;
 import akka.Done;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
 // #solr-update-settings
 import akka.stream.alpakka.solr.SolrUpdateSettings;
 // #solr-update-settings
@@ -65,7 +64,6 @@ public class SolrTest {
   private static SolrClient solrClient;
   private static SolrClient cl;
   private static ActorSystem system = ActorSystem.create();
-  private static ActorMaterializer materializer = ActorMaterializer.create(system);
   // #init-client
   private static final int zookeeperPort = 9984;
   private static final String zookeeperHost = "127.0.0.1:" + zookeeperPort + "/solr";
@@ -131,8 +129,7 @@ public class SolrTest {
                 })
             .groupedWithin(5, Duration.ofMillis(10))
             .runWith(
-                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient),
-                materializer)
+                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient), system)
             // explicit commit when stream ended
             .thenApply(
                 done -> {
@@ -151,7 +148,7 @@ public class SolrTest {
     CompletionStage<List<String>> res2 =
         SolrSource.fromTupleStream(stream2)
             .map(t -> tupleToBook.apply(t).title)
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
 
     List<String> result = new ArrayList<>(resultOf(res2));
 
@@ -196,7 +193,7 @@ public class SolrTest {
             .runWith(
                 SolrSink.beans(
                     collectionName, SolrUpdateSettings.create(), solrClient, BookBean.class),
-                materializer)
+                system)
             // explicit commit when stream ended
             .thenApply(
                 done -> {
@@ -215,7 +212,7 @@ public class SolrTest {
     CompletionStage<List<String>> res2 =
         SolrSource.fromTupleStream(stream2)
             .map(t -> tupleToBook.apply(t).title)
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
 
     List<String> result = new ArrayList<>(resultOf(res2));
 
@@ -245,7 +242,7 @@ public class SolrTest {
             .runWith(
                 SolrSink.typeds(
                     collectionName, SolrUpdateSettings.create(), bookToDoc, solrClient, Book.class),
-                materializer)
+                system)
             // explicit commit when stream ended
             .thenApply(
                 done -> {
@@ -264,7 +261,7 @@ public class SolrTest {
     CompletionStage<List<String>> res2 =
         SolrSource.fromTupleStream(stream2)
             .map(t -> tupleToBook.apply(t).title)
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
 
     List<String> result = new ArrayList<>(resultOf(res2));
 
@@ -294,7 +291,7 @@ public class SolrTest {
             .via(
                 SolrFlow.typeds(
                     collectionName, SolrUpdateSettings.create(), bookToDoc, solrClient, Book.class))
-            .runWith(Sink.ignore(), materializer)
+            .runWith(Sink.ignore(), system)
             // explicit commit when stream ended
             .thenApply(
                 done -> {
@@ -313,7 +310,7 @@ public class SolrTest {
     CompletionStage<List<String>> res2 =
         SolrSource.fromTupleStream(stream2)
             .map(t -> tupleToBook.apply(t).title)
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
 
     List<String> result = new ArrayList<>(resultOf(res2));
 
@@ -374,7 +371,7 @@ public class SolrTest {
                         .collect(Collectors.toList()))
             .map(ConsumerMessage::createCommittableOffsetBatch)
             .mapAsync(1, CommittableOffsetBatch::commitJavadsl)
-            .runWith(Sink.ignore(), materializer);
+            .runWith(Sink.ignore(), system);
     // #kafka-example
 
     resultOf(completion);
@@ -391,7 +388,7 @@ public class SolrTest {
     CompletionStage<List<String>> res2 =
         SolrSource.fromTupleStream(stream)
             .map(t -> tupleToBook.apply(t).title)
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
 
     List<String> result = new ArrayList<>(resultOf(res2));
 
@@ -415,8 +412,7 @@ public class SolrTest {
                 })
             .groupedWithin(5, Duration.ofMillis(10))
             .runWith(
-                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient),
-                materializer)
+                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient), system)
             // explicit commit when stream ended
             .thenApply(
                 done -> {
@@ -441,8 +437,7 @@ public class SolrTest {
                 })
             .groupedWithin(5, Duration.ofMillis(10))
             .runWith(
-                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient),
-                materializer)
+                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient), system)
             // explicit commit when stream ended
             .thenApply(
                 done -> {
@@ -461,7 +456,7 @@ public class SolrTest {
     CompletionStage<List<String>> res3 =
         SolrSource.fromTupleStream(stream3)
             .map(t -> tupleToBook.apply(t).title)
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
 
     List<String> result = new ArrayList<>(resultOf(res3));
     List<String> expect = Collections.emptyList();
@@ -483,8 +478,7 @@ public class SolrTest {
                 })
             .groupedWithin(5, Duration.ofMillis(10))
             .runWith(
-                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient),
-                materializer)
+                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient), system)
             // explicit commit when stream ended
             .thenApply(
                 done -> {
@@ -514,8 +508,7 @@ public class SolrTest {
                 })
             .groupedWithin(5, Duration.ofMillis(10))
             .runWith(
-                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient),
-                materializer)
+                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient), system)
             // explicit commit when stream ended
             .thenApply(
                 done -> {
@@ -537,7 +530,7 @@ public class SolrTest {
                   Book b = tupleToBook.apply(t);
                   return b.title + ". " + b.comment;
                 })
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
 
     List<String> result = new ArrayList<>(resultOf(res3));
     List<String> expect =
@@ -571,8 +564,7 @@ public class SolrTest {
                 })
             .groupedWithin(5, Duration.ofMillis(10))
             .runWith(
-                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient),
-                materializer)
+                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient), system)
             // explicit commit when stream ended
             .thenApply(
                 done -> {
@@ -602,8 +594,7 @@ public class SolrTest {
                 })
             .groupedWithin(5, Duration.ofMillis(10))
             .runWith(
-                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient),
-                materializer)
+                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient), system)
             // explicit commit when stream ended
             .thenApply(
                 done -> {
@@ -625,7 +616,7 @@ public class SolrTest {
                   Book b = tupleToBook.apply(t);
                   return b.title + ". " + b.comment;
                 })
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
 
     List<String> result = new ArrayList<>(resultOf(res3));
 
@@ -657,8 +648,7 @@ public class SolrTest {
                 })
             .groupedWithin(5, Duration.ofMillis(10))
             .runWith(
-                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient),
-                materializer)
+                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient), system)
             // explicit commit when stream ended
             .thenApply(
                 done -> {
@@ -684,8 +674,7 @@ public class SolrTest {
                 })
             .groupedWithin(5, Duration.ofMillis(10))
             .runWith(
-                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient),
-                materializer)
+                SolrSink.documents(collectionName, SolrUpdateSettings.create(), solrClient), system)
             // explicit commit when stream ended
             .thenApply(
                 done -> {
@@ -704,7 +693,7 @@ public class SolrTest {
     CompletionStage<List<String>> res3 =
         SolrSource.fromTupleStream(stream3)
             .map(t -> tupleToBook.apply(t).title)
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
 
     List<String> result = new ArrayList<>(resultOf(res3));
     List<String> expect = Collections.emptyList();
@@ -751,7 +740,7 @@ public class SolrTest {
                         .collect(Collectors.toList()))
             .map(ConsumerMessage::createCommittableOffsetBatch)
             .mapAsync(1, CommittableOffsetBatch::commitJavadsl)
-            .runWith(Sink.ignore(), materializer);
+            .runWith(Sink.ignore(), system);
     // #kafka-example-PT
 
     resultOf(completion);

--- a/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
+++ b/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
@@ -14,7 +14,6 @@ import akka.stream.alpakka.solr._
 import akka.stream.alpakka.solr.scaladsl.{SolrFlow, SolrSink, SolrSource}
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.{ActorMaterializer, Materializer}
 import akka.testkit.TestKit
 import org.apache.solr.client.solrj.embedded.JettyConfig
 import org.apache.solr.client.solrj.impl.{CloudSolrClient, ZkClientClusterStateProvider}
@@ -43,8 +42,6 @@ class SolrSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with Sca
   private var zkTestServer: ZkTestServer = _
   implicit val system: ActorSystem = ActorSystem()
   implicit val commitExecutionContext: ExecutionContext = ExecutionContext.global
-
-  implicit val materializer: Materializer = ActorMaterializer()
 
   final val predefinedCollection = "collection1"
 


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Upgrading all `kinesis` dependencies and removing the `akka.stream.{ActorMaterializer, Materializer}` kinesis tests as akka streams now uses the system wide materializer

Also applies updates from Akka 2.6 for solr.

References #2487 
References #2498 