### PR TITLE
HDFS: New path per file

### DIFF
--- a/hdfs/src/main/mima-filters/2.x.backwards.excludes/PR2578.backwards.excludes
+++ b/hdfs/src/main/mima-filters/2.x.backwards.excludes/PR2578.backwards.excludes
@@ -1,0 +1,2 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.hdfs.HdfsWritingSettings.this")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.alpakka.hdfs.FilePathGenerator.newPathForEachFile")

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/extractor/TimestampExtractor.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/extractor/TimestampExtractor.scala
@@ -19,7 +19,7 @@ abstract class DefaultTimestampExtractor extends TimestampExtractor {
 }
 
 class NoTimestampExtractor extends DefaultTimestampExtractor {
-  override def extract(source: Any): Long = ???
+  override def extract(source: Any): Long = -1L
 }
 
 object TimestampExtractor {

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/extractor/TimestampExtractor.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/extractor/TimestampExtractor.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.hdfs.impl.extractor
+
+import akka.annotation.InternalApi
+
+/**
+ * Internal API
+ */
+@InternalApi
+private[hdfs] trait TimestampExtractor {
+  def extract(source: Any): Long
+}
+
+abstract class DefaultTimestampExtractor extends TimestampExtractor {
+  override def extract(source: Any): Long
+}
+
+class NoTimestampExtractor extends DefaultTimestampExtractor {
+  override def extract(source: Any): Long = ???
+}
+
+object TimestampExtractor {
+  def none: TimestampExtractor = new NoTimestampExtractor
+}

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/extractor/TimestampExtractor.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/extractor/TimestampExtractor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.stream.alpakka.hdfs.impl.extractor

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/DataWriter.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/DataWriter.scala
@@ -21,8 +21,9 @@ private[writer] final case class DataWriter(
     override val overwrite: Boolean
 ) extends HdfsWriter[FSDataOutputStream, ByteString] {
 
-  override protected lazy val target: Path =
-    getOrCreatePath(maybeTargetPath, createTargetPath(pathGenerator, 0))
+  override protected def target(rotationCount: Long, timestamp: Long): Path =
+    if (pathGenerator.newPathForEachFile) createTargetPath(pathGenerator, rotationCount, timestamp)
+    else getOrCreatePath(maybeTargetPath, createTargetPath(pathGenerator, 0))
 
   override def sync(): Unit = output.hsync()
 

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/HdfsWriter.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/HdfsWriter.scala
@@ -9,6 +9,8 @@ import akka.stream.alpakka.hdfs.FilePathGenerator
 import akka.stream.alpakka.hdfs.impl.writer.HdfsWriter._
 import org.apache.hadoop.fs.{FileSystem, Path}
 
+import java.lang.System.currentTimeMillis
+
 /**
  * Internal API
  */
@@ -17,25 +19,26 @@ private[hdfs] trait HdfsWriter[W, I] {
 
   protected lazy val output: W = create(fs, temp)
 
-  protected lazy val temp: Path = tempFromTarget(pathGenerator, target)
+  protected lazy val temp: Path = tempFromTarget(pathGenerator, target())
 
-  def moveToTarget(): Boolean = {
-    if (!fs.exists(target.getParent))
-      fs.mkdirs(target.getParent)
+  def moveToTarget(rotationCount: Long = 0, timestamp: Long): Boolean = {
+    val currTarget = target(rotationCount, timestamp)
+    if (!fs.exists(currTarget.getParent))
+      fs.mkdirs(currTarget.getParent)
     // mimics FileContext#rename(temp, target, Options.Rename.Overwrite) semantics
-    if (overwrite) fs.delete(target, false)
-    fs.rename(temp, target)
+    if (overwrite) fs.delete(currTarget, false)
+    fs.rename(temp, currTarget)
   }
 
   def sync(): Unit
 
-  def targetPath: String = target.toString
+  def targetPath(rotationCount: Long, timestamp: Long): String = target(rotationCount, timestamp).toString
 
   def write(input: I, separator: Option[Array[Byte]]): Long
 
   def rotate(rotationCount: Long): HdfsWriter[W, I]
 
-  protected def target: Path
+  protected def target(rotationCount: Long = 0, timestamp: Long = -1): Path
 
   protected def fs: FileSystem
 
@@ -53,8 +56,8 @@ private[hdfs] trait HdfsWriter[W, I] {
 @InternalApi
 private[writer] object HdfsWriter {
 
-  def createTargetPath(generator: FilePathGenerator, c: Long): Path =
-    generator(c, System.currentTimeMillis / 1000)
+  def createTargetPath(generator: FilePathGenerator, c: Long, timestamp: Long = -1): Path =
+    generator(c, if (generator.newPathForEachFile) timestamp else currentTimeMillis / 1000)
 
   def tempFromTarget(generator: FilePathGenerator, target: Path): Path =
     new Path(generator.tempDirectory, target.getName)

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/HdfsWriter.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/HdfsWriter.scala
@@ -21,7 +21,7 @@ private[hdfs] trait HdfsWriter[W, I] {
 
   protected lazy val temp: Path = tempFromTarget(pathGenerator, target())
 
-  def moveToTarget(rotationCount: Long = 0, timestamp: Long): Boolean = {
+  def moveToTarget(rotationCount: Long, timestamp: Long): Boolean = {
     val currTarget = target(rotationCount, timestamp)
     if (!fs.exists(currTarget.getParent))
       fs.mkdirs(currTarget.getParent)

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/SequenceWriter.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/impl/writer/SequenceWriter.scala
@@ -24,8 +24,9 @@ private[writer] final case class SequenceWriter[K <: Writable, V <: Writable](
     maybeTargetPath: Option[Path]
 ) extends HdfsWriter[SequenceFile.Writer, (K, V)] {
 
-  override protected lazy val target: Path =
-    getOrCreatePath(maybeTargetPath, createTargetPath(pathGenerator, 0))
+  override protected def target(rotationCount: Long, timestamp: Long): Path =
+    if (pathGenerator.newPathForEachFile) createTargetPath(pathGenerator, rotationCount, timestamp)
+    else getOrCreatePath(maybeTargetPath, createTargetPath(pathGenerator, 0))
 
   override def sync(): Unit = output.hsync()
 

--- a/hdfs/src/main/scala/akka/stream/alpakka/hdfs/model.scala
+++ b/hdfs/src/main/scala/akka/stream/alpakka/hdfs/model.scala
@@ -73,24 +73,30 @@ final case class HdfsWriteMessage[T, P](source: T, passThrough: P, timestamp: Lo
 
 object HdfsWriteMessage {
 
+  private val defaultPerMessageTimestamp = -1L
+
   /**
    * Scala API - creates [[HdfsWriteMessage]] to use when not using passThrough
+   * and per-message timestamp
    *
    * @param source a message
    */
   def apply[T](source: T): HdfsWriteMessage[T, NotUsed] =
-    HdfsWriteMessage(source, NotUsed, -1)
+    HdfsWriteMessage(source, NotUsed, defaultPerMessageTimestamp)
 
   /**
    * Scala API - creates [[HdfsWriteMessage]] to use when not using passThrough
+   * and per-message timestamp
    *
    * @param source a message
+   * @param passThrough pass-through data
    */
   def apply[T, P](source: T, passThrough: P): HdfsWriteMessage[T, P] =
-    HdfsWriteMessage(source, passThrough, -1)
+    HdfsWriteMessage(source, passThrough, defaultPerMessageTimestamp)
 
   /**
    * Java API - creates [[HdfsWriteMessage]] to use when not using passThrough
+   * and per-message timestamp
    *
    * @param source a message
    */
@@ -99,12 +105,13 @@ object HdfsWriteMessage {
 
   /**
    * Java API - creates [[HdfsWriteMessage]] to use with passThrough
+   * and without per-message timestamp
    *
    * @param source a message
    * @param passThrough pass-through data
    */
   def create[T, P](source: T, passThrough: P): HdfsWriteMessage[T, P] =
-    HdfsWriteMessage(source, passThrough, -1)
+    HdfsWriteMessage(source, passThrough, defaultPerMessageTimestamp)
 
 }
 
@@ -150,6 +157,8 @@ object FilePathGenerator {
    *
    * @param f    a function that takes rotation count and timestamp to return path of output
    * @param temp the temporary directory that [[akka.stream.alpakka.hdfs.impl.HdfsFlowStage]] use
+   * @param pathForEachFile turns on/off a possibility to create a new path for each file
+   *                        which depends on rotation count and timestamp supplied by hdfs messages
    */
   def apply(f: (Long, Long) => String,
             temp: String = DefaultTempDirectory,

--- a/hdfs/src/test/scala/akka/stream/alpakka/hdfs/util/TestUtils.scala
+++ b/hdfs/src/test/scala/akka/stream/alpakka/hdfs/util/TestUtils.scala
@@ -120,6 +120,9 @@ object ScalaTestUtils extends TestUtils with Matchers {
   def verifyOutputFileSize(fs: FileSystem, logs: Sequence[RotationMessage]): Assertion =
     ScalaTestUtils.getFiles(fs).size shouldEqual logs.size
 
+  def verifyOutputFileSizeInArbitraryPath(f: () => Sequence[FileStatus], logs: Sequence[RotationMessage]): Assertion =
+    f().size shouldEqual logs.size
+
   def readLogs(fs: FileSystem, logs: Sequence[RotationMessage]): Sequence[String] =
     logs.map(log => new Path(destination, log.path)).map(f => read(fs.open(f)))
 

--- a/hdfs/src/test/scala/docs/scaladsl/HdfsWriterSpec.scala
+++ b/hdfs/src/test/scala/docs/scaladsl/HdfsWriterSpec.scala
@@ -85,7 +85,7 @@ class HdfsWriterSpec
 
       readLogsWithFlatten(fs, logs) shouldEqual books2.flatMap(_.utf8String)
     }
-//
+
     "use file size rotation and produce five files" in {
       val flow = HdfsFlow.data(
         fs,
@@ -167,7 +167,7 @@ class HdfsWriterSpec
       verifyOutputFileSize(fs, logs)
       readLogsWithFlatten(fs, logs) shouldBe data.flatMap(_.utf8String)
     }
-//
+
     "use buffer rotation and produce three files" in {
       val flow = HdfsFlow.data(
         fs,


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/akka/alpakka/issues/2577

Adding by the PR a **FilePathGenerator** option of creating a new path for each file depending on rotation count and timestamp supplied by hdfs messages.
An assumption is that each hdfs message in addition to source and passThrough contains a timestamp. This timestamp in succession is used to create a file path. The specific file path format as before is defined in a function supplied to **FilePathGenerator**.
An example of specific path template we can use for path creation with this option on:
`s"/$year/$month/$day/$hour-$rotationCount"`.
