### PR TITLE
JMS maxAckInterval

### DIFF
--- a/docs/src/main/paradox/jms/consumer.md
+++ b/docs/src/main/paradox/jms/consumer.md
@@ -58,7 +58,8 @@ connectionRetrySettings | Retry characteristics if the connection failed to be e
 sessionCount            | Number of parallel sessions to use for receiving JMS messages.       | defaults to `1`     |
 bufferSize              | Maximum number of messages to prefetch before applying backpressure. | 100                 |
 ackTimeout              | For use with JMS transactions, only: maximum time given to a message to be committed or rolled back. | 1 second  |
-ackFlushTimeout         | For use with AckSource, only: Timeout for flushing acknowledges back to the broker | Empty               |
+maxAckInterval          | For use with AckSource, only: The max duration before the queued acks are sent to the broker | Empty               |
+maxPendingAcks          | For use with AckSource, only: The amount of acks that get queued before being sent to the broker | 100               |
 selector                | JMS selector expression (see [below](#using-jms-selectors))          | Empty               |
 connectionStatusSubscriptionTimeout | 5 seconds | Time to wait for subscriber of connection status events before starting to discard them |
 
@@ -95,7 +96,7 @@ The `sessionCount` parameter controls the number of JMS sessions to run in paral
 *  Using multiple sessions increases throughput, especially if acknowledging message by message is desired.
 *  Messages may arrive out of order if `sessionCount` is larger than 1.
 *  Message-by-message acknowledgement can be achieved by setting `bufferSize` to 0, thus disabling buffering. The outstanding messages before backpressure will be the `sessionCount`.
-*  If buffering is enabled, setting `ackFlushTimeout` will mean acknowledgment happens at most `ackFlushTimeout` time after `ackEnvelope.acknowledge()` is called. If not set, acknowledgment will not reach the broker until a new message arrives. 
+*  If buffering is enabled, setting `maxAckInterval` will mean acknowledgment happens at most `maxAckInterval` time after `ackEnvelope.acknowledge()` is called. If not set, acknowledgment will not reach the broker until a new message arrives. 
 *  The default `AcknowledgeMode` is `ClientAcknowledge` but can be overridden to custom `AcknowledgeMode`s, even implementation-specific ones by setting the `AcknowledgeMode` in the `JmsConsumerSettings` when creating the stream.
 
 @@@ warning

--- a/docs/src/main/paradox/jms/consumer.md
+++ b/docs/src/main/paradox/jms/consumer.md
@@ -96,7 +96,7 @@ The `sessionCount` parameter controls the number of JMS sessions to run in paral
 *  Using multiple sessions increases throughput, especially if acknowledging message by message is desired.
 *  Messages may arrive out of order if `sessionCount` is larger than 1.
 *  Message-by-message acknowledgement can be achieved by setting `bufferSize` to 0, thus disabling buffering. The outstanding messages before backpressure will be the `sessionCount`.
-*  If buffering is enabled, setting `maxAckInterval` will mean acknowledgment happens at most `maxAckInterval` time after `ackEnvelope.acknowledge()` is called. If not set, acknowledgment will not reach the broker until a new message arrives. 
+*  If buffering is enabled then it's possible for messages to remain in the buffer and never be acknowledged (or acknowledged after a long time) when no new elements arrive to reach the `maxPendingAcks` threshold. By setting `maxAckInterval` messages will be acknowledged after the defined interval or number of pending acks, whichever comes first. 
 *  The default `AcknowledgeMode` is `ClientAcknowledge` but can be overridden to custom `AcknowledgeMode`s, even implementation-specific ones by setting the `AcknowledgeMode` in the `JmsConsumerSettings` when creating the stream.
 
 @@@ warning

--- a/docs/src/main/paradox/jms/consumer.md
+++ b/docs/src/main/paradox/jms/consumer.md
@@ -58,6 +58,7 @@ connectionRetrySettings | Retry characteristics if the connection failed to be e
 sessionCount            | Number of parallel sessions to use for receiving JMS messages.       | defaults to `1`     |
 bufferSize              | Maximum number of messages to prefetch before applying backpressure. | 100                 |
 ackTimeout              | For use with JMS transactions, only: maximum time given to a message to be committed or rolled back. | 1 second  |
+ackFlushTimeout         | For use with AckSource, only: Timeout for flushing acknowledges back to the broker | Empty               |
 selector                | JMS selector expression (see [below](#using-jms-selectors))          | Empty               |
 connectionStatusSubscriptionTimeout | 5 seconds | Time to wait for subscriber of connection status events before starting to discard them |
 
@@ -94,6 +95,7 @@ The `sessionCount` parameter controls the number of JMS sessions to run in paral
 *  Using multiple sessions increases throughput, especially if acknowledging message by message is desired.
 *  Messages may arrive out of order if `sessionCount` is larger than 1.
 *  Message-by-message acknowledgement can be achieved by setting `bufferSize` to 0, thus disabling buffering. The outstanding messages before backpressure will be the `sessionCount`.
+*  If buffering is enabled, setting `ackFlushTimeout` will mean acknowledgment happens at most `ackFlushTimeout` time after `ackEnvelope.acknowledge()` is called. If not set, acknowledgment will not reach the broker until a new message arrives. 
 *  The default `AcknowledgeMode` is `ClientAcknowledge` but can be overridden to custom `AcknowledgeMode`s, even implementation-specific ones by setting the `AcknowledgeMode` in the `JmsConsumerSettings` when creating the stream.
 
 @@@ warning

--- a/jms/src/main/mima-filters/2.0.0-M2.backwards.excludes/PR2583.excludes
+++ b/jms/src/main/mima-filters/2.0.0-M2.backwards.excludes/PR2583.excludes
@@ -1,0 +1,2 @@
+ProblemFilters.exclude[MissingClassProblem]("akka.stream.alpakka.jms.StopMessageListenerException")
+ProblemFilters.exclude[MissingClassProblem]("akka.stream.alpakka.jms.StopMessageListenerException$")

--- a/jms/src/main/resources/reference.conf
+++ b/jms/src/main/resources/reference.conf
@@ -35,8 +35,7 @@ alpakka.jms {
     credentials = off
     # Number of parallel sessions to use for receiving JMS messages.
     session-count = 1
-    # Buffer size for maximum number for messages read from JMS when there is no demand
-    # (or acks are pending for acknowledged consumers).
+    # Buffer size for maximum number for messages read from JMS when there is no demand.
     buffer-size = 100
     # JMS selector expression.
     # See https://docs.oracle.com/cd/E19798-01/821-1841/bncer/index.html
@@ -53,6 +52,10 @@ alpakka.jms {
     # For use with transactions, if true the stream fails if Alpakka rolls back the transaction
     # when `ack-timeout` is hit.
     fail-stream-on-ack-timeout = false
+    # Max interval before sending queued acknowledges back to the broker. (Used by AckSources.)
+    # max-ack-interval = 5 seconds
+    # Max number of acks queued by AckSource before they are sent to broker. (Unless MaxAckInterval is specified).
+    max-pending-acks = 100
     # How long the stage should preserve connection status events for the first subscriber before discarding them
     connection-status-subscription-timeout = 5 seconds
   }

--- a/jms/src/main/resources/reference.conf
+++ b/jms/src/main/resources/reference.conf
@@ -55,7 +55,7 @@ alpakka.jms {
     # Max interval before sending queued acknowledges back to the broker. (Used by AckSources.)
     # max-ack-interval = 5 seconds
     # Max number of acks queued by AckSource before they are sent to broker. (Unless MaxAckInterval is specified).
-    max-pending-acks = 100
+    max-pending-acks = ${alpakka.jms.consumer.buffer-size}
     # How long the stage should preserve connection status events for the first subscriber before discarding them
     connection-status-subscription-timeout = 5 seconds
   }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
@@ -23,6 +23,7 @@ final class JmsConsumerSettings private (
     val selector: Option[String],
     val acknowledgeMode: Option[AcknowledgeMode],
     val ackTimeout: scala.concurrent.duration.Duration,
+    val ackFlushTimeout: scala.concurrent.duration.FiniteDuration,
     val failStreamOnAckTimeout: Boolean,
     val connectionStatusSubscriptionTimeout: scala.concurrent.duration.FiniteDuration
 ) extends akka.stream.alpakka.jms.JmsSettings {
@@ -71,6 +72,9 @@ final class JmsConsumerSettings private (
   /** Timeout for acknowledge. (Used by TX consumers.) */
   def withAckTimeout(value: scala.concurrent.duration.Duration): JmsConsumerSettings = copy(ackTimeout = value)
 
+  /** Timeout for flushing acknowledges back to the broker. (Used by AckSources.) */
+  def withAckFlushTimeout(value: scala.concurrent.duration.FiniteDuration): JmsConsumerSettings = copy(ackFlushTimeout = value)
+
   /** Java API: Timeout for acknowledge. (Used by TX consumers.) */
   def withAckTimeout(value: java.time.Duration): JmsConsumerSettings = copy(ackTimeout = value.asScala)
 
@@ -98,6 +102,7 @@ final class JmsConsumerSettings private (
       selector: Option[String] = selector,
       acknowledgeMode: Option[AcknowledgeMode] = acknowledgeMode,
       ackTimeout: scala.concurrent.duration.Duration = ackTimeout,
+      ackFlushTimeout: scala.concurrent.duration.FiniteDuration = ackFlushTimeout,
       failStreamOnAckTimeout: Boolean = failStreamOnAckTimeout,
       connectionStatusSubscriptionTimeout: scala.concurrent.duration.FiniteDuration =
         connectionStatusSubscriptionTimeout
@@ -111,6 +116,7 @@ final class JmsConsumerSettings private (
     selector = selector,
     acknowledgeMode = acknowledgeMode,
     ackTimeout = ackTimeout,
+    ackFlushTimeout = ackFlushTimeout,
     failStreamOnAckTimeout = failStreamOnAckTimeout,
     connectionStatusSubscriptionTimeout = connectionStatusSubscriptionTimeout
   )
@@ -158,6 +164,8 @@ object JmsConsumerSettings {
     val acknowledgeMode =
       getOption("acknowledge-mode", c => AcknowledgeMode.from(c.getString("acknowledge-mode")))
     val ackTimeout = c.getDuration("ack-timeout").asScala
+    val ackFlushTimeoutDuration = c.getDuration("ack-flush-timeout").asScala
+    val ackFlushTimeout = FiniteDuration(ackFlushTimeoutDuration.length, ackFlushTimeoutDuration.unit)
     val failStreamOnAckTimeout = c.getBoolean("fail-stream-on-ack-timeout")
     val connectionStatusSubscriptionTimeout = c.getDuration("connection-status-subscription-timeout").asScala
     new JmsConsumerSettings(
@@ -170,6 +178,7 @@ object JmsConsumerSettings {
       selector,
       acknowledgeMode,
       ackTimeout,
+      ackFlushTimeout,
       failStreamOnAckTimeout,
       connectionStatusSubscriptionTimeout
     )

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
@@ -212,7 +212,7 @@ object JmsConsumerSettings {
   /**
    * Java API: Reads from the given config.
    *
-   * @param c                 Config instance read configuration from
+   * @param c Config instance read configuration from
    * @param connectionFactory Factory to use for creating JMS connections.
    */
   def create(c: Config, connectionFactory: javax.jms.ConnectionFactory): JmsConsumerSettings =
@@ -221,7 +221,7 @@ object JmsConsumerSettings {
   /**
    * Java API: Reads from the default config provided by the actor system at `alpakka.jms.consumer`.
    *
-   * @param actorSystem       The actor system
+   * @param actorSystem The actor system
    * @param connectionFactory Factory to use for creating JMS connections.
    */
   def create(actorSystem: ActorSystem, connectionFactory: javax.jms.ConnectionFactory): JmsConsumerSettings =
@@ -230,7 +230,7 @@ object JmsConsumerSettings {
   /**
    * Java API: Reads from the default config provided by the actor system at `alpakka.jms.consumer`.
    *
-   * @param actorSystem       The actor system
+   * @param actorSystem The actor system
    * @param connectionFactory Factory to use for creating JMS connections.
    */
   def create(actorSystem: ClassicActorSystemProvider,

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsConsumerSettings.scala
@@ -89,7 +89,7 @@ final class JmsConsumerSettings private (
   def withFailStreamOnAckTimeout(value: Boolean): JmsConsumerSettings =
     if (failStreamOnAckTimeout == value) this else copy(failStreamOnAckTimeout = value)
 
-  /**  Timeout for connection status subscriber */
+  /** Timeout for connection status subscriber */
   def withConnectionStatusSubscriptionTimeout(value: FiniteDuration): JmsConsumerSettings =
     copy(connectionStatusSubscriptionTimeout = value)
 
@@ -150,7 +150,7 @@ object JmsConsumerSettings {
   /**
    * Reads from the given config.
    *
-   * @param c                 Config instance read configuration from
+   * @param c Config instance read configuration from
    * @param connectionFactory Factory to use for creating JMS connections.
    */
   def apply(c: Config, connectionFactory: javax.jms.ConnectionFactory): JmsConsumerSettings = {
@@ -168,8 +168,7 @@ object JmsConsumerSettings {
     val sessionCount = c.getInt("session-count")
     val bufferSize = c.getInt("buffer-size")
     val selector = getStringOption("selector")
-    val acknowledgeMode =
-      getOption("acknowledge-mode", c => AcknowledgeMode.from(c.getString("acknowledge-mode")))
+    val acknowledgeMode = getOption("acknowledge-mode", c => AcknowledgeMode.from(c.getString("acknowledge-mode")))
     val ackTimeout = c.getDuration("ack-timeout").asScala
     val ackFlushTimeoutDuration = getOption("ack-flush-timeout", config => c.getDuration("ack-flush-timeout").asScala)
     val ackFlushTimeout = ackFlushTimeoutDuration.map(duration => FiniteDuration(duration.length, duration.unit))

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsExceptions.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsExceptions.scala
@@ -52,8 +52,6 @@ case object RetrySkippedOnMissingConnection
     extends Exception("JmsProducer is not connected, send attempt skipped")
     with NoStackTrace
 
-final case class StopMessageListenerException() extends Exception("Stopping MessageListener.")
-
 case object JmsNotConnected extends Exception("JmsConnector is not connected") with NoStackTrace
 
 case class JmsConnectTimedOut(message: String) extends TimeoutException(message)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsAckSourceStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsAckSourceStage.scala
@@ -51,7 +51,9 @@ private[jms] final class JmsAckSourceStage(settings: JmsConsumerSettings, destin
     override protected def onSessionOpened(jmsSession: JmsConsumerSession): Unit =
       jmsSession match {
         case session: JmsAckSession =>
-          scheduleOnce(FlushAcknowledgementsTimerKey(session, ackFlushTimeout), ackFlushTimeout)
+          ackFlushTimeout.foreach { timeout =>
+            scheduleOnce(FlushAcknowledgementsTimerKey(session, timeout), timeout)
+          }
           session
             .createConsumer(settings.selector)
             .map { consumer =>
@@ -104,4 +106,5 @@ private[jms] final class JmsAckSourceStage(settings: JmsConsumerSettings, destin
           )
       }
   }
+
 }

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsAckSourceStage.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsAckSourceStage.scala
@@ -52,7 +52,7 @@ private[jms] final class JmsAckSourceStage(settings: JmsConsumerSettings, destin
       jmsSession match {
         case session: JmsAckSession =>
           ackFlushTimeout.foreach { timeout =>
-            scheduleOnce(FlushAcknowledgementsTimerKey(session, timeout), timeout)
+            scheduleWithFixedDelay(FlushAcknowledgementsTimerKey(session), timeout, timeout)
           }
           session
             .createConsumer(settings.selector)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsConnector.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsConnector.scala
@@ -215,10 +215,7 @@ private[jms] trait JmsConnector[S <: JmsSession] {
 
   override def onTimer(timerKey: Any): Unit = timerKey match {
     case FlushAcknowledgementsTimerKey(session) =>
-      session.ackQueue.forEach(_.apply())
-      session.ackQueue.clear()
-      session.pendingAck = 0
-
+      session.drainAcks()
     case AttemptConnect(attempt, backoffMaxed) =>
       log.info("{} retries connecting, attempt {}", attributes.nameLifted.mkString, attempt)
       initSessionAsync(attempt, backoffMaxed)

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/Sessions.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/Sessions.scala
@@ -7,9 +7,11 @@ package akka.stream.alpakka.jms.impl
 import java.util.concurrent.ArrayBlockingQueue
 
 import akka.annotation.InternalApi
-import akka.stream.alpakka.jms.{Destination, DurableTopic, StopMessageListenerException}
+import akka.stream.alpakka.jms.{Destination, DurableTopic}
+import akka.util.OptionVal
 import javax.jms
 
+import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -22,9 +24,9 @@ private[jms] sealed trait JmsSession {
 
   def session: jms.Session
 
-  private[jms] def closeSession(): Unit = session.close()
-
   private[jms] def abortSession(): Unit = closeSession()
+
+  private[jms] def closeSession(): Unit = session.close()
 }
 
 /**
@@ -66,6 +68,8 @@ private[jms] class JmsConsumerSession(val connection: jms.Connection,
     }
 }
 
+case object SessionClosed
+
 /**
  * Internal API.
  */
@@ -77,17 +81,44 @@ private[jms] final class JmsAckSession(override val connection: jms.Connection,
                                        val maxPendingAcks: Int)
     extends JmsConsumerSession(connection, session, jmsDestination, settingsDestination) {
 
+  private val ackQueue = new ArrayBlockingQueue[Either[SessionClosed.type, () => Unit]](maxPendingAcks + 1)
   private[jms] var pendingAck = 0
-  private[jms] val ackQueue = new ArrayBlockingQueue[() => Unit](maxPendingAcks + 1)
+  private var listenerRunning = true
 
-  def ack(message: jms.Message): Unit = ackQueue.put(message.acknowledge _)
+  def isListenerRunning: Boolean = listenerRunning
+
+  def maxPendingAcksReached: Boolean = pendingAck > maxPendingAcks
+
+  def ack(message: jms.Message): Unit = ackQueue.put(Right(message.acknowledge _))
 
   override def closeSession(): Unit = stopMessageListenerAndCloseSession()
 
   override def abortSession(): Unit = stopMessageListenerAndCloseSession()
 
   private def stopMessageListenerAndCloseSession(): Unit = {
-    ackQueue.put(() => throw StopMessageListenerException())
+    ackQueue.put(Left(SessionClosed))
     session.close()
   }
+
+  def ackBackpressure() = {
+    ackQueue.take() match {
+      case Left(SessionClosed) =>
+        listenerRunning = false
+      case Right(action) =>
+        action()
+        pendingAck -= 1
+    }
+  }
+
+  @tailrec
+  def drainAcks(): Unit =
+    OptionVal(ackQueue.poll()) match {
+      case OptionVal.Some(Left(SessionClosed)) =>
+        listenerRunning = false
+      case OptionVal.Some(Right(action)) =>
+        action()
+        pendingAck -= 1
+        drainAcks()
+      case OptionVal.None =>
+    }
 }

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsSharedServerSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsSharedServerSpec.scala
@@ -29,6 +29,8 @@ abstract class JmsSharedServerSpec extends JmsSpec {
     }
   }
 
+  protected def isQueueEmpty(queueName: String): Boolean = jmsBroker.service.checkQueueSize(queueName)
+
   override def withConnectionFactory()(test: ConnectionFactory => Unit): Unit = {
     test(connectionFactory)
   }

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
@@ -301,7 +301,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
         .run()
 
       val jmsSource: Source[AckEnvelope, JmsConsumerControl] = JmsConsumer.ackSource(
-        JmsConsumerSettings(system, connectionFactory).withSessionCount(5).withBufferSize(0).withQueue("numbers")
+        JmsConsumerSettings(system, connectionFactory).withSessionCount(5).withBufferSize(0).withMaxPendingAcks(0).withQueue("numbers")
       )
 
       val resultQueue = new LinkedBlockingQueue[String]()
@@ -414,14 +414,14 @@ class JmsAckConnectorsSpec extends JmsSpec {
 
       val testQueue = "test"
       val aMessage = "message"
-      val flushTimeout = 1.second
+      val maxAckInterval = 1.second
       Source
         .single(aMessage)
         .runWith(JmsProducer.textSink(JmsProducerSettings(producerConfig, connectionFactory).withQueue(testQueue)))
       val source = JmsConsumer.ackSource(
         JmsConsumerSettings(system, connectionFactory)
-          .withBufferSize(100)
-          .withAckFlushTimeout(flushTimeout)
+          .withMaxPendingAcks(100)
+          .withMaxAckInterval(maxAckInterval)
           .withQueue(testQueue)
       )
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
@@ -301,7 +301,11 @@ class JmsAckConnectorsSpec extends JmsSpec {
         .run()
 
       val jmsSource: Source[AckEnvelope, JmsConsumerControl] = JmsConsumer.ackSource(
-        JmsConsumerSettings(system, connectionFactory).withSessionCount(5).withBufferSize(0).withMaxPendingAcks(0).withQueue("numbers")
+        JmsConsumerSettings(system, connectionFactory)
+          .withSessionCount(5)
+          .withBufferSize(0)
+          .withMaxPendingAcks(0)
+          .withQueue("numbers")
       )
 
       val resultQueue = new LinkedBlockingQueue[String]()
@@ -366,7 +370,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
     }
 
     "shutdown when waiting to acknowledge messages" in withServer() { server =>
-      val connectionFactory = server.createQueueConnectionFactory
+      val connectionFactory = server.createConnectionFactory
 
       val in = 0 to 25 map (i => ('a' + i).asInstanceOf[Char].toString)
       Source(in).runWith(JmsProducer.textSink(JmsProducerSettings(producerConfig, connectionFactory).withQueue("test")))
@@ -409,7 +413,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
       streamDone.failed.futureValue.getMessage shouldBe "aborted"
     }
 
-    "flush acknowledgments to broker after flush.timeout triggers" in withServer() { server =>
+    "send acknowledgments back to the broker after max.ack.interval" in withServer() { server =>
       val connectionFactory = server.createConnectionFactory
 
       val testQueue = "test"

--- a/jms/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
@@ -386,14 +386,14 @@ class JmsBufferedAckConnectorsSpec extends JmsSharedServerSpec {
     "flush acknowledgments to broker after flush.timeout triggers" in withConnectionFactory() { connectionFactory =>
       val testQueue = "test"
       val aMessage = "message"
-      val flushTimeout = 1.second
+      val maxAckInterval = 1.second
       Source
         .single(aMessage)
         .runWith(JmsProducer.textSink(JmsProducerSettings(producerConfig, connectionFactory).withQueue(testQueue)))
       val source = JmsConsumer.ackSource(
         JmsConsumerSettings(system, connectionFactory)
-          .withBufferSize(100)
-          .withAckFlushTimeout(flushTimeout)
+          .withMaxPendingAcks(100)
+          .withMaxAckInterval(maxAckInterval)
           .withQueue(testQueue)
       )
 

--- a/jms/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
@@ -10,10 +10,12 @@ import akka.Done
 import akka.stream.alpakka.jms._
 import akka.stream.alpakka.jms.scaladsl.{JmsConsumer, JmsConsumerControl, JmsProducer}
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.testkit.scaladsl.TestSink
 import akka.stream.{KillSwitches, ThrottleMode}
 import org.apache.activemq.ActiveMQSession
 import javax.jms.{JMSException, TextMessage}
 import org.scalatest.Inspectors._
+import org.scalatest.time.Span.convertSpanToDuration
 
 import scala.annotation.tailrec
 import scala.collection.{immutable, mutable}
@@ -379,6 +381,48 @@ class JmsBufferedAckConnectorsSpec extends JmsSharedServerSpec {
         s.toInt
       }
       resultList.toSet should contain theSameElementsAs numsIn.map(_.toString)
+    }
+
+    "flush acknowledgments to broker after flush.timeout triggers" in withConnectionFactory() { connectionFactory =>
+      val testQueue = "test"
+      val aMessage = "message"
+      val flushTimeout = 1.second
+      Source
+        .single(aMessage)
+        .runWith(JmsProducer.textSink(JmsProducerSettings(producerConfig, connectionFactory).withQueue(testQueue)))
+      val source = JmsConsumer.ackSource(
+        JmsConsumerSettings(system, connectionFactory)
+          .withBufferSize(100)
+          .withAckFlushTimeout(flushTimeout)
+          .withQueue(testQueue)
+      )
+
+      val (consumerControl, probe) = source
+        .map { env =>
+          env.acknowledge()
+          env.message match {
+            case message: TextMessage => Some(message.getText)
+            case _ => None
+
+          }
+        }
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      probe.requestNext(convertSpanToDuration(patienceConfig.timeout)) shouldBe Some(aMessage)
+
+      eventually {
+        isQueueEmpty(testQueue) shouldBe true
+      }
+
+      consumerControl.shutdown()
+      probe.expectComplete()
+
+      // Consuming again should give us no elements, as msg was acked and therefore removed from the broker
+      val (emptyConsumerControl, emptySourceProbe) = source.toMat(TestSink.probe)(Keep.both).run()
+      emptySourceProbe.ensureSubscription().expectNoMessage()
+      emptyConsumerControl.shutdown()
+      emptySourceProbe.expectComplete()
     }
   }
 }

--- a/jms/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
@@ -383,7 +383,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSharedServerSpec {
       resultList.toSet should contain theSameElementsAs numsIn.map(_.toString)
     }
 
-    "flush acknowledgments to broker after flush.timeout triggers" in withConnectionFactory() { connectionFactory =>
+    "send acknowledgments back to the broker after max.ack.interval" in withConnectionFactory() { connectionFactory =>
       val testQueue = "test"
       val aMessage = "message"
       val maxAckInterval = 1.second


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #2583 .
Adds timeout for flushing acks back to the JMS broker instead on relying only on buffer completion.
