### PR TITLE
Update OrientDB to Akka 2.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -237,7 +237,7 @@ lazy val mqttStreamingBench = internalProject("mqtt-streaming-bench")
   .dependsOn(mqtt, mqttStreaming)
 
 lazy val orientdb =
-  alpakkaProject("orientdb", "orientdb", Dependencies.OrientDB, Test / fork := true, fatalWarnings := true)
+  alpakkaProject("orientdb", "orientdb", Dependencies.OrientDB, Test / fork := true, fatalWarnings := false)
 
 lazy val reference = internalProject("reference", Dependencies.Reference, fatalWarnings := true)
   .dependsOn(testkit % Test)

--- a/build.sbt
+++ b/build.sbt
@@ -237,7 +237,7 @@ lazy val mqttStreamingBench = internalProject("mqtt-streaming-bench")
   .dependsOn(mqtt, mqttStreaming)
 
 lazy val orientdb =
-  alpakkaProject("orientdb", "orientdb", Dependencies.OrientDB, Test / fork := true, fatalWarnings := false)
+  alpakkaProject("orientdb", "orientdb", Dependencies.OrientDB, Test / fork := true, fatalWarnings := true)
 
 lazy val reference = internalProject("reference", Dependencies.Reference, fatalWarnings := true)
   .dependsOn(testkit % Test)

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/impl/OrientDbFlowStage.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/impl/OrientDbFlowStage.scala
@@ -105,7 +105,7 @@ private[orientdb] class OrientDbFlowStage[T, C](
           client.save(document)
         case OrientDbWriteMessage(oRecord: ORecord, _) =>
           client.save(oRecord)
-        case OrientDbWriteMessage(others: _, _) =>
+        case OrientDbWriteMessage(others, _) =>
           failStage(new RuntimeException(s"unexpected type [${others.getClass}], ORecord required"))
       }
   }

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/impl/OrientDbFlowStage.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/impl/OrientDbFlowStage.scala
@@ -103,10 +103,8 @@ private[orientdb] class OrientDbFlowStage[T, C](
             }
           document.setClassName(className)
           client.save(document)
-          ()
         case OrientDbWriteMessage(oRecord: ORecord, _) =>
           client.save(oRecord)
-          ()
         case OrientDbWriteMessage(others: AnyRef, _) =>
           failStage(new RuntimeException(s"unexpected type [${others.getClass()}], ORecord required"))
       }
@@ -123,7 +121,6 @@ private[orientdb] class OrientDbFlowStage[T, C](
       messages.foreach {
         case OrientDbWriteMessage(typeRecord: Any, _) =>
           oObjectClient.save(typeRecord)
-          ()
       }
 
   }

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/impl/OrientDbFlowStage.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/impl/OrientDbFlowStage.scala
@@ -105,8 +105,8 @@ private[orientdb] class OrientDbFlowStage[T, C](
           client.save(document)
         case OrientDbWriteMessage(oRecord: ORecord, _) =>
           client.save(oRecord)
-        case OrientDbWriteMessage(others: AnyRef, _) =>
-          failStage(new RuntimeException(s"unexpected type [${others.getClass()}], ORecord required"))
+        case OrientDbWriteMessage(others: _, _) =>
+          failStage(new RuntimeException(s"unexpected type [${others.getClass}], ORecord required"))
       }
   }
 

--- a/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
+++ b/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
@@ -7,7 +7,6 @@ package docs.javadsl;
 import akka.Done;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
 import akka.stream.alpakka.orientdb.OrientDbWriteMessage;
 import akka.stream.alpakka.orientdb.OrientDbSourceSettings;
 import akka.stream.alpakka.orientdb.OrientDbWriteSettings;
@@ -50,7 +49,6 @@ public class OrientDbTest {
   private static OPartitionedDatabasePool oDatabase;
   private static ODatabaseDocumentTx client;
   private static ActorSystem system;
-  private static ActorMaterializer materializer;
 
   // #init-settings
 
@@ -143,7 +141,6 @@ public class OrientDbTest {
   @BeforeClass
   public static void setup() throws Exception {
     system = ActorSystem.create();
-    materializer = ActorMaterializer.create(system);
 
     oServerAdmin = new OServerAdmin(url).connect(username, password);
     if (!oServerAdmin.existsDatabase(dbName, "plocal")) {
@@ -233,7 +230,7 @@ public class OrientDbTest {
             .groupedWithin(10, Duration.ofMillis(10))
             .runWith(
                 OrientDbSink.create(sinkClass1, OrientDbWriteSettings.create(oDatabase)),
-                materializer);
+                system);
 
     f1.toCompletableFuture().get(10, TimeUnit.SECONDS);
 
@@ -241,7 +238,7 @@ public class OrientDbTest {
     CompletionStage<List<String>> result =
         OrientDbSource.create(sinkClass1, OrientDbSourceSettings.create(oDatabase))
             .map(m -> m.oDocument().<String>field("book_title"))
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
     // #run-odocument
 
     List<String> res = new ArrayList<>(result.toCompletableFuture().get(10, TimeUnit.SECONDS));
@@ -280,7 +277,7 @@ public class OrientDbTest {
             .runWith(
                 OrientDbSink.typed(
                     sinkClass2, OrientDbWriteSettings.create(oDatabase), sink2.class),
-                materializer);
+                system);
     // #run-typed
 
     f1.toCompletableFuture().get(10, TimeUnit.SECONDS);
@@ -295,7 +292,7 @@ public class OrientDbTest {
                   ODatabaseRecordThreadLocal.instance().set(db);
                   return m.oDocument().getBook_title();
                 })
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
 
     List<String> result = new ArrayList<>(f2.toCompletableFuture().get(10, TimeUnit.SECONDS));
 
@@ -352,7 +349,7 @@ public class OrientDbTest {
               messages.stream().forEach(message -> commitToKafka.accept(message.passThrough()));
               return NotUsed.getInstance();
             })
-        .runWith(Sink.seq(), materializer)
+        .runWith(Sink.seq(), system)
         .toCompletableFuture()
         .get(10, TimeUnit.SECONDS);
     // #kafka-example
@@ -362,7 +359,7 @@ public class OrientDbTest {
     List<Object> result2 =
         OrientDbSource.create(sink6, OrientDbSourceSettings.create(oDatabase), null)
             .map(m -> m.oDocument().field("book_title"))
-            .runWith(Sink.seq(), materializer)
+            .runWith(Sink.seq(), system)
             .toCompletableFuture()
             .get(10, TimeUnit.SECONDS);
 
@@ -383,7 +380,7 @@ public class OrientDbTest {
             .map(m -> OrientDbWriteMessage.create(m.oDocument()))
             .groupedWithin(10, Duration.ofMillis(10))
             .via(OrientDbFlow.create(sink3, OrientDbWriteSettings.create(oDatabase)))
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
     // #run-flow
 
     f1.toCompletableFuture().get(10, TimeUnit.SECONDS);
@@ -392,7 +389,7 @@ public class OrientDbTest {
     CompletionStage<List<String>> f2 =
         OrientDbSource.create(sink3, OrientDbSourceSettings.create(oDatabase), null)
             .map(m -> m.oDocument().<String>field("book_title"))
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
 
     List<String> result2 = new ArrayList<>(f2.toCompletableFuture().get(10, TimeUnit.SECONDS));
 

--- a/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
+++ b/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
@@ -229,8 +229,7 @@ public class OrientDbTest {
             .map(m -> OrientDbWriteMessage.create(m.oDocument()))
             .groupedWithin(10, Duration.ofMillis(10))
             .runWith(
-                OrientDbSink.create(sinkClass1, OrientDbWriteSettings.create(oDatabase)),
-                system);
+                OrientDbSink.create(sinkClass1, OrientDbWriteSettings.create(oDatabase)), system);
 
     f1.toCompletableFuture().get(10, TimeUnit.SECONDS);
 

--- a/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala
+++ b/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala
@@ -15,7 +15,6 @@ import akka.stream.alpakka.orientdb.{
 }
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import com.orientechnologies.orient.`object`.db.OObjectDatabaseTx
@@ -41,7 +40,6 @@ class OrientDbSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 100.millis)
 
   implicit val system: ActorSystem = ActorSystem()
-  implicit val materializer: Materializer = ActorMaterializer()
 
   //#init-settings
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -362,9 +362,9 @@ object Dependencies {
 
   val OrientDB = Seq(
     libraryDependencies ++= Seq(
-        ("com.orientechnologies" % "orientdb-graphdb" % "3.0.34")
+        ("com.orientechnologies" % "orientdb-graphdb" % "3.1.9")
           .exclude("com.tinkerpop.blueprints", "blueprints-core"),
-        "com.orientechnologies" % "orientdb-object" % "3.0.34" // ApacheV2
+        "com.orientechnologies" % "orientdb-object" % "3.1.9" // ApacheV2
       )
   )
 


### PR DESCRIPTION
- Update OrientDB according to the checklist in #2491 
- Update OrientDB dependencies to their latest version

I've kept `fatalWarnings` set to `false` due to the deprecation warnings from the OrientDB SDK. I looked at it a little bit but it seems like quite a large refactor to update Alpakka to not use deprecated APIs

References #2491
