### PR TITLE
OrientDB: Propagate correct types to updated OrientDB Java API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,7 +233,7 @@ services:
     volumes:
       - ./mqtt/src/test/travis:/mqtt/config/conf.d
   orientdb:
-    image: orientdb:3.0.13
+    image: orientdb:3.1.9
     ports:
       - "2424:2424"
     environment:

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/impl/OrientDbFlowStage.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/impl/OrientDbFlowStage.scala
@@ -102,9 +102,9 @@ private[orientdb] class OrientDbFlowStage[T, C](
                 document.field(fieldName, fieldVal)
             }
           document.setClassName(className)
-          client.save(document)
+          client.save[ODocument](document)
         case OrientDbWriteMessage(oRecord: ORecord, _) =>
-          client.save(oRecord)
+          client.save[ORecord](oRecord)
         case OrientDbWriteMessage(others, _) =>
           failStage(new RuntimeException(s"unexpected type [${others.getClass}], ORecord required"))
       }
@@ -120,7 +120,7 @@ private[orientdb] class OrientDbFlowStage[T, C](
     protected def write(messages: immutable.Seq[OrientDbWriteMessage[T, C]]): Unit =
       messages.foreach {
         case OrientDbWriteMessage(typeRecord: Any, _) =>
-          oObjectClient.save(typeRecord)
+          oObjectClient.save[Object](typeRecord)
       }
 
   }


### PR DESCRIPTION
Fixes #2605 

References #2491 

The OrientDB Java API has changed significantly since the last "makeover" in #1445. This should get things working for now.