### PR TITLE
google-common: create release artifact and docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ lazy val alpakka = project
     files,
     ftp,
     geode,
+    googleCommon,
     googleCloudBigQuery,
     googleCloudPubSub,
     googleCloudPubSubGrpc,
@@ -174,12 +175,13 @@ lazy val geode =
     fatalWarnings := true
   )
 
-lazy val googleCommon = internalProject(
+lazy val googleCommon = alpakkaProject(
   "google-common",
+  "google.common",
   Dependencies.GoogleCommon,
   Test / fork := true,
   fatalWarnings := true
-).disablePlugins(MimaPlugin).dependsOn(testkit % Test)
+).dependsOn(testkit % Test)
 
 lazy val googleCloudBigQuery = alpakkaProject(
   "google-cloud-bigquery",
@@ -372,6 +374,8 @@ lazy val docs = project
         "javadoc.org.apache.kudu.base_url" -> s"https://kudu.apache.org/releases/${Dependencies.KuduVersion}/apidocs/",
         "javadoc.org.apache.hadoop.base_url" -> s"https://hadoop.apache.org/docs/r${Dependencies.HadoopVersion}/api/",
         "javadoc.software.amazon.awssdk.base_url" -> "https://sdk.amazonaws.com/java/api/latest/",
+        "javadoc.com.google.auth.base_url" -> "https://www.javadoc.io/doc/com.google.auth/google-auth-library-credentials/latest/",
+        "javadoc.com.google.auth.link_style" -> "direct",
         "javadoc.com.fasterxml.jackson.annotation.base_url" -> "https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-annotations/latest/",
         "javadoc.com.fasterxml.jackson.annotation.link_style" -> "direct",
         // Scala

--- a/build.sbt
+++ b/build.sbt
@@ -181,7 +181,7 @@ lazy val googleCommon = alpakkaProject(
   Dependencies.GoogleCommon,
   Test / fork := true,
   fatalWarnings := true
-).dependsOn(testkit % Test)
+).disablePlugins(MimaPlugin)
 
 lazy val googleCloudBigQuery = alpakkaProject(
   "google-cloud-bigquery",

--- a/docs/src/main/paradox/google-cloud-bigquery.md
+++ b/docs/src/main/paradox/google-cloud-bigquery.md
@@ -49,17 +49,8 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Configuration
 
-Shared settings for all Google connectors are read by default from the `alpakka.google` configuration section in your `application.conf`.
-Credentials will be loaded automatically:
-
-1. From the file path specified by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or another [“well-known” location](https://medium.com/google-cloud/use-google-cloud-user-credentials-when-testing-containers-locally-acb57cd4e4da); or
-2. When running in a [Compute Engine](https://cloud.google.com/compute) instance.
-
-Credentials can also be specified manually in your configuration file.
-
-If you use a non-standard configuration path or need multiple different configurations, please refer to @ref[the attributes section below](google-cloud-bigquery.md#apply-custom-settings-to-a-part-of-the-stream) to see how to apply different configuration to different parts of the stream.
-All of the common configuration settings for Google connectors can be found in the @github[reference.conf](/google-cloud-common/src/main/resources/reference.conf).
-Additional BigQuery-specific configuration settings can be found in its own @github[reference.conf](/google-cloud-bigquery/src/main/resources/reference.conf).
+The BigQuery connector @ref[shares its basic configuration](google-common.md) with all the Google connectors in Alpakka.
+Additional BigQuery-specific configuration settings can be found in its @github[reference.conf](/google-cloud-bigquery/src/main/resources/reference.conf).
 
 ## Imports
 
@@ -141,7 +132,7 @@ Java
 As a cost-saving alternative to streaming inserts, you can also add data to a table via asynchronous load jobs.
 The @scala[@apidoc[BigQuery.insertAllAsync[In]](BigQuery$)] @java[@apidoc[BigQuery.<In>insertAllAsync](BigQuery$)] method creates a flow that starts a series of batch load jobs.
 By default, a new load job is created every minute to attempt to emulate near-real-time streaming inserts, although there is no guarantee when the job will actually run.
-The frequency with which new load jobs are created is controlled by the `alpakka.google.bigquery.load-job.per-table-quota` configuration setting.
+The frequency with which new load jobs are created is controlled by the `alpakka.google.bigquery.load-job-per-table-quota` configuration setting.
 
 @@@warning
 

--- a/docs/src/main/paradox/google-cloud-pub-sub-grpc.md
+++ b/docs/src/main/paradox/google-cloud-pub-sub-grpc.md
@@ -59,15 +59,7 @@ yourself, but we recommend upgrading.
 
 ## Configuration
 
-Shared settings for all Google connectors are read by default from the `alpakka.google` configuration section in your `application.conf`.
-Credentials will be loaded automatically:
-
-1. From the file path specified by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or another [“well-known” location](https://medium.com/google-cloud/use-google-cloud-user-credentials-when-testing-containers-locally-acb57cd4e4da); or
-2. When running in a [Compute Engine](https://cloud.google.com/compute) instance.
-
-Credentials can also be specified manually in your configuration file.
-
-All of the common configuration settings for Google connectors can be found in the @github[reference.conf](/google-cloud-common/src/main/resources/reference.conf).
+The PubSub gRPC connector @ref[shares its basic configuration](google-common.md) with all the Google connectors in Alpakka.
 Additional PubSub-specific configuration settings can be found in its own @github[reference.conf](/google-cloud-pub-sub-grpc/src/main/resources/reference.conf).
 
 The defaults can be changed (for example when testing against the emulator) by tweaking the reference configuration:

--- a/docs/src/main/paradox/google-cloud-pub-sub-grpc.md
+++ b/docs/src/main/paradox/google-cloud-pub-sub-grpc.md
@@ -59,8 +59,8 @@ yourself, but we recommend upgrading.
 
 ## Configuration
 
-The PubSub gRPC connector @ref[shares its basic configuration](google-common.md) with all the Google connectors in Alpakka.
-Additional PubSub-specific configuration settings can be found in its own @github[reference.conf](/google-cloud-pub-sub-grpc/src/main/resources/reference.conf).
+The Pub/Sub gRPC connector @ref[shares its basic configuration](google-common.md) with all the Google connectors in Alpakka.
+Additional Pub/Sub-specific configuration settings can be found in its own @github[reference.conf](/google-cloud-pub-sub-grpc/src/main/resources/reference.conf).
 
 The defaults can be changed (for example when testing against the emulator) by tweaking the reference configuration:
 

--- a/docs/src/main/paradox/google-cloud-pub-sub.md
+++ b/docs/src/main/paradox/google-cloud-pub-sub.md
@@ -38,15 +38,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Usage
 
-Shared settings for all Google connectors are read by default from the `alpakka.google` configuration section in your `application.conf`.
-Credentials will be loaded automatically:
-
-1. From the file path specified by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or another [“well-known” location](https://medium.com/google-cloud/use-google-cloud-user-credentials-when-testing-containers-locally-acb57cd4e4da); or
-2. When running in a [Compute Engine](https://cloud.google.com/compute) instance.
-
-Credentials can also be specified manually in your configuration file.
-
-All of the common configuration settings for Google connectors can be found in the @github[reference.conf](/google-cloud-common/src/main/resources/reference.conf).
+The PubSub connector @ref[shares its basic configuration](google-common.md) with all the Google connectors in Alpakka.
 Additional PubSub-specific configuration settings can be found in its own @github[reference.conf](/google-cloud-pub-sub/src/main/resources/reference.conf).
 
 @@snip [snip](/google-cloud-pub-sub/src/test/resources/application.conf) { #init-credentials }

--- a/docs/src/main/paradox/google-cloud-pub-sub.md
+++ b/docs/src/main/paradox/google-cloud-pub-sub.md
@@ -38,10 +38,8 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Usage
 
-The PubSub connector @ref[shares its basic configuration](google-common.md) with all the Google connectors in Alpakka.
-Additional PubSub-specific configuration settings can be found in its own @github[reference.conf](/google-cloud-pub-sub/src/main/resources/reference.conf).
-
-@@snip [snip](/google-cloud-pub-sub/src/test/resources/application.conf) { #init-credentials }
+The Pub/Sub connector @ref[shares its basic configuration](google-common.md) with all the Google connectors in Alpakka.
+Additional Pub/Sub-specific configuration settings can be found in its own @github[reference.conf](/google-cloud-pub-sub/src/main/resources/reference.conf).
 
 And prepare the actor system.
 

--- a/docs/src/main/paradox/google-cloud-storage.md
+++ b/docs/src/main/paradox/google-cloud-storage.md
@@ -37,10 +37,6 @@ The table below shows direct dependencies of this module and the second tab show
 The Storage connector @ref[shares its basic configuration](google-common.md) with all the Google connectors in Alpakka.
 Additional Storage-specific configuration settings can be found in its own @github[reference.conf](/google-cloud-storage/src/main/resources/reference.conf).
 
-HOCON:
-: @@snip [snip](/google-cloud-storage/src/test/resources/application.conf) { #settings }
-
-
 ## Store a file in Google Cloud Storage
 
 A file can be uploaded to Google Cloud Storage by creating a source of @apidoc[akka.util.ByteString] and running that with a sink created from @scala[@scaladoc[GCStorage.resumableUpload](akka.stream.alpakka.googlecloud.storage.scaladsl.GCStorage$)]@java[@scaladoc[GCStorage.resumableUpload](akka.stream.alpakka.googlecloud.storage.javadsl.GCStorage$)].

--- a/docs/src/main/paradox/google-cloud-storage.md
+++ b/docs/src/main/paradox/google-cloud-storage.md
@@ -34,17 +34,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Configuration
 
-Shared settings for all Google connectors are read by default from the `alpakka.google` configuration section in your `application.conf`.
-Credentials will be loaded automatically:
-
-1. From the file path specified by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or another [“well-known” location](https://medium.com/google-cloud/use-google-cloud-user-credentials-when-testing-containers-locally-acb57cd4e4da); or
-2. When running in a [Compute Engine](https://cloud.google.com/compute) instance.
-
-Credentials can also be specified manually in your configuration file.
-
-If you use a non-standard configuration path or need multiple different configurations, please refer to @ref[the attributes section below](google-cloud-storage.md#apply-google-cloud-storage-settings-to-a-part-of-the-stream) to see how to apply different configuration to different parts of the stream.
-
-All of the common configuration settings for Google connectors can be found in the @github[reference.conf](/google-cloud-common/src/main/resources/reference.conf).
+The Storage connector @ref[shares its basic configuration](google-common.md) with all the Google connectors in Alpakka.
 Additional Storage-specific configuration settings can be found in its own @github[reference.conf](/google-cloud-storage/src/main/resources/reference.conf).
 
 HOCON:

--- a/docs/src/main/paradox/google-common.md
+++ b/docs/src/main/paradox/google-common.md
@@ -1,0 +1,72 @@
+# Google Common
+
+The `google-common` module provides central configuration for Google connectors in Alpakka as well as basic support for interfacing with Google APIs.
+
+## Artifacts
+
+@@dependency [sbt,Maven,Gradle] {
+group=com.lightbend.akka
+artifact=akka-stream-alpakka-reference_$scala.binary.version$
+version=$project.version$
+symbol2=AkkaVersion
+value2=$akka.version$
+group2=com.typesafe.akka
+artifact2=akka-stream_$scala.binary.version$
+version2=AkkaVersion
+}
+
+The table below shows direct dependencies of this module and the second tab shows all libraries it depends on transitively.
+
+@@dependencies { projectId="google-common" }
+
+## Configuration
+
+Shared settings for all Google connectors are read by default from the `alpakka.google` configuration section in your `application.conf`.
+The available options and their default values are documented in the `reference.conf`.
+If you use a non-standard configuration path or need multiple different configurations please refer to the sections below.
+
+@@snip [reference.conf](/google-common/src/main/resources/reference.conf)
+
+## Credentials
+
+Credentials will be loaded automatically:
+
+1. From the file path specified by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or another [“well-known” location](https://medium.com/google-cloud/use-google-cloud-user-credentials-when-testing-containers-locally-acb57cd4e4da); or
+2. When running in a [Compute Engine](https://cloud.google.com/compute) instance.
+
+Credentials can also be specified manually in your configuration file.
+
+## Accessing settings
+
+@apidoc[GoogleSettings$] provides methods to retrieve settings from your configuration and @apidoc[GoogleAttributes$] to access the settings attached to a stream.
+@scala[Additionally, if there is an implicit @apidoc[akka.actor.ActorSystem] in scope, then so will be an implicit instance of the default @apidoc[GoogleSettings].]
+
+Scala
+
+: @@snip [snip](/google-common/src/test/scala/docs/scaladsl/GoogleCommonDoc.scala) { #accessing-settings }
+
+Java
+
+: @@snip [snip](/google-common/src/test/java/docs/javadsl/GoogleCommonDoc.java) { #accessing-settings }
+
+## Apply custom settings to a part of the stream
+
+In certain situations it may be desirable to modify the @apidoc[GoogleSettings] applied to a part of the stream, for example to use different credentials or change the @apidoc[akka.stream.alpakka.google.RetrySettings].
+This is accomplished by adding @apidoc[GoogleAttributes$] to your stream.
+
+Scala
+
+: @@snip [snip](/google-common/src/test/scala/docs/scaladsl/GoogleCommonDoc.scala) { #custom-settings }
+
+Java
+
+: @@snip [snip](/google-common/src/test/java/docs/javadsl/GoogleCommonDoc.java) { #custom-settings }
+
+## Interop with Google Java client libraries
+
+Instances of the @apidoc[akka.stream.alpakka.google.auth.Credentials] class can be converted via the `toGoogle()` method to @javadoc[Credentials](com.google.auth.Credentials) compatible with Google Java client libraries.
+
+## Accessing other Google APIs
+
+The @apidoc[Google$] @scala[object] @java[class] provides methods for interfacing with Google APIs.
+You can use it to access APIs that are not currently supported by Alpakka and build new connectors.

--- a/docs/src/main/paradox/google-fcm.md
+++ b/docs/src/main/paradox/google-fcm.md
@@ -42,10 +42,6 @@ The table below shows direct dependencies of this module and the second tab show
 
 The FCM connector @ref[shares its basic configuration](google-common.md) with all the Google connectors in Alpakka.
 Additional FCM-specific configuration settings can be found in its own @github[reference.conf](/google-fcm/src/main/resources/reference.conf).
-
-@@snip [snip](/google-fcm/src/test/resources/application.conf) { #init-credentials }
-
-The last two parameters in the above example are the predefined values.
 You can send test notifications [(so called validate only).](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages/send)
 And you can set the number of maximum concurrent connections.
 There is a limitation in the docs; from one IP you can have maximum 1k pending connections,

--- a/docs/src/main/paradox/google-fcm.md
+++ b/docs/src/main/paradox/google-fcm.md
@@ -40,15 +40,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Settings
 
-Shared settings for all Google connectors are read by default from the `alpakka.google` configuration section in your `application.conf`.
-Credentials will be loaded automatically:
-
-1. From the file path specified by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or another [“well-known” location](https://medium.com/google-cloud/use-google-cloud-user-credentials-when-testing-containers-locally-acb57cd4e4da); or
-2. When running in a [Compute Engine](https://cloud.google.com/compute) instance.
-
-Credentials can also be specified manually in your configuration file.
-
-All of the common configuration settings for Google connectors can be found in the @github[reference.conf](/google-cloud-common/src/main/resources/reference.conf).
+The FCM connector @ref[shares its basic configuration](google-common.md) with all the Google connectors in Alpakka.
 Additional FCM-specific configuration settings can be found in its own @github[reference.conf](/google-fcm/src/main/resources/reference.conf).
 
 @@snip [snip](/google-fcm/src/test/resources/application.conf) { #init-credentials }

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -32,6 +32,7 @@ The [Alpakka project](https://doc.akka.io/docs/alpakka/current/) is an open sour
 * [File](file.md)
 * [FS2](external/fs2.md)
 * [FTP](ftp.md)
+* [Google Common](google-common.md)
 * [Google Cloud BigQuery](google-cloud-bigquery.md)
 * [Google Cloud Pub/Sub](google-cloud-pub-sub.md)
 * [Google Cloud Pub/Sub gRPC](google-cloud-pub-sub-grpc.md)

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/Credentials.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/Credentials.scala
@@ -73,14 +73,14 @@ abstract class Credentials private[auth] () {
 
   /**
    * Wraps these credentials as a [[com.google.auth.Credentials]] for interop with Google's Java client libraries.
-   * @param ec the [[ExecutionContext]] to use for blocking requests if credentials are requested synchronously
+   * @param ec the [[scala.concurrent.ExecutionContext]] to use for blocking requests if credentials are requested synchronously
    * @param settings additional request settings
    */
   def asGoogle(implicit ec: ExecutionContext, settings: RequestSettings): GoogleCredentials
 
   /**
    * Java API: Wraps these credentials as a [[com.google.auth.Credentials]] for interop with Google's Java client libraries.
-   * @param exec the [[Executor]] to use for blocking requests if credentials are requested synchronously
+   * @param exec the [[java.util.concurrent.Executor]] to use for blocking requests if credentials are requested synchronously
    * @param settings additional request settings
    */
   final def asGoogle(exec: Executor, settings: RequestSettings): GoogleCredentials =

--- a/google-common/src/main/scala/akka/stream/alpakka/google/util/Retry.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/util/Retry.scala
@@ -16,7 +16,7 @@ import scala.util.control.{NoStackTrace, NonFatal}
 import scala.util.{Failure, Success, Try}
 
 /**
- * A wrapper for a [[Throwable]] indicating that it should be retried.
+ * A wrapper for a [[java.lang.Throwable]] indicating that it should be retried.
  * The underlying exception can be accessed with `getCause()`.
  */
 final case class Retry private (ex: Throwable) extends Throwable(ex) with NoStackTrace

--- a/google-common/src/test/java/docs/javadsl/GoogleCommonDoc.java
+++ b/google-common/src/test/java/docs/javadsl/GoogleCommonDoc.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.javadsl;
+
+import akka.actor.ActorSystem;
+import akka.stream.Graph;
+import akka.stream.alpakka.google.GoogleAttributes;
+import akka.stream.alpakka.google.GoogleSettings;
+import akka.stream.javadsl.Source;
+
+public class GoogleCommonDoc {
+
+  ActorSystem system = null;
+  Graph<?, ?> stream = null;
+
+  void accessingSettings() {
+    // #accessing-settings
+    GoogleSettings defaultSettings = GoogleSettings.create(system);
+    GoogleSettings customSettings = GoogleSettings.create("my-app.custom-google-config", system);
+    Source.fromMaterializer(
+        (mat, attr) -> {
+          GoogleSettings settings = GoogleAttributes.resolveSettings(mat, attr);
+          return Source.empty();
+        });
+    // #accessing-settings
+  }
+
+  void customSettings() {
+    // #custom-settings
+    stream.addAttributes(GoogleAttributes.settingsPath("my-app.custom-google-config"));
+
+    GoogleSettings defaultSettings = GoogleSettings.create(system);
+    GoogleSettings customSettings = defaultSettings.withProjectId("my-other-project");
+    stream.addAttributes(GoogleAttributes.settings(customSettings));
+    // #custom-settings
+  }
+}

--- a/google-common/src/test/scala/docs/scaladsl/GoogleCommonDoc.scala
+++ b/google-common/src/test/scala/docs/scaladsl/GoogleCommonDoc.scala
@@ -8,7 +8,10 @@ import akka.actor.ActorSystem
 import akka.stream.Graph
 import akka.stream.alpakka.google.{GoogleAttributes, GoogleSettings}
 import akka.stream.scaladsl.Source
+import com.github.ghik.silencer.silent
 
+@silent("never used")
+@silent("dead code")
 class GoogleCommonDoc {
 
   implicit val system: ActorSystem = ???

--- a/google-common/src/test/scala/docs/scaladsl/GoogleCommonDoc.scala
+++ b/google-common/src/test/scala/docs/scaladsl/GoogleCommonDoc.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.scaladsl
+
+import akka.actor.ActorSystem
+import akka.stream.Graph
+import akka.stream.alpakka.google.{GoogleAttributes, GoogleSettings}
+import akka.stream.scaladsl.Source
+
+class GoogleCommonDoc {
+
+  implicit val system: ActorSystem = ???
+  val stream: Graph[Nothing, Nothing] = ???
+
+  { //#accessing-settings
+    val defaultSettings = GoogleSettings()
+    val customSettings = GoogleSettings("my-app.custom-google-config")
+    Source.fromMaterializer { (mat, attr) =>
+      val settings: GoogleSettings = GoogleAttributes.resolveSettings(mat, attr)
+      Source.empty
+    }
+    //#accessing-settings
+  }
+
+  {
+    //#custom-settings
+    stream.addAttributes(GoogleAttributes.settingsPath("my-app.custom-google-config"))
+
+    val defaultSettings = GoogleSettings()
+    val customSettings = defaultSettings.withProjectId("my-other-project")
+    stream.addAttributes(GoogleAttributes.settings(customSettings))
+    //#custom-settings
+  }
+
+}


### PR DESCRIPTION
References #2623, #2630

Upgrades `google-common` to a full-fledged module, so that it has a published release artifact and docs.