### PR TITLE
google-common: fix docs typo

### DIFF
--- a/docs/src/main/paradox/google-common.md
+++ b/docs/src/main/paradox/google-common.md
@@ -6,7 +6,7 @@ The `google-common` module provides central configuration for Google connectors 
 
 @@dependency [sbt,Maven,Gradle] {
 group=com.lightbend.akka
-artifact=akka-stream-alpakka-reference_$scala.binary.version$
+artifact=akka-stream-alpakka-google-common_$scala.binary.version$
 version=$project.version$
 symbol2=AkkaVersion
 value2=$akka.version$


### PR DESCRIPTION
Corrects the artifact id in the sbt/maven/gradle section.