### PR TITLE
Remove the CMSClassUnloadingEnabled jvm flag

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,3 @@
 -Dfile.encoding=UTF8
 -Xms1g
 -Xss6M
--XX:+CMSClassUnloadingEnabled


### PR DESCRIPTION
The flag `-XX:+CMSClassUnloadingEnabled` deprecated after the Java 9 release. And it is pointless without the flag `-XX:+UseConcMarkSweepGC` that deprecated too. I would like to remove it from the `.jvmopts`