### PR TITLE
Google: Drop old jwt-core dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -224,7 +224,6 @@ object Dependencies {
         "io.spray" %% "spray-json" % "1.3.6",
         "com.fasterxml.jackson.core" % "jackson-annotations" % JacksonDatabindVersion,
         "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % JacksonDatabindVersion % Test,
-        "com.pauldijou" %% "jwt-core" % "3.1.0", //ApacheV2
         "io.specto" % "hoverfly-java" % hoverflyVersion % Test //ApacheV2
       ) ++ Mockito ++ Silencer
   )
@@ -233,7 +232,6 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "com.pauldijou" %% "jwt-core" % JwtCoreVersion, // ApacheV2
         "com.github.tomakehurst" % "wiremock" % "2.25.1" % Test // ApacheV2
       ) ++ Mockito ++ Silencer
   )
@@ -254,7 +252,6 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "com.pauldijou" %% "jwt-core" % JwtCoreVersion // ApacheV2
       ) ++ Mockito ++ Silencer
   )
 
@@ -262,7 +259,6 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "com.pauldijou" %% "jwt-core" % JwtCoreVersion, //ApacheV2
         "io.specto" % "hoverfly-java" % hoverflyVersion % Test // ApacheV2
       ) ++ Mockito ++ Silencer
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -251,7 +251,7 @@ object Dependencies {
   val GoogleFcm = Seq(
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion
       ) ++ Mockito ++ Silencer
   )
 


### PR DESCRIPTION
This drops the `jwt-core` dependency from the Google connectors since this is now handled in `google-common`.

Unfortunately, this is currently a potentially fatal bug: the `google-common` module depends on a recent version of `jwt-scala` that has a new Maven organization name but retains the same package name as `jwt-core`, which IIUC creates a classpath conflict that SBT will not automatically resolve via eviction. Due to API changes, if the old `JWT` classes are used instead of the new then authorization requests to Google will fail.
