### PR TITLE
Elasticsearch has Header and HttpsContext Settings

### DIFF
--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -40,6 +40,8 @@ Java
 | baseUrl             | Empty   | The base URL of Elasticsearch. Should not include a trailing slash. |
 | username            | None    | The username to authenticate with                                   |
 | password            | None    | The password to authenticate with                                   |
+| headers             | None    | List of headers that should be sent with the http request.          |
+| connectionContext   | None    | The connectionContext that will be used with the http request. This can be used for TLS Auth instead of basic auth (username/password) by setting the SSLContext within the connectionContext.  |
 
 ## Elasticsearch parameters
 

--- a/elasticsearch/src/main/mima-filters/3.0.0-M1.backwards.excludes/PR2652.excludes
+++ b/elasticsearch/src/main/mima-filters/3.0.0-M1.backwards.excludes/PR2652.excludes
@@ -1,0 +1,2 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.elasticsearch.ElasticsearchConnectionSettings.copy*")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.elasticsearch.ElasticsearchConnectionSettings.this")

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchConnectionSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchConnectionSettings.scala
@@ -4,10 +4,20 @@
 
 package akka.stream.alpakka.elasticsearch
 
+import akka.http.scaladsl.HttpsConnectionContext
+import akka.http.scaladsl.model.HttpHeader
+import akka.http.scaladsl.model.HttpHeader.ParsingResult
+import akka.japi.Util
+
+import scala.collection.JavaConverters._
+import scala.compat.java8.OptionConverters
+
 final class ElasticsearchConnectionSettings private (
     val baseUrl: String,
     val username: Option[String],
-    val password: Option[String]
+    val password: Option[String],
+    val headers: List[HttpHeader],
+    val connectionContext: Option[HttpsConnectionContext]
 ) {
 
   def withBaseUrl(value: String): ElasticsearchConnectionSettings = copy(baseUrl = value)
@@ -17,21 +27,73 @@ final class ElasticsearchConnectionSettings private (
 
   def hasCredentialsDefined: Boolean = username.isDefined && password.isDefined
 
-  def copy(baseUrl: String = baseUrl,
-           username: Option[String] = username,
-           password: Option[String] = password): ElasticsearchConnectionSettings =
-    new ElasticsearchConnectionSettings(baseUrl = baseUrl, username = username, password = password)
+  /** Scala API */
+  def withHeaders(headers: List[HttpHeader]): ElasticsearchConnectionSettings =
+    copy(headers = headers)
+
+  /** Java API */
+  def withHeaders(headers: java.util.List[akka.http.javadsl.model.HttpHeader]): ElasticsearchConnectionSettings = {
+    val scalaHeaders = headers.asScala
+      .map(x => {
+        HttpHeader.parse(x.name(), x.value()) match {
+          case ParsingResult.Ok(header, _) => header
+          case ParsingResult.Error(error) =>
+            throw new Exception(s"Unable to convert java HttpHeader to scala HttpHeader: ${error.summary}")
+        }
+      })
+      .toList
+
+    copy(headers = scalaHeaders)
+  }
+
+  /** Scala API */
+  def withConnectionContext(connectionContext: HttpsConnectionContext): ElasticsearchConnectionSettings =
+    copy(connectionContext = Option(connectionContext))
+
+  /** Java API */
+  def withConnectionContext(
+      connectionContext: akka.http.javadsl.HttpsConnectionContext
+  ): ElasticsearchConnectionSettings = {
+    val scalaContext = new HttpsConnectionContext(
+      connectionContext.getSslContext,
+      None,
+      OptionConverters.toScala(connectionContext.getEnabledCipherSuites).map(Util.immutableSeq(_)),
+      OptionConverters.toScala(connectionContext.getEnabledProtocols).map(Util.immutableSeq(_)),
+      OptionConverters.toScala(connectionContext.getClientAuth),
+      OptionConverters.toScala(connectionContext.getSslParameters)
+    )
+
+    copy(connectionContext = Option(scalaContext))
+  }
+
+  def hasConnectionContextDefined: Boolean = connectionContext.isDefined
+
+  private def copy(
+      baseUrl: String = baseUrl,
+      username: Option[String] = username,
+      password: Option[String] = password,
+      headers: List[HttpHeader] = headers,
+      connectionContext: Option[HttpsConnectionContext] = connectionContext
+  ): ElasticsearchConnectionSettings =
+    new ElasticsearchConnectionSettings(baseUrl = baseUrl,
+                                        username = username,
+                                        password = password,
+                                        headers = headers,
+                                        connectionContext = connectionContext)
 
   override def toString =
-    s"""ElasticsearchConnectionSettings(baseUrl=$baseUrl,username=$username,password=${password.fold("")(_ => "***")})"""
+    s"""ElasticsearchConnectionSettings(baseUrl=$baseUrl,username=$username,password=${password.fold("")(
+      _ => "***"
+    )},headers=${headers.mkString(";")},connectionContext=$connectionContext)"""
 }
 
 object ElasticsearchConnectionSettings {
 
   /** Scala API */
-  def apply(baseUrl: String): ElasticsearchConnectionSettings = new ElasticsearchConnectionSettings(baseUrl, None, None)
+  def apply(baseUrl: String): ElasticsearchConnectionSettings =
+    new ElasticsearchConnectionSettings(baseUrl, None, None, List.empty, None)
 
   /** Java API */
   def create(baseUrl: String): ElasticsearchConnectionSettings =
-    new ElasticsearchConnectionSettings(baseUrl, None, None)
+    new ElasticsearchConnectionSettings(baseUrl, None, None, List.empty, None)
 }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchApi.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchApi.scala
@@ -22,7 +22,9 @@ import scala.concurrent.Future
         request.addCredentials(BasicHttpCredentials(connectionSettings.username.get, connectionSettings.password.get))
       )
     } else {
-      http.singleRequest(request)
+      http.singleRequest(request,
+                         connectionContext =
+                           connectionSettings.connectionContext.getOrElse(http.defaultClientHttpsContext))
     }
   }
 }


### PR DESCRIPTION
The current ElasticsearchAPI only supports basic auth. By including
header options as well as the HttpsContext there would be additional
options to keep previous functionality but still moving forward with
AkkaHttp.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
