### PR TITLE
elasticsearch: support for sort in searchparams

### DIFF
--- a/docs/src/main/paradox/elasticsearch.md
+++ b/docs/src/main/paradox/elasticsearch.md
@@ -250,6 +250,10 @@ Scala
 Java
 : @@snip [snip](/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV5Test.java) { #custom-search-params }
 
-Additionally, support for [custom routing](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-routing-field.html) 
-is available through the `routing` key. Add this key and the respective value in 'searchParams' map, to route your search directly to the shard that holds
-the document you are looking for and enjoy improved response times.
+
+#### Routing
+Support for [custom routing](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-routing-field.html) 
+is available through the `routing` key. Add this key and the respective value in 'searchParams' map, to route your search directly to the shard that holds the document you are looking for and enjoy improved response times.
+
+#### Sort
+Support for sort is available through the `sort` key in `searchParams` map. If no sort is given, the source will use `sort=_doc` to maximize performance, as indicated by [elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results).

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSource.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/scaladsl/ElasticsearchSource.scala
@@ -128,7 +128,7 @@ object ElasticsearchSource {
         case None => {
           val scrollId = jsObj.fields("_scroll_id").asInstanceOf[JsString].value
           val hits = jsObj.fields("hits").asJsObject.fields("hits").asInstanceOf[JsArray]
-          val messages = hits.elements.reverse.map { element =>
+          val messages = hits.elements.map { element =>
             val doc = element.asJsObject
             val id = doc.fields("_id").asInstanceOf[JsString].value
             val source = doc.fields("_source").asJsObject

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpecUtils.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpecUtils.scala
@@ -31,15 +31,18 @@ trait ElasticsearchSpecUtils { this: AnyWordSpec with ScalaFutures =>
   import spray.json._
   import DefaultJsonProtocol._
 
-  case class Book(title: String, shouldSkip: Option[Boolean] = None)
+  case class Book(title: String, shouldSkip: Option[Boolean] = None, price: Int = 10)
 
-  implicit val format: JsonFormat[Book] = jsonFormat2(Book)
+  implicit val format: JsonFormat[Book] = jsonFormat3(Book)
   //#define-class
 
-  def register(connectionSettings: ElasticsearchConnectionSettings, indexName: String, title: String): Unit = {
+  def register(connectionSettings: ElasticsearchConnectionSettings,
+               indexName: String,
+               title: String,
+               price: Int): Unit = {
     val request = HttpRequest(HttpMethods.POST)
       .withUri(Uri(connectionSettings.baseUrl).withPath(Path(s"/$indexName/_doc")))
-      .withEntity(ContentTypes.`application/json`, s"""{"title": "$title"}""")
+      .withEntity(ContentTypes.`application/json`, s"""{"title": "$title", "price": $price}""")
     http.singleRequest(request).futureValue
   }
 
@@ -68,13 +71,13 @@ trait ElasticsearchSpecUtils { this: AnyWordSpec with ScalaFutures =>
       .runWith(Sink.seq)
 
   def insertTestData(connectionSettings: ElasticsearchConnectionSettings): Unit = {
-    register(connectionSettings, "source", "Akka in Action")
-    register(connectionSettings, "source", "Programming in Scala")
-    register(connectionSettings, "source", "Learning Scala")
-    register(connectionSettings, "source", "Scala for Spark in Production")
-    register(connectionSettings, "source", "Scala Puzzlers")
-    register(connectionSettings, "source", "Effective Akka")
-    register(connectionSettings, "source", "Akka Concurrency")
+    register(connectionSettings, "source", "Akka in Action", 10)
+    register(connectionSettings, "source", "Programming in Scala", 20)
+    register(connectionSettings, "source", "Learning Scala", 10)
+    register(connectionSettings, "source", "Scala for Spark in Production", 5)
+    register(connectionSettings, "source", "Scala Puzzlers", 10)
+    register(connectionSettings, "source", "Effective Akka", 10)
+    register(connectionSettings, "source", "Akka Concurrency", 10)
     flushAndRefresh(connectionSettings, "source")
   }
 

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV5Spec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV5Spec.scala
@@ -21,10 +21,11 @@ import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import akka.{Done, NotUsed}
-import spray.json.{jsonReader, JsObject, JsString}
+import spray.json.jsonReader
 
 import scala.collection.immutable
 import scala.concurrent.Future
+import spray.json._
 
 class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUtils {
 
@@ -161,9 +162,9 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
       // #string
       val write: Future[immutable.Seq[WriteResult[String, NotUsed]]] = Source(
         immutable.Seq(
-          WriteMessage.createIndexMessage("1", s"""{"title": "Das Parfum"}"""),
-          WriteMessage.createIndexMessage("2", s"""{"title": "Faust"}"""),
-          WriteMessage.createIndexMessage("3", s"""{"title": "Die unendliche Geschichte"}""")
+          WriteMessage.createIndexMessage("1", Book("Das Parfum").toJson.toString()),
+          WriteMessage.createIndexMessage("2", Book("Faust").toJson.toString()),
+          WriteMessage.createIndexMessage("3", Book("Die unendliche Geschichte").toJson.toString())
         )
       ).via(
           ElasticsearchFlow.create(
@@ -375,7 +376,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
         committedOffsets = committedOffsets :+ offset
 
       val indexName = "sink6-none"
-      register(connectionSettings, indexName, "dummy") // need to create index else exception in reading below
+      register(connectionSettings, indexName, "dummy", 10) // need to create index else exception in reading below
 
       val kafkaToEs = Source(messagesFromKafka) // Assume we get this from Kafka
         .map { kafkaMessage: KafkaMessage =>
@@ -452,9 +453,9 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
 
       // Docs should contain both columns
       readBooks.futureValue.sortBy(_.fields("title").compactPrint) shouldEqual Seq(
-        JsObject("title" -> JsString("Book 1")),
-        JsObject("title" -> JsString("Book 3")),
-        JsObject("title" -> JsString("Book 5"))
+        Book("Book 1").toJson,
+        Book("Book 3").toJson,
+        Book("Book 5").toJson
       )
     }
 


### PR DESCRIPTION
Fix for https://github.com/akka/alpakka/issues/2656 also a partial fix for https://github.com/akka/alpakka/issues/591 (only for sort)

Support for user-defined sort in elasticsearch connector.
Previously, `sort=_doc` query param was forced, and SprayJsonReader reversed the order for each chunk (I'm curious why?).

if sort is in searchParams keep it and do not add query param, else add `sort=_doc` query param (as before)

Changing response order when _doc is used is not breaking since by design _doc does not guarantee any order

![image](https://user-images.githubusercontent.com/3693562/114730817-7d90aa80-9d41-11eb-9552-87d880ddce61.png)

# Before:
with docs with prices indexed in order `[1,2,3,4,5,6]` and passing a sort in `searchParams`

```
GET /_search?scroll=1m&sort=_doc
{
  "size": 2,
  "sort": ["price"]
}
```
=>
after reader `[2,1,4,3,6,5]`

```
GET /_search?scroll=1m&sort=_doc
{
  "size": 2,
  "sort": [{"price": "desc"}]
}
```
=>
after reader `[5,6,3,4,1,2]`

# After:
```
GET /_search?scroll=1m
{
  "size": 2,
  "sort": ["price"]
}
```
=>
after reader `[1,2,3,4,5,6]`

```
GET /_search?scroll=1m
{
  "size": 2,
  "sort": [{"price": "desc"}]
}
```
=>
after reader `[6,5,4,3,2,1]`

NB: thanks to all the devs building alpakka (and akka in general), these are amazing tools!