### PR TITLE
UDP: flow with socket options

### DIFF
--- a/udp/src/main/scala/akka/stream/alpakka/udp/impl/UdpBind.scala
+++ b/udp/src/main/scala/akka/stream/alpakka/udp/impl/UdpBind.scala
@@ -34,10 +34,7 @@ import scala.concurrent.{Future, Promise}
 
   override def preStart(): Unit = {
     implicit val sender = getStageActor(processIncoming).ref
-    if (options.nonEmpty)
-      IO(Udp) ! Udp.Bind(sender, localAddress, options)
-    else
-      IO(Udp) ! Udp.Bind(sender, localAddress)
+    IO(Udp) ! Udp.Bind(sender, localAddress, options)
   }
 
   override def postStop(): Unit =

--- a/udp/src/main/scala/akka/stream/alpakka/udp/impl/UdpBind.scala
+++ b/udp/src/main/scala/akka/stream/alpakka/udp/impl/UdpBind.scala
@@ -15,14 +15,14 @@ import akka.stream.alpakka.udp.Datagram
 import akka.stream.stage._
 
 import scala.Option
-import scala.collection.immutable.Traversable
+import scala.collection.immutable.Iterable
 import scala.concurrent.{Future, Promise}
 
 /**
  * Binds to the given local address using UDP manager actor.
  */
 @InternalApi private[udp] final class UdpBindLogic(localAddress: InetSocketAddress,
-                                                   options: Option[Traversable[SocketOption]],
+                                                   options: Option[Iterable[SocketOption]],
                                                    boundPromise: Promise[InetSocketAddress])(
     val shape: FlowShape[Datagram, Datagram]
 )(implicit val system: ActorSystem)
@@ -85,7 +85,7 @@ import scala.concurrent.{Future, Promise}
 }
 
 @InternalApi private[udp] final class UdpBindFlow(localAddress: InetSocketAddress,
-                                                  options: Option[Traversable[SocketOption]])(
+                                                  options: Option[Iterable[SocketOption]])(
     implicit val system: ActorSystem
 ) extends GraphStageWithMaterializedValue[FlowShape[Datagram, Datagram], Future[InetSocketAddress]] {
 

--- a/udp/src/main/scala/akka/stream/alpakka/udp/impl/UdpSend.scala
+++ b/udp/src/main/scala/akka/stream/alpakka/udp/impl/UdpSend.scala
@@ -13,7 +13,7 @@ import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import akka.stream._
 
 import scala.Option
-import scala.collection.immutable.Traversable
+import scala.collection.immutable.Iterable
 
 /**
  * Sends incoming messages to the corresponding destination addresses.
@@ -21,7 +21,7 @@ import scala.collection.immutable.Traversable
  * is passed-through to the output for possible further processing.
  */
 @InternalApi private[udp] final class UdpSendLogic(val shape: FlowShape[Datagram, Datagram],
-                                                   options: Option[Traversable[SocketOption]])(
+                                                   options: Option[Iterable[SocketOption]])(
     implicit val system: ActorSystem
 ) extends GraphStageLogic(shape) {
 
@@ -74,7 +74,7 @@ import scala.collection.immutable.Traversable
   )
 }
 
-@InternalApi private[udp] final class UdpSendFlow(options: Option[Traversable[SocketOption]])(
+@InternalApi private[udp] final class UdpSendFlow(options: Option[Iterable[SocketOption]])(
     implicit val system: ActorSystem
 ) extends GraphStage[FlowShape[Datagram, Datagram]] {
 

--- a/udp/src/main/scala/akka/stream/alpakka/udp/impl/UdpSend.scala
+++ b/udp/src/main/scala/akka/stream/alpakka/udp/impl/UdpSend.scala
@@ -33,10 +33,7 @@ import scala.collection.immutable.Iterable
 
   override def preStart(): Unit = {
     getStageActor(processIncoming)
-    if (options.nonEmpty)
-      IO(Udp) ! Udp.SimpleSender(options)
-    else
-      IO(Udp) ! Udp.SimpleSender
+    IO(Udp) ! Udp.SimpleSender(options)
   }
 
   override def postStop(): Unit =

--- a/udp/src/main/scala/akka/stream/alpakka/udp/impl/UdpSend.scala
+++ b/udp/src/main/scala/akka/stream/alpakka/udp/impl/UdpSend.scala
@@ -7,16 +7,20 @@ package akka.stream.alpakka.udp.impl
 import akka.actor.{ActorRef, ActorSystem, PoisonPill}
 import akka.annotation.InternalApi
 import akka.io.{IO, Udp}
+import akka.io.Inet.SocketOption
 import akka.stream.alpakka.udp.Datagram
 import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import akka.stream._
+
+import scala.collection.immutable.Traversable
 
 /**
  * Sends incoming messages to the corresponding destination addresses.
  * After send command is issued to the UDP manager actor the message
  * is passed-through to the output for possible further processing.
  */
-@InternalApi private[udp] final class UdpSendLogic(val shape: FlowShape[Datagram, Datagram])(
+@InternalApi private[udp] final class UdpSendLogic(val shape: FlowShape[Datagram, Datagram],
+                                                   options: Traversable[SocketOption] = Nil)(
     implicit val system: ActorSystem
 ) extends GraphStageLogic(shape) {
 
@@ -29,7 +33,11 @@ import akka.stream._
 
   override def preStart(): Unit = {
     getStageActor(processIncoming)
-    IO(Udp) ! Udp.SimpleSender
+    if (options != null) {
+      IO(Udp) ! Udp.SimpleSender(options)
+    } else {
+      IO(Udp) ! Udp.SimpleSender
+    }
   }
 
   override def postStop(): Unit =
@@ -66,12 +74,13 @@ import akka.stream._
   )
 }
 
-@InternalApi private[udp] final class UdpSendFlow(implicit val system: ActorSystem)
-    extends GraphStage[FlowShape[Datagram, Datagram]] {
+@InternalApi private[udp] final class UdpSendFlow(options: Traversable[SocketOption] = Nil)(
+    implicit val system: ActorSystem
+) extends GraphStage[FlowShape[Datagram, Datagram]] {
 
   val in: Inlet[Datagram] = Inlet("UdpSendFlow.in")
   val out: Outlet[Datagram] = Outlet("UdpSendFlow.in")
 
   val shape: FlowShape[Datagram, Datagram] = FlowShape.of(in, out)
-  override def createLogic(inheritedAttributes: Attributes) = new UdpSendLogic(shape)
+  override def createLogic(inheritedAttributes: Attributes) = new UdpSendLogic(shape, options)
 }

--- a/udp/src/main/scala/akka/stream/alpakka/udp/javadsl/Udp.scala
+++ b/udp/src/main/scala/akka/stream/alpakka/udp/javadsl/Udp.scala
@@ -24,6 +24,8 @@ object Udp {
    * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message. All incoming messages are also emitted from the flow for
    * subsequent processing.
+   *
+   * @param system the actor system
    */
   def sendFlow(system: ActorSystem): Flow[Datagram, Datagram, NotUsed] =
     scaladsl.Udp.sendFlow()(system).asJava
@@ -32,6 +34,8 @@ object Udp {
    * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message. All incoming messages are also emitted from the flow for
    * subsequent processing.
+   *
+   * @param system the actor system
    */
   def sendFlow(system: ClassicActorSystemProvider): Flow[Datagram, Datagram, NotUsed] =
     scaladsl.Udp.sendFlow()(system).asJava
@@ -40,6 +44,9 @@ object Udp {
    * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message. All incoming messages are also emitted from the flow for
    * subsequent processing.
+   *
+   * @param options UDP socket options
+   * @param system the actor system
    */
   def sendFlow(options: JIterable[SocketOption], system: ActorSystem): Flow[Datagram, Datagram, NotUsed] =
     scaladsl.Udp.sendFlow(options.asScala.toIndexedSeq)(system).asJava
@@ -48,6 +55,9 @@ object Udp {
    * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message. All incoming messages are also emitted from the flow for
    * subsequent processing.
+   *
+   * @param options UDP socket options
+   * @param system the actor system
    */
   def sendFlow(options: JIterable[SocketOption],
                system: ClassicActorSystemProvider): Flow[Datagram, Datagram, NotUsed] =
@@ -56,6 +66,8 @@ object Udp {
   /**
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message.
+   *
+   * @param system the actor system
    */
   def sendSink(system: ActorSystem): Sink[Datagram, NotUsed] =
     scaladsl.Udp.sendSink()(system).asJava
@@ -63,6 +75,8 @@ object Udp {
   /**
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message.
+   *
+   * @param system the actor system
    */
   def sendSink(system: ClassicActorSystemProvider): Sink[Datagram, NotUsed] =
     scaladsl.Udp.sendSink()(system).asJava
@@ -70,6 +84,9 @@ object Udp {
   /**
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message.
+   *
+   * @param options UDP socket options
+   * @param system the actor system
    */
   def sendSink(options: JIterable[SocketOption], system: ActorSystem): Sink[Datagram, NotUsed] =
     scaladsl.Udp.sendSink(options.asScala.toIndexedSeq)(system).asJava
@@ -77,6 +94,9 @@ object Udp {
   /**
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message.
+   *
+   * @param options UDP socket options
+   * @param system the actor system
    */
   def sendSink(options: JIterable[SocketOption], system: ClassicActorSystemProvider): Sink[Datagram, NotUsed] =
     scaladsl.Udp.sendSink(options.asScala.toIndexedSeq)(system).asJava
@@ -85,6 +105,9 @@ object Udp {
    * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
    * messages to the `localAddress` are emitted from the flow. All incoming messages to the flow
    * are sent to the remote address contained in the message.
+   *
+   * @param localAddress UDP socket address
+   * @param system the actor system
    */
   def bindFlow(localAddress: InetSocketAddress,
                system: ActorSystem): Flow[Datagram, Datagram, CompletionStage[InetSocketAddress]] =
@@ -94,6 +117,9 @@ object Udp {
    * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
    * messages to the `localAddress` are emitted from the flow. All incoming messages to the flow
    * are sent to the remote address contained in the message.
+   *
+   * @param localAddress UDP socket address
+   * @param system the actor system
    */
   def bindFlow(localAddress: InetSocketAddress,
                system: ClassicActorSystemProvider): Flow[Datagram, Datagram, CompletionStage[InetSocketAddress]] =
@@ -103,6 +129,10 @@ object Udp {
    * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
    * messages to the `localAddress` are emitted from the flow. All incoming messages to the flow
    * are sent to the remote address contained in the message.
+   *
+   * @param localAddress UDP socket address
+   * @param options UDP socket options
+   * @param system the actor system
    */
   def bindFlow(localAddress: InetSocketAddress,
                options: JIterable[SocketOption],
@@ -113,6 +143,10 @@ object Udp {
    * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
    * messages to the `localAddress` are emitted from the flow. All incoming messages to the flow
    * are sent to the remote address contained in the message.
+   *
+   * @param localAddress UDP socket address
+   * @param options UDP socket options
+   * @param system the actor system
    */
   def bindFlow(localAddress: InetSocketAddress,
                options: JIterable[SocketOption],

--- a/udp/src/main/scala/akka/stream/alpakka/udp/javadsl/Udp.scala
+++ b/udp/src/main/scala/akka/stream/alpakka/udp/javadsl/Udp.scala
@@ -8,14 +8,17 @@ import java.net.InetSocketAddress
 import java.util.concurrent.CompletionStage
 
 import akka.NotUsed
+import akka.io.Inet.SocketOption
 import akka.actor.{ActorSystem, ClassicActorSystemProvider}
 import akka.stream.alpakka.udp.Datagram
 import akka.stream.javadsl.{Flow, Sink}
 import akka.stream.alpakka.udp.scaladsl
+import akka.util.ccompat.JavaConverters._
 
 import scala.compat.java8.FutureConverters._
 
 object Udp {
+  import java.lang.{Iterable => JIterable}
 
   /**
    * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
@@ -34,6 +37,23 @@ object Udp {
     scaladsl.Udp.sendFlow()(system).asJava
 
   /**
+   * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
+   * contained in the message. All incoming messages are also emitted from the flow for
+   * subsequent processing.
+   */
+  def sendFlow(options: JIterable[SocketOption], system: ActorSystem): Flow[Datagram, Datagram, NotUsed] =
+    scaladsl.Udp.sendFlow(options.asScala.toIndexedSeq)(system).asJava
+
+  /**
+   * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
+   * contained in the message. All incoming messages are also emitted from the flow for
+   * subsequent processing.
+   */
+  def sendFlow(options: JIterable[SocketOption],
+               system: ClassicActorSystemProvider): Flow[Datagram, Datagram, NotUsed] =
+    scaladsl.Udp.sendFlow(options.asScala.toIndexedSeq)(system).asJava
+
+  /**
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message.
    */
@@ -46,6 +66,20 @@ object Udp {
    */
   def sendSink(system: ClassicActorSystemProvider): Sink[Datagram, NotUsed] =
     scaladsl.Udp.sendSink()(system).asJava
+
+  /**
+   * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
+   * contained in the message.
+   */
+  def sendSink(options: JIterable[SocketOption], system: ActorSystem): Sink[Datagram, NotUsed] =
+    scaladsl.Udp.sendSink(options.asScala.toIndexedSeq)(system).asJava
+
+  /**
+   * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
+   * contained in the message.
+   */
+  def sendSink(options: JIterable[SocketOption], system: ClassicActorSystemProvider): Sink[Datagram, NotUsed] =
+    scaladsl.Udp.sendSink(options.asScala.toIndexedSeq)(system).asJava
 
   /**
    * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
@@ -64,4 +98,24 @@ object Udp {
   def bindFlow(localAddress: InetSocketAddress,
                system: ClassicActorSystemProvider): Flow[Datagram, Datagram, CompletionStage[InetSocketAddress]] =
     scaladsl.Udp.bindFlow(localAddress)(system).mapMaterializedValue(_.toJava).asJava
+
+  /**
+   * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
+   * messages to the `localAddress` are emitted from the flow. All incoming messages to the flow
+   * are sent to the remote address contained in the message.
+   */
+  def bindFlow(localAddress: InetSocketAddress,
+               options: JIterable[SocketOption],
+               system: ActorSystem): Flow[Datagram, Datagram, CompletionStage[InetSocketAddress]] =
+    scaladsl.Udp.bindFlow(localAddress, options.asScala.toIndexedSeq)(system).mapMaterializedValue(_.toJava).asJava
+
+  /**
+   * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
+   * messages to the `localAddress` are emitted from the flow. All incoming messages to the flow
+   * are sent to the remote address contained in the message.
+   */
+  def bindFlow(localAddress: InetSocketAddress,
+               options: JIterable[SocketOption],
+               system: ClassicActorSystemProvider): Flow[Datagram, Datagram, CompletionStage[InetSocketAddress]] =
+    scaladsl.Udp.bindFlow(localAddress, options.asScala.toIndexedSeq)(system).mapMaterializedValue(_.toJava).asJava
 }

--- a/udp/src/main/scala/akka/stream/alpakka/udp/scaladsl/Udp.scala
+++ b/udp/src/main/scala/akka/stream/alpakka/udp/scaladsl/Udp.scala
@@ -24,6 +24,8 @@ object Udp {
    * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message. All incoming messages are also emitted from the flow for
    * subsequent processing.
+   *
+   * @param system implicit actor system
    */
   def sendFlow()(implicit system: ClassicActorSystemProvider): Flow[Datagram, Datagram, NotUsed] =
     sendFlow(system.classicSystem)
@@ -32,6 +34,8 @@ object Udp {
    * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message. All incoming messages are also emitted from the flow for
    * subsequent processing.
+   *
+   * @param system the actor system
    */
   def sendFlow(system: ActorSystem): Flow[Datagram, Datagram, NotUsed] =
     Flow.fromGraph(new UdpSendFlow(Option.empty)(system))
@@ -40,6 +44,9 @@ object Udp {
    * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message. All incoming messages are also emitted from the flow for
    * subsequent processing.
+   *
+   * @param options UDP socket options
+   * @param system implicit actor system
    */
   def sendFlow(
       options: Iterable[SocketOption]
@@ -50,6 +57,9 @@ object Udp {
    * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message. All incoming messages are also emitted from the flow for
    * subsequent processing.
+   *
+   * @param options UDP socket options
+   * @param system the actor system
    */
   def sendFlow(options: Iterable[SocketOption], system: ActorSystem): Flow[Datagram, Datagram, NotUsed] =
     Flow.fromGraph(new UdpSendFlow(Option(options))(system))
@@ -57,18 +67,25 @@ object Udp {
   /**
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message.
+   *
+   * @param system implicit actor system
    */
   def sendSink()(implicit system: ClassicActorSystemProvider): Sink[Datagram, NotUsed] = sendFlow().to(Sink.ignore)
 
   /**
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message.
+   *
+   * @param system the actor system
    */
   def sendSink(system: ActorSystem): Sink[Datagram, NotUsed] = sendFlow(system).to(Sink.ignore)
 
   /**
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message.
+   *
+   * @param options UDP socket options
+   * @param system implicit actor system
    */
   def sendSink(options: Iterable[SocketOption])(
       implicit system: ClassicActorSystemProvider
@@ -77,6 +94,9 @@ object Udp {
   /**
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message.
+   *
+   * @param options UDP socket options
+   * @param system the actor system
    */
   def sendSink(options: Iterable[SocketOption], system: ActorSystem): Sink[Datagram, NotUsed] =
     sendFlow(options, system).to(Sink.ignore)
@@ -85,6 +105,9 @@ object Udp {
    * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
    * messages to the `localAddress` are emitted from the flow. All incoming messages to the flow
    * are sent to the remote address contained in the message.
+   *
+   * @param localAddress UDP socket address
+   * @param system implicit actor system
    */
   def bindFlow(
       localAddress: InetSocketAddress
@@ -95,6 +118,9 @@ object Udp {
    * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
    * messages to the `localAddress` are emitted from the flow. All incoming messages to the flow
    * are sent to the remote address contained in the message.
+   *
+   * @param localAddress UDP socket address
+   * @param system the actor system
    */
   def bindFlow(localAddress: InetSocketAddress,
                system: ActorSystem): Flow[Datagram, Datagram, Future[InetSocketAddress]] =
@@ -104,6 +130,10 @@ object Udp {
    * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
    * messages to the `localAddress` are emitted from the flow. All incoming messages to the flow
    * are sent to the remote address contained in the message.
+   *
+   * @param localAddress UDP socket address
+   * @param options UDP socket options
+   * @param system implicit actor system
    */
   def bindFlow(
       localAddress: InetSocketAddress,
@@ -115,6 +145,10 @@ object Udp {
    * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
    * messages to the `localAddress` are emitted from the flow. All incoming messages to the flow
    * are sent to the remote address contained in the message.
+   *
+   * @param localAddress UDP socket address
+   * @param options UDP socket options
+   * @param system the actor system
    */
   def bindFlow(localAddress: InetSocketAddress,
                options: Iterable[SocketOption],

--- a/udp/src/main/scala/akka/stream/alpakka/udp/scaladsl/Udp.scala
+++ b/udp/src/main/scala/akka/stream/alpakka/udp/scaladsl/Udp.scala
@@ -14,7 +14,6 @@ import akka.stream.alpakka.udp.impl.{UdpBindFlow, UdpSendFlow}
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Flow
 
-import scala.Option
 import scala.collection.immutable.Iterable
 import scala.concurrent.Future
 
@@ -38,7 +37,7 @@ object Udp {
    * @param system the actor system
    */
   def sendFlow(system: ActorSystem): Flow[Datagram, Datagram, NotUsed] =
-    Flow.fromGraph(new UdpSendFlow(Option.empty)(system))
+    Flow.fromGraph(new UdpSendFlow()(system))
 
   /**
    * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
@@ -62,7 +61,7 @@ object Udp {
    * @param system the actor system
    */
   def sendFlow(options: Iterable[SocketOption], system: ActorSystem): Flow[Datagram, Datagram, NotUsed] =
-    Flow.fromGraph(new UdpSendFlow(Option(options))(system))
+    Flow.fromGraph(new UdpSendFlow(options)(system))
 
   /**
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
@@ -124,7 +123,7 @@ object Udp {
    */
   def bindFlow(localAddress: InetSocketAddress,
                system: ActorSystem): Flow[Datagram, Datagram, Future[InetSocketAddress]] =
-    Flow.fromGraph(new UdpBindFlow(localAddress, Option.empty)(system))
+    Flow.fromGraph(new UdpBindFlow(localAddress)(system))
 
   /**
    * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
@@ -153,5 +152,5 @@ object Udp {
   def bindFlow(localAddress: InetSocketAddress,
                options: Iterable[SocketOption],
                system: ActorSystem): Flow[Datagram, Datagram, Future[InetSocketAddress]] =
-    Flow.fromGraph(new UdpBindFlow(localAddress, Option(options))(system))
+    Flow.fromGraph(new UdpBindFlow(localAddress, options)(system))
 }

--- a/udp/src/main/scala/akka/stream/alpakka/udp/scaladsl/Udp.scala
+++ b/udp/src/main/scala/akka/stream/alpakka/udp/scaladsl/Udp.scala
@@ -14,6 +14,7 @@ import akka.stream.alpakka.udp.impl.{UdpBindFlow, UdpSendFlow}
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Flow
 
+import scala.Option
 import scala.collection.immutable.Traversable
 import scala.concurrent.Future
 
@@ -33,7 +34,7 @@ object Udp {
    * subsequent processing.
    */
   def sendFlow(system: ActorSystem): Flow[Datagram, Datagram, NotUsed] =
-    Flow.fromGraph(new UdpSendFlow()(system))
+    Flow.fromGraph(new UdpSendFlow(Option.empty)(system))
 
   /**
    * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
@@ -51,7 +52,7 @@ object Udp {
    * subsequent processing.
    */
   def sendFlow(options: Traversable[SocketOption], system: ActorSystem): Flow[Datagram, Datagram, NotUsed] =
-    Flow.fromGraph(new UdpSendFlow(options)(system))
+    Flow.fromGraph(new UdpSendFlow(Option(options))(system))
 
   /**
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
@@ -97,7 +98,7 @@ object Udp {
    */
   def bindFlow(localAddress: InetSocketAddress,
                system: ActorSystem): Flow[Datagram, Datagram, Future[InetSocketAddress]] =
-    Flow.fromGraph(new UdpBindFlow(localAddress)(system))
+    Flow.fromGraph(new UdpBindFlow(localAddress, Option.empty)(system))
 
   /**
    * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
@@ -118,5 +119,5 @@ object Udp {
   def bindFlow(localAddress: InetSocketAddress,
                options: Traversable[SocketOption],
                system: ActorSystem): Flow[Datagram, Datagram, Future[InetSocketAddress]] =
-    Flow.fromGraph(new UdpBindFlow(localAddress, options)(system))
+    Flow.fromGraph(new UdpBindFlow(localAddress, Option(options))(system))
 }

--- a/udp/src/main/scala/akka/stream/alpakka/udp/scaladsl/Udp.scala
+++ b/udp/src/main/scala/akka/stream/alpakka/udp/scaladsl/Udp.scala
@@ -8,11 +8,13 @@ import java.net.InetSocketAddress
 
 import akka.NotUsed
 import akka.actor.{ActorSystem, ClassicActorSystemProvider}
+import akka.io.Inet.SocketOption
 import akka.stream.alpakka.udp.Datagram
 import akka.stream.alpakka.udp.impl.{UdpBindFlow, UdpSendFlow}
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Flow
 
+import scala.collection.immutable.Traversable
 import scala.concurrent.Future
 
 object Udp {
@@ -34,6 +36,24 @@ object Udp {
     Flow.fromGraph(new UdpSendFlow()(system))
 
   /**
+   * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
+   * contained in the message. All incoming messages are also emitted from the flow for
+   * subsequent processing.
+   */
+  def sendFlow(
+      options: Traversable[SocketOption]
+  )(implicit system: ClassicActorSystemProvider): Flow[Datagram, Datagram, NotUsed] =
+    sendFlow(options, system.classicSystem)
+
+  /**
+   * Creates a flow that will send all incoming [UdpMessage] messages to the remote address
+   * contained in the message. All incoming messages are also emitted from the flow for
+   * subsequent processing.
+   */
+  def sendFlow(options: Traversable[SocketOption], system: ActorSystem): Flow[Datagram, Datagram, NotUsed] =
+    Flow.fromGraph(new UdpSendFlow(options)(system))
+
+  /**
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message.
    */
@@ -44,6 +64,21 @@ object Udp {
    * contained in the message.
    */
   def sendSink(system: ActorSystem): Sink[Datagram, NotUsed] = sendFlow(system).to(Sink.ignore)
+
+  /**
+   * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
+   * contained in the message.
+   */
+  def sendSink(options: Traversable[SocketOption])(
+      implicit system: ClassicActorSystemProvider
+  ): Sink[Datagram, NotUsed] = sendFlow(options).to(Sink.ignore)
+
+  /**
+   * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
+   * contained in the message.
+   */
+  def sendSink(options: Traversable[SocketOption], system: ActorSystem): Sink[Datagram, NotUsed] =
+    sendFlow(options, system).to(Sink.ignore)
 
   /**
    * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
@@ -63,4 +98,25 @@ object Udp {
   def bindFlow(localAddress: InetSocketAddress,
                system: ActorSystem): Flow[Datagram, Datagram, Future[InetSocketAddress]] =
     Flow.fromGraph(new UdpBindFlow(localAddress)(system))
+
+  /**
+   * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
+   * messages to the `localAddress` are emitted from the flow. All incoming messages to the flow
+   * are sent to the remote address contained in the message.
+   */
+  def bindFlow(
+      localAddress: InetSocketAddress,
+      options: Traversable[SocketOption]
+  )(implicit system: ClassicActorSystemProvider): Flow[Datagram, Datagram, Future[InetSocketAddress]] =
+    bindFlow(localAddress, options, system.classicSystem)
+
+  /**
+   * Creates a flow that upon materialization binds to the given `localAddress`. All incoming
+   * messages to the `localAddress` are emitted from the flow. All incoming messages to the flow
+   * are sent to the remote address contained in the message.
+   */
+  def bindFlow(localAddress: InetSocketAddress,
+               options: Traversable[SocketOption],
+               system: ActorSystem): Flow[Datagram, Datagram, Future[InetSocketAddress]] =
+    Flow.fromGraph(new UdpBindFlow(localAddress, options)(system))
 }

--- a/udp/src/main/scala/akka/stream/alpakka/udp/scaladsl/Udp.scala
+++ b/udp/src/main/scala/akka/stream/alpakka/udp/scaladsl/Udp.scala
@@ -15,7 +15,7 @@ import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Flow
 
 import scala.Option
-import scala.collection.immutable.Traversable
+import scala.collection.immutable.Iterable
 import scala.concurrent.Future
 
 object Udp {
@@ -42,7 +42,7 @@ object Udp {
    * subsequent processing.
    */
   def sendFlow(
-      options: Traversable[SocketOption]
+      options: Iterable[SocketOption]
   )(implicit system: ClassicActorSystemProvider): Flow[Datagram, Datagram, NotUsed] =
     sendFlow(options, system.classicSystem)
 
@@ -51,7 +51,7 @@ object Udp {
    * contained in the message. All incoming messages are also emitted from the flow for
    * subsequent processing.
    */
-  def sendFlow(options: Traversable[SocketOption], system: ActorSystem): Flow[Datagram, Datagram, NotUsed] =
+  def sendFlow(options: Iterable[SocketOption], system: ActorSystem): Flow[Datagram, Datagram, NotUsed] =
     Flow.fromGraph(new UdpSendFlow(Option(options))(system))
 
   /**
@@ -70,7 +70,7 @@ object Udp {
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message.
    */
-  def sendSink(options: Traversable[SocketOption])(
+  def sendSink(options: Iterable[SocketOption])(
       implicit system: ClassicActorSystemProvider
   ): Sink[Datagram, NotUsed] = sendFlow(options).to(Sink.ignore)
 
@@ -78,7 +78,7 @@ object Udp {
    * Creates a sink that will send all incoming [UdpMessage] messages to the remote address
    * contained in the message.
    */
-  def sendSink(options: Traversable[SocketOption], system: ActorSystem): Sink[Datagram, NotUsed] =
+  def sendSink(options: Iterable[SocketOption], system: ActorSystem): Sink[Datagram, NotUsed] =
     sendFlow(options, system).to(Sink.ignore)
 
   /**
@@ -107,7 +107,7 @@ object Udp {
    */
   def bindFlow(
       localAddress: InetSocketAddress,
-      options: Traversable[SocketOption]
+      options: Iterable[SocketOption]
   )(implicit system: ClassicActorSystemProvider): Flow[Datagram, Datagram, Future[InetSocketAddress]] =
     bindFlow(localAddress, options, system.classicSystem)
 
@@ -117,7 +117,7 @@ object Udp {
    * are sent to the remote address contained in the message.
    */
   def bindFlow(localAddress: InetSocketAddress,
-               options: Traversable[SocketOption],
+               options: Iterable[SocketOption],
                system: ActorSystem): Flow[Datagram, Datagram, Future[InetSocketAddress]] =
     Flow.fromGraph(new UdpBindFlow(localAddress, Option(options))(system))
 }

--- a/udp/src/test/java/docs/javadsl/UdpTest.java
+++ b/udp/src/test/java/docs/javadsl/UdpTest.java
@@ -99,19 +99,13 @@ public class UdpTest {
 
   @Test
   public void testSendAndReceiveMessagesWithOptions() throws Exception {
-    // #bind-address
     final InetSocketAddress bindToLocal = new InetSocketAddress("localhost", 0);
-    // #bind-address
 
-    // #bind-socket-option
     final List<Inet.SocketOption> bindSocketOptions = new ArrayList<>();
     bindSocketOptions.add(new InetProtocolFamily());
-    // #bind-socket-option
 
-    // #bind-flow
     final Flow<Datagram, Datagram, CompletionStage<InetSocketAddress>> bindFlow =
         Udp.bindFlow(bindToLocal, bindSocketOptions, system);
-    // #bind-flow
 
     final Pair<
             Pair<TestPublisher.Probe<Datagram>, CompletionStage<InetSocketAddress>>,
@@ -123,32 +117,24 @@ public class UdpTest {
                 .run(system);
 
     {
-      // #send-datagrams
       final InetSocketAddress destination = new InetSocketAddress("my.server", 27015);
-      // #send-datagrams
     }
 
     final InetSocketAddress destination = materialized.first().second().toCompletableFuture().get();
 
-    // #send-datagrams
     final Integer messagesToSend = 100;
-    // #send-datagrams
 
-    // #send-socket-option
     final List<Inet.SocketOption> sendSocketOptions = new ArrayList<>();
     sendSocketOptions.add(new InetProtocolFamily());
-    // #send-socket-option
 
     final TestSubscriber.Probe<Datagram> sub = materialized.second();
     sub.ensureSubscription();
     sub.request(messagesToSend);
 
-    // #send-datagrams
     Source.range(1, messagesToSend)
         .map(i -> ByteString.fromString("Message " + i))
         .map(bs -> Datagram.create(bs, destination))
         .runWith(Udp.sendSink(sendSocketOptions, system), system);
-    // #send-datagrams
 
     for (int i = 0; i < messagesToSend; i++) {
       sub.requestNext();

--- a/udp/src/test/java/docs/javadsl/UdpTest.java
+++ b/udp/src/test/java/docs/javadsl/UdpTest.java
@@ -6,6 +6,7 @@ package docs.javadsl;
 
 import akka.actor.ActorSystem;
 import akka.io.Inet;
+import akka.io.UdpSO;
 import akka.japi.Pair;
 import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.alpakka.udp.Datagram;
@@ -102,7 +103,7 @@ public class UdpTest {
     final InetSocketAddress bindToLocal = new InetSocketAddress("localhost", 0);
 
     final List<Inet.SocketOption> bindSocketOptions = new ArrayList<>();
-    bindSocketOptions.add(new InetProtocolFamily());
+    bindSocketOptions.add(UdpSO.broadcast(true));
 
     final Flow<Datagram, Datagram, CompletionStage<InetSocketAddress>> bindFlow =
         Udp.bindFlow(bindToLocal, bindSocketOptions, system);
@@ -125,7 +126,7 @@ public class UdpTest {
     final Integer messagesToSend = 100;
 
     final List<Inet.SocketOption> sendSocketOptions = new ArrayList<>();
-    sendSocketOptions.add(new InetProtocolFamily());
+    sendSocketOptions.add(UdpSO.broadcast(true));
 
     final TestSubscriber.Probe<Datagram> sub = materialized.second();
     sub.ensureSubscription();
@@ -140,13 +141,5 @@ public class UdpTest {
       sub.requestNext();
     }
     sub.cancel();
-  }
-
-  private class InetProtocolFamily extends Inet.DatagramChannelCreator {
-
-    @Override
-    public DatagramChannel create() throws Exception {
-      return DatagramChannel.open(StandardProtocolFamily.INET);
-    }
   }
 }

--- a/udp/src/test/java/docs/javadsl/UdpTest.java
+++ b/udp/src/test/java/docs/javadsl/UdpTest.java
@@ -101,8 +101,7 @@ public class UdpTest {
 
   List<InetAddress> listAllBroadcastAddresses() throws SocketException {
     List<InetAddress> broadcastList = new ArrayList<>();
-    Enumeration<NetworkInterface> interfaces
-            = NetworkInterface.getNetworkInterfaces();
+    Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
     while (interfaces.hasMoreElements()) {
       NetworkInterface networkInterface = interfaces.nextElement();
 
@@ -111,9 +110,9 @@ public class UdpTest {
       }
 
       networkInterface.getInterfaceAddresses().stream()
-              .map(a -> a.getBroadcast())
-              .filter(Objects::nonNull)
-              .forEach(broadcastList::add);
+          .map(a -> a.getBroadcast())
+          .filter(Objects::nonNull)
+          .forEach(broadcastList::add);
     }
     return broadcastList;
   }

--- a/udp/src/test/scala/docs/scaladsl/UdpSpec.scala
+++ b/udp/src/test/scala/docs/scaladsl/UdpSpec.scala
@@ -6,7 +6,7 @@ package docs.scaladsl
 
 import java.net.InetSocketAddress
 import akka.actor.ActorSystem
-import akka.io.Inet
+import akka.io.UdpSO
 import akka.stream.Materializer
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.alpakka.udp.Datagram
@@ -91,7 +91,7 @@ class UdpSpec
     "send and receive messages with options" in {
 
       val bindFlow: Flow[Datagram, Datagram, Future[InetSocketAddress]] =
-        Udp.bindFlow(bindToLocal, List(InetProtocolFamily()))
+        Udp.bindFlow(bindToLocal, List(UdpSO.broadcast(true)))
 
       val ((pub, bound), sub) = TestSource
         .probe[Datagram](system)
@@ -114,7 +114,7 @@ class UdpSpec
       Source(1 to messagesToSend)
         .map(i => ByteString(s"Message $i"))
         .map(Datagram(_, destination))
-        .runWith(Udp.sendSink(List(InetProtocolFamily())))
+        .runWith(Udp.sendSink(List(UdpSO.broadcast(true))))
 
       (1 to messagesToSend).foreach { _ =>
         sub.requestNext()
@@ -162,11 +162,4 @@ class UdpSpec
     }
   }
 
-}
-
-private case class InetProtocolFamily() extends Inet.DatagramChannelCreator {
-
-  override def create() = {
-    super.create()
-  }
 }

--- a/udp/src/test/scala/docs/scaladsl/UdpSpec.scala
+++ b/udp/src/test/scala/docs/scaladsl/UdpSpec.scala
@@ -90,10 +90,8 @@ class UdpSpec
 
     "send and receive messages with options" in {
 
-      // #bind-flow
       val bindFlow: Flow[Datagram, Datagram, Future[InetSocketAddress]] =
         Udp.bindFlow(bindToLocal, List(InetProtocolFamily()))
-      // #bind-flow
 
       val ((pub, bound), sub) = TestSource
         .probe[Datagram](system)
@@ -104,26 +102,19 @@ class UdpSpec
       val destination = bound.futureValue
 
       {
-        // #send-datagrams
         val destination = new InetSocketAddress("my.server", 27015)
-        // #send-datagrams
         destination
       }
 
-      // #send-datagrams
       val messagesToSend = 100
-
-      // #send-datagrams
 
       sub.ensureSubscription()
       sub.request(messagesToSend)
 
-      // #send-datagrams
       Source(1 to messagesToSend)
         .map(i => ByteString(s"Message $i"))
         .map(Datagram(_, destination))
         .runWith(Udp.sendSink(List(InetProtocolFamily())))
-      // #send-datagrams
 
       (1 to messagesToSend).foreach { _ =>
         sub.requestNext()


### PR DESCRIPTION
I have extended the UDP bind / send flows to allow passing SocketOptions to the Akka UDP manager.

I have a requirement to join channels once the socket is bound and this wasn't possible without the ability to pass options.

This is my first stab at writing any Scala code, so apologies if there are any linting / coding idioms I may have missed.