### PR TITLE
BigQuery API improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -181,7 +181,7 @@ lazy val googleCommon = alpakkaProject(
   Dependencies.GoogleCommon,
   Test / fork := true,
   fatalWarnings := true
-).disablePlugins(MimaPlugin)
+)
 
 lazy val googleCloudBigQuery = alpakkaProject(
   "google-cloud-bigquery",
@@ -189,7 +189,7 @@ lazy val googleCloudBigQuery = alpakkaProject(
   Dependencies.GoogleBigQuery,
   Test / fork := true,
   fatalWarnings := true
-).dependsOn(googleCommon).disablePlugins(MimaPlugin).enablePlugins(spray.boilerplate.BoilerplatePlugin)
+).dependsOn(googleCommon).enablePlugins(spray.boilerplate.BoilerplatePlugin)
 
 lazy val googleCloudPubSub = alpakkaProject(
   "google-cloud-pub-sub",

--- a/build.sbt
+++ b/build.sbt
@@ -181,7 +181,7 @@ lazy val googleCommon = alpakkaProject(
   Dependencies.GoogleCommon,
   Test / fork := true,
   fatalWarnings := true
-)
+).disablePlugins(MimaPlugin)
 
 lazy val googleCloudBigQuery = alpakkaProject(
   "google-cloud-bigquery",

--- a/google-cloud-bigquery/src/main/mima-filters/3.0.0-M1.backwards.excludes/2663-job-configuration
+++ b/google-cloud-bigquery/src/main/mima-filters/3.0.0-M1.backwards.excludes/2663-job-configuration
@@ -1,0 +1,4 @@
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.googlecloud.bigquery.model.JobConfiguration.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.googlecloud.bigquery.model.JobConfiguration.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.googlecloud.bigquery.model.JobConfiguration.this")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.googlecloud.bigquery.model.JobConfiguration.unapply")

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/javadsl/BigQuery.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/javadsl/BigQuery.scala
@@ -375,7 +375,7 @@ object BigQuery extends Google {
     ScalaBigQuery.cancelJob(jobId, location.asScala)(system, settings).toJava
 
   /**
-   * Loads data into BigQuery via a series of asynchronous load jobs created at the rate `loadJobPerTableQuota`.
+   * Loads data into BigQuery via a series of asynchronous load jobs created at the rate [[akka.stream.alpakka.googlecloud.bigquery.BigQuerySettings.loadJobPerTableQuota]].
    * @note WARNING: Pending the resolution of [[https://issuetracker.google.com/176002651 BigQuery issue 176002651]] this method may not work as expected.
    *       As a workaround, you can use the config setting `akka.http.parsing.conflicting-content-type-header-processing-mode = first` with Akka HTTP v10.2.4 or later.
    *
@@ -390,6 +390,25 @@ object BigQuery extends Google {
                          marshaller: Marshaller[In, RequestEntity]): Flow[In, Job, NotUsed] = {
     implicit val m = marshaller.asScalaCastOutput[sm.RequestEntity]
     ScalaBigQuery.insertAllAsync[In](datasetId, tableId).asJava[In]
+  }
+
+  /**
+   * Loads data into BigQuery via a series of asynchronous load jobs created at the rate [[akka.stream.alpakka.googlecloud.bigquery.BigQuerySettings.loadJobPerTableQuota]].
+   * @note WARNING: Pending the resolution of [[https://issuetracker.google.com/176002651 BigQuery issue 176002651]] this method may not work as expected.
+   *       As a workaround, you can use the config setting `akka.http.parsing.conflicting-content-type-header-processing-mode = first` with Akka HTTP v10.2.4 or later.
+   *
+   * @param datasetId dataset ID of the table to insert into
+   * @param tableId table ID of the table to insert into
+   * @param marshaller [[akka.http.javadsl.marshalling.Marshaller]] for [[In]]
+   * @tparam In the data model for each record
+   * @return a [[akka.stream.javadsl.Flow]] that uploads each [[In]] and emits a [[Job]] for every upload job created
+   */
+  def insertAllAsync[In](datasetId: String,
+                         tableId: String,
+                         labels: util.Optional[util.Map[String, String]],
+                         marshaller: Marshaller[In, RequestEntity]): Flow[In, Job, NotUsed] = {
+    implicit val m = marshaller.asScalaCastOutput[sm.RequestEntity]
+    ScalaBigQuery.insertAllAsync[In](datasetId, tableId, labels.asScala.map(_.asScala.toMap)).asJava[In]
   }
 
   /**

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/DatasetJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/DatasetJsonProtocol.scala
@@ -22,10 +22,10 @@ import scala.compat.java8.OptionConverters._
  * @param labels the labels associated with this dataset
  * @param location the geographic location where the dataset should reside
  */
-final case class Dataset(datasetReference: DatasetReference,
-                         friendlyName: Option[String],
-                         labels: Option[Map[String, String]],
-                         location: Option[String]) {
+final case class Dataset private (datasetReference: DatasetReference,
+                                  friendlyName: Option[String],
+                                  labels: Option[Map[String, String]],
+                                  location: Option[String]) {
 
   def getDatasetReference = datasetReference
   def getFriendlyName = friendlyName.asJava
@@ -77,7 +77,7 @@ object Dataset {
  * @param datasetId A unique ID for this dataset, without the project name
  * @param projectId The ID of the project containing this dataset
  */
-final case class DatasetReference(datasetId: Option[String], projectId: Option[String]) {
+final case class DatasetReference private (datasetId: Option[String], projectId: Option[String]) {
 
   def getDatasetId = datasetId.asJava
   def getProjectId = projectId.asJava
@@ -116,7 +116,7 @@ object DatasetReference {
  * @param nextPageToken a token that can be used to request the next results page
  * @param datasets an array of the dataset resources in the project
  */
-final case class DatasetListResponse(nextPageToken: Option[String], datasets: Option[Seq[Dataset]]) {
+final case class DatasetListResponse private (nextPageToken: Option[String], datasets: Option[Seq[Dataset]]) {
 
   def getNextPageToken = nextPageToken.asJava
   def getDatasets = datasets.map(_.asJava).asJava

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/ErrorProtoJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/ErrorProtoJsonProtocol.scala
@@ -20,7 +20,7 @@ import scala.compat.java8.OptionConverters._
  * @param location specifies where the error occurred, if present
  * @param message A human-readable description of the error
  */
-final case class ErrorProto(reason: Option[String], location: Option[String], message: Option[String]) {
+final case class ErrorProto private (reason: Option[String], location: Option[String], message: Option[String]) {
 
   @silent("never used")
   @JsonCreator

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/JobJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/JobJsonProtocol.scala
@@ -22,9 +22,9 @@ import scala.compat.java8.OptionConverters._
  * @param jobReference reference describing the unique-per-user name of the job
  * @param status the status of this job
  */
-final case class Job(configuration: Option[JobConfiguration],
-                     jobReference: Option[JobReference],
-                     status: Option[JobStatus]) {
+final case class Job private (configuration: Option[JobConfiguration],
+                              jobReference: Option[JobReference],
+                              status: Option[JobStatus]) {
 
   def getConfiguration = configuration.asJava
   def getJobReference = jobReference.asJava
@@ -133,11 +133,11 @@ object JobConfiguration {
  * @param writeDisposition specifies the action that occurs if the destination table already exists
  * @param sourceFormat the format of the data files
  */
-final case class JobConfigurationLoad(schema: Option[TableSchema],
-                                      destinationTable: Option[TableReference],
-                                      createDisposition: Option[CreateDisposition],
-                                      writeDisposition: Option[WriteDisposition],
-                                      sourceFormat: Option[SourceFormat]) {
+final case class JobConfigurationLoad private (schema: Option[TableSchema],
+                                               destinationTable: Option[TableReference],
+                                               createDisposition: Option[CreateDisposition],
+                                               writeDisposition: Option[WriteDisposition],
+                                               sourceFormat: Option[SourceFormat]) {
 
   def getSchema = schema.asJava
   def getDestinationTable = destinationTable.asJava
@@ -200,7 +200,7 @@ object JobConfigurationLoad {
   implicit val configurationLoadFormat: JsonFormat[JobConfigurationLoad] = jsonFormat5(apply)
 }
 
-final case class CreateDisposition(value: String) extends StringEnum
+final case class CreateDisposition private (value: String) extends StringEnum
 object CreateDisposition {
 
   /**
@@ -217,7 +217,7 @@ object CreateDisposition {
   implicit val format: JsonFormat[CreateDisposition] = StringEnum.jsonFormat(apply)
 }
 
-final case class WriteDisposition(value: String) extends StringEnum
+final case class WriteDisposition private (value: String) extends StringEnum
 object WriteDisposition {
 
   /**
@@ -237,7 +237,7 @@ object WriteDisposition {
   implicit val format: JsonFormat[WriteDisposition] = StringEnum.jsonFormat(apply)
 }
 
-sealed case class SourceFormat(value: String) extends StringEnum
+sealed case class SourceFormat private (value: String) extends StringEnum
 object SourceFormat {
 
   /**
@@ -259,7 +259,7 @@ object SourceFormat {
  * @param jobId the ID of the job
  * @param location the geographic location of the job
  */
-final case class JobReference(projectId: Option[String], jobId: Option[String], location: Option[String]) {
+final case class JobReference private (projectId: Option[String], jobId: Option[String], location: Option[String]) {
 
   @silent("never used")
   @JsonCreator
@@ -313,7 +313,7 @@ object JobReference {
  * @param errors the first errors encountered during the running of the job
  * @param state running state of the job
  */
-final case class JobStatus(errorResult: Option[ErrorProto], errors: Option[Seq[ErrorProto]], state: JobState) {
+final case class JobStatus private (errorResult: Option[ErrorProto], errors: Option[Seq[ErrorProto]], state: JobState) {
 
   def getErrorResult = errorResult.asJava
   def getErrors = errors.map(_.asJava).asJava
@@ -350,7 +350,7 @@ object JobStatus {
   implicit val format: JsonFormat[JobStatus] = jsonFormat3(apply)
 }
 
-final case class JobState(value: String) extends StringEnum
+final case class JobState private (value: String) extends StringEnum
 object JobState {
 
   /**
@@ -370,7 +370,7 @@ object JobState {
   implicit val format: JsonFormat[JobState] = StringEnum.jsonFormat(apply)
 }
 
-final case class JobCancelResponse(job: Job) {
+final case class JobCancelResponse private (job: Job) {
   def getJob = job
   def withJob(job: Job) =
     copy(job = job)

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/JobJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/JobJsonProtocol.scala
@@ -70,17 +70,34 @@ object Job {
  * @see [[https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration BigQuery reference]]
  *
  * @param load configures a load job
+ * @param labels the labels associated with this job
  */
-final case class JobConfiguration(load: Option[JobConfigurationLoad]) {
+final case class JobConfiguration(load: Option[JobConfigurationLoad], labels: Option[Map[String, String]]) {
   def getLoad = load.asJava
+  def getLabels = labels.asJava
 
   def withLoad(load: Option[JobConfigurationLoad]) =
     copy(load = load)
   def withLoad(load: util.Optional[JobConfigurationLoad]) =
     copy(load = load.asScala)
+
+  def withLabels(labels: Option[Map[String, String]]) =
+    copy(labels = labels)
+  def withLabels(labels: util.Optional[util.Map[String, String]]) =
+    copy(labels = labels.asScala.map(_.asScala.toMap))
 }
 
 object JobConfiguration {
+
+  /**
+   * JobConfiguration model
+   * @see [[https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration BigQuery reference]]
+   *
+   * @param load configures a load job
+   * @return a [[JobConfiguration]]
+   */
+  def apply(load: Option[JobConfigurationLoad]): JobConfiguration =
+    apply(load, None)
 
   /**
    * Java API: JobConfiguration model
@@ -92,7 +109,18 @@ object JobConfiguration {
   def create(load: util.Optional[JobConfigurationLoad]) =
     JobConfiguration(load.asScala)
 
-  implicit val format: JsonFormat[JobConfiguration] = jsonFormat1(apply)
+  /**
+   * Java API: JobConfiguration model
+   * @see [[https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration BigQuery reference]]
+   *
+   * @param load configures a load job
+   * @param labels the labels associated with this job
+   * @return a [[JobConfiguration]]
+   */
+  def create(load: util.Optional[JobConfigurationLoad], labels: util.Optional[util.Map[String, String]]) =
+    JobConfiguration(load.asScala, labels.asScala.map(_.asScala.toMap))
+
+  implicit val format: JsonFormat[JobConfiguration] = jsonFormat2(apply)
 }
 
 /**

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/JobJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/JobJsonProtocol.scala
@@ -72,7 +72,7 @@ object Job {
  * @param load configures a load job
  * @param labels the labels associated with this job
  */
-final case class JobConfiguration(load: Option[JobConfigurationLoad], labels: Option[Map[String, String]]) {
+final case class JobConfiguration private (load: Option[JobConfigurationLoad], labels: Option[Map[String, String]]) {
   def getLoad = load.asJava
   def getLabels = labels.asJava
 

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
@@ -32,13 +32,13 @@ import scala.concurrent.duration.FiniteDuration
  * @param useLegacySql specifies whether to use BigQuery's legacy SQL dialect for this query
  * @param requestId a unique user provided identifier to ensure idempotent behavior for queries
  */
-final case class QueryRequest(query: String,
-                              maxResults: Option[Int],
-                              defaultDataset: Option[DatasetReference],
-                              timeout: Option[FiniteDuration],
-                              dryRun: Option[Boolean],
-                              useLegacySql: Option[Boolean],
-                              requestId: Option[String]) {
+final case class QueryRequest private (query: String,
+                                       maxResults: Option[Int],
+                                       defaultDataset: Option[DatasetReference],
+                                       timeout: Option[FiniteDuration],
+                                       dryRun: Option[Boolean],
+                                       useLegacySql: Option[Boolean],
+                                       requestId: Option[String]) {
 
   def getQuery = query
   def getMaxResults = maxResults.asPrimitive
@@ -144,16 +144,16 @@ object QueryRequest {
  * @tparam T the data model for each row
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-final case class QueryResponse[+T](schema: Option[TableSchema],
-                                   jobReference: JobReference,
-                                   totalRows: Option[Long],
-                                   pageToken: Option[String],
-                                   rows: Option[Seq[T]],
-                                   totalBytesProcessed: Option[Long],
-                                   jobComplete: Boolean,
-                                   errors: Option[Seq[ErrorProto]],
-                                   cacheHit: Option[Boolean],
-                                   numDmlAffectedRows: Option[Long]) {
+final case class QueryResponse[+T] private (schema: Option[TableSchema],
+                                            jobReference: JobReference,
+                                            totalRows: Option[Long],
+                                            pageToken: Option[String],
+                                            rows: Option[Seq[T]],
+                                            totalBytesProcessed: Option[Long],
+                                            jobComplete: Boolean,
+                                            errors: Option[Seq[ErrorProto]],
+                                            cacheHit: Option[Boolean],
+                                            numDmlAffectedRows: Option[Long]) {
 
   @silent("never used")
   @JsonCreator

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/TableDataJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/TableDataJsonProtocol.scala
@@ -28,7 +28,7 @@ import scala.compat.java8.OptionConverters._
  * @tparam T the data model of each row
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-final case class TableDataListResponse[+T](totalRows: Long, pageToken: Option[String], rows: Option[Seq[T]]) {
+final case class TableDataListResponse[+T] private (totalRows: Long, pageToken: Option[String], rows: Option[Seq[T]]) {
 
   @silent("never used")
   @JsonCreator
@@ -90,10 +90,10 @@ object TableDataListResponse {
  * @tparam T the data model of each row
  */
 @JsonInclude(Include.NON_NULL)
-final case class TableDataInsertAllRequest[+T](skipInvalidRows: Option[Boolean],
-                                               ignoreUnknownValues: Option[Boolean],
-                                               templateSuffix: Option[String],
-                                               rows: Seq[Row[T]]) {
+final case class TableDataInsertAllRequest[+T] private (skipInvalidRows: Option[Boolean],
+                                                        ignoreUnknownValues: Option[Boolean],
+                                                        templateSuffix: Option[String],
+                                                        rows: Seq[Row[T]]) {
 
   @JsonIgnore def getSkipInvalidRows = skipInvalidRows.map(lang.Boolean.valueOf).asJava
   @JsonIgnore def getIgnoreUnknownValues = ignoreUnknownValues.map(lang.Boolean.valueOf).asJava
@@ -172,7 +172,7 @@ object TableDataInsertAllRequest {
  * @param json the record this row contains
  * @tparam T the data model of the record
  */
-final case class Row[+T](insertId: Option[String], json: T) {
+final case class Row[+T] private (insertId: Option[String], json: T) {
 
   def getInsertId = insertId.asJava
   def getJson = json
@@ -205,7 +205,7 @@ object Row {
  * TableDataInsertAllResponse model
  * @see [[https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll#response-body BigQuery reference]]
  */
-final case class TableDataInsertAllResponse(insertErrors: Option[Seq[InsertError]]) {
+final case class TableDataInsertAllResponse private (insertErrors: Option[Seq[InsertError]]) {
   def getInsertErrors = insertErrors.map(_.asJava).asJava
 
   def withInsertErrors(insertErrors: Option[Seq[InsertError]]) =
@@ -232,7 +232,7 @@ object TableDataInsertAllResponse {
  * InsertError model
  * @see [[https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll#response-body BigQuery reference]]
  */
-final case class InsertError(index: Int, errors: Option[Seq[ErrorProto]]) {
+final case class InsertError private (index: Int, errors: Option[Seq[ErrorProto]]) {
   def getIndex = index
   def getErrors = errors.map(_.asJava).asJava
 

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/TableJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/TableJsonProtocol.scala
@@ -26,11 +26,11 @@ import scala.compat.java8.OptionConverters._
  * @param numRows the number of rows of data in this table
  * @param location the geographic location where the table resides
  */
-final case class Table(tableReference: TableReference,
-                       labels: Option[Map[String, String]],
-                       schema: Option[TableSchema],
-                       numRows: Option[Long],
-                       location: Option[String]) {
+final case class Table private (tableReference: TableReference,
+                                labels: Option[Map[String, String]],
+                                schema: Option[TableSchema],
+                                numRows: Option[Long],
+                                location: Option[String]) {
 
   def getTableReference = tableReference
   def getLabels = labels.map(_.asJava).asJava
@@ -99,7 +99,7 @@ object Table {
  * @param datasetId the ID of the dataset containing this table
  * @param tableId the ID of the table
  */
-final case class TableReference(projectId: Option[String], datasetId: String, tableId: Option[String]) {
+final case class TableReference private (projectId: Option[String], datasetId: String, tableId: Option[String]) {
 
   def getProjectId = projectId.asJava
   def getDatasetId = datasetId
@@ -142,7 +142,7 @@ object TableReference {
  *
  * @param fields describes the fields in a table
  */
-final case class TableSchema(fields: Seq[TableFieldSchema]) {
+final case class TableSchema private (fields: Seq[TableFieldSchema]) {
 
   @silent("never used")
   @JsonCreator
@@ -190,10 +190,10 @@ object TableSchema {
  * @param mode the field mode
  * @param fields describes the nested schema fields if the type property is set to `RECORD`
  */
-final case class TableFieldSchema(name: String,
-                                  `type`: TableFieldSchemaType,
-                                  mode: Option[TableFieldSchemaMode],
-                                  fields: Option[Seq[TableFieldSchema]]) {
+final case class TableFieldSchema private (name: String,
+                                           `type`: TableFieldSchemaType,
+                                           mode: Option[TableFieldSchemaMode],
+                                           fields: Option[Seq[TableFieldSchema]]) {
 
   @silent("never used")
   @JsonCreator
@@ -270,7 +270,7 @@ object TableFieldSchema {
   )
 }
 
-final case class TableFieldSchemaType(value: String) extends StringEnum
+final case class TableFieldSchemaType private (value: String) extends StringEnum
 object TableFieldSchemaType {
 
   /**
@@ -320,7 +320,7 @@ object TableFieldSchemaType {
   implicit val format: JsonFormat[TableFieldSchemaType] = StringEnum.jsonFormat(apply)
 }
 
-final case class TableFieldSchemaMode(value: String) extends StringEnum
+final case class TableFieldSchemaMode private (value: String) extends StringEnum
 object TableFieldSchemaMode {
 
   /**
@@ -348,7 +348,9 @@ object TableFieldSchemaMode {
  * @param tables tables in the requested dataset
  * @param totalItems the total number of tables in the dataset
  */
-final case class TableListResponse(nextPageToken: Option[String], tables: Option[Seq[Table]], totalItems: Option[Int]) {
+final case class TableListResponse private (nextPageToken: Option[String],
+                                            tables: Option[Seq[Table]],
+                                            totalItems: Option[Int]) {
 
   def getNextPageToken = nextPageToken.asJava
   def getTables = tables.map(_.asJava).asJava

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/schema/Schema.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/schema/Schema.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.googlecloud.bigquery.scaladsl.schema
+
+import akka.stream.alpakka.googlecloud.bigquery.model.TableSchema
+
+object Schema {
+
+  /**
+   * Materialize an implicit [[TableSchema]] for `T`
+   */
+  def apply[T](implicit writer: TableSchemaWriter[T]): TableSchema =
+    writer.write
+}


### PR DESCRIPTION
1. Adds a labels field to `JobConfiguration` and `insertAllAsync`. Not 100% binary compatible to 3.0.0-M1 because of case class stuff, but if important can probably be fixed?
2. Creates a `Schema` singleton object to help materialize implicit `TableSchema` for a class `T`