### PR TITLE
google-common: Improve log messages for application default credentials

### DIFF
--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/Credentials.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/Credentials.scala
@@ -26,15 +26,19 @@ object Credentials {
    */
   def apply(c: Config)(implicit system: ClassicActorSystemProvider): Credentials = c.getString("provider") match {
     case "application-default" =>
+      val log = Logging(system.classicSystem, getClass)
       try {
-        parseServiceAccount(c)
+        val creds = parseServiceAccount(c)
+        log.info("Using service account credentials")
+        creds
       } catch {
         case NonFatal(ex1) =>
           try {
-            parseComputeEngine(c)
+            val creds = parseComputeEngine(c)
+            log.info("Using Compute Engine credentials")
+            creds
           } catch {
             case NonFatal(ex2) =>
-              val log = Logging(system.classicSystem, getClass)
               log.warning("Unable to find Application Default Credentials for Google APIs")
               log.warning("Service account: {}", ex1.getMessage)
               log.warning("Compute Engine: {}", ex2.getMessage)

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/Credentials.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/Credentials.scala
@@ -6,6 +6,7 @@ package akka.stream.alpakka.google.auth
 
 import akka.actor.ClassicActorSystemProvider
 import akka.annotation.DoNotInherit
+import akka.event.Logging
 import akka.http.scaladsl.model.headers.HttpCredentials
 import akka.stream.alpakka.google.RequestSettings
 import akka.util.JavaDurationConverters._
@@ -33,7 +34,10 @@ object Credentials {
             parseComputeEngine(c)
           } catch {
             case NonFatal(ex2) =>
-              system.classicSystem.log.warning("Unable to find application default credentials", ex1, ex2)
+              val log = Logging(system.classicSystem, getClass)
+              log.warning("Unable to find Application Default Credentials for Google APIs")
+              log.warning("Service account: {}", ex1.getMessage)
+              log.warning("Compute Engine: {}", ex2.getMessage)
               parseNone(c) // TODO Once credentials are guaranteed to be managed centrally we can throw an error instead
           }
       }


### PR DESCRIPTION
One last fix for 3.0.0 that substantially improves the log messages for application default credentials, especially when they are not found. The previous logging code was badly broken.