### PR TITLE
mqtt-streaming: Accommodate source.queue change in Akka 2.6

### DIFF
--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -1951,7 +1951,7 @@ class MqttSessionSpec
       val client2 = TestProbe()
       val toClient2 = Sink.foreach[ByteString](bytes => client2.ref ! bytes)
       val (client2Connection, fromClient2) = Source
-        .queue[ByteString](1, OverflowStrategy.dropHead)
+        .queue[ByteString](0, OverflowStrategy.dropHead)
         .toMat(BroadcastHub.sink)(Keep.both)
         .run()
 


### PR DESCRIPTION
The `Source.queue` implementation has been modified a few times since Akka 2.6 was released which broke this test.
