### PR TITLE
JMS: upgrade to jms-testkit 1.0.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -308,7 +308,7 @@ object Dependencies {
         "com.ibm.mq" % "com.ibm.mq.allclient" % "9.2.0.0" % Test, // IBM International Program License Agreement https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/maven/licenses/L-APIG-AZYF2E/LI_en.html
         "org.apache.activemq" % "activemq-broker" % "5.16.0" % Test, // ApacheV2
         "org.apache.activemq" % "activemq-client" % "5.16.0" % Test, // ApacheV2
-        "io.github.sullis" %% "jms-testkit" % "0.5.0" % Test // ApacheV2
+        "io.github.sullis" %% "jms-testkit" % "1.0.1" % Test // ApacheV2
       ) ++ Mockito,
     // Having JBoss as a first resolver is a workaround for https://github.com/coursier/coursier/issues/200
     externalResolvers := ("jboss" at "https://repository.jboss.org/nexus/content/groups/public") +: externalResolvers.value


### PR DESCRIPTION
jms-testkit 1.0.1 supports Scala 2.x and Scala 3.0.0
