### PR TITLE
Google Pub/Sub gRPC: docs for subscription in AcknowledgeRequest

### DIFF
--- a/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
+++ b/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
@@ -176,10 +176,13 @@ class IntegrationSpec
           message.ackId
         }
         .groupedWithin(10, 1.second)
-        .map(ids =>
-          AcknowledgeRequest()
-           .withSubscription(s"projects/$projectId/subscriptions/$subscription")
-           .withAckIds(ids)
+        .map(
+          ids =>
+            AcknowledgeRequest()
+              .withSubscription(
+                s"projects/$projectId/subscriptions/$subscription"
+              )
+              .withAckIds(ids)
         )
         .to(ackSink)
       //#acknowledge

--- a/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
+++ b/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
@@ -176,7 +176,11 @@ class IntegrationSpec
           message.ackId
         }
         .groupedWithin(10, 1.second)
-        .map(ids => AcknowledgeRequest(ackIds = ids))
+        .map(ids =>
+          AcknowledgeRequest()
+           .withSubscription(s"projects/$projectId/subscriptions/$subscription")
+           .withAckIds(ids)
+        )
         .to(ackSink)
       //#acknowledge
     }


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #2354

This adds, in the documentation examples, `.withSubscription` to the `AcknowledgeRequest` construction. The current example code would have acks failing with an invalid resource error.