### PR TITLE
[BigQuery] Add extra params to the QueryRequest

### DIFF
--- a/google-cloud-bigquery/src/main/mima-filters/3.0.0.backwards.excludes/2679-query-request
+++ b/google-cloud-bigquery/src/main/mima-filters/3.0.0.backwards.excludes/2679-query-request
@@ -1,0 +1,4 @@
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.googlecloud.bigquery.model.QueryRequest.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.googlecloud.bigquery.model.QueryRequest.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.googlecloud.bigquery.model.QueryRequest.this")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.googlecloud.bigquery.model.QueryRequest.unapply")

--- a/google-cloud-bigquery/src/main/mima-filters/3.0.0.backwards.excludes/2679-query-request
+++ b/google-cloud-bigquery/src/main/mima-filters/3.0.0.backwards.excludes/2679-query-request
@@ -1,4 +1,3 @@
 ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.googlecloud.bigquery.model.QueryRequest.unapply")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.googlecloud.bigquery.model.QueryRequest.copy")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.googlecloud.bigquery.model.QueryRequest.this")
-ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.alpakka.googlecloud.bigquery.model.QueryRequest.unapply")

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
@@ -41,8 +41,8 @@ final case class QueryRequest private (query: String,
                                        dryRun: Option[Boolean],
                                        useLegacySql: Option[Boolean],
                                        requestId: Option[String],
-                                       location: Option[String] = None,
-                                       maximumBytesBilled: Option[Long] = None) {
+                                       location: Option[String],
+                                       maximumBytesBilled: Option[Long]) {
 
   def getQuery = query
   def getMaxResults = maxResults.asPrimitive

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
@@ -41,8 +41,8 @@ final case class QueryRequest private (query: String,
                                        dryRun: Option[Boolean],
                                        useLegacySql: Option[Boolean],
                                        requestId: Option[String],
-                                       location: Option[String],
-                                       maximumBytesBilled: Option[Long]) {
+                                       location: Option[String] = None,
+                                       maximumBytesBilled: Option[Long] = None) {
 
   def getQuery = query
   def getMaxResults = maxResults.asPrimitive
@@ -111,8 +111,6 @@ object QueryRequest {
    * @param dryRun if set to `true` BigQuery doesn't run the job and instead returns statistics about the job such as how many bytes would be processed
    * @param useLegacySql specifies whether to use BigQuery's legacy SQL dialect for this query
    * @param requestId a unique user provided identifier to ensure idempotent behavior for queries
-   * @param location the geographic location where the job should run
-   * @param maximumBytesBilled limits the number of bytes billed for this query
    * @return a [[QueryRequest]]
    */
   def create(query: String,
@@ -121,9 +119,7 @@ object QueryRequest {
              timeout: util.Optional[Duration],
              dryRun: util.Optional[lang.Boolean],
              useLegacySql: util.Optional[lang.Boolean],
-             requestId: util.Optional[String],
-             location: util.Optional[String],
-             maximumBytesBilled: util.OptionalLong) =
+             requestId: util.Optional[String]) =
     QueryRequest(
       query,
       maxResults.asScala,
@@ -131,9 +127,7 @@ object QueryRequest {
       timeout.asScala.map(_.asScala),
       dryRun.asScala.map(_.booleanValue),
       useLegacySql.asScala.map(_.booleanValue),
-      requestId.asScala,
-      location.asScala,
-      maximumBytesBilled.asScala
+      requestId.asScala
     )
 
   implicit val format: RootJsonFormat[QueryRequest] = jsonFormat(

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
@@ -127,7 +127,9 @@ object QueryRequest {
       timeout.asScala.map(_.asScala),
       dryRun.asScala.map(_.booleanValue),
       useLegacySql.asScala.map(_.booleanValue),
-      requestId.asScala
+      requestId.asScala,
+      None,
+      None,
     )
 
   implicit val format: RootJsonFormat[QueryRequest] = jsonFormat(

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
@@ -31,6 +31,8 @@ import scala.concurrent.duration.FiniteDuration
  * @param dryRun if set to `true` BigQuery doesn't run the job and instead returns statistics about the job such as how many bytes would be processed
  * @param useLegacySql specifies whether to use BigQuery's legacy SQL dialect for this query
  * @param requestId a unique user provided identifier to ensure idempotent behavior for queries
+ * @param location the geographic location where the job should run
+ * @param maximumBytesBilled limits the number of bytes billed for this query
  */
 final case class QueryRequest private (query: String,
                                        maxResults: Option[Int],
@@ -38,7 +40,9 @@ final case class QueryRequest private (query: String,
                                        timeout: Option[FiniteDuration],
                                        dryRun: Option[Boolean],
                                        useLegacySql: Option[Boolean],
-                                       requestId: Option[String]) {
+                                       requestId: Option[String],
+                                       location: Option[String],
+                                       maximumBytesBilled: Option[Long]) {
 
   def getQuery = query
   def getMaxResults = maxResults.asPrimitive
@@ -47,6 +51,8 @@ final case class QueryRequest private (query: String,
   def getDryRun = dryRun.map(lang.Boolean.valueOf).asJava
   def getUseLegacySql = useLegacySql.map(lang.Boolean.valueOf).asJava
   def getRequestId = requestId.asJava
+  def getLocation = location.asJava
+  def getMaximumBytesBilled = maximumBytesBilled.asJava
 
   def withQuery(query: String) =
     copy(query = query)
@@ -80,6 +86,16 @@ final case class QueryRequest private (query: String,
     copy(requestId = requestId)
   def withRequestId(requestId: util.Optional[String]) =
     copy(requestId = requestId.asScala)
+
+  def withLocation(location: Option[String]) =
+    copy(location = location)
+  def withLocation(location: util.Optional[String]) =
+    copy(location = location.asScala)
+
+  def withMaximumBytesBilled(maximumBytesBilled: Option[Long]) =
+    copy(maximumBytesBilled = maximumBytesBilled)
+  def withMaximumBytesBilled(maximumBytesBilled: util.OptionalLong) =
+    copy(maximumBytesBilled = maximumBytesBilled.asScala)
 }
 
 object QueryRequest {
@@ -95,6 +111,8 @@ object QueryRequest {
    * @param dryRun if set to `true` BigQuery doesn't run the job and instead returns statistics about the job such as how many bytes would be processed
    * @param useLegacySql specifies whether to use BigQuery's legacy SQL dialect for this query
    * @param requestId a unique user provided identifier to ensure idempotent behavior for queries
+   * @param location the geographic location where the job should run
+   * @param maximumBytesBilled limits the number of bytes billed for this query
    * @return a [[QueryRequest]]
    */
   def create(query: String,
@@ -103,7 +121,9 @@ object QueryRequest {
              timeout: util.Optional[Duration],
              dryRun: util.Optional[lang.Boolean],
              useLegacySql: util.Optional[lang.Boolean],
-             requestId: util.Optional[String]) =
+             requestId: util.Optional[String],
+             location: util.Optional[String],
+             maximumBytesBilled: util.OptionalLong) =
     QueryRequest(
       query,
       maxResults.asScala,
@@ -111,7 +131,9 @@ object QueryRequest {
       timeout.asScala.map(_.asScala),
       dryRun.asScala.map(_.booleanValue),
       useLegacySql.asScala.map(_.booleanValue),
-      requestId.asScala
+      requestId.asScala,
+      location.asScala,
+      maximumBytesBilled.asScala
     )
 
   implicit val format: RootJsonFormat[QueryRequest] = jsonFormat(
@@ -122,7 +144,9 @@ object QueryRequest {
     "timeoutMs",
     "dryRun",
     "useLegacySql",
-    "requestId"
+    "requestId",
+    "location",
+    "maximumBytesBilled"
   )
 }
 

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
@@ -129,7 +129,7 @@ object QueryRequest {
       useLegacySql.asScala.map(_.booleanValue),
       requestId.asScala,
       None,
-      None,
+      None
     )
 
   implicit val format: RootJsonFormat[QueryRequest] = jsonFormat(

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
@@ -42,7 +42,7 @@ final case class QueryRequest private (query: String,
                                        dryRun: Option[Boolean],
                                        useLegacySql: Option[Boolean],
                                        location: Option[String],
-                                       labels: Map[String, String],
+                                       labels: Option[Map[String, String]],
                                        maximumBytesBilled: Option[Long],
                                        requestId: Option[String]) {
 
@@ -100,10 +100,10 @@ final case class QueryRequest private (query: String,
   def withMaximumBytesBilled(maximumBytesBilled: util.OptionalLong) =
     copy(maximumBytesBilled = maximumBytesBilled.asScala)
 
-  def withLabels(labels: Map[String, String]) =
+  def withLabels(labels: Option[Map[String, String]]) =
     copy(labels = labels)
-  def withLabels(labels: util.Map[String, String]) =
-    copy(labels = labels.asScala.toMap)
+  def withLabels(labels: util.Optional[util.Map[String, String]]) =
+    copy(labels = labels.asScala.map(_.asScala.toMap))
 }
 
 object QueryRequest {
@@ -115,7 +115,7 @@ object QueryRequest {
             dryRun: Option[Boolean],
             useLegacySql: Option[Boolean],
             requestId: Option[String]): QueryRequest =
-    QueryRequest(query, maxResults, defaultDataset, timeout, dryRun, useLegacySql, None, Map.empty, None, requestId)
+    QueryRequest(query, maxResults, defaultDataset, timeout, dryRun, useLegacySql, None, None, None, requestId)
 
   /**
    * Java API: QueryRequest model
@@ -145,7 +145,7 @@ object QueryRequest {
       dryRun.asScala.map(_.booleanValue),
       useLegacySql.asScala.map(_.booleanValue),
       None,
-      Map.empty,
+      None,
       None,
       requestId.asScala
     )
@@ -158,10 +158,10 @@ object QueryRequest {
     "timeoutMs",
     "dryRun",
     "useLegacySql",
-    "requestId",
     "location",
+    "labels",
     "maximumBytesBilled",
-    "labels"
+    "requestId"
   )
 }
 

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/BigQueryQueries.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/BigQueryQueries.scala
@@ -40,7 +40,7 @@ private[scaladsl] trait BigQueryQueries { this: BigQueryRest =>
   def query[Out](query: String, dryRun: Boolean = false, useLegacySql: Boolean = true)(
       implicit um: FromEntityUnmarshaller[QueryResponse[Out]]
   ): Source[Out, Future[QueryResponse[Out]]] = {
-    val request = QueryRequest(query, None, None, None, Some(dryRun), Some(useLegacySql), None, None, None)
+    val request = QueryRequest(query, None, None, None, Some(dryRun), Some(useLegacySql), None)
     this.query(request).mapMaterializedValue(_._2)
   }
 

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/BigQueryQueries.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/BigQueryQueries.scala
@@ -40,7 +40,7 @@ private[scaladsl] trait BigQueryQueries { this: BigQueryRest =>
   def query[Out](query: String, dryRun: Boolean = false, useLegacySql: Boolean = true)(
       implicit um: FromEntityUnmarshaller[QueryResponse[Out]]
   ): Source[Out, Future[QueryResponse[Out]]] = {
-    val request = QueryRequest(query, None, None, None, Some(dryRun), Some(useLegacySql), None)
+    val request = QueryRequest(query, None, None, None, Some(dryRun), Some(useLegacySql), None, None, None)
     this.query(request).mapMaterializedValue(_._2)
   }
 


### PR DESCRIPTION
I want to add extra params to the BigQuery query request. 
- `location` the geographic location where the job should run
- `maximumBytesBilled` limits the number of bytes billed for this query

These params described here https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#QueryRequest

References #xxxx
