### PR TITLE
Use JDK 8 for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,24 @@ services:
 git:
   depth: 500
 
-# using jabba for custom jdk management (see ./scripts/build.sh)
+addons:
+  hosts:
+    # to run tests locally, these hostnames need to resolve to localhost IP
+    - hbase
+  apt:
+    sources:
+      # Official debian package for AdoptOpenJDK from https://adoptopenjdk.net/installation.html#linux-pkg
+      - sourceline: deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ xenial main
+        key_url: https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public
+    packages:
+      - adoptopenjdk-8-hotspot
+
+before_install:
+  - whereis java
+  # build, test and release using JDK 8 to make sure alpakka works with it
+  - export JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
+  - export PATH=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/bin:$PATH
+  - java -version
 
 # default script for jobs, that do not have any specified
 script: ./scripts/travis.sh
@@ -176,11 +193,6 @@ cache:
     - $HOME/.sbt
     - $HOME/.jabba
   timeout: 900
-
-addons:
-  hosts:
-    # to run tests locally, these hostnames need to resolve to localhost IP
-    - hbase
 
 env:
   global:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,14 +5,6 @@ set -x
 PRE_CMD=$1
 CMD=$2
 
-[ "$TRAVIS_EVENT_TYPE" == "cron" ] && JDK="adopt@~1.11-0" || JDK="adopt@~1.8-0"
-
-# using jabba for custom jdk management
-if [ ! -f ~/.jabba/jabba.sh ]; then curl -L -v --retry 5 -o jabba-install.sh https://raw.githubusercontent.com/shyiko/jabba/0.11.2/install.sh && bash jabba-install.sh; fi
-. ~/.jabba/jabba.sh
-jabba install "$JDK"
-jabba use "$JDK"
-java -version
 $PRE_CMD
 
 sbt -sbt-launch-repo https://repo1.maven.org/maven2 -jvm-opts .jvmopts-travis "$CMD"


### PR DESCRIPTION
Use apt to install jdk8 and always build, test and release with it from travis. Apt setup copied from akka-persistence-cassandra.

References #2680
