### PR TITLE
elasticsearch: Nop

### DIFF
--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/WriteMessage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/WriteMessage.scala
@@ -28,6 +28,7 @@ private[elasticsearch] object Operation {
   object Update extends Operation("update")
   object Upsert extends Operation("update")
   object Delete extends Operation("delete")
+  object Nop extends Operation("nop")
 }
 
 final class WriteMessage[T, PT] private (val operation: Operation,
@@ -124,6 +125,9 @@ object WriteMessage {
 
   def createDeleteMessage[T](id: String): WriteMessage[T, NotUsed] =
     new WriteMessage(Delete, id = Option(id), None)
+
+  def createNopMessage[T](): WriteMessage[T, NotUsed] =
+    new WriteMessage(Nop, id = None, None)
 
 }
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
@@ -74,29 +74,29 @@ private[elasticsearch] final class ElasticsearchSimpleFlowStage[T, C](
       log.debug("Posting data to Elasticsearch: {}", json)
 
       if (json.nonEmpty) {
-      val uri = baseUri.withPath(Path(endpoint))
-      val request = HttpRequest(HttpMethods.POST)
-        .withUri(uri)
-        .withEntity(HttpEntity(NDJsonProtocol.`application/x-ndjson`, json))
+        val uri = baseUri.withPath(Path(endpoint))
+        val request = HttpRequest(HttpMethods.POST)
+          .withUri(uri)
+          .withEntity(HttpEntity(NDJsonProtocol.`application/x-ndjson`, json))
 
-      ElasticsearchApi
-        .executeRequest(
-          request,
-          connectionSettings = settings.connection
-        )
-        .map {
-          case HttpResponse(StatusCodes.OK, _, responseEntity, _) =>
-            Unmarshal(responseEntity)
-              .to[String]
-              .map(json => responseHandler.invoke((messages, resultsPassthrough, json)))
-          case HttpResponse(status, _, responseEntity, _) =>
-            Unmarshal(responseEntity).to[String].map { body =>
-              failureHandler.invoke(
-                (resultsPassthrough,
-                 new RuntimeException(s"Request failed for POST $uri, got $status with body: $body"))
-              )
-            }
-        }
+        ElasticsearchApi
+          .executeRequest(
+            request,
+            connectionSettings = settings.connection
+          )
+          .map {
+            case HttpResponse(StatusCodes.OK, _, responseEntity, _) =>
+              Unmarshal(responseEntity)
+                .to[String]
+                .map(json => responseHandler.invoke((messages, resultsPassthrough, json)))
+            case HttpResponse(status, _, responseEntity, _) =>
+              Unmarshal(responseEntity).to[String].map { body =>
+                failureHandler.invoke(
+                  (resultsPassthrough,
+                   new RuntimeException(s"Request failed for POST $uri, got $status with body: $body"))
+                )
+              }
+          }
       } else {
         // if all NOPs, pretend an empty response:
         handleResponse( (messages, resultsPassthrough, """{"took":0, "errors": false, "items":[]}"""))

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
@@ -73,6 +73,7 @@ private[elasticsearch] final class ElasticsearchSimpleFlowStage[T, C](
 
       log.debug("Posting data to Elasticsearch: {}", json)
 
+      if (json.nonEmpty) {
       val uri = baseUri.withPath(Path(endpoint))
       val request = HttpRequest(HttpMethods.POST)
         .withUri(uri)
@@ -96,6 +97,10 @@ private[elasticsearch] final class ElasticsearchSimpleFlowStage[T, C](
               )
             }
         }
+      } else {
+        // if all NOPs, pretend an empty response:
+        handleResponse( (messages, resultsPassthrough, """{"took":0, "errors": false, "items":[]}"""))
+      }
     }
 
     private def handleFailure(

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
@@ -99,7 +99,7 @@ private[elasticsearch] final class ElasticsearchSimpleFlowStage[T, C](
           }
       } else {
         // if all NOPs, pretend an empty response:
-        handleResponse( (messages, resultsPassthrough, """{"took":0, "errors": false, "items":[]}"""))
+        handleResponse((messages, resultsPassthrough, """{"took":0, "errors": false, "items":[]}"""))
       }
     }
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApi.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApi.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.elasticsearch.impl
 
 import akka.annotation.InternalApi
-import akka.stream.alpakka.elasticsearch.Operation.{Create, Delete, Index, Update, Upsert}
+import akka.stream.alpakka.elasticsearch.Operation.{Create, Delete, Index, Nop, Update, Upsert}
 import akka.stream.alpakka.elasticsearch.{WriteMessage, WriteResult}
 import spray.json._
 
@@ -25,14 +25,7 @@ private[impl] abstract class RestBulkApi[T, C] {
 
     // If some commands in bulk request failed, pass failed messages to follows.
     val items = responseJson.asJsObject.fields("items").asInstanceOf[JsArray]
-    val messageResults: immutable.Seq[WriteResult[T, C]] = items.elements.zip(messages).map {
-      case (item, message) =>
-        val command = message.operation.command
-        val res = item.asJsObject.fields(command).asJsObject
-        val error: Option[String] = res.fields.get("error").map(_.toString())
-        new WriteResult(message, error)
-    }
-    messageResults
+    buildMessageResults(items, messages)
   }
 
   def optionalString(fieldName: String, value: Option[String]): Option[(String, JsString)] =
@@ -46,7 +39,35 @@ private[impl] abstract class RestBulkApi[T, C] {
     case Upsert => "\n" + JsObject("doc" -> messageSource.parseJson, "doc_as_upsert" -> JsTrue).toString
     case Update => "\n" + JsObject("doc" -> messageSource.parseJson).toString
     case Delete => ""
+    case Nop => ""
   }
 
   def constructSharedFields(message: WriteMessage[T, C]): Seq[(String, JsString)]
+
+  /** NOPs don't come back so slip them into the results like this: */
+  private
+  def buildMessageResults(items: JsArray,
+                          messages: immutable.Seq[WriteMessage[T, C]]): immutable.Seq[WriteResult[T, C]] = {
+    val ret = new immutable.VectorBuilder[WriteResult[T, C]]
+    ret.sizeHint(messages)
+    val itemsIter = items.elements.iterator
+    messages.foreach { message =>
+      if (message.operation == Nop) {
+        // client just wants to pass-through:
+        ret += new WriteResult(message, None)
+      } else {
+        if (itemsIter.hasNext) {
+          // good message
+          val command = message.operation.command
+          val res = itemsIter.next().asJsObject.fields(command).asJsObject
+          val error: Option[String] = res.fields.get("error").map(_.toString())
+          ret += new WriteResult(message, error)
+        } else {
+          // error?
+          ret += new WriteResult(message, None)
+        }
+      }
+    }
+    ret.result()
+  }
 }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApi.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApi.scala
@@ -45,9 +45,8 @@ private[impl] abstract class RestBulkApi[T, C] {
   def constructSharedFields(message: WriteMessage[T, C]): Seq[(String, JsString)]
 
   /** NOPs don't come back so slip them into the results like this: */
-  private
-  def buildMessageResults(items: JsArray,
-                          messages: immutable.Seq[WriteMessage[T, C]]): immutable.Seq[WriteResult[T, C]] = {
+  private def buildMessageResults(items: JsArray,
+                                  messages: immutable.Seq[WriteMessage[T, C]]): immutable.Seq[WriteResult[T, C]] = {
     val ret = new immutable.VectorBuilder[WriteResult[T, C]]
     ret.sizeHint(messages)
     val itemsIter = items.elements.iterator

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApiV5.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApiV5.scala
@@ -57,7 +57,7 @@ private[impl] final class RestBulkApiV5[T, C](indexName: String,
           case Nop => "" -> JsObject()
         }
         if (tuple._1.nonEmpty)
-        JsObject(tuple).compactPrint + messageToJson(message, message.source.fold("")(messageWriter.convert))
+          JsObject(tuple).compactPrint + messageToJson(message, message.source.fold("")(messageWriter.convert))
         else
           ""
       }

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApiV5.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApiV5.scala
@@ -62,9 +62,9 @@ private[impl] final class RestBulkApiV5[T, C](indexName: String,
           ""
       }
       .filter(_.nonEmpty) match {
-        case Nil => "" // if all NOPs
-        case x => x.mkString("", "\n", "\n")
-      }
+      case Nil => "" // if all NOPs
+      case x => x.mkString("", "\n", "\n")
+    }
 
   override def constructSharedFields(message: WriteMessage[T, C]): Seq[(String, JsString)] = {
     val operationFields = if (allowExplicitIndex) {

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApiV5.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApiV5.scala
@@ -54,10 +54,17 @@ private[impl] final class RestBulkApiV5[T, C](indexName: String,
                 optionalString("version_type", versionType)
               ).flatten
             "delete" -> JsObject(sharedFields ++ fields: _*)
+          case Nop => "" -> JsObject()
         }
+        if (tuple._1.nonEmpty)
         JsObject(tuple).compactPrint + messageToJson(message, message.source.fold("")(messageWriter.convert))
+        else
+          ""
       }
-      .mkString("", "\n", "\n")
+      .filter(_.nonEmpty) match {
+        case Nil => "" // if all NOPs
+        case x => x.mkString("", "\n", "\n")
+      }
 
   override def constructSharedFields(message: WriteMessage[T, C]): Seq[(String, JsString)] = {
     val operationFields = if (allowExplicitIndex) {

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApiV7.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApiV7.scala
@@ -45,10 +45,17 @@ private[impl] final class RestBulkApiV7[T, C](indexName: String,
                 optionalString("version_type", versionType)
               ).flatten
             "delete" -> JsObject(sharedFields ++ fields: _*)
+          case Nop => "" -> JsObject()
         }
+        if (tuple._1.nonEmpty)
         JsObject(tuple).compactPrint + messageToJson(message, message.source.fold("")(messageWriter.convert))
+        else
+          ""
       }
-      .mkString("", "\n", "\n")
+      .filter(_.nonEmpty) match {
+        case Nil => ""  // if all NOPs
+        case x => x.mkString("", "\n", "\n")
+      }
 
   override def constructSharedFields(message: WriteMessage[T, C]): Seq[(String, JsString)] = {
     val operationFields = if (allowExplicitIndex) {

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApiV7.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApiV7.scala
@@ -53,9 +53,9 @@ private[impl] final class RestBulkApiV7[T, C](indexName: String,
           ""
       }
       .filter(_.nonEmpty) match {
-        case Nil => ""  // if all NOPs
-        case x => x.mkString("", "\n", "\n")
-      }
+      case Nil => "" // if all NOPs
+      case x => x.mkString("", "\n", "\n")
+    }
 
   override def constructSharedFields(message: WriteMessage[T, C]): Seq[(String, JsString)] = {
     val operationFields = if (allowExplicitIndex) {

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApiV7.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/RestBulkApiV7.scala
@@ -48,7 +48,7 @@ private[impl] final class RestBulkApiV7[T, C](indexName: String,
           case Nop => "" -> JsObject()
         }
         if (tuple._1.nonEmpty)
-        JsObject(tuple).compactPrint + messageToJson(message, message.source.fold("")(messageWriter.convert))
+          JsObject(tuple).compactPrint + messageToJson(message, message.source.fold("")(messageWriter.convert))
         else
           ""
       }

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpecUtils.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpecUtils.scala
@@ -31,9 +31,9 @@ trait ElasticsearchSpecUtils { this: AnyWordSpec with ScalaFutures =>
   import spray.json._
   import DefaultJsonProtocol._
 
-  case class Book(title: String)
+  case class Book(title: String, shouldSkip: Option[Boolean] = None)
 
-  implicit val format: JsonFormat[Book] = jsonFormat1(Book)
+  implicit val format: JsonFormat[Book] = jsonFormat2(Book)
   //#define-class
 
   def register(connectionSettings: ElasticsearchConnectionSettings, indexName: String, title: String): Unit = {

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV5Spec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV5Spec.scala
@@ -239,6 +239,176 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
         .map(_.book.title)
     }
 
+    "kafka-example - store documents and pass Responses with passThrough in bulk" in assertAllStagesStopped {
+
+      //#kafka-example
+      // We're going to pretend we got messages from kafka.
+      // After we've written them to Elastic, we want
+      // to commit the offset to Kafka
+
+      case class KafkaOffset(offset: Int)
+      case class KafkaMessage(book: Book, offset: KafkaOffset)
+
+      val messagesFromKafka = List(
+        KafkaMessage(Book("Book 1"), KafkaOffset(0)),
+        KafkaMessage(Book("Book 2"), KafkaOffset(1)),
+        KafkaMessage(Book("Book 3"), KafkaOffset(2))
+      )
+
+      var committedOffsets = Vector[KafkaOffset]()
+
+      def commitToKafka(offset: KafkaOffset): Unit =
+        committedOffsets = committedOffsets :+ offset
+
+      val indexName = "sink6-bulk"
+      val kafkaToEs = Source(messagesFromKafka) // Assume we get this from Kafka
+        .map { kafkaMessage: KafkaMessage =>
+          val book = kafkaMessage.book
+          val id = book.title
+
+          // Transform message so that we can write to elastic
+          WriteMessage.createIndexMessage(id, book).withPassThrough(kafkaMessage.offset)
+        }
+        .grouped(2)
+        .via( // write to elastic
+          ElasticsearchFlow.createBulk[Book, KafkaOffset](
+            constructElasticsearchParams(indexName, "_doc", ApiVersion.V5),
+            settings = baseWriteSettings
+          )
+        )
+        .map(_.map { result =>
+          if (!result.success) throw new Exception("Failed to write message to elastic")
+          // Commit to kafka
+          commitToKafka(result.message.passThrough)
+        })
+        .runWith(Sink.ignore)
+
+      kafkaToEs.futureValue shouldBe Done
+      //#kafka-example
+      flushAndRefresh(connectionSettings, indexName)
+
+      // Make sure all messages was committed to kafka
+      committedOffsets.map(_.offset) should contain theSameElementsAs Seq(0, 1, 2)
+      readTitlesFrom(ApiVersion.V5, baseSourceSettings, indexName).futureValue.toList should contain allElementsOf messagesFromKafka
+        .map(_.book.title)
+    }
+
+    "kafka-example - store documents and pass Responses with passThrough skipping some w/ NOP" in assertAllStagesStopped {
+
+      //#kafka-example
+      // We're going to pretend we got messages from kafka.
+      // After we've written them to Elastic, we want
+      // to commit the offset to Kafka
+
+      case class KafkaOffset(offset: Int)
+      case class KafkaMessage(book: Book, offset: KafkaOffset)
+
+      val messagesFromKafka = List(
+        KafkaMessage(Book("Book A", shouldSkip=Some(true)), KafkaOffset(0)),
+        KafkaMessage(Book("Book 1"                       ), KafkaOffset(1)),
+        KafkaMessage(Book("Book 2"                       ), KafkaOffset(2)),
+        KafkaMessage(Book("Book B", shouldSkip=Some(true)), KafkaOffset(3)),
+        KafkaMessage(Book("Book 3"                       ), KafkaOffset(4)),
+        KafkaMessage(Book("Book C", shouldSkip=Some(true)), KafkaOffset(5))
+      )
+
+      var committedOffsets = Vector[KafkaOffset]()
+
+      def commitToKafka(offset: KafkaOffset): Unit =
+        committedOffsets = committedOffsets :+ offset
+
+      val indexName = "sink6-nop"
+      val kafkaToEs = Source(messagesFromKafka) // Assume we get this from Kafka
+        .map { kafkaMessage: KafkaMessage =>
+          val book = kafkaMessage.book
+          val id = book.title
+
+          // Transform message so that we can write to elastic
+          if (book.shouldSkip.getOrElse(false))
+            WriteMessage.createNopMessage[Book]().withPassThrough(kafkaMessage.offset)
+          else
+            WriteMessage.createIndexMessage(id, book).withPassThrough(kafkaMessage.offset)
+        }
+        .via( // write to elastic
+          ElasticsearchFlow.createWithPassThrough[Book, KafkaOffset](
+            constructElasticsearchParams(indexName, "_doc", ApiVersion.V5),
+            settings = baseWriteSettings
+          )
+        )
+        .map { result =>
+          if (!result.success) throw new Exception("Failed to write message to elastic")
+          // Commit to kafka
+          commitToKafka(result.message.passThrough)
+        }
+        .runWith(Sink.ignore)
+
+      kafkaToEs.futureValue shouldBe Done
+      //#kafka-example
+      flushAndRefresh(connectionSettings, indexName)
+
+      // Make sure all messages was committed to kafka
+      committedOffsets.map(_.offset) should contain theSameElementsAs Seq(0, 1, 2, 3, 4, 5)
+      readTitlesFrom(ApiVersion.V5, baseSourceSettings, indexName).futureValue.toList should contain allElementsOf messagesFromKafka.filterNot(_.book.shouldSkip.getOrElse(false))
+        .map(_.book.title)
+    }
+
+    "kafka-example - skip all NOP documents and pass Responses with passThrough" in assertAllStagesStopped {
+
+      //#kafka-example
+      // We're going to pretend we got messages from kafka.
+      // After we've written them to Elastic, we want
+      // to commit the offset to Kafka
+
+      case class KafkaOffset(offset: Int)
+      case class KafkaMessage(book: Book, offset: KafkaOffset)
+
+      val messagesFromKafka = List( 
+        KafkaMessage(Book("Book 1", shouldSkip=Some(true)), KafkaOffset(0)),
+        KafkaMessage(Book("Book 2", shouldSkip=Some(true)), KafkaOffset(1)),
+        KafkaMessage(Book("Book 3", shouldSkip=Some(true)), KafkaOffset(2))
+      )
+
+      var committedOffsets = Vector[KafkaOffset]()
+
+      def commitToKafka(offset: KafkaOffset): Unit =
+        committedOffsets = committedOffsets :+ offset
+
+      val indexName = "sink6-none"
+      register(connectionSettings, indexName, "dummy")  // need to create index else exception in reading below
+
+      val kafkaToEs = Source(messagesFromKafka) // Assume we get this from Kafka
+        .map { kafkaMessage: KafkaMessage =>
+          val book = kafkaMessage.book
+          val id = book.title
+
+          // Transform message so that we can write to elastic
+          if (book.shouldSkip.getOrElse(false))
+            WriteMessage.createNopMessage[Book]().withPassThrough(kafkaMessage.offset)
+          else
+            WriteMessage.createIndexMessage(id, book).withPassThrough(kafkaMessage.offset)
+        }
+        .via( // write to elastic
+          ElasticsearchFlow.createWithPassThrough[Book, KafkaOffset](
+            constructElasticsearchParams(indexName, "_doc", ApiVersion.V5),
+            settings = baseWriteSettings
+          )
+        )
+        .map { result =>
+          if (!result.success) throw new Exception("Failed to write message to elastic")
+          // Commit to kafka
+          commitToKafka(result.message.passThrough)
+        }
+        .runWith(Sink.ignore)
+
+      kafkaToEs.futureValue shouldBe Done
+      //#kafka-example
+      flushAndRefresh(connectionSettings, indexName)
+
+      // Make sure all messages was committed to kafka
+      committedOffsets.map(_.offset) should contain theSameElementsAs Seq(0, 1, 2)
+      readTitlesFrom(ApiVersion.V5, baseSourceSettings, indexName).futureValue.toList shouldBe List("dummy")
+    }
+
     "handle multiple types of operations correctly" in assertAllStagesStopped {
       val indexName = "sink8"
       //#multiple-operations

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV5Spec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV5Spec.scala
@@ -304,12 +304,12 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
       case class KafkaMessage(book: Book, offset: KafkaOffset)
 
       val messagesFromKafka = List(
-        KafkaMessage(Book("Book A", shouldSkip=Some(true)), KafkaOffset(0)),
-        KafkaMessage(Book("Book 1"                       ), KafkaOffset(1)),
-        KafkaMessage(Book("Book 2"                       ), KafkaOffset(2)),
-        KafkaMessage(Book("Book B", shouldSkip=Some(true)), KafkaOffset(3)),
-        KafkaMessage(Book("Book 3"                       ), KafkaOffset(4)),
-        KafkaMessage(Book("Book C", shouldSkip=Some(true)), KafkaOffset(5))
+        KafkaMessage(Book("Book A", shouldSkip = Some(true)), KafkaOffset(0)),
+        KafkaMessage(Book("Book 1"), KafkaOffset(1)),
+        KafkaMessage(Book("Book 2"), KafkaOffset(2)),
+        KafkaMessage(Book("Book B", shouldSkip = Some(true)), KafkaOffset(3)),
+        KafkaMessage(Book("Book 3"), KafkaOffset(4)),
+        KafkaMessage(Book("Book C", shouldSkip = Some(true)), KafkaOffset(5))
       )
 
       var committedOffsets = Vector[KafkaOffset]()
@@ -348,7 +348,8 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
 
       // Make sure all messages was committed to kafka
       committedOffsets.map(_.offset) should contain theSameElementsAs Seq(0, 1, 2, 3, 4, 5)
-      readTitlesFrom(ApiVersion.V5, baseSourceSettings, indexName).futureValue.toList should contain allElementsOf messagesFromKafka.filterNot(_.book.shouldSkip.getOrElse(false))
+      readTitlesFrom(ApiVersion.V5, baseSourceSettings, indexName).futureValue.toList should contain allElementsOf messagesFromKafka
+        .filterNot(_.book.shouldSkip.getOrElse(false))
         .map(_.book.title)
     }
 
@@ -362,10 +363,10 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
       case class KafkaOffset(offset: Int)
       case class KafkaMessage(book: Book, offset: KafkaOffset)
 
-      val messagesFromKafka = List( 
-        KafkaMessage(Book("Book 1", shouldSkip=Some(true)), KafkaOffset(0)),
-        KafkaMessage(Book("Book 2", shouldSkip=Some(true)), KafkaOffset(1)),
-        KafkaMessage(Book("Book 3", shouldSkip=Some(true)), KafkaOffset(2))
+      val messagesFromKafka = List(
+        KafkaMessage(Book("Book 1", shouldSkip = Some(true)), KafkaOffset(0)),
+        KafkaMessage(Book("Book 2", shouldSkip = Some(true)), KafkaOffset(1)),
+        KafkaMessage(Book("Book 3", shouldSkip = Some(true)), KafkaOffset(2))
       )
 
       var committedOffsets = Vector[KafkaOffset]()
@@ -374,7 +375,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
         committedOffsets = committedOffsets :+ offset
 
       val indexName = "sink6-none"
-      register(connectionSettings, indexName, "dummy")  // need to create index else exception in reading below
+      register(connectionSettings, indexName, "dummy") // need to create index else exception in reading below
 
       val kafkaToEs = Source(messagesFromKafka) // Assume we get this from Kafka
         .map { kafkaMessage: KafkaMessage =>

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV7Spec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV7Spec.scala
@@ -288,12 +288,12 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
       case class KafkaMessage(book: Book, offset: KafkaOffset)
 
       val messagesFromKafka = List(
-        KafkaMessage(Book("Book A", shouldSkip=Some(true)), KafkaOffset(0)),
-        KafkaMessage(Book("Book 1"                       ), KafkaOffset(1)),
-        KafkaMessage(Book("Book 2"                       ), KafkaOffset(2)),
-        KafkaMessage(Book("Book B", shouldSkip=Some(true)), KafkaOffset(3)),
-        KafkaMessage(Book("Book 3"                       ), KafkaOffset(4)),
-        KafkaMessage(Book("Book C", shouldSkip=Some(true)), KafkaOffset(5))
+        KafkaMessage(Book("Book A", shouldSkip = Some(true)), KafkaOffset(0)),
+        KafkaMessage(Book("Book 1"), KafkaOffset(1)),
+        KafkaMessage(Book("Book 2"), KafkaOffset(2)),
+        KafkaMessage(Book("Book B", shouldSkip = Some(true)), KafkaOffset(3)),
+        KafkaMessage(Book("Book 3"), KafkaOffset(4)),
+        KafkaMessage(Book("Book C", shouldSkip = Some(true)), KafkaOffset(5))
       )
 
       var committedOffsets = Vector[KafkaOffset]()
@@ -332,7 +332,8 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
 
       // Make sure all messages was committed to kafka
       committedOffsets.map(_.offset) should contain theSameElementsAs Seq(0, 1, 2, 3, 4, 5)
-      readTitlesFrom(ApiVersion.V7, baseSourceSettings, indexName).futureValue.toList should contain allElementsOf messagesFromKafka.filterNot(_.book.shouldSkip.getOrElse(false))
+      readTitlesFrom(ApiVersion.V7, baseSourceSettings, indexName).futureValue.toList should contain allElementsOf messagesFromKafka
+        .filterNot(_.book.shouldSkip.getOrElse(false))
         .map(_.book.title)
     }
 
@@ -346,9 +347,9 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
       case class KafkaMessage(book: Book, offset: KafkaOffset)
 
       val messagesFromKafka = List(
-        KafkaMessage(Book("Book 1", shouldSkip=Some(true)), KafkaOffset(0)),
-        KafkaMessage(Book("Book 2", shouldSkip=Some(true)), KafkaOffset(1)),
-        KafkaMessage(Book("Book 3", shouldSkip=Some(true)), KafkaOffset(2))
+        KafkaMessage(Book("Book 1", shouldSkip = Some(true)), KafkaOffset(0)),
+        KafkaMessage(Book("Book 2", shouldSkip = Some(true)), KafkaOffset(1)),
+        KafkaMessage(Book("Book 3", shouldSkip = Some(true)), KafkaOffset(2))
       )
 
       var committedOffsets = Vector[KafkaOffset]()
@@ -357,7 +358,7 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
         committedOffsets = committedOffsets :+ offset
 
       val indexName = "sink6-none"
-      register(connectionSettings, indexName, "dummy")  // need to create index else exception in reading below
+      register(connectionSettings, indexName, "dummy") // need to create index else exception in reading below
 
       val kafkaToEs = Source(messagesFromKafka) // Assume we get this from Kafka
         .map { kafkaMessage: KafkaMessage =>

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV7Spec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV7Spec.scala
@@ -225,6 +225,173 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
         .map(_.book.title)
     }
 
+    "kafka-example - store documents and pass Responses with passThrough in bulk" in assertAllStagesStopped {
+
+      // We're going to pretend we got messages from kafka.
+      // After we've written them to Elastic, we want
+      // to commit the offset to Kafka
+
+      case class KafkaOffset(offset: Int)
+      case class KafkaMessage(book: Book, offset: KafkaOffset)
+
+      val messagesFromKafka = List(
+        KafkaMessage(Book("Book 1"), KafkaOffset(0)),
+        KafkaMessage(Book("Book 2"), KafkaOffset(1)),
+        KafkaMessage(Book("Book 3"), KafkaOffset(2))
+      )
+
+      var committedOffsets = Vector[KafkaOffset]()
+
+      def commitToKafka(offset: KafkaOffset): Unit =
+        committedOffsets = committedOffsets :+ offset
+
+      val indexName = "sink6-bulk"
+      val kafkaToEs = Source(messagesFromKafka) // Assume we get this from Kafka
+        .map { kafkaMessage: KafkaMessage =>
+          val book = kafkaMessage.book
+          val id = book.title
+
+          // Transform message so that we can write to elastic
+          WriteMessage.createIndexMessage(id, book).withPassThrough(kafkaMessage.offset)
+        }
+        .grouped(2)
+        .via( // write to elastic
+          ElasticsearchFlow.createBulk[Book, KafkaOffset](
+            constructElasticsearchParams(indexName, "_doc", ApiVersion.V7),
+            settings = baseWriteSettings
+          )
+        )
+        .map(_.map { result =>
+          if (!result.success) throw new Exception("Failed to write message to elastic")
+          // Commit to kafka
+          commitToKafka(result.message.passThrough)
+        })
+        .runWith(Sink.ignore)
+
+      kafkaToEs.futureValue shouldBe Done
+
+      flushAndRefresh(connectionSettings, indexName)
+
+      // Make sure all messages was committed to kafka
+      committedOffsets.map(_.offset) should contain theSameElementsAs Seq(0, 1, 2)
+      readTitlesFrom(ApiVersion.V7, baseSourceSettings, indexName).futureValue.toList should contain allElementsOf messagesFromKafka
+        .map(_.book.title)
+    }
+
+    "kafka-example - store documents and pass Responses with passThrough skipping some w/ NOP" in assertAllStagesStopped {
+
+      // We're going to pretend we got messages from kafka.
+      // After we've written them to Elastic, we want
+      // to commit the offset to Kafka
+
+      case class KafkaOffset(offset: Int)
+      case class KafkaMessage(book: Book, offset: KafkaOffset)
+
+      val messagesFromKafka = List(
+        KafkaMessage(Book("Book A", shouldSkip=Some(true)), KafkaOffset(0)),
+        KafkaMessage(Book("Book 1"                       ), KafkaOffset(1)),
+        KafkaMessage(Book("Book 2"                       ), KafkaOffset(2)),
+        KafkaMessage(Book("Book B", shouldSkip=Some(true)), KafkaOffset(3)),
+        KafkaMessage(Book("Book 3"                       ), KafkaOffset(4)),
+        KafkaMessage(Book("Book C", shouldSkip=Some(true)), KafkaOffset(5))
+      )
+
+      var committedOffsets = Vector[KafkaOffset]()
+
+      def commitToKafka(offset: KafkaOffset): Unit =
+        committedOffsets = committedOffsets :+ offset
+
+      val indexName = "sink6-nop"
+      val kafkaToEs = Source(messagesFromKafka) // Assume we get this from Kafka
+        .map { kafkaMessage: KafkaMessage =>
+          val book = kafkaMessage.book
+          val id = book.title
+
+          // Transform message so that we can write to elastic
+          if (book.shouldSkip.getOrElse(false))
+            WriteMessage.createNopMessage[Book]().withPassThrough(kafkaMessage.offset)
+          else
+            WriteMessage.createIndexMessage(id, book).withPassThrough(kafkaMessage.offset)
+        }
+        .via( // write to elastic
+          ElasticsearchFlow.createWithPassThrough[Book, KafkaOffset](
+            constructElasticsearchParams(indexName, "_doc", ApiVersion.V7),
+            settings = baseWriteSettings
+          )
+        )
+        .map { result =>
+          if (!result.success) throw new Exception("Failed to write message to elastic")
+          // Commit to kafka
+          commitToKafka(result.message.passThrough)
+        }
+        .runWith(Sink.ignore)
+
+      kafkaToEs.futureValue shouldBe Done
+
+      flushAndRefresh(connectionSettings, indexName)
+
+      // Make sure all messages was committed to kafka
+      committedOffsets.map(_.offset) should contain theSameElementsAs Seq(0, 1, 2, 3, 4, 5)
+      readTitlesFrom(ApiVersion.V7, baseSourceSettings, indexName).futureValue.toList should contain allElementsOf messagesFromKafka.filterNot(_.book.shouldSkip.getOrElse(false))
+        .map(_.book.title)
+    }
+
+    "kafka-example - skip all NOP documents and pass Responses with passThrough" in assertAllStagesStopped {
+
+      // We're going to pretend we got messages from kafka.
+      // After we've written them to Elastic, we want
+      // to commit the offset to Kafka
+
+      case class KafkaOffset(offset: Int)
+      case class KafkaMessage(book: Book, offset: KafkaOffset)
+
+      val messagesFromKafka = List(
+        KafkaMessage(Book("Book 1", shouldSkip=Some(true)), KafkaOffset(0)),
+        KafkaMessage(Book("Book 2", shouldSkip=Some(true)), KafkaOffset(1)),
+        KafkaMessage(Book("Book 3", shouldSkip=Some(true)), KafkaOffset(2))
+      )
+
+      var committedOffsets = Vector[KafkaOffset]()
+
+      def commitToKafka(offset: KafkaOffset): Unit =
+        committedOffsets = committedOffsets :+ offset
+
+      val indexName = "sink6-none"
+      register(connectionSettings, indexName, "dummy")  // need to create index else exception in reading below
+
+      val kafkaToEs = Source(messagesFromKafka) // Assume we get this from Kafka
+        .map { kafkaMessage: KafkaMessage =>
+          val book = kafkaMessage.book
+          val id = book.title
+
+          // Transform message so that we can write to elastic
+          if (book.shouldSkip.getOrElse(false))
+            WriteMessage.createNopMessage[Book]().withPassThrough(kafkaMessage.offset)
+          else
+            WriteMessage.createIndexMessage(id, book).withPassThrough(kafkaMessage.offset)
+        }
+        .via( // write to elastic
+          ElasticsearchFlow.createWithPassThrough[Book, KafkaOffset](
+            constructElasticsearchParams(indexName, "_doc", ApiVersion.V7),
+            settings = baseWriteSettings
+          )
+        )
+        .map { result =>
+          if (!result.success) throw new Exception("Failed to write message to elastic")
+          // Commit to kafka
+          commitToKafka(result.message.passThrough)
+        }
+        .runWith(Sink.ignore)
+
+      kafkaToEs.futureValue shouldBe Done
+
+      flushAndRefresh(connectionSettings, indexName)
+
+      // Make sure all messages was committed to kafka
+      committedOffsets.map(_.offset) should contain theSameElementsAs Seq(0, 1, 2)
+      readTitlesFrom(ApiVersion.V7, baseSourceSettings, indexName).futureValue.toList shouldBe List("dummy")
+    }
+
     "handle multiple types of operations correctly" in assertAllStagesStopped {
       val indexName = "sink8"
       val requests = List[WriteMessage[Book, NotUsed]](


### PR DESCRIPTION
`Operation.Nop` to permit a pass-through `WriteMessage` that does not do any index changes.

For example, if `Source` is a kafka message and `Sink` is a kafka commit, some messages may not warrant any elasticsearch index changes. So pass the message through with a nop.

Fixes #2694