### PR TITLE
Handle failed Future when invoking ES endpoint

### DIFF
--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
@@ -14,7 +14,7 @@ import akka.stream.stage._
 import akka.stream._
 
 import scala.collection.immutable
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
  * INTERNAL API.
@@ -96,6 +96,11 @@ private[elasticsearch] final class ElasticsearchSimpleFlowStage[T, C](
                    new RuntimeException(s"Request failed for POST $uri, got $status with body: $body"))
                 )
               }
+          }
+          .recoverWith {
+            case cause: Throwable =>
+              failureHandler.invoke((Nil, new RuntimeException(s"Request failed for POST $uri", cause)))
+              Future.failed(cause)
           }
       } else {
         // if all NOPs, pretend an empty response:


### PR DESCRIPTION
Invocation of an ES endpoint may not be complete and thus returning failed future. This can happen if the host is not reachable (covered in the test) or in other cases. The one that happened in my project was caused by misconfigured Akka HTTP Client. The server was not responding in the desired time (1 second) and the Future was completed with a failure (`akka.stream.scaladsl.TcpIdleTimeoutException: TCP idle-timeout encountered on connection to [xxx:yyyy], no bytes passed in the last 1 second`). The failure was not handled, and the whole stream was stoping processing without any notification.

In this fix, I added a `recoverWith` and invoke the `failureHandler` within it.