### PR TITLE
Fix equals method for MetaHeaders and AES256

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/S3Headers.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/S3Headers.scala
@@ -32,7 +32,7 @@ final class MetaHeaders private (val metaHeaders: Map[String, String]) {
     ")"
 
   override def equals(other: Any): Boolean = other match {
-    case that: S3Headers =>
+    case that: MetaHeaders =>
       Objects.equals(this.metaHeaders, that.metaHeaders)
     case _ => false
   }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/headers/ServerSideEncryption.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/headers/ServerSideEncryption.scala
@@ -48,7 +48,7 @@ final class AES256 private[headers] () extends ServerSideEncryption {
     ")"
 
   override def equals(other: Any): Boolean = other match {
-    case that: KMS => true
+    case that: AES256 => true
     case _ => false
   }
 


### PR DESCRIPTION
The `equals` method in `MetaHeaders` incorrectly checks if the other type is a `S3Headers`. This is likely an accident since in both cases both types have a field called `metaHeaders`