### PR TITLE
Only remove ETag quotes conditionally

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/Utils.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/Utils.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.s3
+
+private[s3] object Utils {
+
+  /** Removes S3 ETag quotes in the same way the official AWS tooling does. See
+   * https://github.com/aws/aws-sdk-java/blob/f935a3758b771a25f628f1d296cb61044a82b4ac/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/ServiceUtils.java#L122
+   */
+  def removeQuotes(string: String): String = {
+    val trimmed = string.trim()
+    val tail = if (trimmed.startsWith("\"")) trimmed.drop(1) else trimmed
+    if (tail.endsWith("\"")) tail.dropRight(1) else tail
+  }
+}

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
@@ -11,7 +11,7 @@ import akka.annotation.InternalApi
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport
 import akka.http.scaladsl.model.{ContentTypes, HttpCharsets, MediaTypes, Uri}
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
-import akka.stream.alpakka.s3.{ListBucketResultCommonPrefixes, ListBucketResultContents}
+import akka.stream.alpakka.s3.{ListBucketResultCommonPrefixes, ListBucketResultContents, Utils}
 
 import scala.util.Try
 import scala.xml.NodeSeq
@@ -65,7 +65,7 @@ import scala.xml.NodeSeq
             ListBucketResultContents(
               (x \ "Name").text,
               (c \ "Key").text,
-              (c \ "ETag").text.drop(1).dropRight(1),
+              Utils.removeQuotes((c \ "ETag").text),
               (c \ "Size").text.toLong,
               Instant.parse((c \ "LastModified").text),
               (c \ "StorageClass").text
@@ -87,7 +87,7 @@ import scala.xml.NodeSeq
       case x =>
         val lastModified = Instant.parse((x \ "LastModified").text)
         val eTag = (x \ "ETag").text
-        CopyPartResult(lastModified, eTag.dropRight(1).drop(1))
+        CopyPartResult(lastModified, Utils.removeQuotes(eTag))
     }
   }
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
@@ -347,7 +347,7 @@ final class ObjectMetadata private (
    *         as calculated by Amazon S3.
    */
   lazy val eTag: Option[String] = metadata.collectFirst {
-    case e: ETag => e.etag.value.drop(1).dropRight(1)
+    case e: ETag => Utils.removeQuotes(e.etag.value)
   }
 
   /**


### PR DESCRIPTION
So we've been trying to use alpakka with IBM Cloud Object Storage (COS). We observed that COS worked with all the standard S3 tooling, but `multipartCopy` did not work with Alpakka and would fail with a "no such part" error. After some digging, it turns out that COS does not quote the ETag in the `CopyPart` response. Alpakka assumes this to be quoted, and simply drops the first and last character. This ends up mangling the ETag, causing it to not be found when completing the copy.

Standard S3 libraries [removes quotes *if present*](https://github.com/aws/aws-sdk-java/blob/f935a3758b771a25f628f1d296cb61044a82b4ac/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/ServiceUtils.java#L122), so it works correctly in this case. Although one might argue that COS should quote the ETag in the `CopyResult`, I also think Alpakka should follow the standard S3 tooling and handle this case gracefully.

This PR removes quotes in the same manner as the AWS tooling does. It basically just trims and then checks if the leading/trailing character is a `"` and removes it if so.