### PR TITLE
BigQuery: Use `effectivePort` instead of `port`

### DIFF
--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/BigQueryTableData.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/BigQueryTableData.scala
@@ -134,8 +134,8 @@ private[scaladsl] trait BigQueryTableData { this: BigQueryRest =>
         }
 
         val pool = {
-          val authority = BigQueryEndpoints.endpoint.authority
-          GoogleHttp().cachedHostConnectionPool[TableDataInsertAllResponse](authority.host.address, authority.port)(um)
+          val uri = BigQueryEndpoints.endpoint
+          GoogleHttp().cachedHostConnectionPool[TableDataInsertAllResponse](uri.authority.host.address, uri.effectivePort)(um)
         }
 
         Flow[TableDataInsertAllRequest[In]]

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/BigQueryTableData.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/BigQueryTableData.scala
@@ -135,7 +135,8 @@ private[scaladsl] trait BigQueryTableData { this: BigQueryRest =>
 
         val pool = {
           val uri = BigQueryEndpoints.endpoint
-          GoogleHttp().cachedHostConnectionPool[TableDataInsertAllResponse](uri.authority.host.address, uri.effectivePort)(um)
+          GoogleHttp().cachedHostConnectionPool[TableDataInsertAllResponse](uri.authority.host.address,
+                                                                            uri.effectivePort)(um)
         }
 
         Flow[TableDataInsertAllRequest[In]]


### PR DESCRIPTION
References #2706, #2662