### PR TITLE
Google Common: Fix path to the well-known credentials file

### DIFF
--- a/google-common/src/main/resources/reference.conf
+++ b/google-common/src/main/resources/reference.conf
@@ -21,9 +21,9 @@ alpakka.google {
       # See https://github.com/googleapis/google-auth-library-java/blob/master/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java#L237
       path = ${user.home}/.config
       path = ${?APPDATA} # Windows-only
-      path = ${path}/gcloud
+      path = ${alpakka.google.credentials.service-account.path}/gcloud
       path = ${?CLOUDSDK_CONFIG}
-      path = ${path}/application_default_credentials.json
+      path = ${alpakka.google.credentials.service-account.path}/application_default_credentials.json
       path = ${?GOOGLE_APPLICATION_CREDENTIALS}
 
       # Always required regardless of where credentials are read from


### PR DESCRIPTION
Fixes #2711 
