### PR TITLE
AWS S3: Skip forward-proxy settings on optional overrides

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/settings.scala
@@ -508,7 +508,8 @@ object S3Settings {
     }
 
     val maybeForwardProxy =
-      if (c.hasPath("forward-proxy")) Some(ForwardProxy(c.getConfig("forward-proxy")))
+      if (c.hasPath("forward-proxy") && c.hasPath("forward-proxy.host") && c.hasPath("forward-proxy.port"))
+        Some(ForwardProxy(c.getConfig("forward-proxy")))
       else None
 
     if (c.hasPath("path-style-access"))


### PR DESCRIPTION
The config parser for `S3Settings` uses `c.hasPath("forward-proxy")` to see if any of the values inside of `forward-proxy` in order to determine whether to skip parsing the entire `forward-proxy` section.

Unfortunately `c.hasPath` returns `true` if you provide optional environment overrides even when they are not set, i.e. if you do something like this (which is a supported typesafe config way of overriding specific config)

```
forward-proxy {
  host = ${?HOST}
  port = ${?PORT}
  credentials {
    username = ${?CREDENTIALS_USERNAME}
    password = ${?CREDENTIALS_PASSWORD}
  }
}
```

and you don't actually set any of these environment variables then `S3Settings` will immediately fail on instantiation with 

```
com.typesafe.config.ConfigException$Missing: reference.conf  No configuration setting found for key 'host'
```

Even though none of the variables have actually been overridden. The solution to this is to not only check if `c.hasPath("forward-proxy")` returns `true`, but also the other mandatory fields that are part of the `forward-proxy` configuration (in this case `host` and `port`)