### PR TITLE
Add GCSSettings to make endpointUrl + basePath configurable

### DIFF
--- a/google-cloud-storage/src/main/resources/reference.conf
+++ b/google-cloud-storage/src/main/resources/reference.conf
@@ -20,3 +20,12 @@ alpakka.google {
     token-scope = deprecated // "https://www.googleapis.com/auth/devstorage.read_write" // default
   }
 }
+
+alpakka.google {
+
+    cloud-storage {
+        endpoint-url = "https://storage.googleapis.com/"
+        base-path = "/storage/v1"
+    }
+
+}

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/GCSAttributes.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/GCSAttributes.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.googlecloud.storage
+
+import akka.stream.Attributes
+import akka.stream.Attributes.Attribute
+
+object GCSAttributes {
+
+  /**
+   * Settings to use for the GCS stream
+   */
+  def settings(settings: GCSSettings): Attributes = Attributes(GCSSettingsValue(settings))
+
+  /**
+   * Config path which will be used to resolve required GCStorage settings
+   */
+  def settingsPath(path: String): Attributes = Attributes(GCSSettingsPath(path))
+
+}
+
+final class GCSSettingsPath private (val path: String) extends Attribute
+
+object GCSSettingsPath {
+  val Default = GCSSettingsPath(GCSSettings.ConfigPath)
+
+  def apply(path: String) = new GCSSettingsPath(path)
+}
+
+final class GCSSettingsValue private (val settings: GCSSettings) extends Attribute
+
+object GCSSettingsValue {
+  def apply(settings: GCSSettings) = new GCSSettingsValue(settings)
+}

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/GCSExt.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/GCSExt.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.googlecloud.storage
+
+import akka.actor.{ClassicActorSystemProvider, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+
+/**
+ * Manages one [[GCSSettings]] per `ActorSystem`.
+ */
+final class GCSExt private (sys: ExtendedActorSystem) extends Extension {
+  val settings: GCSSettings = settings(GCSSettings.ConfigPath)
+
+  def settings(prefix: String): GCSSettings = GCSSettings(sys.settings.config.getConfig(prefix))
+}
+
+object GCSExt extends ExtensionId[GCSExt] with ExtensionIdProvider {
+  override def lookup = GCSExt
+  override def createExtension(system: ExtendedActorSystem) = new GCSExt(system)
+
+  /**
+   * Java API.
+   * Get the GCS extension with the classic actors API.
+   */
+  override def get(system: akka.actor.ActorSystem): GCSExt = super.apply(system)
+
+  /**
+   * Java API.
+   * Get the GCS extension with the new actors API.
+   */
+  override def get(system: ClassicActorSystemProvider): GCSExt = super.apply(system)
+}

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/settings.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/settings.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.googlecloud.storage
+
+import akka.actor.{ActorSystem, ClassicActorSystemProvider}
+import com.typesafe.config.Config
+
+import java.util.Objects
+
+object GCSSettings {
+  val ConfigPath = "alpakka.google.cloud-storage"
+
+  /**
+   * Reads from the given config.
+   */
+  def apply(c: Config): GCSSettings = {
+    val endpointUrl = c.getString("endpoint-url")
+    val basePath = c.getString("base-path")
+    new GCSSettings(endpointUrl, basePath)
+  }
+
+  /**
+   * Java API: Reads from the given config.
+   */
+  def create(c: Config): GCSSettings = apply(c)
+
+  /** Scala API */
+  def apply(endpointUrl: String, basePath: String): GCSSettings =
+    new GCSSettings(endpointUrl, basePath)
+
+  /** Java API */
+  def create(endpointUrl: String, basePath: String): GCSSettings =
+    apply(endpointUrl, basePath)
+
+  /**
+   * Scala API: Creates [[GCSSettings]] from the [[com.typesafe.config.Config Config]] attached to an actor system.
+   */
+  def apply()(implicit system: ClassicActorSystemProvider): GCSSettings = apply(system.classicSystem)
+
+  /**
+   * Scala API: Creates [[GCSSettings]] from the [[com.typesafe.config.Config Config]] attached to an [[akka.actor.ActorSystem]].
+   */
+  def apply(system: ActorSystem): GCSSettings = apply(system.settings.config.getConfig(ConfigPath))
+
+  /**
+   * Java API: Creates [[GCSSettings]] from the [[com.typesafe.config.Config Config]] attached to an actor system.
+   */
+  def create(system: ClassicActorSystemProvider): GCSSettings = apply(system.classicSystem)
+
+  /**
+   * Java API: Creates [[GCSSettings]] from the [[com.typesafe.config.Config Config]] attached to an [[akka.actor.ActorSystem]].
+   */
+  def create(system: ActorSystem): GCSSettings = apply(system)
+}
+
+final class GCSSettings private (val endpointUrl: String, val basePath: String) {
+
+  private def copy(endpointUrl: String = endpointUrl, basePath: String = basePath): GCSSettings =
+    new GCSSettings(endpointUrl, basePath)
+
+  def withEndpointUrl(value: String): GCSSettings = copy(endpointUrl = value)
+
+  def withBasePath(value: String): GCSSettings = copy(basePath = value)
+
+  /** Java API */
+  def getEndpointUrl: String = endpointUrl
+
+  /** Java API */
+  def getBasePath: String = basePath
+
+  override def toString: String =
+    "GCSSettings(" +
+    s"endpointUrl=$endpointUrl," +
+    s"basePath=$basePath)"
+
+  override def equals(other: Any): Boolean = other match {
+    case that: GCSSettings =>
+      Objects.equals(this.endpointUrl, that.endpointUrl) &&
+      Objects.equals(this.basePath, that.basePath)
+  }
+
+  override def hashCode(): Int =
+    Objects.hash(this.endpointUrl, this.basePath)
+}

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCSExtSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCSExtSpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.googlecloud.storage
+
+import akka.actor.ActorSystem
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
+import com.typesafe.config.ConfigFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters._
+
+class GCSExtSpec extends AnyFlatSpec with Matchers with LogCapturing {
+  "GCSExt" should "reuse application config from actor system" in {
+    val endpointUrl = "https://storage.googleapis.com/"
+    val basePath = "/storage/v1"
+
+    val config = ConfigFactory.parseMap(
+      Map(
+        "alpakka.google.cloud-storage.endpoint-url" -> endpointUrl,
+        "alpakka.google.cloud-storage.base-path" -> basePath
+      ).asJava
+    )
+
+    implicit val system = ActorSystem.create("gcs", config)
+    val ext = GCSExt(system)
+
+    ext.settings.endpointUrl shouldBe endpointUrl
+    ext.settings.basePath shouldBe basePath
+  }
+
+}

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCSSettingsSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCSSettingsSpec.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.googlecloud.storage
+
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
+import com.typesafe.config.ConfigFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters._
+
+class GCSSettingsSpec extends AnyFlatSpec with Matchers with LogCapturing {
+  "GCSSettings" should "create settings from application config" in {
+    val endpointUrl = "https://storage.googleapis.com/"
+    val basePath = "/storage/v1"
+
+    val config = ConfigFactory.parseMap(
+      Map(
+        "endpoint-url" -> endpointUrl,
+        "base-path" -> basePath
+      ).asJava
+    )
+
+    val settings = GCSSettings(config)
+
+    settings.endpointUrl shouldBe endpointUrl
+    settings.basePath shouldBe basePath
+  }
+
+}


### PR DESCRIPTION
This PR adds a `GCSSettings` for `google-cloud-stroage` in order to give the ability to configure the host and the basePath. This is mainly done due to the fact that its currently not possible to test GCS using an implementation such as https://github.com/fsouza/fake-gcs-server since the endpoints are hardcoded at https://github.com/akka/alpakka/blob/f2971ca8a4a71b541cddbd5bf35af3a2a56efe71/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStream.scala#L33-L34.

Of note is there was a previous `GCStorageSettings` which was deprecated beforehand since there are a lot of settings that are shared between Google services. In order to not create conflicts/confusion, a seperate `GCSSettings` was created and it contains settings that are **only** specific to Google Cloud Storage so from a design PoV there shouldn't be any issues (common settings go into `GoogleSettings`, google service specific settings i.e. endpoints for a specific service go into the projects specific settings).

Tests were also made to make sure that the settings were correctly loaded. Afaik no binary incompatible changes were introduced.

If this PR is accepted/merged it means its also possible to use https://github.com/fsouza/fake-gcs-server to test GCS in alpakka in a similra fashion to how S3 is being tested with https://min.io/ (currently the tests just an in memory mock which is arguably not ideal).