### PR TITLE
S3: Add MultiPartUpload and ListParts APIs

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/Utils.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/Utils.scala
@@ -14,4 +14,15 @@ private[s3] object Utils {
     val tail = if (trimmed.startsWith("\"")) trimmed.drop(1) else trimmed
     if (tail.endsWith("\"")) tail.dropRight(1) else tail
   }
+
+  /**
+   * This method returns `None` if given an empty `String`. This is typically used when parsing
+   * XML since its common to have XML elements with an empty text value inside.
+   */
+  def emptyStringToOption(value: String): Option[String] =
+    if (value == "")
+      None
+    else
+      Some(value)
+
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -126,6 +126,23 @@ import scala.concurrent.{ExecutionContext, Future}
     s3Request(s3Location = s3Location, method = method)
       .withDefaultHeaders(headers)
 
+  def uploadManagementRequest(
+      s3Location: S3Location,
+      uploadId: String,
+      method: HttpMethod,
+      headers: Seq[HttpHeader] = Seq.empty[HttpHeader]
+  )(implicit conf: S3Settings): HttpRequest =
+    s3Request(s3Location,
+              method,
+              _.withQuery(
+                Query(
+                  Map(
+                    "uploadId" -> uploadId
+                  )
+                )
+              ))
+      .withDefaultHeaders(headers)
+
   def uploadRequest(s3Location: S3Location,
                     payload: Source[ByteString, _],
                     contentLength: Long,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -56,6 +56,57 @@ import scala.concurrent.{ExecutionContext, Future}
       .withUri(requestUri(bucket, None).withQuery(query))
   }
 
+  def listMultipartUploads(
+      bucket: String,
+      prefix: Option[String] = None,
+      continuationToken: Option[ListMultipartUploadContinuationToken] = None,
+      delimiter: Option[String] = None,
+      headers: Seq[HttpHeader] = Nil
+  )(implicit conf: S3Settings): HttpRequest = {
+
+    val baseQuery = Seq(
+      "prefix" -> prefix,
+      "delimiter" -> delimiter,
+      "key-marker" -> continuationToken.map(_.nextKeyMarker),
+      "upload-id-marker" -> continuationToken.map(_.nextUploadIdMarker)
+    ).collect { case (k, Some(v)) => k -> v }.toMap
+
+    // We need to manually construct a query here because the Uri for getting a list of multipart uploads requires a
+    // query param `uploads` which has no value and the current Query dsl doesn't support mixing query params that have
+    // values with query params that do not have values
+    val query =
+      if (baseQuery.isEmpty)
+        Query("uploads")
+      else {
+        val rest = baseQuery.map { case (k, v) => s"$k=$v" }.mkString("&")
+        Query(s"uploads&$rest")
+      }
+
+    HttpRequest(HttpMethods.GET)
+      .withHeaders(Host(requestAuthority(bucket, conf.s3RegionProvider.getRegion)) +: headers)
+      .withUri(requestUri(bucket, None).withQuery(query))
+  }
+
+  def listParts(
+      bucket: String,
+      key: String,
+      uploadId: String,
+      continuationToken: Option[Int],
+      headers: Seq[HttpHeader] = Nil
+  )(implicit conf: S3Settings): HttpRequest = {
+
+    val query = Query(
+      Seq(
+        "part-number-marker" -> continuationToken.map(_.toString),
+        "uploadId" -> Some(uploadId)
+      ).collect { case (k, Some(v)) => k -> v }.toMap
+    )
+
+    HttpRequest(HttpMethods.GET)
+      .withHeaders(Host(requestAuthority(bucket, conf.s3RegionProvider.getRegion)) +: headers)
+      .withUri(requestUri(bucket, Some(key)).withQuery(query))
+  }
+
   def getDownloadRequest(s3Location: S3Location,
                          method: HttpMethod = HttpMethods.GET,
                          s3Headers: Seq[HttpHeader] = Seq.empty,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
@@ -11,7 +11,7 @@ import akka.annotation.InternalApi
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport
 import akka.http.scaladsl.model.{ContentTypes, HttpCharsets, MediaTypes, Uri}
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
-import akka.stream.alpakka.s3.{ListBucketResultCommonPrefixes, ListBucketResultContents, Utils}
+import akka.stream.alpakka.s3._
 
 import scala.util.Try
 import scala.xml.NodeSeq
@@ -88,6 +88,111 @@ import scala.xml.NodeSeq
         val lastModified = Instant.parse((x \ "LastModified").text)
         val eTag = (x \ "ETag").text
         CopyPartResult(lastModified, Utils.removeQuotes(eTag))
+    }
+  }
+
+  implicit val listMultipartUploadsResultUnmarshaller: FromEntityUnmarshaller[ListMultipartUploadsResult] = {
+    nodeSeqUnmarshaller(MediaTypes.`application/xml` withCharset HttpCharsets.`UTF-8`).map {
+      case NodeSeq.Empty => throw Unmarshaller.NoContentException
+      case x =>
+        val bucket = (x \ "Bucket").text
+        val keyMarker = (x \ "KeyMarker").headOption.flatMap(x => Utils.emptyStringToOption(x.text))
+        val uploadIdMarker = (x \ "UploadIdMarker").headOption.flatMap(x => Utils.emptyStringToOption(x.text))
+        val nextKeyMarker = (x \ "NextKeyMarker").headOption.flatMap(x => Utils.emptyStringToOption(x.text))
+        val nextUploadIdMarker = (x \ "NextUploadIdMarker").headOption.flatMap(x => Utils.emptyStringToOption(x.text))
+        val delimiter = (x \ "Delimiter").headOption.flatMap(x => Utils.emptyStringToOption(x.text))
+        val maxUploads = (x \ "MaxUploads").text.toInt
+        val truncated = (x \ isTruncated).text == "true"
+        val uploads = (x \\ "Upload").map { u =>
+          val key = (u \ "Key").text
+          val uploadId = (u \ "UploadId").text
+
+          val initiator = (u \\ "Initiator").map { i =>
+            val id = (i \ "ID").text
+            val displayName = (i \ "DisplayName").text
+            AWSIdentity(id, displayName)
+          }.head
+
+          val owner = (u \\ "Owner").map { o =>
+            val id = (o \ "ID").text
+            val displayName = (o \ "DisplayName").text
+            AWSIdentity(id, displayName)
+          }.head
+
+          val storageClass = (u \ "StorageClass").text
+          val initiated = Instant.parse((u \ "Initiated").text)
+
+          ListMultipartUploadResultUploads(key, uploadId, initiator, owner, storageClass, initiated)
+        }
+
+        val commonPrefixes = (x \ "CommonPrefixes").map { cp =>
+          ListMultipartUploadResultCommonPrefixes((cp \ "Prefix").text)
+        }
+
+        ListMultipartUploadsResult(bucket,
+                                   keyMarker,
+                                   uploadIdMarker,
+                                   nextKeyMarker,
+                                   nextUploadIdMarker,
+                                   delimiter,
+                                   maxUploads,
+                                   truncated,
+                                   uploads,
+                                   commonPrefixes)
+    }
+  }
+
+  implicit val listPartsResultUnmarshaller: FromEntityUnmarshaller[ListPartsResult] = {
+    nodeSeqUnmarshaller(MediaTypes.`application/xml` withCharset HttpCharsets.`UTF-8`).map {
+      case NodeSeq.Empty => throw Unmarshaller.NoContentException
+      case x =>
+        val bucket = (x \ "Bucket").text
+        val key = (x \ "Key").text
+        val uploadId = (x \ "UploadId").text
+        val partNumberMarker =
+          (x \ "PartNumberMarker").headOption.flatMap(x => Utils.emptyStringToOption(x.text)).map(_.toInt)
+        val nextPartNumberMarker =
+          (x \ "NextPartNumberMarker").headOption.flatMap(x => Utils.emptyStringToOption(x.text)).map(_.toInt)
+
+        val maxParts = (x \ "MaxParts").text.toInt
+        val truncated = (x \ isTruncated).text == "true"
+
+        val parts = (x \\ "Part").map { u =>
+          val lastModified = Instant.parse((u \ "LastModified").text)
+          val eTag = (u \ "ETag").text
+          val partNumber = (u \\ "PartNumber").text.toInt
+          val size = (u \\ "Size").text.toLong
+
+          ListPartsResultParts(lastModified, eTag, partNumber, size)
+        }
+
+        val initiator = (x \\ "Initiator").map { i =>
+          val id = (i \ "ID").text
+          val displayName = (i \ "DisplayName").text
+          AWSIdentity(id, displayName)
+        }.head
+
+        val owner = (x \\ "Owner").map { o =>
+          val id = (o \ "ID").text
+          val displayName = (o \ "DisplayName").text
+          AWSIdentity(id, displayName)
+        }.head
+
+        val storageClass = (x \ "StorageClass").text
+
+        ListPartsResult(
+          bucket,
+          key,
+          uploadId,
+          partNumberMarker,
+          nextPartNumberMarker,
+          maxParts,
+          truncated,
+          parts,
+          initiator,
+          owner,
+          storageClass
+        )
     }
   }
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
@@ -642,6 +642,72 @@ object S3 {
     multipartUpload(bucket, key, ContentTypes.APPLICATION_OCTET_STREAM)
 
   /**
+   * Uploads a S3 Object by making multiple requests
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param uploadId the upload that you want to resume
+   * @param previousParts The previously uploaded parts ending just before when this upload will commence
+   * @param contentType an optional [[akka.http.javadsl.model.ContentType ContentType]]
+   * @param s3Headers any headers you want to add
+   * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.util.ByteString ByteString]]'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
+   */
+  def resumeMultipartUpload(bucket: String,
+                            key: String,
+                            uploadId: String,
+                            previousParts: java.lang.Iterable[Part],
+                            contentType: ContentType,
+                            s3Headers: S3Headers): Sink[ByteString, CompletionStage[MultipartUploadResult]] = {
+    S3Stream
+      .resumeMultipartUpload(S3Location(bucket, key),
+                             uploadId,
+                             previousParts.asScala.toList,
+                             contentType.asInstanceOf[ScalaContentType],
+                             s3Headers)
+      .mapMaterializedValue(_.toJava)
+      .asJava
+  }
+
+  /**
+   * Uploads a S3 Object by making multiple requests
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param uploadId the upload that you want to resume
+   * @param previousParts The previously uploaded parts ending just before when this upload will commence
+   * @param contentType an optional [[akka.http.javadsl.model.ContentType ContentType]]
+   * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.util.ByteString ByteString]]'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
+   */
+  def resumeMultipartUpload(bucket: String,
+                            key: String,
+                            uploadId: String,
+                            previousParts: java.lang.Iterable[Part],
+                            contentType: ContentType): Sink[ByteString, CompletionStage[MultipartUploadResult]] =
+    resumeMultipartUpload(bucket,
+                          key,
+                          uploadId,
+                          previousParts,
+                          contentType,
+                          S3Headers.empty.withCannedAcl(CannedAcl.Private))
+
+  /**
+   * Uploads a S3 Object by making multiple requests
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param uploadId the upload that you want to resume
+   * @param previousParts The previously uploaded parts ending just before when this upload will commence
+   * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.util.ByteString ByteString]]'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
+   */
+  def resumeMultipartUpload(
+      bucket: String,
+      key: String,
+      uploadId: String,
+      previousParts: java.lang.Iterable[Part]
+  ): Sink[ByteString, CompletionStage[MultipartUploadResult]] =
+    resumeMultipartUpload(bucket, key, uploadId, previousParts, ContentTypes.APPLICATION_OCTET_STREAM)
+
+  /**
    * Copy a S3 Object by making multiple requests.
    *
    * @param sourceBucket the source s3 bucket name

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
@@ -530,6 +530,77 @@ object S3 {
       .asJava
 
   /**
+   * Will return in progress or aborted multipart uploads. This will automatically page through all keys with the given parameters.
+   *
+   * @param bucket Which bucket that you list in-progress multipart uploads for
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @return [[akka.stream.scaladsl.Source Source]] of [[ListMultipartUploadResultUploads]]
+   */
+  def listMultipartUpload(bucket: String, prefix: Optional[String]): Source[ListMultipartUploadResultUploads, NotUsed] =
+    listMultipartUpload(bucket, prefix, S3Headers.empty)
+
+  /**
+   * Will return in progress or aborted multipart uploads. This will automatically page through all keys with the given parameters.
+   *
+   * @param bucket Which bucket that you list in-progress multipart uploads for
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.scaladsl.Source Source]] of [[ListMultipartUploadResultUploads]]
+   */
+  def listMultipartUpload(bucket: String,
+                          prefix: Optional[String],
+                          s3Headers: S3Headers): Source[ListMultipartUploadResultUploads, NotUsed] =
+    scaladsl.S3.listMultipartUpload(bucket, prefix.asScala, s3Headers).asJava
+
+  /**
+   * Will return in progress or aborted multipart uploads with optional prefix. This will automatically page through all keys with the given parameters.
+   *
+   * @param bucket Which bucket that you list in-progress multipart uploads for
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.scaladsl.Source Source]] of ([[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListMultipartUploadResultUploads ListMultipartUploadResultUploads]], [[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListMultipartUploadResultCommonPrefixes ListMultipartUploadResultCommonPrefixes]])
+   */
+  def listMultipartUploadAndCommonPrefixes(
+      bucket: String,
+      delimiter: String,
+      prefix: Optional[String],
+      s3Headers: S3Headers = S3Headers.empty
+  ): Source[akka.japi.Pair[java.util.List[ListMultipartUploadResultUploads],
+                           java.util.List[ListMultipartUploadResultCommonPrefixes]], NotUsed] =
+    S3Stream
+      .listMultipartUploadAndCommonPrefixes(bucket, delimiter, prefix.asScala, s3Headers)
+      .map {
+        case (uploads, commonPrefixes) => akka.japi.Pair(uploads.asJava, commonPrefixes.asJava)
+      }
+      .asJava
+
+  /**
+   * List uploaded parts for a specific upload. This will automatically page through all keys with the given parameters.
+   *
+   * @param bucket Under which bucket the upload parts are contained
+   * @param key They key where the parts were uploaded to
+   * @param uploadId Unique identifier of the upload for which you want to list the uploaded parts
+   * @return [[akka.stream.scaladsl.Source Source]] of [[ListPartsResultParts]]
+   */
+  def listParts(bucket: String, key: String, uploadId: String): Source[ListPartsResultParts, NotUsed] =
+    listParts(bucket, key, uploadId, S3Headers.empty)
+
+  /**
+   * List uploaded parts for a specific upload. This will automatically page through all keys with the given parameters.
+   *
+   * @param bucket Under which bucket the upload parts are contained
+   * @param key They key where the parts were uploaded to
+   * @param uploadId Unique identifier of the upload for which you want to list the uploaded parts
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.scaladsl.Source Source]] of [[ListPartsResultParts]]
+   */
+  def listParts(bucket: String,
+                key: String,
+                uploadId: String,
+                s3Headers: S3Headers): Source[ListPartsResultParts, NotUsed] =
+    scaladsl.S3.listParts(bucket, key, uploadId, s3Headers).asJava
+
+  /**
    * Uploads a S3 Object by making multiple requests
    *
    * @param bucket the s3 bucket name

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
@@ -1083,6 +1083,70 @@ object S3 {
   def checkIfBucketExistsSource(bucketName: String, s3Headers: S3Headers): Source[BucketAccess, NotUsed] =
     S3Stream.checkIfBucketExistsSource(bucketName, s3Headers).asJava
 
+  /**
+   * Delete all existing parts for a specific upload id
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
+   * @param bucketName Which bucket the upload is inside
+   * @param key The key for the upload
+   * @param uploadId Unique identifier of the upload
+   * @return [[java.util.concurrent.CompletionStage CompletionStage]] of type [[Done]] as API doesn't return any additional information
+   */
+  def deleteUpload(bucketName: String, key: String, uploadId: String)(
+      implicit system: ClassicActorSystemProvider,
+      attributes: Attributes = Attributes()
+  ): CompletionStage[Done] =
+    deleteUpload(bucketName, key, uploadId, S3Headers.empty)
+
+  /**
+   * Delete all existing parts for a specific upload
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
+   * @param bucketName Which bucket the upload is inside
+   * @param key The key for the upload
+   * @param uploadId Unique identifier of the upload
+   * @param s3Headers any headers you want to add
+   * @return [[java.util.concurrent.CompletionStage CompletionStage]] of type [[Done]] as API doesn't return any additional information
+   */
+  def deleteUpload(
+      bucketName: String,
+      key: String,
+      uploadId: String,
+      s3Headers: S3Headers
+  )(implicit system: ClassicActorSystemProvider, attributes: Attributes): CompletionStage[Done] =
+    S3Stream
+      .deleteUpload(bucketName, key, uploadId, s3Headers)(SystemMaterializer(system).materializer, attributes)
+      .toJava
+
+  /**
+   * Delete all existing parts for a specific upload
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
+   * @param bucketName Which bucket the upload is inside
+   * @param key The key for the upload
+   * @param uploadId Unique identifier of the upload
+   * @return [[akka.stream.javadsl.Source Source]] of type [[Done]] as API doesn't return any additional information
+   */
+  def deleteUploadSource(bucketName: String, key: String, uploadId: String): Source[Done, NotUsed] =
+    deleteUploadSource(bucketName, key, uploadId, S3Headers.empty)
+
+  /**
+   * Delete all existing parts for a specific upload
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
+   *
+   * @param bucketName Which bucket the upload is inside
+   * @param key The key for the upload
+   * @param uploadId Unique identifier of the upload
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.javadsl.Source Source]] of type [[Done]] as API doesn't return any additional information
+   */
+  def deleteUploadSource(bucketName: String,
+                         key: String,
+                         uploadId: String,
+                         s3Headers: S3Headers): Source[Done, NotUsed] =
+    S3Stream.deleteUploadSource(bucketName, key, uploadId, s3Headers).asJava
+
   private def func[T, R](f: T => R) = new akka.japi.function.Function[T, R] {
     override def apply(param: T): R = f(param)
   }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
@@ -708,6 +708,47 @@ object S3 {
     resumeMultipartUpload(bucket, key, uploadId, previousParts, ContentTypes.APPLICATION_OCTET_STREAM)
 
   /**
+   * Complete a multipart upload with an already given list of parts
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
+   * @param bucket bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param uploadId the upload that you want to complete
+   * @param parts A list of all of the parts for the multipart upload
+   * @return [[java.util.concurrent.CompletionStage CompletionStage]] of type [[MultipartUploadResult]]
+   */
+  def completeMultipartUpload(bucket: String, key: String, uploadId: String, parts: java.lang.Iterable[Part])(
+      implicit system: ClassicActorSystemProvider,
+      attributes: Attributes = Attributes()
+  ): CompletionStage[MultipartUploadResult] =
+    completeMultipartUpload(bucket, key, uploadId, parts, S3Headers.empty)
+
+  /**
+   * Complete a multipart upload with an already given list of parts
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
+   * @param bucket bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param uploadId the upload that you want to complete
+   * @param parts A list of all of the parts for the multipart upload
+   * @param s3Headers any headers you want to add
+   * @return [[java.util.concurrent.CompletionStage CompletionStage]] of type [[MultipartUploadResult]]
+   */
+  def completeMultipartUpload(
+      bucket: String,
+      key: String,
+      uploadId: String,
+      parts: java.lang.Iterable[Part],
+      s3Headers: S3Headers
+  )(implicit system: ClassicActorSystemProvider, attributes: Attributes): CompletionStage[MultipartUploadResult] =
+    S3Stream
+      .completeMultipartUpload(S3Location(bucket, key), uploadId, parts.asScala.toList, s3Headers)(
+        SystemMaterializer(system).materializer,
+        attributes
+      )
+      .toJava
+
+  /**
    * Copy a S3 Object by making multiple requests.
    *
    * @param sourceBucket the source s3 bucket name

--- a/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
@@ -4,11 +4,12 @@
 
 package akka.stream.alpakka.s3
 
+import java.time.Instant
 import java.util.{Objects, Optional}
-
 import akka.http.scaladsl.model.{DateTime, HttpHeader, IllegalUriException, Uri}
 import akka.http.scaladsl.model.headers._
 import akka.stream.alpakka.s3.AccessStyle.PathAccessStyle
+import com.github.ghik.silencer.silent
 
 import scala.collection.immutable.Seq
 import scala.collection.immutable
@@ -112,6 +113,247 @@ object MultipartUploadResult {
     etag,
     versionId.asScala
   )
+}
+
+final class AWSIdentity private (val id: String, val displayName: String) {
+
+  /** Java API */
+  def getId: String = id
+
+  /** Java API */
+  def getDisplayName: String = displayName
+
+  def withId(value: String): AWSIdentity = copy(id = value)
+  def withDisplayName(value: String): AWSIdentity = copy(displayName = value)
+
+  private def copy(id: String = id, displayName: String = displayName): AWSIdentity = new AWSIdentity(
+    id,
+    displayName
+  )
+
+  override def toString: String =
+    "AWSIdentity(" +
+    s"id=$id," +
+    s"displayName=$displayName" +
+    ")"
+
+  override def equals(other: Any): Boolean =
+    other match {
+      case that: AWSIdentity =>
+        Objects.equals(this.id, that.id) &&
+        Objects.equals(this.displayName, that.displayName)
+      case _ => false
+    }
+
+  override def hashCode(): Int =
+    Objects.hash(id, displayName)
+
+}
+
+object AWSIdentity {
+
+  /** Scala API */
+  def apply(id: String, displayName: String): AWSIdentity = new AWSIdentity(id, displayName)
+
+  /** Java API */
+  def create(id: String, displayName: String): AWSIdentity = apply(id, displayName)
+
+}
+
+final class ListMultipartUploadResultUploads private (val key: String,
+                                                      val uploadId: String,
+                                                      val initiator: AWSIdentity,
+                                                      val owner: AWSIdentity,
+                                                      val storageClass: String,
+                                                      val initiated: Instant) {
+
+  /** Java API */
+  def getKey: String = key
+
+  /** Java API */
+  def getUploadId: String = uploadId
+
+  /** Java API */
+  def getInitiator: AWSIdentity = initiator
+
+  /** Java API */
+  def getOwner: AWSIdentity = owner
+
+  /** Java API */
+  def getStorageClass: String = storageClass
+
+  /** Java API */
+  def getInitiated: Instant = initiated
+
+  def withKey(value: String): ListMultipartUploadResultUploads = copy(key = value)
+  def withUploadId(value: String): ListMultipartUploadResultUploads = copy(uploadId = value)
+  def withInitiator(value: AWSIdentity): ListMultipartUploadResultUploads = copy(initiator = value)
+  def withOwner(value: AWSIdentity): ListMultipartUploadResultUploads = copy(owner = value)
+  def withStorageClass(value: String): ListMultipartUploadResultUploads = copy(storageClass = value)
+  def withInitiated(value: Instant): ListMultipartUploadResultUploads = copy(initiated = value)
+
+  private def copy(key: String = key,
+                   uploadId: String = uploadId,
+                   initiator: AWSIdentity = initiator,
+                   owner: AWSIdentity = owner,
+                   storageClass: String = storageClass,
+                   initiated: Instant = initiated): ListMultipartUploadResultUploads =
+    new ListMultipartUploadResultUploads(
+      key = key,
+      uploadId = uploadId,
+      initiator = initiator,
+      owner = owner,
+      storageClass = storageClass,
+      initiated = initiated
+    )
+
+  override def toString: String =
+    "ListMultipartUploadResultUploads(" +
+    s"key=$key," +
+    s"uploadId=$uploadId," +
+    s"initiator=$initiator," +
+    s"owner=$owner," +
+    s"storageClass=$storageClass," +
+    s"initiated=$initiated" +
+    ")"
+
+  override def equals(other: Any): Boolean =
+    other match {
+      case that: ListMultipartUploadResultUploads =>
+        Objects.equals(this.key, that.key) &&
+        Objects.equals(this.uploadId, that.uploadId) &&
+        Objects.equals(this.initiator, that.initiator) &&
+        Objects.equals(this.owner, that.owner) &&
+        Objects.equals(this.storageClass, that.storageClass) &&
+        Objects.equals(this.initiated, that.initiated)
+      case _ => false
+    }
+
+  override def hashCode(): Int =
+    Objects.hash(key, uploadId, initiator, owner, storageClass, initiated)
+}
+
+object ListMultipartUploadResultUploads {
+
+  /** Scala API */
+  def apply(key: String,
+            uploadId: String,
+            initiator: AWSIdentity,
+            owner: AWSIdentity,
+            storageClass: String,
+            initiated: Instant): ListMultipartUploadResultUploads =
+    new ListMultipartUploadResultUploads(key, uploadId, initiator, owner, storageClass, initiated)
+
+  /** Java API */
+  def create(key: String,
+             uploadId: String,
+             initiator: AWSIdentity,
+             owner: AWSIdentity,
+             storageClass: String,
+             initiated: Instant): ListMultipartUploadResultUploads =
+    apply(key, uploadId, initiator, owner, storageClass, initiated)
+}
+
+final class ListMultipartUploadResultCommonPrefixes private (val prefix: String) {
+
+  /** Java API */
+  def getPrefix: String = prefix
+
+  def withPrefix(value: String): ListMultipartUploadResultCommonPrefixes = copy(prefix = value)
+
+  // Warning is only being generated here because there is a single argument in the parameter list. If more fields
+  // get added to ListMultipartUploadResultCommonPrefixes then the `@silent` is no longer needed
+  @silent
+  private def copy(prefix: String = prefix): ListMultipartUploadResultCommonPrefixes =
+    new ListMultipartUploadResultCommonPrefixes(prefix)
+
+  override def toString: String =
+    "ListMultipartUploadResultCommonPrefixes(" +
+    s"prefix=$prefix" +
+    ")"
+
+  override def equals(other: Any): Boolean =
+    other match {
+      case that: ListMultipartUploadResultCommonPrefixes =>
+        Objects.equals(this.prefix, that.prefix)
+      case _ => false
+    }
+
+  override def hashCode(): Int =
+    Objects.hash(prefix)
+}
+
+object ListMultipartUploadResultCommonPrefixes {
+
+  /** Scala API */
+  def apply(prefix: String): ListMultipartUploadResultCommonPrefixes =
+    new ListMultipartUploadResultCommonPrefixes(prefix)
+
+  /** Java API */
+  def create(prefix: String): ListMultipartUploadResultCommonPrefixes = apply(prefix)
+}
+
+final class ListPartsResultParts(val lastModified: Instant, val eTag: String, val partNumber: Int, val size: Long) {
+
+  /** Java API */
+  def getLastModified: Instant = lastModified
+
+  /** Java API */
+  def getETag: String = eTag
+
+  /** Java API */
+  def getPartNumber: Int = partNumber
+
+  /** Java API */
+  def getSize: Long = size
+
+  def withLastModified(value: Instant): ListPartsResultParts = copy(lastModified = value)
+  def withETag(value: String): ListPartsResultParts = copy(eTag = value)
+  def withPartNumber(value: Int): ListPartsResultParts = copy(partNumber = value)
+  def withSize(value: Long): ListPartsResultParts = copy(size = value)
+
+  private def copy(lastModified: Instant = lastModified,
+                   eTag: String = eTag,
+                   partNumber: Int = partNumber,
+                   size: Long = size): ListPartsResultParts =
+    new ListPartsResultParts(
+      lastModified,
+      eTag,
+      partNumber,
+      size
+    )
+
+  override def toString: String =
+    "ListPartsResultParts(" +
+    s"lastModified=$lastModified," +
+    s"eTag=$eTag," +
+    s"partNumber=$partNumber," +
+    s"size=$size" +
+    ")"
+
+  override def equals(other: Any): Boolean =
+    other match {
+      case that: ListPartsResultParts =>
+        Objects.equals(this.lastModified, that.lastModified) &&
+        Objects.equals(this.eTag, that.eTag) &&
+        Objects.equals(this.partNumber, that.partNumber) &&
+        Objects.equals(this.size, that.size)
+      case _ => false
+    }
+
+  override def hashCode(): Int =
+    Objects.hash(lastModified, eTag, Int.box(partNumber), Long.box(size))
+}
+
+object ListPartsResultParts {
+
+  /** Scala API */
+  def apply(lastModified: Instant, eTag: String, partNumber: Int, size: Long): ListPartsResultParts =
+    new ListPartsResultParts(lastModified, eTag, partNumber, size)
+
+  /** Java API */
+  def create(lastModified: Instant, eTag: String, partNumber: Int, size: Long): ListPartsResultParts =
+    apply(lastModified, eTag, partNumber, size)
 }
 
 /**

--- a/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
@@ -343,6 +343,8 @@ final class ListPartsResultParts(val lastModified: Instant, val eTag: String, va
 
   override def hashCode(): Int =
     Objects.hash(lastModified, eTag, Int.box(partNumber), Long.box(size))
+
+  def toPart: Part = Part(eTag, partNumber)
 }
 
 object ListPartsResultParts {
@@ -354,6 +356,47 @@ object ListPartsResultParts {
   /** Java API */
   def create(lastModified: Instant, eTag: String, partNumber: Int, size: Long): ListPartsResultParts =
     apply(lastModified, eTag, partNumber, size)
+}
+
+final class Part(val eTag: String, val partNumber: Int) {
+
+  /** Java API */
+  def getETag: String = eTag
+
+  /** Java API */
+  def getPartNumber: Int = partNumber
+
+  def withETag(value: String): Part = copy(eTag = value)
+
+  def withPartNumber(value: Int): Part = copy(partNumber = value)
+
+  private def copy(eTag: String = eTag, partNumber: Int = partNumber): Part = new Part(eTag, partNumber)
+
+  override def toString: String =
+    "Part(" +
+    s"eTag=$eTag," +
+    s"partNumber=$partNumber" +
+    ")"
+
+  override def equals(other: Any): Boolean =
+    other match {
+      case that: Part =>
+        Objects.equals(this.eTag, that.eTag) &&
+        Objects.equals(this.partNumber, that.partNumber)
+    }
+
+  override def hashCode(): Int =
+    Objects.hash(this.eTag, Int.box(this.partNumber))
+
+}
+
+object Part {
+
+  /** Scala API */
+  def apply(eTag: String, partNumber: Int): Part = new Part(eTag, partNumber)
+
+  /** Java API */
+  def create(eTag: String, partNumber: Int): Part = new Part(eTag, partNumber)
 }
 
 /**

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
@@ -462,6 +462,46 @@ object S3 {
       )
 
   /**
+   * Complete a multipart upload with an already given list of parts
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param uploadId the upload that you want to complete
+   * @param parts A list of all of the parts for the multipart upload
+   *
+   * @return [[scala.concurrent.Future Future]] of type [[MultipartUploadResult]]
+   */
+  def completeMultipartUpload(bucket: String, key: String, uploadId: String, parts: immutable.Iterable[Part])(
+      implicit system: ClassicActorSystemProvider,
+      attributes: Attributes = Attributes()
+  ): Future[MultipartUploadResult] =
+    S3Stream.completeMultipartUpload(S3Location(bucket, key), uploadId, parts, S3Headers.empty)
+
+  /**
+   * Complete a multipart upload with an already given list of parts
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param uploadId the upload that you want to complete
+   * @param parts A list of all of the parts for the multipart upload
+   * @param s3Headers any headers you want to add
+   *
+   * @return [[scala.concurrent.Future Future]] of type [[MultipartUploadResult]]
+   */
+  def completeMultipartUpload(
+      bucket: String,
+      key: String,
+      uploadId: String,
+      parts: immutable.Iterable[Part],
+      s3Headers: S3Headers
+  )(implicit system: ClassicActorSystemProvider, attributes: Attributes): Future[MultipartUploadResult] =
+    S3Stream.completeMultipartUpload(S3Location(bucket, key), uploadId, parts, s3Headers)
+
+  /**
    * Copy an S3 object from source bucket to target bucket using multi part copy upload.
    *
    * @param sourceBucket source s3 bucket name

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
@@ -571,4 +571,67 @@ object S3 {
    */
   def checkIfBucketExistsSource(bucketName: String, s3Headers: S3Headers): Source[BucketAccess, NotUsed] =
     S3Stream.checkIfBucketExistsSource(bucketName, s3Headers)
+
+  /**
+   * Delete all existing parts for a specific upload id
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
+   *
+   * @param bucketName Which bucket the upload is inside
+   * @param key The key for the upload
+   * @param uploadId Unique identifier of the upload
+   * @return [[scala.concurrent.Future Future]] of type [[Done]] as API doesn't return any additional information
+   */
+  def deleteUpload(bucketName: String, key: String, uploadId: String)(
+      implicit system: ClassicActorSystemProvider,
+      attributes: Attributes = Attributes()
+  ): Future[Done] =
+    deleteUpload(bucketName, key, uploadId, S3Headers.empty)
+
+  /**
+   * Delete all existing parts for a specific upload
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
+   * @param bucketName Which bucket the upload is inside
+   * @param key The key for the upload
+   * @param uploadId Unique identifier of the upload
+   * @param s3Headers any headers you want to add
+   * @return [[scala.concurrent.Future Future]] of type [[Done]] as API doesn't return any additional information
+   */
+  def deleteUpload(
+      bucketName: String,
+      key: String,
+      uploadId: String,
+      s3Headers: S3Headers
+  )(implicit system: ClassicActorSystemProvider, attributes: Attributes): Future[Done] =
+    S3Stream.deleteUpload(bucketName, key, uploadId, s3Headers)
+
+  /**
+   * Delete all existing parts for a specific upload
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
+   * @param bucketName Which bucket the upload is inside
+   * @param key The key for the upload
+   * @param uploadId Unique identifier of the upload
+   * @return [[akka.stream.scaladsl.Source Source]] of type [[Done]] as API doesn't return any additional information
+   */
+  def deleteUploadSource(bucketName: String, key: String, uploadId: String): Source[Done, NotUsed] =
+    deleteUploadSource(bucketName, key, uploadId, S3Headers.empty)
+
+  /**
+   * Delete all existing parts for a specific upload
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
+   *
+   * @param bucketName Which bucket the upload is inside
+   * @param key The key for the upload
+   * @param uploadId Unique identifier of the upload
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.scaladsl.Source Source]] of type [[Done]] as API doesn't return any additional information
+   */
+  def deleteUploadSource(bucketName: String,
+                         key: String,
+                         uploadId: String,
+                         s3Headers: S3Headers): Source[Done, NotUsed] =
+    S3Stream.deleteUploadSource(bucketName, key, uploadId, s3Headers)
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
@@ -264,6 +264,76 @@ object S3 {
     S3Stream.listBucketAndCommonPrefixes(bucket, delimiter, prefix, s3Headers)
 
   /**
+   * Will return in progress or aborted multipart uploads. This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html
+   * @param bucket Which bucket that you list in-progress multipart uploads for
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @return [[akka.stream.scaladsl.Source Source]] of [[ListMultipartUploadResultUploads]]
+   */
+  def listMultipartUpload(bucket: String, prefix: Option[String]): Source[ListMultipartUploadResultUploads, NotUsed] =
+    listMultipartUpload(bucket, prefix, S3Headers.empty)
+
+  /**
+   * Will return in progress or aborted multipart uploads. This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html
+   * @param bucket Which bucket that you list in-progress multipart uploads for
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.scaladsl.Source Source]] of [[ListMultipartUploadResultUploads]]
+   */
+  def listMultipartUpload(bucket: String,
+                          prefix: Option[String],
+                          s3Headers: S3Headers): Source[ListMultipartUploadResultUploads, NotUsed] =
+    S3Stream.listMultipartUpload(bucket, prefix, s3Headers)
+
+  /**
+   * Will return in progress or aborted multipart uploads with optional prefix. This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html
+   * @param bucket Which bucket that you list in-progress multipart uploads for
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.scaladsl.Source Source]] of ([[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListMultipartUploadResultUploads ListMultipartUploadResultUploads]], [[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListMultipartUploadResultCommonPrefixes ListMultipartUploadResultCommonPrefixes]])
+   */
+  def listMultipartUploadAndCommonPrefixes(
+      bucket: String,
+      delimiter: String,
+      prefix: Option[String] = None,
+      s3Headers: S3Headers = S3Headers.empty
+  ): Source[(Seq[ListMultipartUploadResultUploads], Seq[ListMultipartUploadResultCommonPrefixes]), NotUsed] =
+    S3Stream.listMultipartUploadAndCommonPrefixes(bucket, delimiter, prefix, s3Headers)
+
+  /**
+   * List uploaded parts for a specific upload. This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html
+   * @param bucket Under which bucket the upload parts are contained
+   * @param key They key where the parts were uploaded to
+   * @param uploadId Unique identifier of the upload for which you want to list the uploaded parts
+   * @return [[akka.stream.scaladsl.Source Source]] of [[ListPartsResultParts]]
+   */
+  def listParts(bucket: String, key: String, uploadId: String): Source[ListPartsResultParts, NotUsed] =
+    listParts(bucket, key, uploadId, S3Headers.empty)
+
+  /**
+   * List uploaded parts for a specific upload. This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html
+   * @param bucket Under which bucket the upload parts are contained
+   * @param key They key where the parts were uploaded to
+   * @param uploadId Unique identifier of the upload for which you want to list the uploaded parts
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.scaladsl.Source Source]] of [[ListPartsResultParts]]
+   */
+  def listParts(bucket: String,
+                key: String,
+                uploadId: String,
+                s3Headers: S3Headers): Source[ListPartsResultParts, NotUsed] =
+    S3Stream.listParts(bucket, key, uploadId, s3Headers)
+
+  /**
    * Uploads a S3 Object by making multiple requests
    *
    * @param bucket the s3 bucket name

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.s3.scaladsl
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import akka.http.scaladsl.Http
-import akka.stream.Attributes
+import akka.stream.{Attributes, KillSwitches, SharedKillSwitch}
 import akka.stream.alpakka.s3.AccessStyle.PathAccessStyle
 import akka.stream.alpakka.s3.BucketAccess.{AccessGranted, NotExists}
 import akka.stream.alpakka.s3._
@@ -25,6 +25,8 @@ import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.regions.providers._
 
+import scala.annotation.tailrec
+import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -371,6 +373,120 @@ trait S3IntegrationSpec
             .runFold(0)((result, _) => result + 1)
             .futureValue
         numOfKeysForPrefix shouldEqual 0
+    }
+  }
+
+  @tailrec
+  final def createStringCollectionWithMinChunkSizeRec(numberOfChunks: Int,
+                                                      stringAcc: BigInt = BigInt(0),
+                                                      currentChunk: Int = 0,
+                                                      result: Vector[ByteString] = Vector.empty): Vector[ByteString] = {
+
+    if (currentChunk == numberOfChunks)
+      result
+    else {
+      val newAcc = stringAcc + 1
+
+      result.lift(currentChunk) match {
+        case Some(currentString) =>
+          val newString = ByteString(s"\n${newAcc.toString()}")
+          if (currentString.length <= S3.MinChunkSize) {
+            val appendedString = currentString ++ newString
+            createStringCollectionWithMinChunkSizeRec(numberOfChunks,
+                                                      newAcc,
+                                                      currentChunk,
+                                                      result.updated(currentChunk, appendedString))
+          } else {
+            val newChunk = currentChunk + 1
+            val newResult = {
+              // // We are at the last index at this point so don't append a new entry at the end of the Vector
+              if (currentChunk == numberOfChunks - 1)
+                result
+              else
+                result :+ newString
+            }
+            createStringCollectionWithMinChunkSizeRec(numberOfChunks, newAcc, newChunk, newResult)
+          }
+        case None =>
+          // This case happens right at the start
+          val firstResult = Vector(ByteString("1"))
+          createStringCollectionWithMinChunkSizeRec(numberOfChunks, newAcc, currentChunk, firstResult)
+      }
+    }
+  }
+
+  /**
+   * Creates a `List` of `ByteString` where the size of each ByteString is guaranteed to be at least `S3.MinChunkSize`
+   * in size.
+   *
+   * This is useful for tests that deal with multipart uploads, since S3 persists a part everytime it receives
+   * `S3.MinChunkSize` bytes
+   * @param numberOfChunks The number of chunks to create
+   * @return A List of `ByteString` where each element is at least `S3.MinChunkSize` in size
+   */
+  def createStringCollectionWithMinChunkSize(numberOfChunks: Int): List[ByteString] =
+    createStringCollectionWithMinChunkSizeRec(numberOfChunks).toList
+
+  case object AbortException extends Exception("Aborting multipart upload")
+
+  def createSlowSource(data: immutable.Seq[ByteString],
+                       killSwitch: Option[SharedKillSwitch]): Source[ByteString, NotUsed] = {
+    val base = Source(data)
+      .throttle(1, 10.seconds)
+
+    killSwitch.fold(base)(ks => base.viaMat(ks.flow)(Keep.left))
+  }
+
+  def byteStringToMD5(byteString: ByteString): String = {
+    import java.math.BigInteger
+    import java.security.MessageDigest
+
+    val digest = MessageDigest.getInstance("MD5")
+    digest.update(byteString.asByteBuffer)
+    String.format("%032X", new BigInteger(1, digest.digest())).toLowerCase
+  }
+
+  it should "upload 1 file slowly, cancel it and retrieve a multipart upload + list part" in {
+    // This test doesn't work on Minio since minio doesn't properly implement this API, see
+    // https://github.com/minio/minio/issues/13246
+    assume(this.isInstanceOf[AWSS3IntegrationSpec])
+    val sourceKey = "original/file-slow.txt"
+    val sharedKillSwitch = KillSwitches.shared("abort-multipart-upload")
+
+    val inputData = createStringCollectionWithMinChunkSize(5)
+    val slowSource = createSlowSource(inputData, Some(sharedKillSwitch))
+
+    val multiPartUpload =
+      slowSource.toMat(S3.multipartUpload(defaultBucket, sourceKey).withAttributes(attributes))(Keep.right).run
+
+    val results = for {
+      _ <- akka.pattern.after(20.seconds)(Future {
+        sharedKillSwitch.abort(AbortException)
+      })
+      _ <- multiPartUpload.recover {
+        case AbortException => ()
+      }
+      incomplete <- S3.listMultipartUpload(defaultBucket, None).withAttributes(attributes).runWith(Sink.seq)
+      uploadIds = incomplete.collect {
+        case uploadPart if uploadPart.key == sourceKey => uploadPart.uploadId
+      }
+      parts <- Future.sequence(uploadIds.map { uploadId =>
+        S3.listParts(defaultBucket, sourceKey, uploadId).runWith(Sink.seq)
+      })
+    } yield (uploadIds, incomplete, parts.flatten)
+
+    whenReady(results) {
+      case (uploadIds, incompleteFiles, parts) =>
+        val inputsUntilAbort = inputData.slice(0, 3)
+        incompleteFiles.exists(_.key == sourceKey) shouldBe true
+        parts.nonEmpty shouldBe true
+        uploadIds.size shouldBe 1
+        parts.size shouldBe 3
+        parts.map(_.size) shouldBe inputsUntilAbort.map(_.utf8String.getBytes("UTF-8").length)
+        // In S3 the etag's are actually an MD5 hash of the contents of the part so we can use this to check
+        // that the data has been uploaded correctly and in the right order, see
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
+        parts.map(_.eTag.replaceAll("\"", "")) shouldBe inputsUntilAbort.map(byteStringToMD5)
     }
   }
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -494,6 +494,71 @@ trait S3IntegrationSpec
     }
   }
 
+  it should "upload 1 file slowly, cancel it and then resume it to complete the upload" in {
+    // This test doesn't work on Minio since minio doesn't properly implement this API, see
+    // https://github.com/minio/minio/issues/13246
+    assume(this.isInstanceOf[AWSS3IntegrationSpec])
+    val sourceKey = "original/file-slow-2.txt"
+    val sharedKillSwitch = KillSwitches.shared("abort-multipart-upload-2")
+
+    val inputData = createStringCollectionWithMinChunkSize(6)
+
+    val slowSource = createSlowSource(inputData, Some(sharedKillSwitch))
+
+    val multiPartUpload =
+      slowSource
+        .toMat(S3.multipartUpload(defaultBucket, sourceKey).withAttributes(attributes))(
+          Keep.right
+        )
+        .run
+
+    val results = for {
+      _ <- akka.pattern.after(25.seconds)(Future {
+        sharedKillSwitch.abort(AbortException)
+      })
+      _ <- multiPartUpload.recover {
+        case AbortException => ()
+      }
+      incomplete <- S3.listMultipartUpload(defaultBucket, None).withAttributes(attributes).runWith(Sink.seq)
+
+      uploadId = incomplete.collectFirst {
+        case uploadPart if uploadPart.key == sourceKey => uploadPart.uploadId
+      }.get
+
+      parts <- S3.listParts(defaultBucket, sourceKey, uploadId).runWith(Sink.seq)
+
+      remainingData = inputData.slice(3, 6)
+      _ <- Source(remainingData)
+        .toMat(
+          S3.resumeMultipartUpload(defaultBucket, sourceKey, uploadId, parts.map(_.toPart))
+            .withAttributes(attributes)
+        )(
+          Keep.right
+        )
+        .run
+
+      // This delay is here because sometimes there is a delay when you complete a large file and its
+      // actually downloadable
+      downloaded <- akka.pattern.after(5.seconds)(
+        S3.download(defaultBucket, sourceKey).withAttributes(attributes).runWith(Sink.head).flatMap {
+          case Some((downloadSource, _)) =>
+            downloadSource
+              .runWith(Sink.seq)
+          case None => throw new Exception(s"Expected object in bucket $defaultBucket with key $sourceKey")
+        }
+      )
+
+      _ <- S3.deleteObject(defaultBucket, sourceKey).withAttributes(attributes).runWith(Sink.head)
+    } yield downloaded
+
+    whenReady(results) { downloads =>
+      val fullDownloadedFile = downloads.fold(ByteString.empty)(_ ++ _)
+      val fullInputData = inputData.fold(ByteString.empty)(_ ++ _)
+
+      fullInputData.utf8String shouldEqual fullDownloadedFile.utf8String
+    }
+  }
+
   it should "make a bucket with given name" in {
     implicit val attr: Attributes = attributes
     val bucketName = "samplebucket1"


### PR DESCRIPTION
This PR adds https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html and https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html to the S3 API with the ultimate aim of being able to automatically resume a previously aborted S3 multipart upload with the same given bucket/key in the same way that `GCStorage.resumableUpload` works

The implementation of `S3.resumableUpload` still needs to be done using the rough logic outlined in https://stackoverflow.com/questions/53764876/resume-s3-multipart-upload-partetag. The basic implementation of `S3.resumableUpload` is as follows

1. Firstly check if there have been any previously aborted/cancelled multipart uploads for the same given key/bucket by using `S3.listMultipartUpload`. If not then just call already existing `S3.multipartUpload` otherwise
2. With the results of `S3.listMultipartUpload` call `S3.listPart` in order to retrieve the latest `eTag`/`partNumber` ?
3. Call `S3.multipartUpload` with that given `eTag`/`partNumber`

As an additional note I have generalized the `ListBucketState` to work with any arbitrary type rather than just `String` by renaming it to `S3PaginationState` and allowing it to accept a type parameter, this change was put into its own commit so that its clear. This is a necessary because the added API calls either have a different type for a `continuationToken` (i.e. `Int` instead of `String`) or the `continuationToken` requires multiples tokens rather than just a single one. 

@ennru I am creating this PR prematurely as a draft since it ended up being quite big and I want someone else to have a look at it to see if I am on the right track. I have commented on specific parts of the PR just to clarify things

. Here is a checklist of the things that need to be done
* [x] Add list multipart uploads to the S3 API
* [x] Add list parts to the S3 API
* [x] Add a test for multipart uploads
* [x] Add a test for the list part uploads
* [x] Handle issue where AWSIntegration tests work locally against a real S3 but don't work on Alpakka's Travis's CI
* [x] Add  AbortMultipartUpload (i.e. https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html) so that I can cleanup after test runs
* ~~[ ] Add a `S3.resumableUpload` function to the S3 API~~
* ~~[ ] Add a test for the `S3.resumableUpload`~~
* [X] Make `S3Stream.completeMultipartUpload` public with a proper Scala/Java API to allow users to manually complete a multipart upload on their will
* [x] Add `S3.resumeMultipartUpload` so that it accepts an optional sequence of  `partNumber`/`etag` along with an `uploadId` parameter that lets you resume an upload from a given arbitrary part. This will allow you to manually resume a multipart upload, its up to you retrieve these partNumbers/etags.
* [x] Test the adjustment to `S3.multipartUpload`