### PR TITLE
file: Fix exception message

### DIFF
--- a/file/src/main/java/akka/stream/alpakka/file/impl/DirectoryChangesSource.java
+++ b/file/src/main/java/akka/stream/alpakka/file/impl/DirectoryChangesSource.java
@@ -171,7 +171,7 @@ public final class DirectoryChangesSource<T> extends GraphStage<SourceShape<T>> 
               if (buffer.size() > maxBufferSize) {
                 failStage(
                     new RuntimeException(
-                        "Max event buffer size " + maxBufferSize + " reached for $path"));
+                        "Max event buffer size " + maxBufferSize + " reached for " + path));
               }
             }
           }


### PR DESCRIPTION
Properly include path in exception message.

I guess someone mixed up Scala and Java :wink: 