### PR TITLE
S3: Allow bucket creation besides `us-east-1` for AWS

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -199,6 +199,17 @@ import scala.concurrent.{ExecutionContext, Future}
     }
   }
 
+  def createBucketRegionPayload(region: Region)(implicit ec: ExecutionContext): Future[RequestEntity] = {
+    //Do not let the start LocationConstraint be on different lines
+    //  They tend to get split when this file is formatted by IntelliJ unless http://stackoverflow.com/a/19492318/1216965
+    // @formatter:off
+    val payload = <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+      <LocationConstraint>{region.id()}</LocationConstraint>
+    </CreateBucketConfiguration>
+    // @formatter:on
+    Marshal(payload).to[RequestEntity]
+  }
+
   def uploadCopyPartRequest(multipartCopy: MultipartCopy,
                             sourceVersionId: Option[String] = None,
                             s3Headers: Seq[HttpHeader] = Seq.empty)(implicit conf: S3Settings): HttpRequest = {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -649,6 +649,27 @@ trait S3IntegrationSpec
     request.futureValue should equal((Done, Done))
   }
 
+  it should "create a bucket in the non default us-east-1 region" in {
+    val bucketName = "samplebucketotherregion"
+
+    val request = for {
+      _ <- S3
+        .makeBucketSource(bucketName)
+        .withAttributes(S3Attributes.settings(otherRegionSettingsPathStyleAccess))
+        .runWith(Sink.head)
+      result <- S3
+        .checkIfBucketExistsSource(bucketName)
+        .withAttributes(S3Attributes.settings(otherRegionSettingsPathStyleAccess))
+        .runWith(Sink.head)
+      _ <- S3
+        .deleteBucketSource(bucketName)
+        .withAttributes(S3Attributes.settings(otherRegionSettingsPathStyleAccess))
+        .runWith(Sink.head)
+    } yield result
+
+    request.futureValue shouldEqual AccessGranted
+  }
+
   it should "throw an exception while deleting bucket that doesn't exist" in {
     implicit val attr: Attributes = attributes
     S3.deleteBucket(nonExistingBucket).failed.futureValue shouldBe an[S3Exception]


### PR DESCRIPTION
There seems to be another inconsistency between real AWS and Minio wrt creating a bucket in the non default region (i.e. `us-east-1`). With AWS S3 you need an addition XML payload (along with the host/access-style which typically contains the region) in order to create a bucket in a non default `us-east-1` region, with Minio this payload is not required. If the XML payload is not in the make bucket request on AWS you will get the following error

```
The unspecified location constraint is incompatible for the region specific endpoint this request was sent to..
```

For more details you can read https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html , there is already an existing issue at https://github.com/aws/aws-cli/issues/2603#issuecomment-422271388 which demonstrates the same problem (i.e. even with the aws cli you need to provide an additional `LocationConstraint`).

A test is provided but do note the fixes on this PR are only verifiable when running the test against `AWSS3IntegrationSpec`. With `MinioS3IntegrationSpec` you won't notice any difference.
