### PR TITLE
Rename ListMultipartUploadResultCommonPrefixes to CommonPrefixes

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
@@ -126,7 +126,7 @@ import scala.xml.NodeSeq
         }
 
         val commonPrefixes = (x \ "CommonPrefixes").map { cp =>
-          ListMultipartUploadResultCommonPrefixes((cp \ "Prefix").text)
+          CommonPrefixes((cp \ "Prefix").text)
         }
 
         ListMultipartUploadsResult(bucket,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -91,7 +91,7 @@ import scala.util.{Failure, Success, Try}
     maxUploads: Int,
     isTruncated: Boolean,
     uploads: Seq[ListMultipartUploadResultUploads],
-    commonPrefixes: Seq[ListMultipartUploadResultCommonPrefixes]
+    commonPrefixes: Seq[CommonPrefixes]
 ) {
 
   /**
@@ -311,8 +311,7 @@ import scala.util.{Failure, Success, Try}
       delimiter: String,
       prefix: Option[String] = None,
       s3Headers: S3Headers
-  ): Source[(immutable.Seq[ListMultipartUploadResultUploads], immutable.Seq[ListMultipartUploadResultCommonPrefixes]),
-            NotUsed] = {
+  ): Source[(immutable.Seq[ListMultipartUploadResultUploads], immutable.Seq[CommonPrefixes]), NotUsed] = {
 
     def listMultipartUploadCallContentsAndCommonPrefixes(
         token: Option[ListMultipartUploadContinuationToken]
@@ -329,8 +328,7 @@ import scala.util.{Failure, Success, Try}
         implicit val materializer: Materializer = mat
         implicit val attributes: Attributes = attr
         Source
-          .unfoldAsync[ListMultipartUploadState,
-                       (Seq[ListMultipartUploadResultUploads], Seq[ListMultipartUploadResultCommonPrefixes])](
+          .unfoldAsync[ListMultipartUploadState, (Seq[ListMultipartUploadResultUploads], Seq[CommonPrefixes])](
             Starting()
           ) {
             case Finished() => Future.successful(None)

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
@@ -558,15 +558,14 @@ object S3 {
    * @param bucket Which bucket that you list in-progress multipart uploads for
    * @param prefix Prefix of the keys you want to list under passed bucket
    * @param s3Headers any headers you want to add
-   * @return [[akka.stream.scaladsl.Source Source]] of ([[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListMultipartUploadResultUploads ListMultipartUploadResultUploads]], [[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListMultipartUploadResultCommonPrefixes ListMultipartUploadResultCommonPrefixes]])
+   * @return [[akka.stream.scaladsl.Source Source]] of ([[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListMultipartUploadResultUploads ListMultipartUploadResultUploads]], [[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.CommonPrefixes CommonPrefixes]])
    */
   def listMultipartUploadAndCommonPrefixes(
       bucket: String,
       delimiter: String,
       prefix: Optional[String],
       s3Headers: S3Headers = S3Headers.empty
-  ): Source[akka.japi.Pair[java.util.List[ListMultipartUploadResultUploads],
-                           java.util.List[ListMultipartUploadResultCommonPrefixes]], NotUsed] =
+  ): Source[akka.japi.Pair[java.util.List[ListMultipartUploadResultUploads], java.util.List[CommonPrefixes]], NotUsed] =
     S3Stream
       .listMultipartUploadAndCommonPrefixes(bucket, delimiter, prefix.asScala, s3Headers)
       .map {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
@@ -264,27 +264,27 @@ object ListMultipartUploadResultUploads {
     apply(key, uploadId, initiator, owner, storageClass, initiated)
 }
 
-final class ListMultipartUploadResultCommonPrefixes private (val prefix: String) {
+final class CommonPrefixes private (val prefix: String) {
 
   /** Java API */
   def getPrefix: String = prefix
 
-  def withPrefix(value: String): ListMultipartUploadResultCommonPrefixes = copy(prefix = value)
+  def withPrefix(value: String): CommonPrefixes = copy(prefix = value)
 
   // Warning is only being generated here because there is a single argument in the parameter list. If more fields
-  // get added to ListMultipartUploadResultCommonPrefixes then the `@silent` is no longer needed
+  // get added to CommonPrefixes then the `@silent` is no longer needed
   @silent
-  private def copy(prefix: String = prefix): ListMultipartUploadResultCommonPrefixes =
-    new ListMultipartUploadResultCommonPrefixes(prefix)
+  private def copy(prefix: String = prefix): CommonPrefixes =
+    new CommonPrefixes(prefix)
 
   override def toString: String =
-    "ListMultipartUploadResultCommonPrefixes(" +
+    "CommonPrefixes(" +
     s"prefix=$prefix" +
     ")"
 
   override def equals(other: Any): Boolean =
     other match {
-      case that: ListMultipartUploadResultCommonPrefixes =>
+      case that: CommonPrefixes =>
         Objects.equals(this.prefix, that.prefix)
       case _ => false
     }
@@ -293,14 +293,14 @@ final class ListMultipartUploadResultCommonPrefixes private (val prefix: String)
     Objects.hash(prefix)
 }
 
-object ListMultipartUploadResultCommonPrefixes {
+object CommonPrefixes {
 
   /** Scala API */
-  def apply(prefix: String): ListMultipartUploadResultCommonPrefixes =
-    new ListMultipartUploadResultCommonPrefixes(prefix)
+  def apply(prefix: String): CommonPrefixes =
+    new CommonPrefixes(prefix)
 
   /** Java API */
-  def create(prefix: String): ListMultipartUploadResultCommonPrefixes = apply(prefix)
+  def create(prefix: String): CommonPrefixes = apply(prefix)
 }
 
 final class ListPartsResultParts(val lastModified: Instant, val eTag: String, val partNumber: Int, val size: Long) {

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
@@ -296,14 +296,14 @@ object S3 {
    * @param bucket Which bucket that you list in-progress multipart uploads for
    * @param prefix Prefix of the keys you want to list under passed bucket
    * @param s3Headers any headers you want to add
-   * @return [[akka.stream.scaladsl.Source Source]] of ([[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListMultipartUploadResultUploads ListMultipartUploadResultUploads]], [[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListMultipartUploadResultCommonPrefixes ListMultipartUploadResultCommonPrefixes]])
+   * @return [[akka.stream.scaladsl.Source Source]] of ([[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListMultipartUploadResultUploads ListMultipartUploadResultUploads]], [[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.CommonPrefixes CommonPrefixes]])
    */
   def listMultipartUploadAndCommonPrefixes(
       bucket: String,
       delimiter: String,
       prefix: Option[String] = None,
       s3Headers: S3Headers = S3Headers.empty
-  ): Source[(Seq[ListMultipartUploadResultUploads], Seq[ListMultipartUploadResultCommonPrefixes]), NotUsed] =
+  ): Source[(Seq[ListMultipartUploadResultUploads], Seq[CommonPrefixes]), NotUsed] =
     S3Stream.listMultipartUploadAndCommonPrefixes(bucket, delimiter, prefix, s3Headers)
 
   /**


### PR DESCRIPTION
This PR changes `ListMultipartUploadResultCommonPrefixes` to  `CommonPrefixes`. This is done because I am doing an upcoming PR to add listing of object versions (see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html#AmazonS3-ListObjectVersions-response-CommonPrefixes) and I just realized that `CommonPrefixes` is actually a common datastructure in AWS that I want to reuse in that PR.

@ennru @johanandren If this can be merged before the next Alpakka release that would be great. This is a binary breaking change but the code that its breaking has not been released yet (see https://github.com/akka/alpakka/pull/2730)