### PR TITLE
Add ListBucketVersions and improve S3.deleteBucketContents

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,6 +217,9 @@ services:
       sh -c "
         aws --endpoint-url http://minio:9000 s3api create-bucket --bucket my.test.frankfurt
         aws --endpoint-url http://minio:9000 s3api create-bucket --bucket my-test-us-east-1
+        aws --endpoint-url http://minio:9000 s3api create-bucket --bucket my-bucket-with-versioning
+        # TODO: The following does not work due to https://github.com/akka/alpakka/issues/2750
+        aws --endpoint-url http://minio:9000 s3api put-bucket-versioning --bucket my-bucket-with-versioning --versioning-configuration Status=Enabled
       "
   mongo:
     image: mongo

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
@@ -553,12 +553,13 @@ object S3 {
     scaladsl.S3.listMultipartUpload(bucket, prefix.asScala, s3Headers).asJava
 
   /**
-   * Will return in progress or aborted multipart uploads with optional prefix. This will automatically page through all keys with the given parameters.
+   * Will return in progress or aborted multipart uploads with optional prefix and delimiter. This will automatically page through all keys with the given parameters.
    *
    * @param bucket Which bucket that you list in-progress multipart uploads for
    * @param prefix Prefix of the keys you want to list under passed bucket
+   * @param delimiter Delimiter to use for listing only one level of hierarchy
    * @param s3Headers any headers you want to add
-   * @return [[akka.stream.scaladsl.Source Source]] of ([[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListMultipartUploadResultUploads ListMultipartUploadResultUploads]], [[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.CommonPrefixes CommonPrefixes]])
+   * @return [[akka.stream.scaladsl.Source Source]] of [[akka.japi.Pair Pair]] of ([[java.util.List List]] of [[akka.stream.alpakka.s3.ListMultipartUploadResultUploads ListMultipartUploadResultUploads]], [[java.util.List List]] of [[akka.stream.alpakka.s3.CommonPrefixes CommonPrefixes]])
    */
   def listMultipartUploadAndCommonPrefixes(
       bucket: String,
@@ -598,6 +599,94 @@ object S3 {
                 uploadId: String,
                 s3Headers: S3Headers): Source[ListPartsResultParts, NotUsed] =
     scaladsl.S3.listParts(bucket, key, uploadId, s3Headers).asJava
+
+  /**
+   * List all versioned objects for a bucket with optional prefix. This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html
+   * @param bucket Which bucket that you list object versions for
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @return [[akka.stream.scaladsl.Source Source]] of [[akka.japi.Pair Pair]] of ([[java.util.List List]] of [[akka.stream.alpakka.s3.ListObjectVersionsResultVersions ListObjectVersionsResultVersions]], [[java.util.List List]] of [[akka.stream.alpakka.s3.DeleteMarkers DeleteMarkers]])
+   */
+  def listObjectVersions(
+      bucket: String,
+      prefix: Optional[String]
+  ): Source[akka.japi.Pair[java.util.List[ListObjectVersionsResultVersions], java.util.List[DeleteMarkers]], NotUsed] =
+    S3Stream
+      .listObjectVersions(bucket, prefix.asScala, S3Headers.empty)
+      .map {
+        case (versions, markers) => akka.japi.Pair(versions.asJava, markers.asJava)
+      }
+      .asJava
+
+  /**
+   * List all versioned objects for a bucket with optional prefix. This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html
+   * @param bucket Which bucket that you list object versions for
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.scaladsl.Source Source]] of [[akka.japi.Pair Pair]] of ([[java.util.List List]] of [[akka.stream.alpakka.s3.ListObjectVersionsResultVersions ListObjectVersionsResultVersions]], [[java.util.List List]] of [[akka.stream.alpakka.s3.DeleteMarkers DeleteMarkers]])
+   */
+  def listObjectVersions(
+      bucket: String,
+      prefix: Optional[String],
+      s3Headers: S3Headers
+  ): Source[akka.japi.Pair[java.util.List[ListObjectVersionsResultVersions], java.util.List[DeleteMarkers]], NotUsed] =
+    S3Stream
+      .listObjectVersions(bucket, prefix.asScala, s3Headers)
+      .map {
+        case (versions, markers) => akka.japi.Pair(versions.asJava, markers.asJava)
+      }
+      .asJava
+
+  /**
+   * List all versioned objects for a bucket with optional prefix and delimiter. This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html
+   * @param bucket Which bucket that you list object versions for
+   * @param delimiter Delimiter to use for listing only one level of hierarchy
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.scaladsl.Source Source]] of [[akka.japi.Pair Pair]] of ([[java.util.List List]] of [[akka.stream.alpakka.s3.ListObjectVersionsResultVersions ListObjectVersionsResultVersions]], [[java.util.List List]] of [[akka.stream.alpakka.s3.DeleteMarkers DeleteMarkers]])
+   */
+  def listObjectVersions(
+      bucket: String,
+      delimiter: String,
+      prefix: Optional[String],
+      s3Headers: S3Headers
+  ): Source[akka.japi.Pair[java.util.List[ListObjectVersionsResultVersions], java.util.List[DeleteMarkers]], NotUsed] =
+    S3Stream
+      .listObjectVersionsAndCommonPrefixes(bucket, delimiter, prefix.asScala, s3Headers)
+      .map {
+        case (versions, markers, _) =>
+          akka.japi.Pair(versions.asJava, markers.asJava)
+      }
+      .asJava
+
+  /**
+   * List all versioned objects for a bucket with optional prefix and delimiter. This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html
+   * @param bucket Which bucket that you list object versions for
+   * @param delimiter Delimiter to use for listing only one level of hierarchy
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.scaladsl.Source Source]] of [[akka.japi.tuple.Tuple3 Tuple3]] of ([[java.util.List List]] of [[akka.stream.alpakka.s3.ListObjectVersionsResultVersions ListObjectVersionsResultVersions]], [[java.util.List List]] of [[akka.stream.alpakka.s3.DeleteMarkers DeleteMarkers]], [[java.util.List List]] of [[akka.stream.alpakka.s3.CommonPrefixes CommonPrefixes]])
+   */
+  def listObjectVersionsAndCommonPrefixes(bucket: String,
+                                          delimiter: String,
+                                          prefix: Option[String],
+                                          s3Headers: S3Headers): Source[akka.japi.tuple.Tuple3[java.util.List[
+    ListObjectVersionsResultVersions
+  ], java.util.List[DeleteMarkers], java.util.List[CommonPrefixes]], NotUsed] =
+    S3Stream
+      .listObjectVersionsAndCommonPrefixes(bucket, delimiter, prefix, s3Headers)
+      .map {
+        case (versions, markers, prefixes) =>
+          akka.japi.tuple.Tuple3(versions.asJava, markers.asJava, prefixes.asJava)
+      }
+      .asJava
 
   /**
    * Uploads a S3 Object by making multiple requests

--- a/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
@@ -264,6 +264,210 @@ object ListMultipartUploadResultUploads {
     apply(key, uploadId, initiator, owner, storageClass, initiated)
 }
 
+final class ListObjectVersionsResultVersions private (val eTag: String,
+                                                      val isLatest: Boolean,
+                                                      val key: String,
+                                                      val lastModified: Instant,
+                                                      val owner: AWSIdentity,
+                                                      val size: Long,
+                                                      val storageClass: String,
+                                                      val versionId: String) {
+
+  /** Java API */
+  def getETag: String = eTag
+
+  /** Java API */
+  def getIsLatest: Boolean = isLatest
+
+  /** Java API */
+  def getKey: String = key
+
+  /** Java API */
+  def getLastModified: Instant = lastModified
+
+  /** Java API */
+  def getOwner: AWSIdentity = owner
+
+  /** Java API */
+  def getSize: Long = size
+
+  /** Java API */
+  def getStorageClass: String = storageClass
+
+  /** Java API */
+  def getVersionId: String = versionId
+
+  def withETag(value: String): ListObjectVersionsResultVersions = copy(eTag = value)
+
+  def withIsLatest(value: Boolean): ListObjectVersionsResultVersions = copy(isLatest = value)
+
+  def withKey(value: String): ListObjectVersionsResultVersions = copy(key = value)
+
+  def withLastModified(value: Instant): ListObjectVersionsResultVersions = copy(lastModified = value)
+
+  def withOwner(value: AWSIdentity): ListObjectVersionsResultVersions = copy(owner = value)
+
+  def withSize(value: Long): ListObjectVersionsResultVersions = copy(size = value)
+
+  def withStorageClass(value: String): ListObjectVersionsResultVersions = copy(storageClass = value)
+
+  def withVersionId(value: String): ListObjectVersionsResultVersions = copy(versionId = value)
+
+  private def copy(eTag: String = eTag,
+                   isLatest: Boolean = isLatest,
+                   key: String = key,
+                   lastModified: Instant = lastModified,
+                   owner: AWSIdentity = owner,
+                   size: Long = size,
+                   storageClass: String = storageClass,
+                   versionId: String = versionId): ListObjectVersionsResultVersions =
+    new ListObjectVersionsResultVersions(
+      eTag = eTag,
+      isLatest = isLatest,
+      key = key,
+      lastModified = lastModified,
+      owner = owner,
+      size = size,
+      storageClass = storageClass,
+      versionId = versionId
+    )
+
+  override def toString: String =
+    "ListObjectVersionsResultVersions(" +
+    s"eTag=$eTag," +
+    s"isLatest=$isLatest," +
+    s"key=$key," +
+    s"lastModified=$lastModified," +
+    s"owner=$owner," +
+    s"size=$size," +
+    s"storageClass=$storageClass," +
+    s"versionId=$versionId" +
+    ")"
+
+  override def equals(other: Any): Boolean =
+    other match {
+      case that: ListObjectVersionsResultVersions =>
+        Objects.equals(this.eTag, that.eTag) &&
+        Objects.equals(this.isLatest, that.isLatest) &&
+        Objects.equals(this.key, that.key) &&
+        Objects.equals(this.lastModified, that.lastModified) &&
+        Objects.equals(this.owner, that.owner) &&
+        Objects.equals(this.size, that.size) &&
+        Objects.equals(this.storageClass, that.storageClass) &&
+        Objects.equals(this.versionId, that.versionId)
+      case _ => false
+    }
+
+  override def hashCode(): Int =
+    Objects.hash(eTag, Boolean.box(isLatest), key, lastModified, owner, Long.box(size), storageClass, versionId)
+}
+
+object ListObjectVersionsResultVersions {
+
+  /** Scala API */
+  def apply(eTag: String,
+            isLatest: Boolean,
+            key: String,
+            lastModified: Instant,
+            owner: AWSIdentity,
+            size: Long,
+            storageClass: String,
+            versionId: String): ListObjectVersionsResultVersions =
+    new ListObjectVersionsResultVersions(eTag, isLatest, key, lastModified, owner, size, storageClass, versionId)
+
+  /** Java API */
+  def create(eTag: String,
+             isLatest: Boolean,
+             key: String,
+             lastModified: Instant,
+             owner: AWSIdentity,
+             size: Long,
+             storageClass: String,
+             versionId: String): ListObjectVersionsResultVersions =
+    apply(eTag, isLatest, key, lastModified, owner, size, storageClass, versionId)
+}
+
+final class DeleteMarkers private (val isLatest: Boolean,
+                                   val key: String,
+                                   val lastModified: Instant,
+                                   val owner: AWSIdentity,
+                                   val versionId: String) {
+
+  /** Java API */
+  def getIsLatest: Boolean = isLatest
+
+  /** Java API */
+  def getKey: String = key
+
+  /** Java API */
+  def getLastModified: Instant = lastModified
+
+  /** Java API */
+  def getOwner: AWSIdentity = owner
+
+  /** Java API */
+  def getVersionId: String = versionId
+
+  def withIsLatest(value: Boolean): DeleteMarkers = copy(isLatest = value)
+
+  def withKey(value: String): DeleteMarkers = copy(key = value)
+
+  def withLastModified(value: Instant): DeleteMarkers = copy(lastModified = value)
+
+  def withOwner(value: AWSIdentity): DeleteMarkers = copy(owner = value)
+
+  def withVersionId(value: String): DeleteMarkers = copy(versionId = value)
+
+  private def copy(isLatest: Boolean = isLatest,
+                   key: String = key,
+                   lastModified: Instant = lastModified,
+                   owner: AWSIdentity = owner,
+                   versionId: String = versionId): DeleteMarkers =
+    new DeleteMarkers(isLatest, key, lastModified, owner, versionId)
+
+  override def toString: String =
+    "DeleteMarkers(" +
+    s"isLatest=$isLatest," +
+    s"key=$key," +
+    s"lastModified=$lastModified," +
+    s"owner=$owner," +
+    s"versionId=$versionId" +
+    ")"
+
+  override def equals(other: Any): Boolean =
+    other match {
+      case that: DeleteMarkers =>
+        Objects.equals(this.isLatest, that.isLatest) &&
+        Objects.equals(this.key, that.key) &&
+        Objects.equals(this.lastModified, that.lastModified) &&
+        Objects.equals(this.owner, that.owner) &&
+        Objects.equals(this.versionId, that.versionId)
+      case _ => false
+    }
+
+  override def hashCode(): Int =
+    Objects.hash(Boolean.box(isLatest), key, lastModified, owner, owner, versionId)
+}
+
+object DeleteMarkers {
+
+  /** Scala API */
+  def apply(isLatest: Boolean,
+            key: String,
+            lastModified: Instant,
+            owner: AWSIdentity,
+            versionId: String): DeleteMarkers =
+    new DeleteMarkers(isLatest, key, lastModified, owner, versionId)
+
+  /** Java API */
+  def create(isLatest: Boolean,
+             key: String,
+             lastModified: Instant,
+             owner: AWSIdentity,
+             versionId: String): DeleteMarkers =
+    apply(isLatest, key, lastModified, owner, versionId)
+}
+
 final class CommonPrefixes private (val prefix: String) {
 
   /** Java API */

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
@@ -290,10 +290,11 @@ object S3 {
     S3Stream.listMultipartUpload(bucket, prefix, s3Headers)
 
   /**
-   * Will return in progress or aborted multipart uploads with optional prefix. This will automatically page through all keys with the given parameters.
+   * Will return in progress or aborted multipart uploads with optional prefix and delimiter. This will automatically page through all keys with the given parameters.
    *
    * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html
    * @param bucket Which bucket that you list in-progress multipart uploads for
+   * @param delimiter Delimiter to use for listing only one level of hierarchy
    * @param prefix Prefix of the keys you want to list under passed bucket
    * @param s3Headers any headers you want to add
    * @return [[akka.stream.scaladsl.Source Source]] of ([[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListMultipartUploadResultUploads ListMultipartUploadResultUploads]], [[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.CommonPrefixes CommonPrefixes]])
@@ -333,6 +334,76 @@ object S3 {
                 uploadId: String,
                 s3Headers: S3Headers): Source[ListPartsResultParts, NotUsed] =
     S3Stream.listParts(bucket, key, uploadId, s3Headers)
+
+  /**
+   * List all versioned objects for a bucket with optional prefix. This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html
+   * @param bucket Which bucket that you list object versions for
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @return [[akka.stream.scaladsl.Source Source]] of ([[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListObjectVersionsResultVersions ListObjectVersionsResultVersions]], [[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.DeleteMarkers DeleteMarkers]])
+   */
+  def listObjectVersions(
+      bucket: String,
+      prefix: Option[String]
+  ): Source[(Seq[ListObjectVersionsResultVersions], Seq[DeleteMarkers]), NotUsed] =
+    S3Stream.listObjectVersions(bucket, prefix, S3Headers.empty)
+
+  /**
+   * List all versioned objects for a bucket with optional prefix. This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html
+   * @param bucket Which bucket that you list object versions for
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.scaladsl.Source Source]] of ([[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListObjectVersionsResultVersions ListObjectVersionsResultVersions]], [[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.DeleteMarkers DeleteMarkers]])
+   */
+  def listObjectVersions(
+      bucket: String,
+      prefix: Option[String],
+      s3Headers: S3Headers
+  ): Source[(Seq[ListObjectVersionsResultVersions], Seq[DeleteMarkers]), NotUsed] =
+    S3Stream.listObjectVersions(bucket, prefix, s3Headers)
+
+  /**
+   * List all versioned objects for a bucket with optional prefix and delimiter. This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html
+   * @param bucket Which bucket that you list object versions for
+   * @param delimiter Delimiter to use for listing only one level of hierarchy
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.scaladsl.Source Source]] of ([[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListObjectVersionsResultVersions ListObjectVersionsResultVersions]], [[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.DeleteMarkers DeleteMarkers]])
+   */
+  def listObjectVersions(
+      bucket: String,
+      delimiter: String,
+      prefix: Option[String],
+      s3Headers: S3Headers
+  ): Source[(Seq[ListObjectVersionsResultVersions], Seq[DeleteMarkers]), NotUsed] =
+    S3Stream.listObjectVersionsAndCommonPrefixes(bucket, delimiter, prefix, s3Headers).map {
+      case (versions, markers, _) =>
+        (versions, markers)
+    }
+
+  /**
+   * List all versioned objects for a bucket with optional prefix and delimiter. This will automatically page through all keys with the given parameters.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html
+   * @param bucket Which bucket that you list object versions for
+   * @param delimiter Delimiter to use for listing only one level of hierarchy
+   * @param prefix Prefix of the keys you want to list under passed bucket
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.scaladsl.Source Source]] of ([[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.ListObjectVersionsResultVersions ListObjectVersionsResultVersions]], [[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.DeleteMarkers DeleteMarkers]], [[scala.collection.Seq Seq]] of [[akka.stream.alpakka.s3.CommonPrefixes CommonPrefixes]])
+   */
+  def listObjectVersionsAndCommonPrefixes(bucket: String,
+                                          delimiter: String,
+                                          prefix: Option[String],
+                                          s3Headers: S3Headers): Source[
+    (Seq[ListObjectVersionsResultVersions], Seq[DeleteMarkers], Seq[CommonPrefixes]),
+    NotUsed
+  ] =
+    S3Stream.listObjectVersionsAndCommonPrefixes(bucket, delimiter, prefix, s3Headers)
 
   /**
    * Uploads a S3 Object by making multiple requests


### PR DESCRIPTION
This PR adds the listBucketVersions API and also improves the S3.deteBucketContents so that it also deletes all version objects (previously if you had versioned objects then the `S3.deleteBucketContents` wouldn't properly clear the bucket which means that a consequent `S3.deleteBucket` would fail). This also mirrors S3's official documentation on how to clear a bucket, i.e. see https://docs.aws.amazon.com/AmazonS3/latest/userguide/delete-bucket.html.

There were also some minor documentation errors with `listMultipartUploadAndCommonPrefixes` which I fixed.