### PR TITLE
Handle ListMultipartUpload token only has one token defined

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -67,8 +67,8 @@ import scala.concurrent.{ExecutionContext, Future}
     val baseQuery = Seq(
       "prefix" -> prefix,
       "delimiter" -> delimiter,
-      "key-marker" -> continuationToken.map(_.nextKeyMarker),
-      "upload-id-marker" -> continuationToken.map(_.nextUploadIdMarker)
+      "key-marker" -> continuationToken.flatMap(_.nextKeyMarker),
+      "upload-id-marker" -> continuationToken.flatMap(_.nextUploadIdMarker)
     ).collect { case (k, Some(v)) => k -> v }.toMap
 
     // We need to manually construct a query here because the Uri for getting a list of multipart uploads requires a

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -77,8 +77,8 @@ import scala.util.{Failure, Success, Try}
                                                              commonPrefixes: Seq[ListBucketResultCommonPrefixes])
 
 /** Internal Api */
-@InternalApi private[impl] final case class ListMultipartUploadContinuationToken(nextKeyMarker: String,
-                                                                                 nextUploadIdMarker: String)
+@InternalApi private[impl] final case class ListMultipartUploadContinuationToken(nextKeyMarker: Option[String],
+                                                                                 nextUploadIdMarker: Option[String])
 
 /** Internal Api */
 @InternalApi private[impl] final case class ListMultipartUploadsResult(
@@ -96,13 +96,14 @@ import scala.util.{Failure, Success, Try}
 
   /**
    * The continuation token for listing MultipartUpload is a union of both the nextKeyMarker
-   * and the nextUploadIdMarker
+   * and the nextUploadIdMarker. Even though both `nextKeyMarker` and `nextUploadIdMarker` should be
+   * defined (if applicable), for safety reasons we also handle the case where one is defined and not the other.
    */
   def continuationToken: Option[ListMultipartUploadContinuationToken] =
-    for {
-      keyMarker <- nextKeyMarker
-      uploadIdMarker <- nextUploadIdMarker
-    } yield ListMultipartUploadContinuationToken(keyMarker, uploadIdMarker)
+    (nextKeyMarker, nextUploadIdMarker) match {
+      case (None, None) => None
+      case (key, uploadId) => Some(ListMultipartUploadContinuationToken(key, uploadId))
+    }
 
 }
 


### PR DESCRIPTION
Although theoretically speaking when dealing with continuation tokens from `ListMultipartUpload` either both `nextUploadId`/`nextKeyMarker` should be define **OR** neither of them should be defined (i.e. you are at the end of pagination), to be on the safe side this change will also handle the case where either one or the other is defined.