### PR TITLE
Elasticsearch: forward headers on bulk insert in ElasticsearchSimpleFlowStage

### DIFF
--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
@@ -78,6 +78,7 @@ private[elasticsearch] final class ElasticsearchSimpleFlowStage[T, C](
         val request = HttpRequest(HttpMethods.POST)
           .withUri(uri)
           .withEntity(HttpEntity(NDJsonProtocol.`application/x-ndjson`, json))
+          .withHeaders(settings.connection.headers)
 
         ElasticsearchApi
           .executeRequest(


### PR DESCRIPTION
# Problem
enable to authenticate without login/password

# Identification
headers not forward on `onPush()` method in ElasticsearchSimpleFlowStage https://github.com/akka/alpakka/blob/3f1b06faa0d179adca5f072a1b6487acab1fb389/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala#L78-L80

# Resolution
forward header from ElasticsearchConnectionSettings headers to HttpRequest header
