### PR TITLE
S3: Add multipart upload with context

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
@@ -26,7 +26,7 @@ import scala.xml.NodeSeq
     nodeSeqUnmarshaller(MediaTypes.`application/xml`, ContentTypes.`application/octet-stream`) map {
       case NodeSeq.Empty => throw Unmarshaller.NoContentException
       case x =>
-        MultipartUpload(S3Location((x \ "Bucket").text, (x \ "Key").text), (x \ "UploadId").text)
+        MultipartUpload((x \ "Bucket").text, (x \ "Key").text, (x \ "UploadId").text)
     }
   }
 

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/MemoryWithContext.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/MemoryWithContext.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.s3.impl
+
+import akka.annotation.InternalApi
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.util.ByteString
+
+import scala.collection.immutable
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Internal Api
+ *
+ * Buffers the complete incoming stream into memory, which can then be read several times afterwards.
+ *
+ * The stage waits for the incoming stream containing a context to complete. After that, it emits a single Chunk item
+ * on its output which contains the latest context at that point in time. The Chunk contains a `ByteString` source that
+ * can be materialized multiple times, and the total size of the file.
+ *
+ * @param maxSize Maximum size to buffer
+ */
+@InternalApi private[impl] final class MemoryWithContext[C](maxSize: Int)
+    extends GraphStage[FlowShape[(ByteString, C), (Chunk, immutable.Iterable[C])]] {
+  val in = Inlet[(ByteString, C)]("MemoryBuffer.in")
+  val out = Outlet[(Chunk, immutable.Iterable[C])]("MemoryBuffer.out")
+  override val shape = FlowShape.of(in, out)
+
+  override def createLogic(attr: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+      private var buffer = ByteString.empty
+      private val contextBuffer: ListBuffer[C] = new ListBuffer[C]()
+
+      override def onPull(): Unit = if (isClosed(in)) emit() else pull(in)
+
+      override def onPush(): Unit = {
+        val (elem, context) = grab(in)
+        if (buffer.size + elem.size > maxSize) {
+          failStage(new IllegalStateException("Buffer size of " + maxSize + " bytes exceeded."))
+        } else {
+          buffer ++= elem
+          // This is a corner case where context can have a sentinel value of null which represents the initial empty
+          // stream. We don't want to add null's into the final output
+          if (context != null)
+            contextBuffer.append(context)
+          pull(in)
+        }
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        if (isAvailable(out)) emit()
+        completeStage()
+      }
+
+      private def emit(): Unit = emit(out, (MemoryChunk(buffer), contextBuffer.toList), () => completeStage())
+
+      setHandlers(in, out, this)
+    }
+
+}

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/SplitAfterSizeWithContext.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/SplitAfterSizeWithContext.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.s3.impl
+
+import akka.annotation.InternalApi
+import akka.stream.scaladsl.{Flow, SubFlow}
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.util.ByteString
+
+/**
+ * Internal Api
+ *
+ * Splits up a byte stream source into sub-flows of a minimum size while maintaining a Context. Does not attempt to
+ * create chunks of an exact size. Unlike `SplitAfterSize` there is no maximum size since this would imply splitting
+ * up a Context which is not possible to do if the Context is generic.
+ *
+ * This also means that `SplitAfterSizeContext` currently doesn't support buffering since that would require a way to
+ * serialize the Context in the case of a disk buffer which is currently unsupported (we would have to add in a
+ * C => ByteString serializer in the public API)
+ *
+ */
+@InternalApi private[impl] object SplitAfterSizeWithContext {
+  def apply[I, M, C](minChunkSize: Int)(
+      in: Flow[(I, C), (ByteString, C), M]
+  ): SubFlow[(ByteString, C), M, in.Repr, in.Closed] = {
+
+    in.via(insertMarkers(minChunkSize)).splitWhen(_ == NewStream).collect {
+      case (bs: ByteString, context: C @unchecked) => (bs, context)
+    }
+  }
+
+  private case object NewStream
+
+  private def insertMarkers[C](minChunkSize: Long) =
+    new GraphStage[FlowShape[(ByteString, C), Any]] {
+      val in = Inlet[(ByteString, C)]("SplitAfterSize.in")
+      val out = Outlet[Any]("SplitAfterSize.out")
+      override val shape = FlowShape.of(in, out)
+
+      override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+        new GraphStageLogic(shape) with OutHandler with InHandler {
+          var count: Int = 0
+          override def onPull(): Unit = pull(in)
+
+          override def onPush(): Unit = {
+            val (elem, context) = grab(in)
+            count += elem.size
+            if (count >= minChunkSize) {
+              count = 0
+              emitMultiple(out, (elem, context) :: NewStream :: Nil)
+            } else emit(out, (elem, context))
+          }
+
+          setHandlers(in, out, this)
+        }
+    }
+
+}

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
@@ -788,6 +788,11 @@ object S3 {
    * @param chunkUploadSink A sink that's a callback which gets executed whenever an entire Chunk is uploaded to S3
    *                        (successfully or unsuccessfully). Since each chunk can contain more than one emitted element
    *                        from the original flow/source you get provided with the list of context's.
+   *
+   *                        The internal implementation uses `Flow.alsoTo` for `chunkUploadSink` which means that
+   *                        backpressure is applied to the upload stream if `chunkUploadSink` is too slow, likewise any
+   *                        failure will also be propagated to the upload stream. Sink Materialization is also shared
+   *                        with the returned `Sink`.
    * @param contentType an optional [[akka.http.javadsl.model.ContentType ContentType]]
    * @param s3Headers any headers you want to add
    * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.japi.Pair Pair]] of ([[akka.util.ByteString ByteString]] of [[C]])'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
@@ -828,6 +833,11 @@ object S3 {
    * @param chunkUploadSink A sink that's a callback which gets executed whenever an entire Chunk is uploaded to S3
    *                        (successfully or unsuccessfully). Since each chunk can contain more than one emitted element
    *                        from the original flow/source you get provided with the list of context's.
+   *
+   *                        The internal implementation uses `Flow.alsoTo` for `chunkUploadSink` which means that
+   *                        backpressure is applied to the upload stream if `chunkUploadSink` is too slow, likewise any
+   *                        failure will also be propagated to the upload stream. Sink Materialization is also shared
+   *                        with the returned `Sink`.
    * @param contentType an optional [[akka.http.javadsl.model.ContentType ContentType]]
    * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.japi.Pair Pair]] of ([[akka.util.ByteString ByteString]] of [[C]])'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
    */
@@ -856,6 +866,11 @@ object S3 {
    * @param chunkUploadSink A sink that's a callback which gets executed whenever an entire Chunk is uploaded to S3
    *                        (successfully or unsuccessfully). Since each chunk can contain more than one emitted element
    *                        from the original flow/source you get provided with the list of context's.
+   *
+   *                        The internal implementation uses `Flow.alsoTo` for `chunkUploadSink` which means that
+   *                        backpressure is applied to the upload stream if `chunkUploadSink` is too slow, likewise any
+   *                        failure will also be propagated to the upload stream. Sink Materialization is also shared
+   *                        with the returned `Sink`.
    * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.japi.Pair Pair]] of ([[akka.util.ByteString ByteString]] of [[C]])'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUploadWithContext[C](
@@ -947,6 +962,11 @@ object S3 {
    * @param chunkUploadSink A sink that's a callback which gets executed whenever an entire Chunk is uploaded to S3
    *                        (successfully or unsuccessfully). Since each chunk can contain more than one emitted element
    *                        from the original flow/source you get provided with the list of context's.
+   *
+   *                        The internal implementation uses `Flow.alsoTo` for `chunkUploadSink` which means that
+   *                        backpressure is applied to the upload stream if `chunkUploadSink` is too slow, likewise any
+   *                        failure will also be propagated to the upload stream. Sink Materialization is also shared
+   *                        with the returned `Sink`.
    * @param contentType an optional [[akka.http.javadsl.model.ContentType ContentType]]
    * @param s3Headers any headers you want to add
    * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.japi.Pair Pair]] of ([[akka.util.ByteString ByteString]] of [[C]])'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
@@ -995,6 +1015,11 @@ object S3 {
    * @param chunkUploadSink A sink that's a callback which gets executed whenever an entire Chunk is uploaded to S3
    *                        (successfully or unsuccessfully). Since each chunk can contain more than one emitted element
    *                        from the original flow/source you get provided with the list of context's.
+   *
+   *                        The internal implementation uses `Flow.alsoTo` for `chunkUploadSink` which means that
+   *                        backpressure is applied to the upload stream if `chunkUploadSink` is too slow, likewise any
+   *                        failure will also be propagated to the upload stream. Sink Materialization is also shared
+   *                        with the returned `Sink`.
    * @param contentType an optional [[akka.http.javadsl.model.ContentType ContentType]]
    * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.japi.Pair Pair]] of ([[akka.util.ByteString ByteString]] of [[C]])'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
    */
@@ -1030,6 +1055,11 @@ object S3 {
    * @param chunkUploadSink A sink that's a callback which gets executed whenever an entire Chunk is uploaded to S3
    *                        (successfully or unsuccessfully). Since each chunk can contain more than one emitted element
    *                        from the original flow/source you get provided with the list of context's.
+   *
+   *                        The internal implementation uses `Flow.alsoTo` for `chunkUploadSink` which means that
+   *                        backpressure is applied to the upload stream if `chunkUploadSink` is too slow, likewise any
+   *                        failure will also be propagated to the upload stream. Sink Materialization is also shared
+   *                        with the returned `Sink`.
    * @return a [[akka.stream.javadsl.Sink Sink]] that accepts [[akka.japi.Pair Pair]] of ([[akka.util.ByteString ByteString]] of [[C]])'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
    */
   def resumeMultipartUploadWithContext[C](

--- a/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
@@ -16,6 +16,177 @@ import scala.collection.immutable
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
+final class MultipartUpload private (val bucket: String, val key: String, val uploadId: String) {
+
+  /** Java API */
+  def getBucket: String = bucket
+
+  /** Java API */
+  def getKey: String = key
+
+  /** Java API */
+  def getUploadId: String = uploadId
+
+  def withBucket(value: String): MultipartUpload = copy(bucket = value)
+
+  def withKey(value: String): MultipartUpload = copy(key = value)
+
+  def withUploadId(value: String): MultipartUpload = copy(uploadId = value)
+
+  private def copy(bucket: String = bucket, key: String = key, uploadId: String = uploadId): MultipartUpload =
+    new MultipartUpload(
+      bucket,
+      key,
+      uploadId
+    )
+
+  override def toString: String =
+    "MultipartUpload(" +
+    s"bucket=$bucket," +
+    s"key=$key," +
+    s"uploadId=$uploadId" +
+    ")"
+
+  override def equals(other: Any): Boolean = other match {
+    case that: MultipartUpload =>
+      Objects.equals(this.bucket, that.bucket) &&
+      Objects.equals(this.key, that.key) &&
+      Objects.equals(this.uploadId, that.uploadId)
+    case _ => false
+  }
+
+  override def hashCode(): Int =
+    Objects.hash(bucket, key, uploadId)
+}
+
+object MultipartUpload {
+
+  /** Scala API */
+  def apply(bucket: String, key: String, uploadId: String): MultipartUpload = {
+    new MultipartUpload(bucket, key, uploadId)
+  }
+
+  /** Java API */
+  def create(bucket: String, key: String, uploadId: String): MultipartUpload = apply(bucket, key, uploadId)
+}
+
+sealed trait UploadPartResponse {
+
+  /** Scala API */
+  def multipartUpload: MultipartUpload
+
+  /** Scala API */
+  def partNumber: Int
+
+  /** Java API */
+  def getMultipartUpload: MultipartUpload = multipartUpload
+
+  /** Java API */
+  def getPartNumber: Int = partNumber
+}
+
+final class SuccessfulUploadPart private (val multipartUpload: MultipartUpload, val partNumber: Int, val eTag: String)
+    extends UploadPartResponse {
+
+  /** Java API */
+  def getETag: String = eTag
+
+  def withMultipartUpload(value: MultipartUpload): SuccessfulUploadPart = copy(multipartUpload = value)
+
+  def withPartNumber(value: Int): SuccessfulUploadPart = copy(partNumber = value)
+
+  def withETag(value: String): SuccessfulUploadPart = copy(eTag = value)
+
+  private def copy(multipartUpload: MultipartUpload = multipartUpload,
+                   partNumber: Int = partNumber,
+                   eTag: String = eTag): SuccessfulUploadPart =
+    new SuccessfulUploadPart(multipartUpload, partNumber, eTag)
+
+  override def toString: String =
+    "SuccessfulUploadPart(" +
+    s"multipartUpload=$multipartUpload," +
+    s"partNumber=$partNumber," +
+    s"eTag=$eTag" +
+    ")"
+
+  override def equals(other: Any): Boolean = other match {
+    case that: SuccessfulUploadPart =>
+      Objects.equals(this.multipartUpload, that.multipartUpload) &&
+      Objects.equals(this.partNumber, that.partNumber) &&
+      Objects.equals(this.eTag, that.eTag)
+    case _ => false
+  }
+
+  override def hashCode(): Int =
+    Objects.hash(multipartUpload, Int.box(partNumber), eTag)
+
+}
+
+object SuccessfulUploadPart {
+
+  /** Scala API */
+  def apply(multipartUpload: MultipartUpload, partNumber: Int, eTag: String): SuccessfulUploadPart =
+    new SuccessfulUploadPart(
+      multipartUpload,
+      partNumber,
+      eTag
+    )
+
+  /** Java API */
+  def create(multipartUpload: MultipartUpload, partNumber: Int, eTag: String): SuccessfulUploadPart =
+    apply(multipartUpload, partNumber, eTag)
+}
+
+final class FailedUploadPart private (val multipartUpload: MultipartUpload,
+                                      val partNumber: Int,
+                                      val exception: Throwable)
+    extends UploadPartResponse {
+
+  /** Java API */
+  def getException: Throwable = exception
+
+  def withMultipartUpload(value: MultipartUpload): FailedUploadPart = copy(multipartUpload = value)
+
+  def withPartNumber(value: Int): FailedUploadPart = copy(partNumber = value)
+
+  def withException(value: Throwable): FailedUploadPart = copy(exception = value)
+
+  private def copy(multipartUpload: MultipartUpload = multipartUpload,
+                   partNumber: Int = partNumber,
+                   exception: Throwable = exception): FailedUploadPart =
+    new FailedUploadPart(multipartUpload, partNumber, exception)
+
+  override def toString: String =
+    "FailedUploadPart(" +
+    s"multipartUpload=$multipartUpload," +
+    s"partNumber=$partNumber," +
+    s"exception=$exception" +
+    ")"
+
+  override def equals(other: Any): Boolean =
+    other match {
+      case that: FailedUploadPart =>
+        Objects.equals(this.multipartUpload, that.multipartUpload) &&
+        Objects.equals(this.partNumber, that.partNumber) &&
+        Objects.equals(this.exception, that.exception)
+      case _ => false
+    }
+
+  override def hashCode(): Int =
+    Objects.hash(multipartUpload, Int.box(partNumber), exception)
+}
+
+object FailedUploadPart {
+
+  /** Scala API */
+  def apply(multipartUpload: MultipartUpload, partNumber: Int, exception: Throwable): FailedUploadPart =
+    new FailedUploadPart(multipartUpload, partNumber, exception)
+
+  /** Java API */
+  def create(multipartUpload: MultipartUpload, partNumber: Int, exception: Throwable): FailedUploadPart =
+    apply(multipartUpload, partNumber, exception)
+}
+
 final class MultipartUploadResult private (
     val location: Uri,
     val bucket: String,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
@@ -509,6 +509,11 @@ object S3 {
    * @param chunkUploadSink A sink that's a callback which gets executed whenever an entire Chunk is uploaded to S3
    *                        (successfully or unsuccessfully). Since each chunk can contain more than one emitted element
    *                        from the original flow/source you get provided with the list of context's.
+   *
+   *                        The internal implementation uses `Flow.alsoTo` for `chunkUploadSink` which means that
+   *                        backpressure is applied to the upload stream if `chunkUploadSink` is too slow, likewise any
+   *                        failure will also be propagated to the upload stream. Sink Materialization is also shared
+   *                        with the returned `Sink`.
    * @param contentType an optional [[akka.http.scaladsl.model.ContentType ContentType]]
    * @param metaHeaders any meta-headers you want to add
    * @param cannedAcl a [[CannedAcl]], defaults to [[CannedAcl.Private]]
@@ -551,6 +556,11 @@ object S3 {
    * @param chunkUploadSink A sink that's a callback which gets executed whenever an entire Chunk is uploaded to S3
    *                        (successfully or unsuccessfully). Since each chunk can contain more than one emitted element
    *                        from the original flow/source you get provided with the list of context's.
+   *
+   *                        The internal implementation uses `Flow.alsoTo` for `chunkUploadSink` which means that
+   *                        backpressure is applied to the upload stream if `chunkUploadSink` is too slow, likewise any
+   *                        failure will also be propagated to the upload stream. Sink Materialization is also shared
+   *                        with the returned `Sink`.
    * @param contentType an optional [[akka.http.scaladsl.model.ContentType ContentType]]
    * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
    * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4
@@ -630,6 +640,11 @@ object S3 {
    * @param chunkUploadSink A sink that's a callback which gets executed whenever an entire Chunk is uploaded to S3
    *                        (successfully or unsuccessfully). Since each chunk can contain more than one emitted element
    *                        from the original flow/source you get provided with the list of context's.
+   *
+   *                        The internal implementation uses `Flow.alsoTo` for `chunkUploadSink` which means that
+   *                        backpressure is applied to the upload stream if `chunkUploadSink` is too slow, likewise any
+   *                        failure will also be propagated to the upload stream. Sink Materialization is also shared
+   *                        with the returned `Sink`.
    * @param contentType an optional [[akka.http.scaladsl.model.ContentType ContentType]]
    * @param metaHeaders any meta-headers you want to add
    * @param cannedAcl a [[CannedAcl]], defaults to [[CannedAcl.Private]]
@@ -716,6 +731,11 @@ object S3 {
    * @param chunkUploadSink A sink that's a callback which gets executed whenever an entire Chunk is uploaded to S3
    *                        (successfully or unsuccessfully). Since each chunk can contain more than one emitted element
    *                        from the original flow/source you get provided with the list of context's.
+   *
+   *                        The internal implementation uses `Flow.alsoTo` for `chunkUploadSink` which means that
+   *                        backpressure is applied to the upload stream if `chunkUploadSink` is too slow, likewise any
+   *                        failure will also be propagated to the upload stream. Sink Materialization is also shared
+   *                        with the returned `Sink`.
    * @param contentType an optional [[akka.http.scaladsl.model.ContentType ContentType]]
    * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
    * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
@@ -497,6 +497,86 @@ object S3 {
       )
 
   /**
+   * Uploads a S3 Object by making multiple requests. Unlike `multipartUpload`, this version allows you to pass in a
+   * context (typically from a `SourceWithContext`/`FlowWithContext`) along with a chunkUploadSink that defines how to
+   * act whenever a chunk is uploaded.
+   *
+   * Note that this version of resuming multipart upload ignores buffering
+   *
+   * @tparam C The Context that is passed along with the `ByteString`
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param chunkUploadSink A sink that's a callback which gets executed whenever an entire Chunk is uploaded to S3
+   *                        (successfully or unsuccessfully). Since each chunk can contain more than one emitted element
+   *                        from the original flow/source you get provided with the list of context's.
+   * @param contentType an optional [[akka.http.scaladsl.model.ContentType ContentType]]
+   * @param metaHeaders any meta-headers you want to add
+   * @param cannedAcl a [[CannedAcl]], defaults to [[CannedAcl.Private]]
+   * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
+   * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4
+   * @return a [[akka.stream.scaladsl.Sink Sink]] that accepts ([[ByteString]], [[C]])'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
+   */
+  def multipartUploadWithContext[C](
+      bucket: String,
+      key: String,
+      chunkUploadSink: Sink[(UploadPartResponse, immutable.Iterable[C]), NotUsed],
+      contentType: ContentType = ContentTypes.`application/octet-stream`,
+      metaHeaders: MetaHeaders = MetaHeaders(Map()),
+      cannedAcl: CannedAcl = CannedAcl.Private,
+      chunkSize: Int = MinChunkSize,
+      chunkingParallelism: Int = 4,
+      sse: Option[ServerSideEncryption] = None
+  ): Sink[(ByteString, C), Future[MultipartUploadResult]] = {
+    val headers =
+      S3Headers.empty.withCannedAcl(cannedAcl).withMetaHeaders(metaHeaders).withOptionalServerSideEncryption(sse)
+    multipartUploadWithHeadersAndContext(bucket,
+                                         key,
+                                         chunkUploadSink,
+                                         contentType,
+                                         chunkSize,
+                                         chunkingParallelism,
+                                         headers)
+  }
+
+  /**
+   * Uploads a S3 Object by making multiple requests. Unlike `multipartUploadWithHeaders`, this version allows you to
+   * pass in a context (typically from a `SourceWithContext`/`FlowWithContext`) along with a chunkUploadSink that
+   * defines how to act whenever a chunk is uploaded.
+   *
+   * Note that this version of resuming multipart upload ignores buffering
+   *
+   * @tparam C The Context that is passed along with the `ByteString`
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param chunkUploadSink A sink that's a callback which gets executed whenever an entire Chunk is uploaded to S3
+   *                        (successfully or unsuccessfully). Since each chunk can contain more than one emitted element
+   *                        from the original flow/source you get provided with the list of context's.
+   * @param contentType an optional [[akka.http.scaladsl.model.ContentType ContentType]]
+   * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
+   * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4
+   * @param s3Headers any headers you want to add
+   * @return a [[akka.stream.scaladsl.Sink Sink]] that accepts ([[ByteString]], [[C]])'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
+   */
+  def multipartUploadWithHeadersAndContext[C](
+      bucket: String,
+      key: String,
+      chunkUploadSink: Sink[(UploadPartResponse, immutable.Iterable[C]), NotUsed],
+      contentType: ContentType = ContentTypes.`application/octet-stream`,
+      chunkSize: Int = MinChunkSize,
+      chunkingParallelism: Int = 4,
+      s3Headers: S3Headers = S3Headers.empty
+  ): Sink[(ByteString, C), Future[MultipartUploadResult]] =
+    S3Stream
+      .multipartUploadWithContext(
+        S3Location(bucket, key),
+        chunkUploadSink,
+        contentType,
+        s3Headers,
+        chunkSize,
+        chunkingParallelism
+      )
+
+  /**
    * Resumes from a previously aborted multipart upload by providing the uploadId and previous upload part identifiers
    *
    * @param bucket the s3 bucket name
@@ -535,7 +615,59 @@ object S3 {
   }
 
   /**
-   * Resumes from a previously aborted multipart upload by providing the uploadId and previous upload part identifiers
+   * Resumes from a previously aborted multipart upload by providing the uploadId and previous upload part identifiers.
+   * Unlike `resumeMultipartUpload`, this version allows you to pass in a context (typically from a
+   * `SourceWithContext`/`FlowWithContext`) along with a chunkUploadSink that defines how to act whenever a chunk is
+   * uploaded.
+   *
+   * Note that this version of resuming multipart upload ignores buffering
+   *
+   * @tparam C The Context that is passed along with the `ByteString`
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param uploadId the upload that you want to resume
+   * @param previousParts The previously uploaded parts ending just before when this upload will commence
+   * @param chunkUploadSink A sink that's a callback which gets executed whenever an entire Chunk is uploaded to S3
+   *                        (successfully or unsuccessfully). Since each chunk can contain more than one emitted element
+   *                        from the original flow/source you get provided with the list of context's.
+   * @param contentType an optional [[akka.http.scaladsl.model.ContentType ContentType]]
+   * @param metaHeaders any meta-headers you want to add
+   * @param cannedAcl a [[CannedAcl]], defaults to [[CannedAcl.Private]]
+   * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
+   * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4
+   * @return a [[akka.stream.scaladsl.Sink Sink]] that accepts ([[ByteString]], [[C]])'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
+   */
+  def resumeMultipartUploadWithContext[C](
+      bucket: String,
+      key: String,
+      uploadId: String,
+      previousParts: immutable.Iterable[Part],
+      chunkUploadSink: Sink[(UploadPartResponse, immutable.Iterable[C]), NotUsed],
+      contentType: ContentType = ContentTypes.`application/octet-stream`,
+      metaHeaders: MetaHeaders = MetaHeaders(Map()),
+      cannedAcl: CannedAcl = CannedAcl.Private,
+      chunkSize: Int = MinChunkSize,
+      chunkingParallelism: Int = 4,
+      sse: Option[ServerSideEncryption] = None
+  ): Sink[(ByteString, C), Future[MultipartUploadResult]] = {
+    val headers =
+      S3Headers.empty.withCannedAcl(cannedAcl).withMetaHeaders(metaHeaders).withOptionalServerSideEncryption(sse)
+    resumeMultipartUploadWithHeadersAndContext(bucket,
+                                               key,
+                                               uploadId,
+                                               previousParts,
+                                               chunkUploadSink,
+                                               contentType,
+                                               chunkSize,
+                                               chunkingParallelism,
+                                               headers)
+  }
+
+  /**
+   * Resumes from a previously aborted multipart upload by providing the uploadId and previous upload part identifiers.
+   * Unlike `resumeMultipartUpload`, this version allows you to pass in a context (typically from a
+   * `SourceWithContext`/`FlowWithContext`) along with a chunkUploadSink that defines how to act whenever a chunk is
+   * uploaded.
    *
    * @param bucket the s3 bucket name
    * @param key the s3 object key
@@ -562,6 +694,51 @@ object S3 {
         S3Location(bucket, key),
         uploadId,
         previousParts,
+        contentType,
+        s3Headers,
+        chunkSize,
+        chunkingParallelism
+      )
+
+  /**
+   * Resumes from a previously aborted multipart upload by providing the uploadId and previous upload part identifiers.
+   * Unlike `resumeMultipartUploadWithHeaders`, this version allows you to pass in a context (typically from a
+   * `SourceWithContext`/`FlowWithContext`) along with a chunkUploadSink that defines how to act whenever a chunk is
+   * uploaded.
+   *
+   * Note that this version of resuming multipart upload ignores buffering
+   *
+   * @tparam C The Context that is passed along with the `ByteString`
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param uploadId the upload that you want to resume
+   * @param previousParts The previously uploaded parts ending just before when this upload will commence
+   * @param chunkUploadSink A sink that's a callback which gets executed whenever an entire Chunk is uploaded to S3
+   *                        (successfully or unsuccessfully). Since each chunk can contain more than one emitted element
+   *                        from the original flow/source you get provided with the list of context's.
+   * @param contentType an optional [[akka.http.scaladsl.model.ContentType ContentType]]
+   * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
+   * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4
+   * @param s3Headers any headers you want to add
+   * @return a [[akka.stream.scaladsl.Sink Sink]] that accepts ([[ByteString]], [[C]])'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
+   */
+  def resumeMultipartUploadWithHeadersAndContext[C](
+      bucket: String,
+      key: String,
+      uploadId: String,
+      previousParts: immutable.Iterable[Part],
+      chunkUploadSink: Sink[(UploadPartResponse, immutable.Iterable[C]), NotUsed],
+      contentType: ContentType = ContentTypes.`application/octet-stream`,
+      chunkSize: Int = MinChunkSize,
+      chunkingParallelism: Int = 4,
+      s3Headers: S3Headers = S3Headers.empty
+  ): Sink[(ByteString, C), Future[MultipartUploadResult]] =
+    S3Stream
+      .resumeMultipartUploadWithContext(
+        S3Location(bucket, key),
+        uploadId,
+        previousParts,
+        chunkUploadSink,
         contentType,
         s3Headers,
         chunkSize,

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -43,7 +43,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures with 
   val contentType = MediaTypes.`image/jpeg`
   val acl = CannedAcl.PublicRead
   val metaHeaders: Map[String, String] = Map("location" -> "San Francisco", "orientation" -> "portrait")
-  val multipartUpload = MultipartUpload(S3Location("test-bucket", "testKey"), "uploadId")
+  val multipartUpload = MultipartUpload("test-bucket", "testKey", "uploadId")
 
   it should "initiate multipart upload when the region is us-east-1" in {
     implicit val settings = getSettings()
@@ -432,7 +432,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures with 
   it should "add two (source, range) headers to multipart upload (copy) request when byte range populated" in {
     implicit val settings: S3Settings = getSettings()
 
-    val multipartUpload = MultipartUpload(S3Location("target-bucket", "target-key"), UUID.randomUUID().toString)
+    val multipartUpload = MultipartUpload("target-bucket", "target-key", UUID.randomUUID().toString)
     val copyPartition = CopyPartition(1, S3Location("source-bucket", "some/source-key"), Some(ByteRange(0, 5242880L)))
     val multipartCopy = MultipartCopy(multipartUpload, copyPartition)
 
@@ -444,7 +444,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures with 
   it should "add only source header to multipart upload (copy) request when byte range missing" in {
     implicit val settings: S3Settings = getSettings()
 
-    val multipartUpload = MultipartUpload(S3Location("target-bucket", "target-key"), UUID.randomUUID().toString)
+    val multipartUpload = MultipartUpload("target-bucket", "target-key", UUID.randomUUID().toString)
     val copyPartition = CopyPartition(1, S3Location("source-bucket", "some/source-key"))
     val multipartCopy = MultipartCopy(multipartUpload, copyPartition)
 
@@ -456,7 +456,7 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures with 
   it should "add versionId parameter to source header if provided" in {
     implicit val settings: S3Settings = getSettings()
 
-    val multipartUpload = MultipartUpload(S3Location("target-bucket", "target-key"), UUID.randomUUID().toString)
+    val multipartUpload = MultipartUpload("target-bucket", "target-key", UUID.randomUUID().toString)
     val copyPartition = CopyPartition(1, S3Location("source-bucket", "some/source-key"), Some(ByteRange(0, 5242880L)))
     val multipartCopy = MultipartCopy(multipartUpload, copyPartition)
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SplitAfterSizeWithContextSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SplitAfterSizeWithContextSpec.scala
@@ -1,0 +1,77 @@
+package akka.stream.alpakka.s3.impl.auth
+
+import akka.actor.ActorSystem
+import akka.stream.alpakka.s3.impl.SplitAfterSizeWithContext
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
+import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import akka.testkit.TestKit
+import akka.util.ByteString
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+class SplitAfterSizeWithContextSpec(_system: ActorSystem)
+    extends TestKit(_system)
+    with AnyFlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with LogCapturing {
+
+  def this() = this(ActorSystem("SplitAfterSizeSpec"))
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(1.seconds, 5.millis)
+
+  override protected def afterAll(): Unit = TestKit.shutdownActorSystem(system)
+
+  final val MaxChunkSize = 1024
+  "SplitAfterSize" should "yield a single empty substream on no input" in assertAllStagesStopped {
+    Source
+      .empty[(ByteString, Int)]
+      .via(
+        SplitAfterSizeWithContext(10)(Flow[(ByteString, Int)]).concatSubstreams
+      )
+      .runWith(Sink.seq)
+      .futureValue should be(Seq.empty)
+  }
+
+  it should "start a new stream after the element that makes it reach a maximum, but not split the element itself" in assertAllStagesStopped {
+    Source(Vector((ByteString(1, 2, 3, 4, 5), 1), (ByteString(6, 7, 8, 9, 10, 11, 12), 2), (ByteString(13, 14), 3)))
+      .via(
+        SplitAfterSizeWithContext(10)(Flow[(ByteString, Int)])
+          .prefixAndTail(10)
+          .map { case (prefix, tail) => prefix }
+          .concatSubstreams
+      )
+      .runWith(Sink.seq)
+      .futureValue should be(
+      Seq(
+        Seq((ByteString(1, 2, 3, 4, 5), 1), (ByteString(6, 7, 8, 9, 10, 11, 12), 2)),
+        Seq((ByteString(13, 14), 3))
+      )
+    )
+  }
+
+  it should "not split large elements (unlike SplitAfterSize)" in assertAllStagesStopped {
+    Source(Vector((ByteString(bytes(1, 16)), 1), (ByteString(17, 18), 2)))
+      .via(
+        SplitAfterSizeWithContext(10)(Flow[(ByteString, Int)])
+          .prefixAndTail(10)
+          .map { case (prefix, tail) => prefix }
+          .concatSubstreams
+      )
+      .runWith(Sink.seq)
+      .futureValue should be(
+      Seq(
+        Seq((ByteString(bytes(1, 16)), 1)),
+        Seq((ByteString(17, 18), 2))
+      )
+    )
+  }
+
+  def bytes(start: Byte, end: Byte): Array[Byte] = (start to end).map(_.toByte).toArray[Byte]
+
+}

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -26,10 +26,12 @@ import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.regions.providers._
 
+import java.util.concurrent.ConcurrentLinkedQueue
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
 
 trait S3IntegrationSpec
     extends AnyFlatSpecLike
@@ -45,7 +47,7 @@ trait S3IntegrationSpec
   )
   implicit val ec: ExecutionContext = actorSystem.dispatcher
 
-  implicit val defaultPatience: PatienceConfig = PatienceConfig(90.seconds, 100.millis)
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(3.minutes, 100.millis)
 
   val defaultBucket = "my-test-us-east-1"
   val nonExistingBucket = "nowhere"
@@ -471,7 +473,9 @@ trait S3IntegrationSpec
       result.lift(currentChunk) match {
         case Some(currentString) =>
           val newString = ByteString(s"\n${newAcc.toString()}")
-          if (currentString.length <= S3.MinChunkSize) {
+          //TODO: Performance here can be improved by using the same technique as in
+          //createStringCollectionContextWithMinChunkSizeRec to keep track of the current string size in bytes
+          if (currentString.toArray.length < S3.MinChunkSize) {
             val appendedString = currentString ++ newString
             createStringCollectionWithMinChunkSizeRec(numberOfChunks,
                                                       newAcc,
@@ -690,6 +694,112 @@ trait S3IntegrationSpec
       val fullInputData = inputData.slice(0, 3).fold(ByteString.empty)(_ ++ _)
 
       fullInputData.utf8String shouldEqual fullDownloadedFile.utf8String
+    }
+  }
+  @tailrec
+  final def createStringCollectionContextWithMinChunkSizeRec(
+      numberOfChunks: Int,
+      stringAcc: BigInt = BigInt(0),
+      currentChunk: Int = 0,
+      currentChunkSize: Int = 0,
+      result: Vector[Vector[(ByteString, BigInt)]] = Vector.empty
+  ): Vector[Vector[(ByteString, BigInt)]] = {
+
+    if (currentChunk == numberOfChunks)
+      result
+    else {
+      val newAcc = stringAcc + 1
+
+      result.lift(currentChunk) match {
+        case Some(currentStrings) =>
+          val newString = ByteString(s"\n${newAcc.toString()}")
+          if (currentChunkSize < S3.MinChunkSize) {
+            val newChunkSize = currentChunkSize + newString.toArray.length
+            val newEntry = currentStrings :+ ((newString, newAcc))
+            createStringCollectionContextWithMinChunkSizeRec(numberOfChunks,
+                                                             newAcc,
+                                                             currentChunk,
+                                                             newChunkSize,
+                                                             result.updated(currentChunk, newEntry))
+          } else {
+            val newChunk = currentChunk + 1
+            val (newResult, newChunkSize) = {
+              // // We are at the last index at this point so don't append a new entry at the end of the Vector
+              if (currentChunk == numberOfChunks - 1)
+                (result, currentChunkSize)
+              else
+                (result :+ Vector((newString, newAcc)), newString.toArray.length)
+            }
+            createStringCollectionContextWithMinChunkSizeRec(numberOfChunks, newAcc, newChunk, newChunkSize, newResult)
+          }
+        case None =>
+          // This case happens right at the start
+          val initial = ByteString("1")
+          val firstResult = Vector(Vector((initial, newAcc)))
+          createStringCollectionContextWithMinChunkSizeRec(numberOfChunks,
+                                                           newAcc,
+                                                           currentChunk,
+                                                           initial.toArray.length,
+                                                           firstResult)
+      }
+    }
+  }
+
+  /**
+   * Creates a `List` of `List[(ByteString, BigInt)]` where the accumulated size of each ByteString in the list is
+   * guaranteed to be at least `S3.MinChunkSize` in size.
+   *
+   * This is useful for tests that deal with multipart uploads, since S3 persists a part everytime it receives
+   * `S3.MinChunkSize` bytes. Unlike `createStringCollectionWithMinChunkSizeRec` this version also adds an index
+   * to each individual `ByteString` which is helpful when dealing with testing for context
+   * @param numberOfChunks The number of chunks to create
+   * @return A List of `List[ByteString]` where each element is at least `S3.MinChunkSize` in size along with an
+   *         incrementing index for each `ByteString`
+   */
+  def createStringCollectionContextWithMinChunkSize(numberOfChunks: Int): List[List[(ByteString, BigInt)]] =
+    createStringCollectionContextWithMinChunkSizeRec(numberOfChunks).toList.map(_.toList)
+
+  it should "perform a chunked multi-part upload with the correct context" in {
+    val sourceKey = "original/file-context-1.txt"
+    val inputData = createStringCollectionContextWithMinChunkSize(4)
+    val source = Source(inputData.flatten)
+    val originalContexts = inputData.map(_.map { case (_, contexts) => contexts })
+    val originalData = inputData.flatten.map { case (data, _) => data }.fold(ByteString.empty)(_ ++ _)
+    val resultingContexts = new ConcurrentLinkedQueue[List[BigInt]]()
+    val collectContextSink = Sink
+      .foreach[(UploadPartResponse, immutable.Iterable[BigInt])] {
+        case (_, contexts) =>
+          resultingContexts.add(contexts.toList)
+      }
+      .mapMaterializedValue(_ => NotUsed)
+
+    val results = for {
+      _ <- source
+        .toMat(
+          S3.multipartUploadWithContext[BigInt](defaultBucket, sourceKey, collectContextSink, chunkingParallelism = 1)
+            .withAttributes(attributes)
+        )(
+          Keep.right
+        )
+        .run
+      // This delay is here because sometimes there is a delay when you complete a large file and its
+      // actually downloadable
+      downloaded <- akka.pattern.after(5.seconds)(
+        S3.download(defaultBucket, sourceKey).withAttributes(attributes).runWith(Sink.head).flatMap {
+          case Some((downloadSource, _)) =>
+            downloadSource
+              .runWith(Sink.seq)
+          case None => throw new Exception(s"Expected object in bucket $defaultBucket with key $sourceKey")
+        }
+      )
+      _ <- S3.deleteObject(defaultBucket, sourceKey).withAttributes(attributes).runWith(Sink.head)
+
+    } yield downloaded
+
+    whenReady(results) { downloads =>
+      val fullDownloadedFile = downloads.fold(ByteString.empty)(_ ++ _)
+      originalData.utf8String shouldEqual fullDownloadedFile.utf8String
+      originalContexts shouldEqual resultingContexts.asScala.toList
     }
   }
 


### PR DESCRIPTION
References #2760 

This PR is an implementation of the above referenced ticket. It adds custom versions of `multipartUpload`/`resumeMultipartUpload` that allows you to pass a context with the intention of being able to act on that context whenever a chunk is uploaded to S3, either successfully or unsuccessfully. This is done by providing a `chunkUploadSink: Sink[(UploadPartResponse, immutable.Iterable[C]), NotUsed]` which is a `Sink` that gets executed whenever the said Chunk is uploaded. For a very brief summary of the context of this PR, I want to be able to commit kafka commit cursors after S3 successfully uploads a chunk (with the source being kafka messages).

Notes are listed below

- You may have noticed that the `Sink[(UploadPartResponse, immutable.Iterable[C]), NotUsed]` has an `Iterable[C]` rather than just `C`. This is because for any given chunk you can have multiple emitted elements from the initial source. Initially I wanted to just expose the last context belonging to the last emitted element for the chunk but this behavior is not correct, either in the generic API case or in my context of Kafka (i.e. specifically with Kafka I have to upload the latest given cursor for **every** `GroupTopicPartition` and not just the last commit in the chunk)
  - There is an argument that just storing every single commit context inside an `immutable.Iterable` for an entire chunk in memory can be expensive in terms of memory, an alternative is that the user provides a data structure along with how to update it whenever an element is emitted by `SplitAfterSizeWithContext` (in the context of Kafka this would be your batching mechanism with `CommittableOffsetBatch` by maintaining a `Map[GroupTopicPartition, Long]` and only updating an element in place if its offset is larger than the one currently in the map which is currently implemented in Alpakka's Kafka client with `CommittableOffsetBatch`/`CommittableOffsetBatch.apply`)). I am not against this change (and design wise its considered to be superior) however it does make public API more complex.
    - As a counter argument to the "public API more complex part", one can simply provider the current implementation as a default in the argument (i.e. `immutable.Iterator.empty` as the constructor and `+=` as the append) and then for specific use cases like Kafka you can do `CommittableOffsetBatch.empty`/`CommittableOffsetBatch.apply`). One can also provide a data-structure that wraps this constructor/updater to keep things clean.
- The `UploadPartResponse` in the callback sink was an internal `UploadPartResponse` that was made public. This is because when an S3 chunk is uploaded the user of this public API may want to know details, along with whether or not it was successful or not.
  - In regards to `MultipartUpload`, initially it contained an `S3Location` which is an internal API. Rather than making `S3Location` public as well, I instead just modified `MultipartUpload` to have a `key`/`bucket` to minimize whats being exposed
  - In regards to `UploadPartResponse`/`SuccessfulUploadPart`/`FailedUploadPart` the field `index` was renamed to `partNumber`. Since its now public `partNumber` is more clear (its the official terminology in S3 API for the index of an uploaded part).
  - Regarding the `UploadPartResponse` and the fact that its a `trait` that is inherited, I don't think this should cause any issues with Java compatibility. The `sealed` part of the trait is ignored in Java and a bare Scala `trait` converts directly to a Java `interface` (which has 2 inherited implementations). The only impact here is that since Java has no concept of `sealed`, some Java user of alpakka could create their own implementation of `UploadPartResponse` which bypasses the `sealed` check but I fail to see how this is a real problem.
- Originally I wanted to have on generic `chunkAndRequest` that could be reused for the original `multipartUpload`/`resumeMultipartUpload` (by passing in `Nothing` as the context and having a stub for the `Sink` callback)  however I came across some issues so the current implementation just creates a new `chunkAndRequestWithContext`.
  - Buffering is currently not supported with `chunkAndRequestWithContext`. The original reason for this is that with the currently proposed API changes there is no way to support disk buffering because there is no conversion from the context `C` to a `ByteString` (which we need to have to save on disk). Although its definitely possible to add this as a parameter to the public apis (i.e. a `Sink[C, ByteString, Nothing]`) in my view this would just further complicate the feature
    - Its theoretically possible to still support the in memory buffering (a `Sink[C, ByteString, Nothing]` is not required here since we are already storing the context `C` in memory anyways) however there is still an issue where there is a corner case with `maxChunkSize` that splits a `ByteString` (see https://github.com/akka/alpakka/blob/master/s3/src/main/scala/akka/stream/alpakka/s3/impl/SplitAfterSize.scala#L59). Although we can split a `ByteString`, we have no way of splitting a completely generic context `C`. Theoretically this can be fixed in `SplitAfterSizeWithContext` by pushing the entire next pulled element rather than splitting the current element that is being rolled over but again in the case of simplicity I just removed the buffering aspect (also such an implementation would mean that strictly speaking the maximum size is no longer whats defined by `maxChunkSize` but rather `maxChunkSize` + the remaining bytes from the current `pos` of the currently processed ByteString). If this is important I can try and implement it and document this behavior.
  - There is a `null` sentinel value being used where `atLeastOneByteStringAndEmptyContext` is defined. This is the initial case where initially we just passed an empty `ByteString` however now we also have to pass in an empty context for a generic `C` and since this is all internal I used `null` because I found it cleaner/simpler (the other alternative is to have an `Option[C]` and then having to deal with `Option` everywhere). Due to this sentinel value we have to check that `C` is not null in `MemoryWithContext` before we add it to the final `ListBuffer`. I can also change this to use `Option[C]` if so desired.
  - `requestInfoOrUploadState` is one of the few places where I could easily extract methods to reduce some of the boilerplate
- The returning `Sink` thats exposed in the public API is a `Sink[(ByteString, C)]` (or for java a `Pair[ByteString, C]`). Ideally I would have liked to use a `SinkWithContext` but that doesn't exist in akka-streams yet (maybe I should make a feature request for this in akka-streams as this appears to be a valid use case?) 
  
Note that I still need to write tests but I created this PR in the interest of getting feedback if the API/implementation is appropriate (@ennru / @johanandren let me know your thoughts). I also want to do an end2end test for my personal usecase with Kafka to make sure everything is being implemented correctly. I also want to add docs to https://doc.akka.io/docs/alpakka/current/s3.html to add an example of how to use this API since its usage is non trivial.

I also need to add tests, both unit-based style tests for the new `SplitAfterSizeWithContext`/`MemoryWithContext` and also more generic tests that makes sure the whole process works as intended.