### PR TITLE
fix: use directories in testkit

### DIFF
--- a/testkit/src/main/scala/akka/stream/alpakka/testkit/CapturingAppender.scala
+++ b/testkit/src/main/scala/akka/stream/alpakka/testkit/CapturingAppender.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.stream.alpakka.testkit

--- a/testkit/src/main/scala/akka/stream/alpakka/testkit/LogbackUtil.scala
+++ b/testkit/src/main/scala/akka/stream/alpakka/testkit/LogbackUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.stream.alpakka.testkit

--- a/testkit/src/main/scala/akka/stream/alpakka/testkit/javadsl/LogCapturingJunit4.scala
+++ b/testkit/src/main/scala/akka/stream/alpakka/testkit/javadsl/LogCapturingJunit4.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.stream.alpakka.testkit.javadsl

--- a/testkit/src/main/scala/akka/stream/alpakka/testkit/scaladsl/LogCapturing.scala
+++ b/testkit/src/main/scala/akka/stream/alpakka/testkit/scaladsl/LogCapturing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.stream.alpakka.testkit.scaladsl

--- a/testkit/src/main/scala/akka/stream/alpakka/testkit/scaladsl/Repeated.scala
+++ b/testkit/src/main/scala/akka/stream/alpakka/testkit/scaladsl/Repeated.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.stream.alpakka.testkit.scaladsl


### PR DESCRIPTION
As it turns out, the testkit used directory names with `.` in them instead of the regular file layout.﻿
This PR moves the files and fixes their headers.