### PR TITLE
pravega: adapt to Scala 2.13

### DIFF
--- a/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaKVTableSpec.scala
+++ b/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaKVTableSpec.scala
@@ -18,7 +18,7 @@ import docs.scaladsl.Serializers._
 class PravegaKVTableSpec extends PravegaBaseSpec with Repeated {
 
   private val tablewriterSettings: TableWriterSettings[Int, Person] =
-    TableWriterSettingsBuilder[Int, Person]
+    TableWriterSettingsBuilder[Int, Person]()
       .withSerializers(id => new TableKey(intSerializer.serialize(id)))
       .build()
 

--- a/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaStreamAndTableSpec.scala
+++ b/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaStreamAndTableSpec.scala
@@ -27,7 +27,7 @@ class PravegaStreamAndTableSpec extends PravegaBaseSpec with Repeated {
   def readTableFlow(scope: String, tableName: String) = {
     // #table-reading-flow
     val tableSettings: TableSettings[String, Int] =
-      TableReaderSettingsBuilder[String, Int]
+      TableReaderSettingsBuilder[String, Int]()
         .withTableKey(p => new TableKey(stringSerializer.serialize(p)))
         .build()
     PravegaTable
@@ -42,7 +42,7 @@ class PravegaStreamAndTableSpec extends PravegaBaseSpec with Repeated {
 
   def writeTableFlow(scope: String, tableName: String) = {
     val tableWriterSettings: TableWriterSettings[String, Int] =
-      TableWriterSettingsBuilder[String, Int]
+      TableWriterSettingsBuilder[String, Int]()
         .withSerializers(k => new TableKey(stringSerializer.serialize(k)))
         .build()
     PravegaTable.writeFlow(

--- a/pravega/src/test/scala/docs/scaladsl/PravegaReadWriteDocs.scala
+++ b/pravega/src/test/scala/docs/scaladsl/PravegaReadWriteDocs.scala
@@ -89,7 +89,7 @@ class PravegaReadWriteDocs {
 
     }
 
-  implicit val tablewriterSettings = TableWriterSettingsBuilder[Int, Person]
+  implicit val tablewriterSettings = TableWriterSettingsBuilder[Int, Person]()
     .withSerializers(id => new TableKey(intSerializer.serialize(id)))
     .build()
 
@@ -110,7 +110,7 @@ class PravegaReadWriteDocs {
 
   val clientConfig = ClientConfig.builder().build()
 
-  val tableSettings = TableReaderSettingsBuilder[Int, Person]
+  val tableSettings = TableReaderSettingsBuilder[Int, Person]()
     .withTableKey(id => new TableKey(intSerializer.serialize(id)))
     .build()
 

--- a/pravega/src/test/scala/docs/scaladsl/PravegaSettingsSpec.scala
+++ b/pravega/src/test/scala/docs/scaladsl/PravegaSettingsSpec.scala
@@ -78,7 +78,7 @@ class PravegaSettingsSpec extends PravegaBaseSpec with Matchers {
 
     "build TableWriterSettings with programmatic customisation" in {
       //#table-writer-settings
-      val tableWriterSettings = TableWriterSettingsBuilder[Int, String]
+      val tableWriterSettings = TableWriterSettingsBuilder[Int, String]()
         .clientConfigBuilder(_.enableTlsToController(true)) // ClientConfig customization
         .withMaximumInflightMessages(5)
         .withSerializers(str => new TableKey(intSerializer.serialize(str.hashCode())))
@@ -90,7 +90,7 @@ class PravegaSettingsSpec extends PravegaBaseSpec with Matchers {
 
     "build TableReaderSettings with programmatic customisation" in {
       //#table-reader-settings
-      val tableReaderSettings = TableReaderSettingsBuilder[Int, String]
+      val tableReaderSettings = TableReaderSettingsBuilder[Int, String]()
         .clientConfigBuilder(_.enableTlsToController(true)) // ClientConfig customization
         .withMaximumInflightMessages(5)
         .withMaxEntriesAtOnce(100)


### PR DESCRIPTION
The newly merged changes trigger warnings in Scala 2.13. 
This PR fixes those.
