### PR TITLE
cassandra: driver 4.13.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     ports:
       - "5672:5672"
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.0
     ports:
       - "9042:9042"
   couchbase:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -100,8 +100,8 @@ object Dependencies {
   )
 
   val CassandraVersionInDocs = "4.0"
-  val CassandraDriverVersion = "4.10.0"
-  val CassandraDriverVersionInDocs = "4.10"
+  val CassandraDriverVersion = "4.13.0"
+  val CassandraDriverVersionInDocs = "4.13"
 
   val Cassandra = Seq(
     libraryDependencies ++= Seq(
@@ -110,7 +110,7 @@ object Dependencies {
           .exclude("org.apache.tinkerpop", "*") //https://github.com/akka/alpakka/issues/2200
           .exclude("com.esri.geometry", "esri-geometry-api"), //https://github.com/akka/alpakka/issues/2225
         "com.typesafe.akka" %% "akka-discovery" % AkkaVersion % Provided
-      ) ++ JacksonDatabindDependencies
+      )
   )
 
   val Couchbase = Seq(


### PR DESCRIPTION
* Cassandra Java driver 4.13.0
	* drop explicit Jackson, the driver pulls Jackson 2.12.2 
* run against current Cassandra 4.0