### PR TITLE
AWS connectors: use AWS SDK 2.17.113

### DIFF
--- a/dynamodb/src/test/java/docs/javadsl/RetryTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/RetryTest.java
@@ -48,7 +48,7 @@ public class RetryTest {
                         RetryPolicy.builder()
                             .backoffStrategy(BackoffStrategy.defaultStrategy())
                             .throttlingBackoffStrategy(BackoffStrategy.defaultThrottlingStrategy())
-                            .numRetries(SdkDefaultRetrySetting.DEFAULT_MAX_RETRIES)
+                            .numRetries(SdkDefaultRetrySetting.defaultMaxAttempts())
                             .retryCondition(RetryCondition.defaultRetryCondition())
                             .build())
                     .build())

--- a/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala
+++ b/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala
@@ -44,7 +44,7 @@ class RetrySpec
           RetryPolicy.builder
             .backoffStrategy(BackoffStrategy.defaultStrategy)
             .throttlingBackoffStrategy(BackoffStrategy.defaultThrottlingStrategy)
-            .numRetries(SdkDefaultRetrySetting.DEFAULT_MAX_RETRIES)
+            .numRetries(SdkDefaultRetrySetting.defaultMaxAttempts)
             .retryCondition(RetryCondition.defaultRetryCondition)
             .build
         )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -89,8 +89,7 @@ object Dependencies {
           ExclusionRule("software.amazon.awssdk", "apache-client"),
           ExclusionRule("software.amazon.awssdk", "netty-nio-client")
         )
-      )
-      ++ Mockito
+      ) ++ Mockito
   )
 
   val AzureStorageQueue = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
 
   val InfluxDBJavaVersion = "2.15"
 
-  val AwsSdk2Version = "2.11.14"
+  val AwsSdk2Version = "2.17.113"
   val AwsSpiAkkaHttpVersion = "0.0.11"
   // Sync with plugins.sbt
   val AkkaGrpcBinaryVersion = "1.0"
@@ -89,7 +89,7 @@ object Dependencies {
           ExclusionRule("software.amazon.awssdk", "apache-client"),
           ExclusionRule("software.amazon.awssdk", "netty-nio-client")
         )
-      ) ++ JacksonDatabindDependencies
+      )
       ++ Mockito
   )
 
@@ -145,7 +145,7 @@ object Dependencies {
           ExclusionRule("software.amazon.awssdk", "netty-nio-client")
         ),
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion // ApacheV2
-      ) ++ JacksonDatabindDependencies
+      )
   )
 
   val Elasticsearch = Seq(
@@ -345,8 +345,7 @@ object Dependencies {
           ExclusionRule("software.amazon.awssdk", "apache-client"),
           ExclusionRule("software.amazon.awssdk", "netty-nio-client")
         )
-      ) ++ JacksonDatabindDependencies
-      ++ Mockito
+      ) ++ Mockito
   )
 
   val KuduVersion = "1.7.1"
@@ -412,7 +411,7 @@ object Dependencies {
         // in-memory filesystem for file related tests
         "com.google.jimfs" % "jimfs" % "1.1" % Test, // ApacheV2
         "com.github.tomakehurst" % "wiremock-jre8" % "2.26.3" % Test // ApacheV2
-      ) ++ JacksonDatabindDependencies
+      )
   )
 
   val SpringWeb = {
@@ -450,8 +449,7 @@ object Dependencies {
           ExclusionRule("software.amazon.awssdk", "netty-nio-client")
         ),
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion // ApacheV2
-      ) ++ JacksonDatabindDependencies
-      ++ Mockito
+      ) ++ Mockito
   )
 
   val Sns = Seq(
@@ -466,8 +464,7 @@ object Dependencies {
           ExclusionRule("software.amazon.awssdk", "netty-nio-client")
         ),
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion // ApacheV2
-      ) ++ JacksonDatabindDependencies
-      ++ Mockito
+      ) ++ Mockito
   )
 
   val SolrjVersion = "7.7.3"
@@ -495,8 +492,7 @@ object Dependencies {
         ),
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion, // ApacheV2
         "org.mockito" % "mockito-inline" % mockitoVersion % Test // MIT
-      ) ++ JacksonDatabindDependencies
-      ++ Mockito
+      ) ++ Mockito
   )
 
   val Sse = Seq(


### PR DESCRIPTION
The current AWS SDK seems compatible enough.
It does not itself use Jackson anymore so I dropped the Jackson version bump dependencies.