### PR TITLE
Kinesis: clean up contexts in kinesisFlowWithContext on failure

### DIFF
--- a/docs/src/main/paradox/kinesis.md
+++ b/docs/src/main/paradox/kinesis.md
@@ -115,7 +115,9 @@ Batching has a drawback: message order cannot be guaranteed, as some records wit
 More information can be found in the [AWS documentation](https://docs.aws.amazon.com/streams/latest/dev/developing-producers-with-sdk.html#kinesis-using-sdk-java-putrecords) and the [AWS API reference](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html).
 @@@
 
-In order to correlate the results with the original message, an optional user context object of arbitrary type can be associated with every message and will be returned with the corresponding result. This allows keeping track of which messages have been successfully sent to Kinesis even if the message order gets mixed up.
+In order to correlate the results with the original message, an optional user context object of arbitrary type can be associated with every message and will be returned with the corresponding result. This allows keeping track of which messages have been successfully sent to Kinesis even if the message order gets mixed up. 
+
+In cases with context flows, sometimes contexts need to be handled if a batch of messages sent to be published fails. A function for cleanup, `cleanUpContextOnFailure`, can then be added as an argument to the KinesisFlow. This function will then be applied to all messages in the failed batch before an exception is thrown.
 
 Publishing to a Kinesis stream requires an instance of `KinesisFlowSettings`, although a default instance with sane values and a method that returns settings based on the stream shard number are also available:
 

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/javadsl/KinesisFlow.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/javadsl/KinesisFlow.scala
@@ -39,4 +39,15 @@ object KinesisFlow {
       .FlowWithContext[PutRecordsRequestEntry, T]
       .via(scaladsl.KinesisFlow.withContext[T](streamName, settings)(kinesisClient))
       .asJava
+
+  def createWithContext[T](
+      streamName: String,
+      settings: KinesisFlowSettings,
+      cleanUpContextOnFailure: java.util.function.Consumer[T],
+      kinesisClient: KinesisAsyncClient
+  ): FlowWithContext[PutRecordsRequestEntry, T, PutRecordsResultEntry, T, NotUsed] =
+    akka.stream.scaladsl
+      .FlowWithContext[PutRecordsRequestEntry, T]
+      .via(scaladsl.KinesisFlow.withContext[T](streamName, settings, cleanUpContextOnFailure.accept)(kinesisClient))
+      .asJava
 }

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/javadsl/KinesisFlow.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/javadsl/KinesisFlow.scala
@@ -48,6 +48,6 @@ object KinesisFlow {
   ): FlowWithContext[PutRecordsRequestEntry, T, PutRecordsResultEntry, T, NotUsed] =
     akka.stream.scaladsl
       .FlowWithContext[PutRecordsRequestEntry, T]
-      .via(scaladsl.KinesisFlow.withContext[T](streamName, settings, cleanUpContextOnFailure.accept)(kinesisClient))
+      .via(scaladsl.KinesisFlow.withContext[T](streamName, cleanUpContextOnFailure.accept _, settings)(kinesisClient))
       .asJava
 }

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisFlow.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisFlow.scala
@@ -5,7 +5,6 @@
 package akka.stream.alpakka.kinesis.scaladsl
 
 import java.nio.ByteBuffer
-
 import akka.NotUsed
 import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts.parasitic
@@ -38,7 +37,11 @@ object KinesisFlow {
       .via(withContext(streamName, settings))
       .map(_._1)
 
-  def withContext[T](streamName: String, settings: KinesisFlowSettings = KinesisFlowSettings.Defaults)(
+  val NoCleanup: Any => Unit = _ => ()
+
+  def withContext[T](streamName: String,
+                     settings: KinesisFlowSettings = KinesisFlowSettings.Defaults,
+                     cleanUpContextOnFailure: T => Unit = NoCleanup)(
       implicit kinesisClient: KinesisAsyncClient
   ): FlowWithContext[PutRecordsRequestEntry, T, PutRecordsResultEntry, T, NotUsed] = {
     checkClient(kinesisClient)
@@ -58,7 +61,10 @@ object KinesisFlow {
                 PutRecordsRequest.builder().streamName(streamName).records(entries.map(_._1).asJavaCollection).build
               )
               .toScala
-              .transform(handlePutRecordsSuccess(entries), FailurePublishingRecords(_))(parasitic)
+              .transform(handlePutRecordsSuccess(entries), throwable => {
+                entries.foreach(t => cleanUpContextOnFailure(t._2))
+                FailurePublishingRecords(throwable)
+              })(parasitic)
         )
         .mapConcat(identity)
     )

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisFlow.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisFlow.scala
@@ -39,9 +39,12 @@ object KinesisFlow {
 
   val NoCleanup: Any => Unit = _ => ()
 
-  def withContext[T](streamName: String,
-                     settings: KinesisFlowSettings = KinesisFlowSettings.Defaults,
-                     cleanUpContextOnFailure: T => Unit = NoCleanup)(
+  def withContext[T](streamName: String, settings: KinesisFlowSettings = KinesisFlowSettings.Defaults)(
+      implicit kinesisClient: KinesisAsyncClient
+  ): FlowWithContext[PutRecordsRequestEntry, T, PutRecordsResultEntry, T, NotUsed] =
+    withContext(streamName, NoCleanup, settings)
+
+  def withContext[T](streamName: String, cleanUpContextOnFailure: T => Unit, settings: KinesisFlowSettings)(
       implicit kinesisClient: KinesisAsyncClient
   ): FlowWithContext[PutRecordsRequestEntry, T, PutRecordsResultEntry, T, NotUsed] = {
     checkClient(kinesisClient)

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
@@ -129,7 +129,7 @@ class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with Lo
     val (sourceProbe, sinkProbe) =
       TestSource
         .probe[(PutRecordsRequestEntry, Int)]
-        .via(KinesisFlow.withContext(streamName, settings, cleanupContextFunction))
+        .via(KinesisFlow.withContext(streamName, cleanupContextFunction, settings))
         .toMat(TestSink.probe)(Keep.both)
         .run()
   }

--- a/kinesis/src/test/scala/docs/scaladsl/KinesisSnippets.scala
+++ b/kinesis/src/test/scala/docs/scaladsl/KinesisSnippets.scala
@@ -82,10 +82,13 @@ object KinesisSnippets {
   val flow4: FlowWithContext[PutRecordsRequestEntry, String, PutRecordsResultEntry, String, NotUsed] =
     KinesisFlow.withContext("myStreamName", flowSettings)
 
-  val flow5: Flow[(String, ByteString), PutRecordsResultEntry, NotUsed] =
+  val flow5: FlowWithContext[PutRecordsRequestEntry, String, PutRecordsResultEntry, String, NotUsed] =
+    KinesisFlow.withContext("myStreamName", flowSettings, str => println(s"cleaning up $str"))
+
+  val flow6: Flow[(String, ByteString), PutRecordsResultEntry, NotUsed] =
     KinesisFlow.byPartitionAndBytes("myStreamName")
 
-  val flow6: Flow[(String, ByteBuffer), PutRecordsResultEntry, NotUsed] =
+  val flow7: Flow[(String, ByteBuffer), PutRecordsResultEntry, NotUsed] =
     KinesisFlow.byPartitionAndData("myStreamName")
 
   val sink1: Sink[PutRecordsRequestEntry, NotUsed] = KinesisSink("myStreamName")

--- a/kinesis/src/test/scala/docs/scaladsl/KinesisSnippets.scala
+++ b/kinesis/src/test/scala/docs/scaladsl/KinesisSnippets.scala
@@ -83,7 +83,7 @@ object KinesisSnippets {
     KinesisFlow.withContext("myStreamName", flowSettings)
 
   val flow5: FlowWithContext[PutRecordsRequestEntry, String, PutRecordsResultEntry, String, NotUsed] =
-    KinesisFlow.withContext("myStreamName", flowSettings, str => println(s"cleaning up $str"))
+    KinesisFlow.withContext("myStreamName", str => println(s"cleaning up $str"), flowSettings)
 
   val flow6: Flow[(String, ByteString), PutRecordsResultEntry, NotUsed] =
     KinesisFlow.byPartitionAndBytes("myStreamName")


### PR DESCRIPTION
Is one possibility for solving contexts that need handling when writing to a Kinesis data stream fails
References #2814
