### PR TITLE
Use akka-http 10.2.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -345,10 +345,7 @@ lazy val docs = project
         ("http://www\\.eclipse\\.org/".r, _ => "https://www\\.eclipse\\.org/"),
         ("http://pravega\\.io/".r, _ => "https://pravega\\.io/"),
         ("http://www\\.scala-lang\\.org/".r, _ => "https://www\\.scala-lang\\.org/"),
-        ("https://javadoc\\.io/page/".r, _ => "https://javadoc\\.io/static/"),
-        // Add Java module name https://github.com/ThoughtWorksInc/sbt-api-mappings/issues/58
-        ("https://docs\\.oracle\\.com/en/java/javase/11/docs/api/".r,
-         _ => "https://docs\\.oracle\\.com/en/java/javase/11/docs/api/java.base/")
+        ("https://javadoc\\.io/page/".r, _ => "https://javadoc\\.io/static/")
       ),
     Paradox / siteSubdirName := s"docs/alpakka/${projectInfoVersion.value}",
     paradoxProperties ++= Map(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
           cbq -c Administrator:password -e http://couchbase:8093
       "
   elasticmq:
-    image: softwaremill/elasticmq-native:0.14.7
+    image: softwaremill/elasticmq-native:1.3.4
     ports:
       - "9324:9324"
   dynamodb:
@@ -74,13 +74,13 @@ services:
     ports:
       - "8001:8000"
   elasticsearch6:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.23
     ports:
       - "9201:9200"
     environment:
       - "discovery.type=single-node"
   elasticsearch7:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
     ports:
       - "9202:9200"
     environment:

--- a/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
@@ -10,7 +10,6 @@ import akka.actor.ActorSystem;
 import akka.japi.Pair;
 
 // #init-client
-import akka.stream.SystemMaterializer;
 import akka.stream.alpakka.dynamodb.DynamoDbOp;
 import akka.stream.alpakka.dynamodb.javadsl.DynamoDb;
 import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
@@ -18,7 +17,6 @@ import akka.stream.javadsl.FlowWithContext;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.javadsl.SourceWithContext;
-import akka.stream.testkit.javadsl.StreamTestKit;
 import akka.testkit.javadsl.TestKit;
 import org.junit.*;
 // #init-client
@@ -81,11 +79,6 @@ public class ExampleTest {
   public static void tearDown() {
     client.close();
     TestKit.shutdownActorSystem(system);
-  }
-
-  @After
-  public void checkForStageLeaks() {
-    StreamTestKit.assertAllStagesStopped(SystemMaterializer.get(system).materializer());
   }
 
   @Test

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ItemSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ItemSpec.scala
@@ -8,7 +8,6 @@ import java.net.URI
 import akka.actor.ActorSystem
 import akka.stream.alpakka.dynamodb.scaladsl._
 import akka.stream.scaladsl.Sink
-import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import com.github.matsluni.akkahttpspi.AkkaHttpClient
 import org.scalatest._
@@ -45,30 +44,30 @@ class ItemSpec extends TestKit(ActorSystem("ItemSpec")) with AsyncWordSpecLike w
 
     import ItemSpecOps._
 
-    "1) list zero tables" in assertAllStagesStopped {
+    "1) list zero tables" in {
       DynamoDb.single(listTablesRequest).map(_.tableNames.asScala shouldBe empty)
     }
 
-    "2) create a table" in assertAllStagesStopped {
+    "2) create a table" in {
       DynamoDb.single(createTableRequest).map(_.tableDescription.tableStatus shouldBe TableStatus.ACTIVE)
     }
 
-    "3) find a new table" in assertAllStagesStopped {
+    "3) find a new table" in {
       DynamoDb.single(listTablesRequest).map(_.tableNames.asScala should contain(tableName))
     }
 
-    "4) put an item and read it back" in assertAllStagesStopped {
+    "4) put an item and read it back" in {
       for {
         _ <- DynamoDb.single(test4PutItemRequest)
         get <- DynamoDb.single(getItemRequest)
       } yield get.item.get("data").s shouldBe "test4data"
     }
 
-    "5) put two items in a batch" in assertAllStagesStopped {
+    "5) put two items in a batch" in {
       DynamoDb.single(batchWriteItemRequest).map(_.unprocessedItems.size shouldBe 0)
     }
 
-    "6) query two items with page size equal to 1" in assertAllStagesStopped {
+    "6) query two items with page size equal to 1" in {
       DynamoDb
         .source(queryItemsRequest)
         .map(_.items)
@@ -84,7 +83,7 @@ class ItemSpec extends TestKit(ActorSystem("ItemSpec")) with AsyncWordSpecLike w
         }
     }
 
-    "7) delete an item" in assertAllStagesStopped {
+    "7) delete an item" in {
       for {
         _ <- DynamoDb.single(deleteItemRequest)
         get <- DynamoDb.single(getItemRequest)
@@ -94,11 +93,11 @@ class ItemSpec extends TestKit(ActorSystem("ItemSpec")) with AsyncWordSpecLike w
     // The next 3 tests are ignored as DynamoDB Local does not support transactions; they
     // succeed against a cloud instance so can be enabled once local support is available.
 
-    "8) put two items in a transaction" ignore assertAllStagesStopped {
+    "8) put two items in a transaction" ignore {
       DynamoDb.single(transactPutItemsRequest).map(_ => succeed)
     }
 
-    "9) get two items in a transaction" ignore assertAllStagesStopped {
+    "9) get two items in a transaction" ignore {
       DynamoDb.single(transactGetItemsRequest).map { results =>
         val responses = results.responses.asScala
         responses.size shouldBe 2
@@ -107,11 +106,11 @@ class ItemSpec extends TestKit(ActorSystem("ItemSpec")) with AsyncWordSpecLike w
       }
     }
 
-    "10) delete two items in a transaction" ignore assertAllStagesStopped {
+    "10) delete two items in a transaction" ignore {
       DynamoDb.single(transactDeleteItemsRequest).map(_ => succeed)
     }
 
-    "11) delete table" in assertAllStagesStopped {
+    "11) delete table" in {
       for {
         _ <- DynamoDb.single(deleteTableRequest)
         list <- DynamoDb.single(listTablesRequest)

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TableSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TableSpec.scala
@@ -8,7 +8,6 @@ import java.net.URI
 
 import akka.actor.ActorSystem
 import akka.stream.alpakka.dynamodb.scaladsl.DynamoDb
-import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import com.github.matsluni.akkahttpspi.AkkaHttpClient
 import org.scalatest.BeforeAndAfterAll
@@ -44,19 +43,19 @@ class TableSpec extends TestKit(ActorSystem("TableSpec")) with AsyncWordSpecLike
 
     import TableSpecOps._
 
-    "1) create table" in assertAllStagesStopped {
+    "1) create table" in {
       DynamoDb.single(createTableRequest).map(_.tableDescription.tableName shouldBe tableName)
     }
 
-    "2) list tables" in assertAllStagesStopped {
+    "2) list tables" in {
       DynamoDb.single(listTablesRequest).map(_.tableNames.asScala should contain(tableName))
     }
 
-    "3) describe table" in assertAllStagesStopped {
+    "3) describe table" in {
       DynamoDb.single(describeTableRequest).map(_.table.tableName shouldBe tableName)
     }
 
-    "4) update table" in assertAllStagesStopped {
+    "4) update table" in {
       for {
         describe <- DynamoDb.single(describeTableRequest)
         update <- DynamoDb.single(updateTableRequest)
@@ -67,7 +66,7 @@ class TableSpec extends TestKit(ActorSystem("TableSpec")) with AsyncWordSpecLike
     }
 
     // TODO: Enable this test when DynamoDB Local supports TTLs
-    "5) update time to live" ignore assertAllStagesStopped {
+    "5) update time to live" ignore {
       for {
         describe <- DynamoDb.single(describeTimeToLiveRequest)
         update <- DynamoDb.single(updateTimeToLiveRequest)
@@ -77,7 +76,7 @@ class TableSpec extends TestKit(ActorSystem("TableSpec")) with AsyncWordSpecLike
       }
     }
 
-    "6) delete table" in assertAllStagesStopped {
+    "6) delete table" in {
       for {
         _ <- DynamoDb.single(deleteTableRequest)
         list <- DynamoDb.single(listTablesRequest)

--- a/dynamodb/src/test/scala/docs/scaladsl/ExampleSpec.scala
+++ b/dynamodb/src/test/scala/docs/scaladsl/ExampleSpec.scala
@@ -18,7 +18,6 @@ import akka.actor.ActorSystem
 import akka.stream.alpakka.dynamodb.DynamoDbOp._
 import akka.stream.alpakka.dynamodb.scaladsl._
 import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
@@ -87,7 +86,7 @@ class ExampleSpec
       listTablesResult.futureValue
     }
 
-    "allow multiple requests" in assertAllStagesStopped {
+    "allow multiple requests" in {
       // #flow
       val source: Source[DescribeTableResponse, NotUsed] = Source
         .single(CreateTableRequest.builder().tableName("testTable").build())
@@ -99,7 +98,7 @@ class ExampleSpec
       source.runWith(Sink.ignore).failed.futureValue
     }
 
-    "flow with context" in assertAllStagesStopped {
+    "flow with context" in {
       case class SomeContext()
 
       // #withContext
@@ -125,7 +124,7 @@ class ExampleSpec
       writtenSource.runWith(Sink.ignore).failed.futureValue
     }
 
-    "allow multiple requests - single source" in assertAllStagesStopped {
+    "allow multiple requests - single source" in {
       (for {
         create <- DynamoDb.single(CreateTableRequest.builder().tableName("testTable").build())
         describe <- DynamoDb.single(
@@ -134,7 +133,7 @@ class ExampleSpec
       } yield describe.table.itemCount).failed.futureValue
     }
 
-    "provide a paginated requests source" in assertAllStagesStopped {
+    "provide a paginated requests source" in {
       // #paginated
       val scanRequest = ScanRequest.builder().tableName("testTable").build()
 
@@ -145,7 +144,7 @@ class ExampleSpec
       scanPages.runWith(Sink.ignore).failed.futureValue
     }
 
-    "provide a paginated flow" in assertAllStagesStopped {
+    "provide a paginated flow" in {
       val scanRequest = ScanRequest.builder().tableName("testTable").build()
       // #paginated
       val scanPageInFlow: Source[ScanResponse, NotUsed] =

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchConnectionSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchConnectionSettings.scala
@@ -4,12 +4,13 @@
 
 package akka.stream.alpakka.elasticsearch
 
-import akka.http.scaladsl.HttpsConnectionContext
+import akka.http.scaladsl.{ConnectionContext, HttpsConnectionContext}
 import akka.http.scaladsl.model.HttpHeader
 import akka.http.scaladsl.model.HttpHeader.ParsingResult
 import akka.japi.Util
 
 import scala.jdk.CollectionConverters._
+import javax.net.ssl.SSLContext
 import scala.compat.java8.OptionConverters
 
 final class ElasticsearchConnectionSettings private (
@@ -47,10 +48,14 @@ final class ElasticsearchConnectionSettings private (
   }
 
   /** Scala API */
+  @deprecated("prefer ElasticsearchConnectionSettings.withSSLContext", "3.1.0")
+  @Deprecated
   def withConnectionContext(connectionContext: HttpsConnectionContext): ElasticsearchConnectionSettings =
     copy(connectionContext = Option(connectionContext))
 
   /** Java API */
+  @deprecated("prefer ElasticsearchConnectionSettings.withSSLContext", "3.1.0")
+  @Deprecated
   def withConnectionContext(
       connectionContext: akka.http.javadsl.HttpsConnectionContext
   ): ElasticsearchConnectionSettings = {
@@ -64,6 +69,12 @@ final class ElasticsearchConnectionSettings private (
     )
 
     copy(connectionContext = Option(scalaContext))
+  }
+
+  def withSSLContext(
+      sslContext: SSLContext
+  ): ElasticsearchConnectionSettings = {
+    copy(connectionContext = Option(ConnectionContext.httpsClient(sslContext)))
   }
 
   def hasConnectionContextDefined: Boolean = connectionContext.isDefined

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
@@ -8,14 +8,11 @@ import akka.actor.ActorSystem;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.model.ContentTypes;
 import akka.http.javadsl.model.HttpRequest;
-import akka.stream.Materializer;
 import akka.stream.alpakka.elasticsearch.ApiVersion;
 import akka.stream.alpakka.elasticsearch.ElasticsearchConnectionSettings;
 import akka.stream.alpakka.elasticsearch.ElasticsearchParams;
 import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
-import akka.stream.testkit.javadsl.StreamTestKit;
 import akka.testkit.javadsl.TestKit;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -53,11 +50,6 @@ public class ElasticsearchTestBase {
   @AfterClass
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
-  }
-
-  @After
-  public void checkForStageLeaks() {
-    StreamTestKit.assertAllStagesStopped(Materializer.matFromSystem(system));
   }
 
   protected static void prepareIndex(int port, ApiVersion esApiVersion) throws IOException {

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchConnectorBehaviour.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchConnectorBehaviour.scala
@@ -13,7 +13,6 @@ import akka.http.scaladsl.model.{ContentTypes, HttpMethods, HttpRequest, Uri}
 import akka.stream.alpakka.elasticsearch._
 import akka.stream.alpakka.elasticsearch.scaladsl._
 import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.{Done, NotUsed}
 import org.scalatest.Inspectors
 import org.scalatest.concurrent.ScalaFutures
@@ -125,7 +124,7 @@ trait ElasticsearchConnectorBehaviour {
     }
 
     "ElasticsearchFlow" should {
-      "pass through data in `withContext`" in assertAllStagesStopped {
+      "pass through data in `withContext`" in {
         val books = immutable.Seq(
           "Akka in Action",
           "Alpakka Patterns"
@@ -152,7 +151,7 @@ trait ElasticsearchConnectorBehaviour {
         }
       }
 
-      "not post invalid encoded JSON" in assertAllStagesStopped {
+      "not post invalid encoded JSON" in {
         val books = immutable.Seq(
           "Akka in Action",
           "Akka \u00DF Concurrency"
@@ -181,7 +180,7 @@ trait ElasticsearchConnectorBehaviour {
         )
       }
 
-      "retry a failed document and pass retried documents to downstream (create)" in assertAllStagesStopped {
+      "retry a failed document and pass retried documents to downstream (create)" in {
         val indexName = "sink5"
 
         // Create strict mapping to prevent invalid documents
@@ -229,7 +228,7 @@ trait ElasticsearchConnectorBehaviour {
         )
       }
 
-      "retry ALL failed document and pass retried documents to downstream (createWithPassThrough)" in assertAllStagesStopped {
+      "retry ALL failed document and pass retried documents to downstream (createWithPassThrough)" in {
         val indexName = "sink5_1"
 
         val bookNr = 100
@@ -273,7 +272,7 @@ trait ElasticsearchConnectorBehaviour {
         readTitlesFrom(apiVersion, baseSourceSettings, indexName).futureValue should contain theSameElementsAs expectedBookTitles
       }
 
-      "retry a failed document and pass retried documents to downstream (createWithContext)" in assertAllStagesStopped {
+      "retry a failed document and pass retried documents to downstream (createWithContext)" in {
         val indexName = "sink5b"
 
         // Create strict mapping to prevent invalid documents
@@ -327,7 +326,7 @@ trait ElasticsearchConnectorBehaviour {
         )
       }
 
-      "retry ALL failed document and pass retried documents to downstream (createWithContext)" in assertAllStagesStopped {
+      "retry ALL failed document and pass retried documents to downstream (createWithContext)" in {
         val indexName = "sink5_1b"
 
         val bookNr = 100
@@ -370,7 +369,7 @@ trait ElasticsearchConnectorBehaviour {
         readTitlesFrom(apiVersion, baseSourceSettings, indexName).futureValue should contain theSameElementsAs expectedBookTitles
       }
 
-      "store new documents using upsert method and partially update existing ones" in assertAllStagesStopped {
+      "store new documents using upsert method and partially update existing ones" in {
         val books = List(
           ("00001", Book("Book 1")),
           ("00002", Book("Book 2")),
@@ -481,7 +480,7 @@ trait ElasticsearchConnectorBehaviour {
         errorMessages.head should include("version conflict, document already exists (current version [1])")
       }
 
-      "read and write document-version if configured to do so" in assertAllStagesStopped {
+      "read and write document-version if configured to do so" in {
 
         case class VersionTestDoc(id: String, name: String, value: Int)
         implicit val formatVersionTestDoc: JsonFormat[VersionTestDoc] = jsonFormat3(VersionTestDoc)
@@ -580,7 +579,7 @@ trait ElasticsearchConnectorBehaviour {
         result5.head.success shouldBe false
       }
 
-      "allow read and write using configured version type" in assertAllStagesStopped {
+      "allow read and write using configured version type" in {
 
         val indexName = "book-test-version-type"
         val typeName = "_doc"
@@ -624,7 +623,7 @@ trait ElasticsearchConnectorBehaviour {
     "ElasticsearchSource" should {
       insertTestData(connectionSettings)
 
-      "allow search without specifying typeName" in assertAllStagesStopped {
+      "allow search without specifying typeName" in {
         val readWithoutTypeName = ElasticsearchSource
           .typed[Book](
             constructElasticsearchParams("source", "_doc", apiVersion),
@@ -646,7 +645,7 @@ trait ElasticsearchConnectorBehaviour {
         )
       }
 
-      "allow search on index pattern with no matching index" in assertAllStagesStopped {
+      "allow search on index pattern with no matching index" in {
         val readWithoutTypeName = ElasticsearchSource
           .typed[Book](
             constructElasticsearchParams("missing-*", "_doc", apiVersion),
@@ -660,7 +659,7 @@ trait ElasticsearchConnectorBehaviour {
         result shouldEqual Seq()
       }
 
-      "sort by _doc by default" in assertAllStagesStopped {
+      "sort by _doc by default" in {
         val read = ElasticsearchSource
           .typed[Book](
             constructElasticsearchParams("source", "_doc", apiVersion),
@@ -683,7 +682,7 @@ trait ElasticsearchConnectorBehaviour {
                                                       "Akka Concurrency"))
       }
 
-      "sort by user defined field" in assertAllStagesStopped {
+      "sort by user defined field" in {
         val read = ElasticsearchSource
           .typed[Book](
             constructElasticsearchParams("source", "_doc", apiVersion),
@@ -701,7 +700,7 @@ trait ElasticsearchConnectorBehaviour {
 
       }
 
-      "sort by user defined field desc" in assertAllStagesStopped {
+      "sort by user defined field desc" in {
         val read = ElasticsearchSource
           .typed[Book](
             constructElasticsearchParams("source", "_doc", apiVersion),

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV5Spec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV5Spec.scala
@@ -18,7 +18,6 @@ import akka.stream.alpakka.elasticsearch.{
   WriteResult
 }
 import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import akka.{Done, NotUsed}
 import spray.json.jsonReader
@@ -48,7 +47,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
   }
 
   "Un-typed Elasticsearch connector" should {
-    "consume and publish Json documents" in assertAllStagesStopped {
+    "consume and publish Json documents" in {
       val indexName = "sink2"
       //#run-jsobject
       val copy = ElasticsearchSource
@@ -85,7 +84,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
   }
 
   "Typed Elasticsearch connector" should {
-    "consume and publish documents as specific type" in assertAllStagesStopped {
+    "consume and publish documents as specific type" in {
       val indexName = "sink2"
       //#run-typed
       val copy = ElasticsearchSource
@@ -121,7 +120,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
   }
 
   "ElasticsearchFlow" should {
-    "store documents and pass failed documents to downstream" in assertAllStagesStopped {
+    "store documents and pass failed documents to downstream" in {
       val indexName = "sink3"
       //#run-flow
       val copy = ElasticsearchSource
@@ -157,7 +156,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
       )
     }
 
-    "store properly formatted JSON from Strings" in assertAllStagesStopped {
+    "store properly formatted JSON from Strings" in {
       val indexName = "sink3-0"
       // #string
       val write: Future[immutable.Seq[WriteResult[String, NotUsed]]] = Source(
@@ -187,7 +186,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
       )
     }
 
-    "kafka-example - store documents and pass Responses with passThrough" in assertAllStagesStopped {
+    "kafka-example - store documents and pass Responses with passThrough" in {
 
       //#kafka-example
       // We're going to pretend we got messages from kafka.
@@ -240,7 +239,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
         .map(_.book.title)
     }
 
-    "kafka-example - store documents and pass Responses with passThrough in bulk" in assertAllStagesStopped {
+    "kafka-example - store documents and pass Responses with passThrough in bulk" in {
 
       //#kafka-example
       // We're going to pretend we got messages from kafka.
@@ -294,7 +293,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
         .map(_.book.title)
     }
 
-    "kafka-example - store documents and pass Responses with passThrough skipping some w/ NOP" in assertAllStagesStopped {
+    "kafka-example - store documents and pass Responses with passThrough skipping some w/ NOP" in {
 
       //#kafka-example
       // We're going to pretend we got messages from kafka.
@@ -354,7 +353,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
         .map(_.book.title)
     }
 
-    "kafka-example - skip all NOP documents and pass Responses with passThrough" in assertAllStagesStopped {
+    "kafka-example - skip all NOP documents and pass Responses with passThrough" in {
 
       //#kafka-example
       // We're going to pretend we got messages from kafka.
@@ -411,7 +410,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
       readTitlesFrom(ApiVersion.V5, baseSourceSettings, indexName).futureValue.toList shouldBe List("dummy")
     }
 
-    "handle multiple types of operations correctly" in assertAllStagesStopped {
+    "handle multiple types of operations correctly" in {
       val indexName = "sink8"
       //#multiple-operations
       val requests = List[WriteMessage[Book, NotUsed]](
@@ -459,7 +458,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
       )
     }
 
-    "use indexName supplied in message if present" in assertAllStagesStopped {
+    "use indexName supplied in message if present" in {
       // Copy source/_doc to sink2/_doc through typed stream
 
       //#custom-index-name-example
@@ -499,7 +498,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
   }
 
   "ElasticsearchSource" should {
-    "be able to use custom searchParams" in assertAllStagesStopped {
+    "be able to use custom searchParams" in {
       import spray.json._
       import DefaultJsonProtocol._
 

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV7Spec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV7Spec.scala
@@ -9,7 +9,6 @@ import akka.http.scaladsl.model.{HttpMethods, HttpRequest, Uri}
 import akka.stream.alpakka.elasticsearch.scaladsl.{ElasticsearchFlow, ElasticsearchSink, ElasticsearchSource}
 import akka.stream.alpakka.elasticsearch._
 import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestKit
 import akka.{Done, NotUsed}
 import spray.json.jsonReader
@@ -40,7 +39,7 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
   }
 
   "Un-typed Elasticsearch connector" should {
-    "consume and publish Json documents" in assertAllStagesStopped {
+    "consume and publish Json documents" in {
       val indexName = "sink2"
 
       val copy = ElasticsearchSource
@@ -76,7 +75,7 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
   }
 
   "Typed Elasticsearch connector" should {
-    "consume and publish documents as specific type" in assertAllStagesStopped {
+    "consume and publish documents as specific type" in {
       val indexName = "sink2"
 
       val copy = ElasticsearchSource
@@ -111,7 +110,7 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
   }
 
   "ElasticsearchFlow" should {
-    "store documents and pass failed documents to downstream" in assertAllStagesStopped {
+    "store documents and pass failed documents to downstream" in {
       val indexName = "sink3"
 
       val copy = ElasticsearchSource
@@ -146,7 +145,7 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
       )
     }
 
-    "store properly formatted JSON from Strings" in assertAllStagesStopped {
+    "store properly formatted JSON from Strings" in {
       val indexName = "sink3-0"
 
       val write: Future[immutable.Seq[WriteResult[String, NotUsed]]] = Source(
@@ -175,7 +174,7 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
       )
     }
 
-    "kafka-example - store documents and pass Responses with passThrough" in assertAllStagesStopped {
+    "kafka-example - store documents and pass Responses with passThrough" in {
 
       // We're going to pretend we got messages from kafka.
       // After we've written them to Elastic, we want
@@ -227,7 +226,7 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
         .map(_.book.title)
     }
 
-    "kafka-example - store documents and pass Responses with passThrough in bulk" in assertAllStagesStopped {
+    "kafka-example - store documents and pass Responses with passThrough in bulk" in {
 
       // We're going to pretend we got messages from kafka.
       // After we've written them to Elastic, we want
@@ -280,7 +279,7 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
         .map(_.book.title)
     }
 
-    "kafka-example - store documents and pass Responses with passThrough skipping some w/ NOP" in assertAllStagesStopped {
+    "kafka-example - store documents and pass Responses with passThrough skipping some w/ NOP" in {
 
       // We're going to pretend we got messages from kafka.
       // After we've written them to Elastic, we want
@@ -339,7 +338,7 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
         .map(_.book.title)
     }
 
-    "kafka-example - skip all NOP documents and pass Responses with passThrough" in assertAllStagesStopped {
+    "kafka-example - skip all NOP documents and pass Responses with passThrough" in {
 
       // We're going to pretend we got messages from kafka.
       // After we've written them to Elastic, we want
@@ -395,7 +394,7 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
       readTitlesFrom(ApiVersion.V7, baseSourceSettings, indexName).futureValue.toList shouldBe List("dummy")
     }
 
-    "handle multiple types of operations correctly" in assertAllStagesStopped {
+    "handle multiple types of operations correctly" in {
       val indexName = "sink8"
       val requests = List[WriteMessage[Book, NotUsed]](
         WriteMessage.createIndexMessage(id = "00001", source = Book("Book 1")),
@@ -441,7 +440,7 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
       )
     }
 
-    "use indexName supplied in message if present" in assertAllStagesStopped {
+    "use indexName supplied in message if present" in {
       // Copy source/_doc to sink2/_doc through typed stream
 
       val customIndexName = "custom-index"
@@ -479,7 +478,7 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
   }
 
   "ElasticsearchSource" should {
-    "be able to use custom searchParams" in assertAllStagesStopped {
+    "be able to use custom searchParams" in {
       import spray.json._
       import DefaultJsonProtocol._
 

--- a/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/mock/BigQueryMockServer.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/mock/BigQueryMockServer.scala
@@ -115,6 +115,8 @@ class BigQueryMockServer(port: Int) extends BigQueryMockData {
           ???
       })
 
-    Http().bindAndHandleAsync(service, interface = "0.0.0.0", port = port, connectionContext = HttpConnectionContext())
+    Http()
+      .newServerAt("0.0.0.0", port)
+      .bind(service)
   }
 }

--- a/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/mock/BigQueryMockServer.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/mock/BigQueryMockServer.scala
@@ -9,7 +9,7 @@ import akka.actor.ActorSystem
 import akka.grpc.GrpcServiceException
 import akka.grpc.scaladsl.Metadata
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
-import akka.http.scaladsl.{Http, HttpConnectionContext}
+import akka.http.scaladsl.Http
 import akka.stream.scaladsl.Source
 import com.google.cloud.bigquery.storage.v1.arrow.{ArrowRecordBatch, ArrowSchema}
 import com.google.cloud.bigquery.storage.v1.avro.AvroSchema

--- a/google-cloud-pub-sub/src/test/scala/docs/scaladsl/IntegrationSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/docs/scaladsl/IntegrationSpec.scala
@@ -14,7 +14,6 @@ import akka.stream.alpakka.googlecloud.pubsub.scaladsl.GooglePubSub
 import akka.stream.alpakka.googlecloud.pubsub._
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Keep, Sink, Source}
-import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.TestKit
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
@@ -59,7 +58,7 @@ class IntegrationSpec
     val SampleText = s"Hello Google! ${Instant.now.toString}"
     val SampleMessage = new String(Base64.getEncoder.encode(SampleText.getBytes))
 
-    "publish a message and receive it again" in assertAllStagesStopped {
+    "publish a message and receive it again" in {
       // acknowledge any messages left on the subscription from earlier runs
       val cleanup = GooglePubSub
         .subscribe(topic1subscription, config)
@@ -93,7 +92,7 @@ class IntegrationSpec
       readable(received) shouldBe SampleText
     }
 
-    "receive a published message and acknowledge it" in assertAllStagesStopped {
+    "receive a published message and acknowledge it" in {
       val result = GooglePubSub
         .subscribe(topic2subscription, config)
         .map { message =>

--- a/google-common/src/main/scala/akka/stream/alpakka/google/http/ForwardProxyHttpsContext.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/http/ForwardProxyHttpsContext.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.google.http
 
 import akka.annotation.InternalApi
-import akka.http.scaladsl.HttpsConnectionContext
+import akka.http.scaladsl.{ConnectionContext, HttpsConnectionContext}
 
 import java.io.FileInputStream
 import java.security.KeyStore
@@ -28,7 +28,7 @@ private[google] object ForwardProxyHttpsContext {
     tmf.init(trustStore)
     val trustManagers = tmf.getTrustManagers
     sslContext.init(null, trustManagers, null)
-    new HttpsConnectionContext(sslContext)
+    ConnectionContext.httpsClient(sslContext)
   }
 
   private def x509Certificate(trustPemPath: String): X509Certificate = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,11 +17,8 @@ object Dependencies {
   val AwsSpiAkkaHttpVersion = "0.0.11"
   // Sync with plugins.sbt
   val AkkaGrpcBinaryVersion = "1.0"
-  val AkkaHttp101 = "10.1.15"
-  val AkkaHttp102 = "10.2.0"
-  val AkkaHttp1024 = "10.2.4"
-  val AkkaHttpVersion = if (CronBuild) AkkaHttp102 else AkkaHttp101
-  val AkkaHttpBinaryVersion = if (CronBuild) "10.2" else "10.1"
+  val AkkaHttpVersion = "10.2.8"
+  val AkkaHttpBinaryVersion = "10.2"
   val ScalaTestVersion = "3.2.2"
   val mockitoVersion = "3.4.6" // check even https://github.com/scalatest/scalatestplus-mockito/releases
   val hoverflyVersion = "0.13.1"
@@ -206,9 +203,9 @@ object Dependencies {
 
   val GoogleBigQuery = Seq(
     libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-http" % AkkaHttp1024,
-        "com.typesafe.akka" %% "akka-http-jackson" % AkkaHttp1024 % Provided,
-        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttp1024,
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-jackson" % AkkaHttpVersion % Provided,
+        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
         "io.spray" %% "spray-json" % "1.3.6",
         "com.fasterxml.jackson.core" % "jackson-annotations" % JacksonDatabindVersion,
         "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % JacksonDatabindVersion % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val AwsSpiAkkaHttpVersion = "0.0.11"
   // Sync with plugins.sbt
   val AkkaGrpcBinaryVersion = "1.0"
-  val AkkaHttpVersion = "10.2.7"
+  val AkkaHttpVersion = "10.2.9"
   val AkkaHttpBinaryVersion = "10.2"
   val ScalaTestVersion = "3.2.2"
   val mockitoVersion = "3.4.6" // check even https://github.com/scalatest/scalatestplus-mockito/releases

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val AwsSpiAkkaHttpVersion = "0.0.11"
   // Sync with plugins.sbt
   val AkkaGrpcBinaryVersion = "1.0"
-  val AkkaHttpVersion = "10.2.8"
+  val AkkaHttpVersion = "10.2.7"
   val AkkaHttpBinaryVersion = "10.2"
   val ScalaTestVersion = "3.2.2"
   val mockitoVersion = "3.4.6" // check even https://github.com/scalatest/scalatestplus-mockito/releases

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/auth/CanonicalRequest.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/auth/CanonicalRequest.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.s3.impl.auth
 
 import akka.annotation.InternalApi
 import akka.http.scaladsl.model.Uri.{Path, Query}
-import akka.http.scaladsl.model.headers.{`Raw-Request-URI`, `Remote-Address`, `Timeout-Access`, `Tls-Session-Info`}
+import akka.http.scaladsl.model.headers.{`Raw-Request-URI`, `Timeout-Access`, `Tls-Session-Info`, `X-Forwarded-For`}
 import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
 
 // Documentation: http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
@@ -25,7 +25,7 @@ import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
 @InternalApi private[impl] object CanonicalRequest {
   private val akkaSyntheticHeaderNames = List(
     `Raw-Request-URI`.lowercaseName,
-    `Remote-Address`.lowercaseName,
+    `X-Forwarded-For`.lowercaseName,
     `Timeout-Access`.lowercaseName,
     `Tls-Session-Info`.lowercaseName
   )

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -402,7 +402,6 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures with 
 
   it should "support custom endpoint configured by `endpointUrl`" in {
     implicit val system: ActorSystem = ActorSystem("HttpRequestsSpec")
-    import system.dispatcher
 
     try {
       val probe = TestProbe()
@@ -410,10 +409,12 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures with 
 
       import akka.http.scaladsl.server.Directives._
 
-      Http().bindAndHandle(extractRequestContext { ctx =>
-        probe.ref ! ctx.request
-        complete("MOCK")
-      }, address.getHostName, address.getPort)
+      Http()
+        .newServerAt(address.getHostName, address.getPort)
+        .bind(extractRequestContext { ctx =>
+          probe.ref ! ctx.request
+          complete("MOCK")
+        })
 
       implicit val setting: S3Settings =
         getSettings().withEndpointUrl(s"http://${address.getHostName}:${address.getPort}/")

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/CanonicalRequestSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/CanonicalRequestSpec.scala
@@ -166,7 +166,7 @@ class CanonicalRequestSpec extends AnyFlatSpec with Matchers {
       RawHeader("x-amz-content-sha256", "testhash"),
       `Content-Type`(ContentTypes.`application/json`),
       `Raw-Request-URI`("/my.test.bucket/file%2Bname.txt"),
-      `Remote-Address`(RemoteAddress.Unknown)
+      `X-Forwarded-For`(RemoteAddress.Unknown)
     )
     val canonical = CanonicalRequest.from(req)
     canonical.canonicalString should equal(

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -29,7 +29,7 @@ site-link-validator {
     # MVN repository forbids access after a few requests
     "https://mvnrepository.com/artifact/"
     # Errors in Scaladoc from Google Common header `X-Upload-Content-Type`
-    "https://doc.akka.io/api/akka-http/10.2.8/akka/http/impl/util/"
+    "https://doc.akka.io/api/akka-http/10.2.7/akka/http/impl/util/"
   ]
 
   non-https-whitelist = [

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -29,7 +29,7 @@ site-link-validator {
     # MVN repository forbids access after a few requests
     "https://mvnrepository.com/artifact/"
     # Errors in Scaladoc from Google Common header `X-Upload-Content-Type`
-    "https://doc.akka.io/api/akka-http/10.2.7/akka/http/impl/util/"
+    "https://doc.akka.io/api/akka-http/10.2.9/akka/http/impl/util/"
   ]
 
   non-https-whitelist = [

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -29,7 +29,7 @@ site-link-validator {
     # MVN repository forbids access after a few requests
     "https://mvnrepository.com/artifact/"
     # Errors in Scaladoc from Google Common header `X-Upload-Content-Type`
-    "https://doc.akka.io/api/akka-http/10.1.15/akka/http/impl/util/"
+    "https://doc.akka.io/api/akka-http/10.2.8/akka/http/impl/util/"
   ]
 
   non-https-whitelist = [

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
@@ -12,7 +12,6 @@ import akka.Done
 import akka.stream.alpakka.sqs._
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.Keep
-import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSource
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
@@ -27,7 +26,7 @@ import scala.concurrent.duration._
 
 class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestContext with LogCapturing {
 
-  "SqsPublishSink" should "send a message" in assertAllStagesStopped {
+  "SqsPublishSink" should "send a message" in {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
     when(sqsClient.sendMessage(any[SendMessageRequest]))
       .thenReturn(CompletableFuture.completedFuture(SendMessageResponse.builder().build()))
@@ -40,7 +39,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
       .sendMessage(any[SendMessageRequest]())
   }
 
-  it should "fail stage on client failure and fail the promise" in assertAllStagesStopped {
+  it should "fail stage on client failure and fail the promise" in {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
 
     when(sqsClient.sendMessage(any[SendMessageRequest]()))
@@ -61,7 +60,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
       .sendMessage(any[SendMessageRequest]())
   }
 
-  it should "pull a message and publish it to another queue" taggedAs Integration in assertAllStagesStopped {
+  it should "pull a message and publish it to another queue" taggedAs Integration in {
     val queue1 = randomQueueUrl()
     val queue2 = randomQueueUrl()
     implicit val awsSqsClient = sqsClient
@@ -87,7 +86,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
     result.messages().get(0).body() shouldBe "alpakka"
   }
 
-  it should "failure the promise on upstream failure" in assertAllStagesStopped {
+  it should "failure the promise on upstream failure" in {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
     val (probe, future) = TestSource.probe[String].toMat(SqsPublishSink("notused"))(Keep.both).run()
 
@@ -98,7 +97,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
     }
   }
 
-  it should "complete promise after all messages have been sent" in assertAllStagesStopped {
+  it should "complete promise after all messages have been sent" in {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
 
     when(sqsClient.sendMessage(any[SendMessageRequest]))
@@ -118,7 +117,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
       .sendMessage(any[SendMessageRequest]())
   }
 
-  it should "send batch of messages" in assertAllStagesStopped {
+  it should "send batch of messages" in {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
 
     when(sqsClient.sendMessageBatch(any[SendMessageBatchRequest]))
@@ -142,7 +141,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
     )
   }
 
-  it should "send all messages in batches of given size" in assertAllStagesStopped {
+  it should "send all messages in batches of given size" in {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
 
     when(sqsClient.sendMessageBatch(any[SendMessageBatchRequest]))
@@ -184,7 +183,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
     )
   }
 
-  it should "fail if any of the messages in batch failed" in assertAllStagesStopped {
+  it should "fail if any of the messages in batch failed" in {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
 
     when(sqsClient.sendMessageBatch(any[SendMessageBatchRequest]))
@@ -221,7 +220,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
     )
   }
 
-  it should "fail if whole batch is failed" in assertAllStagesStopped {
+  it should "fail if whole batch is failed" in {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
     when(
       sqsClient.sendMessageBatch(any[SendMessageBatchRequest]())
@@ -250,7 +249,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
     )
   }
 
-  it should "send all batches of messages" in assertAllStagesStopped {
+  it should "send all batches of messages" in {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
 
     when(sqsClient.sendMessageBatch(any[SendMessageBatchRequest]))

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceMockSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceMockSpec.scala
@@ -8,7 +8,6 @@ import java.util.concurrent.CompletableFuture
 
 import akka.stream.alpakka.sqs.SqsSourceSettings
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
-import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.{atMost => atMostTimes, _}
@@ -32,7 +31,7 @@ class SqsSourceMockSpec extends AnyFlatSpec with Matchers with DefaultTestContex
     Message.builder().body(s"message $i").build()
   }
 
-  "SqsSource" should "send a request and unwrap the response" in assertAllStagesStopped {
+  "SqsSource" should "send a request and unwrap the response" in {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
     when(sqsClient.receiveMessage(any[ReceiveMessageRequest]))
       .thenReturn(
@@ -61,7 +60,7 @@ class SqsSourceMockSpec extends AnyFlatSpec with Matchers with DefaultTestContex
     probe.cancel()
   }
 
-  it should "buffer messages and acquire them fast with slow sqs" in assertAllStagesStopped {
+  it should "buffer messages and acquire them fast with slow sqs" in {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
     val timeout = 1.second
     val bufferToBatchRatio = 5
@@ -98,7 +97,7 @@ class SqsSourceMockSpec extends AnyFlatSpec with Matchers with DefaultTestContex
     probe.cancel()
   }
 
-  it should "enable throttling on emptyReceives and disable throttling when a new message arrives" in assertAllStagesStopped {
+  it should "enable throttling on emptyReceives and disable throttling when a new message arrives" in {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
     val firstWithDataCount = 30
     val thenEmptyCount = 15

--- a/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
@@ -14,7 +14,6 @@ import akka.stream.alpakka.sqs.SqsAckResult._
 import akka.stream.alpakka.sqs.SqsAckResultEntry._
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{spy, times, verify, when}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -103,7 +102,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
     batchSettings.maxBatchSize should be(10)
   }
 
-  "AckSink" should "pull and delete message" taggedAs Integration in assertAllStagesStopped {
+  "AckSink" should "pull and delete message" taggedAs Integration in {
     new IntegrationFixture {
       sendMessage("alpakka-2")
 
@@ -122,7 +121,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
     }
   }
 
-  it should "pull and delay a message" taggedAs Integration in assertAllStagesStopped {
+  it should "pull and delay a message" taggedAs Integration in {
     new IntegrationFixture {
       sendMessage("alpakka-3")
 
@@ -141,7 +140,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
     }
   }
 
-  it should "pull and ignore a message" taggedAs Integration in assertAllStagesStopped {
+  it should "pull and ignore a message" taggedAs Integration in {
     new IntegrationFixture {
       sendMessage("alpakka-flow-ack")
 
@@ -157,7 +156,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
     }
   }
 
-  "AckFlow" should "pull and delete message via flow" taggedAs Integration in assertAllStagesStopped {
+  "AckFlow" should "pull and delete message via flow" taggedAs Integration in {
     new IntegrationFixture {
       sendMessage("alpakka-flow-ack")
 
@@ -177,7 +176,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
     }
   }
 
-  it should "pull and ignore a message" taggedAs Integration in assertAllStagesStopped {
+  it should "pull and ignore a message" taggedAs Integration in {
     new IntegrationFixture {
       sendMessage("alpakka-flow-ack")
 
@@ -194,7 +193,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
     }
   }
 
-  it should "delete batch of messages" taggedAs Integration in assertAllStagesStopped {
+  it should "delete batch of messages" taggedAs Integration in {
     new IntegrationFixture {
       val messages = for (i <- 0 until 10) yield s"Message - $i"
       sendMessages(messages)
@@ -261,7 +260,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
     future.failed.futureValue shouldBe a[SqsBatchException]
   }
 
-  it should "fail if the batch request failed" in assertAllStagesStopped {
+  it should "fail if the batch request failed" in {
     val messages = for (i <- 0 until 10) yield Message.builder().body(s"Message - $i").build()
 
     implicit val mockAwsSqsClient = mock[SqsAsyncClient]
@@ -282,7 +281,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
     future.failed.futureValue shouldBe a[SqsBatchException]
   }
 
-  it should "fail if the client invocation failed" in assertAllStagesStopped {
+  it should "fail if the client invocation failed" in {
     val messages = for (i <- 0 until 10) yield Message.builder().body(s"Message - $i").build()
 
     implicit val mockAwsSqsClient = mock[SqsAsyncClient]
@@ -300,7 +299,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
     future.failed.futureValue shouldBe a[RuntimeException]
   }
 
-  it should "delete, delay & ignore all messages in batches of given size" taggedAs Integration in assertAllStagesStopped {
+  it should "delete, delay & ignore all messages in batches of given size" taggedAs Integration in {
     new IntegrationFixture {
       val messages = for (i <- 0 until 10) yield s"Message - $i"
       sendMessages(messages)
@@ -326,7 +325,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
     }
   }
 
-  it should "delay batch of messages" taggedAs Integration in assertAllStagesStopped {
+  it should "delay batch of messages" taggedAs Integration in {
     new IntegrationFixture {
       val messages = for (i <- 0 until 10) yield s"Message - $i"
       sendMessages(messages)
@@ -352,7 +351,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
     }
   }
 
-  it should "ignore batch of messages" in assertAllStagesStopped {
+  it should "ignore batch of messages" in {
     val messages = for (i <- 0 until 10) yield Message.builder().body(s"Message - $i").build()
 
     implicit val mockAwsSqsClient = mock[SqsAsyncClient]

--- a/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
@@ -11,7 +11,6 @@ import akka.stream.alpakka.sqs._
 import akka.stream.alpakka.sqs.scaladsl._
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
@@ -88,7 +87,7 @@ class SqsPublishSpec extends AnyFlatSpec with Matchers with DefaultTestContext w
     batchSettings.concurrentRequests shouldBe 1
   }
 
-  "PublishSink" should "publish and pull a message" taggedAs Integration in assertAllStagesStopped {
+  "PublishSink" should "publish and pull a message" taggedAs Integration in {
     new IntegrationFixture {
       val future =
         //#run-string
@@ -102,7 +101,7 @@ class SqsPublishSpec extends AnyFlatSpec with Matchers with DefaultTestContext w
     }
   }
 
-  it should "publish and pull a message provided as a SendMessageRequest" taggedAs Integration in assertAllStagesStopped {
+  it should "publish and pull a message provided as a SendMessageRequest" taggedAs Integration in {
     new IntegrationFixture {
       val future =
         //#run-send-request
@@ -119,7 +118,7 @@ class SqsPublishSpec extends AnyFlatSpec with Matchers with DefaultTestContext w
     }
   }
 
-  it should "publish and pull a message provided as a SendMessageRequest with dynamic queue" taggedAs Integration in assertAllStagesStopped {
+  it should "publish and pull a message provided as a SendMessageRequest with dynamic queue" taggedAs Integration in {
     new IntegrationFixture {
       val future =
         //#run-send-request
@@ -135,7 +134,7 @@ class SqsPublishSpec extends AnyFlatSpec with Matchers with DefaultTestContext w
     }
   }
 
-  it should "publish messages by grouping and pull them" taggedAs Integration in assertAllStagesStopped {
+  it should "publish messages by grouping and pull them" taggedAs Integration in {
     new IntegrationFixture {
       //#group
       val messages = for (i <- 0 until 10) yield s"Message - $i"
@@ -150,7 +149,7 @@ class SqsPublishSpec extends AnyFlatSpec with Matchers with DefaultTestContext w
     }
   }
 
-  it should "publish batch of messages and pull them" taggedAs Integration in assertAllStagesStopped {
+  it should "publish batch of messages and pull them" taggedAs Integration in {
     new IntegrationFixture {
       //#batch-string
       val messages = for (i <- 0 until 10) yield s"Message - $i"
@@ -166,7 +165,7 @@ class SqsPublishSpec extends AnyFlatSpec with Matchers with DefaultTestContext w
     }
   }
 
-  it should "publish batch of SendMessageRequests and pull them" taggedAs Integration in assertAllStagesStopped {
+  it should "publish batch of SendMessageRequests and pull them" taggedAs Integration in {
     new IntegrationFixture {
       //#batch-send-request
       val messages = for (i <- 0 until 10) yield SendMessageRequest.builder().messageBody(s"Message - $i").build()
@@ -182,7 +181,7 @@ class SqsPublishSpec extends AnyFlatSpec with Matchers with DefaultTestContext w
     }
   }
 
-  "PublishFlow" should "put message in a flow, then pass the result further" taggedAs Integration in assertAllStagesStopped {
+  "PublishFlow" should "put message in a flow, then pass the result further" taggedAs Integration in {
     new IntegrationFixture {
       val future =
         //#flow
@@ -202,7 +201,7 @@ class SqsPublishSpec extends AnyFlatSpec with Matchers with DefaultTestContext w
     }
   }
 
-  it should "put message in a flow, then pass the result further with dynamic queue" taggedAs Integration in assertAllStagesStopped {
+  it should "put message in a flow, then pass the result further with dynamic queue" taggedAs Integration in {
     new IntegrationFixture {
       val future =
         //#flow

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -13,7 +13,6 @@ import akka.stream.alpakka.sqs._
 import akka.stream.alpakka.sqs.scaladsl.{DefaultTestContext, SqsSource}
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Keep, Sink}
-import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import com.github.matsluni.akkahttpspi.AkkaHttpClient
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
@@ -62,7 +61,7 @@ class SqsSourceSpec extends AnyFlatSpec with ScalaFutures with Matchers with Def
     future.futureValue.body() shouldBe "alpakka"
   }
 
-  it should "continue streaming if receives an empty response" taggedAs Integration in assertAllStagesStopped {
+  it should "continue streaming if receives an empty response" taggedAs Integration in {
     new IntegrationFixture {
       val (switch, source) = SqsSource(queueUrl, SqsSourceSettings().withWaitTimeSeconds(0))
         .viaMat(KillSwitches.single)(Keep.right)
@@ -77,7 +76,7 @@ class SqsSourceSpec extends AnyFlatSpec with ScalaFutures with Matchers with Def
     }
   }
 
-  it should "terminate on an empty response if requested" taggedAs Integration in assertAllStagesStopped {
+  it should "terminate on an empty response if requested" taggedAs Integration in {
     new IntegrationFixture {
       val future = SqsSource(queueUrl, sqsSourceSettings.withCloseOnEmptyReceive(true))
         .runWith(Sink.ignore)
@@ -94,7 +93,7 @@ class SqsSourceSpec extends AnyFlatSpec with ScalaFutures with Matchers with Def
     future.failed.futureValue.getCause shouldBe a[QueueDoesNotExistException]
   }
 
-  "SqsSource" should "ask for 'All' attributes set in the settings" taggedAs Integration in assertAllStagesStopped {
+  "SqsSource" should "ask for 'All' attributes set in the settings" taggedAs Integration in {
     new IntegrationFixture {
       val attribute = All
       val settings = sqsSourceSettings.withAttribute(attribute)
@@ -117,7 +116,7 @@ class SqsSourceSpec extends AnyFlatSpec with ScalaFutures with Matchers with Def
   }
 
   allAvailableAttributes foreach { attribute =>
-    it should s"ask for '${attribute.name}' set in the settings" taggedAs Integration in assertAllStagesStopped {
+    it should s"ask for '${attribute.name}' set in the settings" taggedAs Integration in {
       new IntegrationFixture {
         val settings = sqsSourceSettings.withAttribute(attribute)
 
@@ -138,7 +137,7 @@ class SqsSourceSpec extends AnyFlatSpec with ScalaFutures with Matchers with Def
     }
   }
 
-  it should "ask for multiple attributes set in the settings" taggedAs Integration in assertAllStagesStopped {
+  it should "ask for multiple attributes set in the settings" taggedAs Integration in {
     new IntegrationFixture {
       val attributes = allAvailableAttributes.filterNot(_ == All)
       val settings = sqsSourceSettings.withAttributes(attributes)
@@ -161,7 +160,7 @@ class SqsSourceSpec extends AnyFlatSpec with ScalaFutures with Matchers with Def
     }
   }
 
-  it should "ask for all the message attributes set in the settings" taggedAs Integration in assertAllStagesStopped {
+  it should "ask for all the message attributes set in the settings" taggedAs Integration in {
     new IntegrationFixture {
       val messageAttributes = Map(
         "attribute-1" -> MessageAttributeValue.builder().stringValue("v1").dataType("String").build(),
@@ -237,7 +236,7 @@ class SqsSourceSpec extends AnyFlatSpec with ScalaFutures with Matchers with Def
     }
   }
 
-  "SqsSource" should "stream a single batch from the queue with custom client" taggedAs Integration in assertAllStagesStopped {
+  "SqsSource" should "stream a single batch from the queue with custom client" taggedAs Integration in {
     new IntegrationFixture {
       /*
     // #init-custom-client
@@ -276,7 +275,7 @@ class SqsSourceSpec extends AnyFlatSpec with ScalaFutures with Matchers with Def
     }
   }
 
-  it should "stream multiple batches from the queue" taggedAs Integration in assertAllStagesStopped {
+  it should "stream multiple batches from the queue" taggedAs Integration in {
     new IntegrationFixture {
       val input =
         for (i <- 1 to 100)
@@ -300,7 +299,7 @@ class SqsSourceSpec extends AnyFlatSpec with ScalaFutures with Matchers with Def
     }
   }
 
-  it should "stream single message at least twice from the queue when visibility timeout passed" taggedAs Integration in assertAllStagesStopped {
+  it should "stream single message at least twice from the queue when visibility timeout passed" taggedAs Integration in {
     new IntegrationFixture {
       val sendMessageRequest =
         SendMessageRequest
@@ -319,7 +318,7 @@ class SqsSourceSpec extends AnyFlatSpec with ScalaFutures with Matchers with Def
     }
   }
 
-  it should "stream single message once from the queue when visibility timeout did not pass" taggedAs Integration in assertAllStagesStopped {
+  it should "stream single message once from the queue when visibility timeout did not pass" taggedAs Integration in {
     new IntegrationFixture {
       val sendMessageRequest =
         SendMessageRequest

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -139,7 +139,7 @@ class SqsSourceSpec extends AnyFlatSpec with ScalaFutures with Matchers with Def
 
   it should "ask for multiple attributes set in the settings" taggedAs Integration in {
     new IntegrationFixture {
-      val attributes = allAvailableAttributes.filterNot(_ == All)
+      val attributes = allAvailableAttributes.filterNot(attr => attr == All || attr == MessageGroupId)
       val settings = sqsSourceSettings.withAttributes(attributes)
 
       val sendMessageRequest =
@@ -343,9 +343,9 @@ object SqsSourceSpec {
     ApproximateFirstReceiveTimestamp,
     ApproximateReceiveCount,
     SenderId,
-    SentTimestamp,
-    MessageDeduplicationId,
-    MessageGroupId
+    SentTimestamp
+    // MessageDeduplicationId, removed from ElasticMq 1.3.4
+    // MessageGroupId, removed from ElasticMq 1.3.4
     // SequenceNumber, not supported by elasticmq
   )
 }

--- a/sse/src/main/scala/akka/stream/alpakka/sse/scaladsl/EventSource.scala
+++ b/sse/src/main/scala/akka/stream/alpakka/sse/scaladsl/EventSource.scala
@@ -8,17 +8,16 @@ package scaladsl
 import akka.NotUsed
 import akka.actor.{ActorSystem, ClassicActorSystemProvider}
 import akka.http.scaladsl.client.RequestBuilding.Get
-import akka.http.scaladsl.coding.Gzip
-import akka.http.scaladsl.model.headers.Accept
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
-import akka.http.scaladsl.unmarshalling.Unmarshal
-import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL, Merge, Source}
-import akka.stream.SourceShape
+import akka.http.scaladsl.coding.Coders
+import akka.http.scaladsl.model.MediaTypes.`text/event-stream`
+import akka.http.scaladsl.model.headers.{`Last-Event-ID`, Accept}
 import akka.http.scaladsl.model.sse.ServerSentEvent
 import akka.http.scaladsl.model.sse.ServerSentEvent.heartbeat
-import akka.http.scaladsl.model.MediaTypes.`text/event-stream`
-import akka.http.scaladsl.model.headers.`Last-Event-ID`
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
+import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.http.scaladsl.unmarshalling.sse.EventStreamUnmarshalling
+import akka.stream.SourceShape
+import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL, Merge, Source}
 
 import scala.concurrent.Future
 import scala.concurrent.duration.{Duration, FiniteDuration}
@@ -99,7 +98,7 @@ object EventSource {
           lastEventId.foldLeft(r)((r, i) => r.addHeader(`Last-Event-ID`(i)))
         }
         send(request)
-          .map(response => Gzip.decodeMessage(response))
+          .map(response => Coders.Gzip.decodeMessage(response))
           .flatMap(Unmarshal(_).to[EventSource])
           .fallbackTo(Future.successful(noEvents))
       }

--- a/sse/src/test/scala/docs/scaladsl/EventSourceSpec.scala
+++ b/sse/src/test/scala/docs/scaladsl/EventSourceSpec.scala
@@ -6,9 +6,8 @@ package docs.scaladsl
 
 import java.net.InetSocketAddress
 import java.nio.charset.StandardCharsets.UTF_8
-
 import akka.actor.{Actor, ActorLogging, ActorSystem, Props, Status}
-import akka.http.scaladsl.coding.Gzip
+import akka.http.scaladsl.coding.Coders
 import akka.http.scaladsl.marshalling.sse.EventStreamMarshalling
 import akka.http.scaladsl.model.MediaTypes.`text/event-stream`
 import akka.http.scaladsl.model.StatusCodes.BadRequest
@@ -69,7 +68,7 @@ object EventSourceSpec {
       }
 
       path("gzipped") {
-        encodeResponseWith(Gzip) {
+        encodeResponseWith(Coders.Gzip) {
           sseRoute
         }
       } ~
@@ -92,7 +91,7 @@ object EventSourceSpec {
 
     private def unbound: Receive = {
       case Bind =>
-        Http(context.system).bindAndHandle(route(size, shouldSetEventId), address, port).pipeTo(self)
+        Http(context.system).newServerAt(address, port).bind(route(size, shouldSetEventId)).pipeTo(self)
         context.become(binding)
     }
 


### PR DESCRIPTION
Rebased @mrooding's PR #2650 to only use the current Akka HTTP version.
Will need a few more changes to avoid deprecated APIs.

Supersedes #2650 