### PR TITLE
json streaming: test for multiple top level array's

### DIFF
--- a/json-streaming/src/test/scala/docs/scaladsl/JsonReaderTest.scala
+++ b/json-streaming/src/test/scala/docs/scaladsl/JsonReaderTest.scala
@@ -75,6 +75,13 @@ class JsonReaderTest extends AnyWordSpec with Matchers with BeforeAndAfterAll wi
       streamed shouldBe Seq("1", "2", "3").map(ByteString.fromString)
     }
 
+    "properly parse stream and stream multiple json array's as the top-level element" in {
+      val content = "[1, 2, 3]"
+
+      val streamed = collect(Source(List.fill(3)(ByteString.fromString(content))).via(JsonReader.select("$[*]")))
+      streamed shouldBe Seq("1", "2", "3", "1", "2", "3", "1", "2", "3").map(ByteString.fromString)
+    }
+
     "accept a pre-compiled json path rather than a string as a parameter" in {
       val path = JsonPathCompiler.compile("$.rows[*].doc")
 


### PR DESCRIPTION
This PR adds a test to verify if unwrapping a JSON array from a top level element works if there are multiple top level JSON array's. The context of the test is here https://discuss.lightbend.com/t/working-with-eof-for-a-source-flow/9481

I think adding this test would be a good idea to verify such behaviour