### PR TITLE
Use Akka HTTP 10.2.9

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val AwsSpiAkkaHttpVersion = "0.0.11"
   // Sync with plugins.sbt
   val AkkaGrpcBinaryVersion = "1.0"
-  val AkkaHttpVersion = "10.2.7"
+  val AkkaHttpVersion = "10.2.9"
   val AkkaHttpBinaryVersion = "10.2"
   val ScalaTestVersion = "3.2.2"
   val mockitoVersion = "3.4.6" // check even https://github.com/scalatest/scalatestplus-mockito/releases

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -29,7 +29,7 @@ site-link-validator {
     # MVN repository forbids access after a few requests
     "https://mvnrepository.com/artifact/"
     # Errors in Scaladoc from Google Common header `X-Upload-Content-Type`
-    "https://doc.akka.io/api/akka-http/10.2.7/akka/http/impl/util/"
+    "https://doc.akka.io/api/akka-http/10.2.9/akka/http/impl/util/"
   ]
 
   non-https-whitelist = [


### PR DESCRIPTION
On top of #2820 to check if latest snapshot works (in preparation of 10.2.9).