### PR TITLE
updated kinesis client to 2.4.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -335,7 +335,7 @@ object Dependencies {
       ) ++ Seq(
         "software.amazon.awssdk" % "kinesis" % AwsSdk2Version, // ApacheV2
         "software.amazon.awssdk" % "firehose" % AwsSdk2Version, // ApacheV2
-        "software.amazon.kinesis" % "amazon-kinesis-client" % "2.3.3" // ApacheV2
+        "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.0" // ApacheV2
       ).map(
         _.excludeAll(
           ExclusionRule("software.amazon.awssdk", "apache-client"),


### PR DESCRIPTION
The kinesis client is over 1 year old, and the recently released version 2.4 contains several bugfixes and, some even directed towards Scala

https://github.com/awslabs/amazon-kinesis-client/blob/master/CHANGELOG.md