### PR TITLE
bump: Akka 2.6.19

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val Scala213 = "2.13.8" // update even in link-validator.conf
   val ScalaVersions = Seq(Scala213)
 
-  val AkkaVersion = "2.6.18"
+  val AkkaVersion = "2.6.19"
   val AkkaBinaryVersion = "2.6"
 
   val InfluxDBJavaVersion = "2.15"


### PR DESCRIPTION
Updates alpakka to use the newest released version of Akka