### PR TITLE
AWS S3: Use testcontainer-scala-scalatest to setup Minio docker

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -113,7 +113,7 @@ jobs:
           - { connector: orientdb,                     pre_cmd: 'docker-compose up -d orientdb' }
           - { connector: pravega,                      pre_cmd: 'docker-compose up -d pravega'}
           - { connector: reference }
-          - { connector: s3,                           pre_cmd: 'docker-compose up -d minio_prep' }
+          - { connector: s3 }
           - { connector: spring-web }
           - { connector: simple-codecs }
           - { connector: slick }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,31 +197,6 @@ services:
     command: tserver
     links:
       - kudu-master
-  minio:
-    image: minio/minio:RELEASE.2020-03-09T18-26-53Z
-    ports:
-      - "9000:9000"
-    environment:
-      - "MINIO_ACCESS_KEY=TESTKEY"
-      - "MINIO_SECRET_KEY=TESTSECRET"
-      - "MINIO_DOMAIN=s3minio.alpakka"
-    command: server /data
-  minio_prep:
-    image: mesosphere/aws-cli
-    links:
-      - "minio"
-    environment:
-      - "AWS_ACCESS_KEY_ID=TESTKEY"
-      - "AWS_SECRET_ACCESS_KEY=TESTSECRET"
-    entrypoint: ""
-    command: >
-      sh -c "
-        aws --endpoint-url http://minio:9000 s3api create-bucket --bucket my.test.frankfurt
-        aws --endpoint-url http://minio:9000 s3api create-bucket --bucket my-test-us-east-1
-        aws --endpoint-url http://minio:9000 s3api create-bucket --bucket my-bucket-with-versioning
-        # TODO: The following does not work due to https://github.com/akka/alpakka/issues/2750
-        aws --endpoint-url http://minio:9000 s3api put-bucket-versioning --bucket my-bucket-with-versioning --versioning-configuration Status=Enabled
-      "
   mongo:
     image: mongo
     ports:

--- a/docs/src/main/paradox/s3.md
+++ b/docs/src/main/paradox/s3.md
@@ -212,6 +212,5 @@ Java
     > s3/test
     ```
 
-> Some test code requires [Minio](https://github.com/minio/minio) running in the background. You can start one quickly using docker:
->
-> `docker-compose up minio_prep`
+> Some test code requires [docker](https://www.docker.com/) to be installed and running. Please read either the
+> [official instructions](https://www.docker.com/get-started/) or refer to your Linux distro.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,6 +20,7 @@ object Dependencies {
   val AkkaHttpVersion = "10.2.9"
   val AkkaHttpBinaryVersion = "10.2"
   val ScalaTestVersion = "3.2.2"
+  val TestContainersScalaTestVersion = "0.40.3"
   val mockitoVersion = "3.4.6" // check even https://github.com/scalatest/scalatestplus-mockito/releases
   val hoverflyVersion = "0.13.1"
 
@@ -46,6 +47,7 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
         "ch.qos.logback" % "logback-classic" % "1.2.3", // Eclipse Public License 1.0
         "org.scalatest" %% "scalatest" % ScalaTestVersion,
+        "com.dimafeng" %% "testcontainers-scala-scalatest" % TestContainersScalaTestVersion,
         "com.novocode" % "junit-interface" % "0.11", // BSD-style
         "ch.qos.logback" % "logback-classic" % "1.2.3", // Eclipse Public License 1.0
         "junit" % "junit" % "4.13" // Eclipse Public License 1.0

--- a/s3/src/test/scala/akka/stream/alpakka/s3/MinioContainer.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/MinioContainer.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.s3
+
+import com.dimafeng.testcontainers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+
+import java.time.Duration
+
+class MinioContainer(accessKey: String, secretKey: String, domain: String)
+    extends GenericContainer(
+      "minio/minio:RELEASE.2020-03-09T18-26-53Z",
+      exposedPorts = List(9000),
+      waitStrategy = Some(Wait.forHttp("/minio/health/ready").forPort(9000).withStartupTimeout(Duration.ofSeconds(10))),
+      command = List("server", "/data"),
+      env = Map(
+        "MINIO_ACCESS_KEY" -> accessKey,
+        "MINIO_SECRET_KEY" -> secretKey,
+        "MINIO_DOMAIN" -> domain
+      )
+    ) {
+
+  def getHostAddress: String =
+    s"http://${container.getContainerIpAddress}:${container.getMappedPort(9000)}"
+
+  def getVirtualHost: String =
+    s"http://{bucket}.$domain:${container.getMappedPort(9000)}"
+
+}

--- a/s3/src/test/scala/akka/stream/alpakka/s3/MinioS3Test.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/MinioS3Test.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.s3
+
+import akka.testkit.TestKitBase
+import com.dimafeng.testcontainers.ForAllTestContainer
+import org.scalatest.Suite
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+
+trait MinioS3Test extends ForAllTestContainer with TestKitBase { self: Suite =>
+  val S3DummyAccessKey = "TESTKEY"
+  val S3DummySecretKey = "TESTSECRET"
+  val S3DummyDomain = "s3minio.alpakka"
+
+  override lazy val container: MinioContainer = new MinioContainer(S3DummyAccessKey, S3DummySecretKey, S3DummyDomain)
+
+  lazy val s3Settings: S3Settings =
+    S3Settings()
+      .withEndpointUrl(container.getHostAddress)
+      .withCredentialsProvider(
+        StaticCredentialsProvider.create(AwsBasicCredentials.create(S3DummyAccessKey, S3DummySecretKey))
+      )
+}


### PR DESCRIPTION
Replaces manual starting of minio docker containers in github actions/docker-compose with https://github.com/testcontainers/testcontainers-scala. The changes are a bit more involved than originally anticipated mainly as a result of a race condition between Actor initialization of a typesafe `Config` and testcontainers starting (basically the issue is that when you do `ActorSystem(config)` this will evaluate immediately when the test initializes which is an issue since that is before the `beforeAll` of scalatest (and hence before container actually starts via testcontainers-scala-scalatest). Note that the usage of `lazy val` is also due to this, i.e. we only want to evaluate settings when needed (which is when the tests are actually run and not immediately)

The solution was rather than using typesafe config to configure the S3 client in tests, we instead use `S3Settings` which along with the usage of `S3Attributes.settings` allows us to evaluate settings whenever we want. The usage of `S3Settings` directly has also provided other benefits.

* Boilerplate was removed from `MinioS3IntegrationSpec`since everything can now easily be configured via the usage of builder pattern on `S3Settings()`. A lot of methods which needed to be overridden in `MinioS3IntegrationSpec` now no longer need to be done so.
* We can now use `TestKit` to setup `ActorSystem` for testing which we couldn't before since we were passing non-static configuration to `ActorSystem`.

I have also verified that the `AWSIntegrationSpec` still works by adding the settings in `s3/src/test/resources/application.conf` as documented.

References: https://github.com/akka/alpakka/issues/2841
