### PR TITLE
AWS S3: Include custom headers in all multipart copy requests

### DIFF
--- a/docs/src/main/paradox/avroparquet.md
+++ b/docs/src/main/paradox/avroparquet.md
@@ -2,7 +2,7 @@
 
 The Avro Parquet connector provides an Akka Stream Source, Sink and Flow for push and pull data to and from Parquet files.
 
-For more information about Apache Parquet please visit the [official documentation](https://parquet.apache.org/documentation/latest/).
+For more information about Apache Parquet please visit the [official documentation](https://parquet.apache.org/docs/).
 
 @@project-info{ projectId="avroparquet" }
 

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -981,9 +981,7 @@ import scala.util.{Failure, Success, Try}
     override def renderInResponses(): Boolean = true
   }
 
-  private def completeMultipartUpload(s3Location: S3Location,
-                                      parts: Seq[SuccessfulUploadPart],
-                                      s3Headers: S3Headers)(
+  private def completeMultipartUpload(s3Location: S3Location, parts: Seq[SuccessfulUploadPart], s3Headers: S3Headers)(
       implicit mat: Materializer,
       attr: Attributes
   ): Future[CompleteMultipartUploadResult] = {


### PR DESCRIPTION
This PR addresses the issue referenced below by ensuring that custom S3 headers passed to multipart copy are included when copying parts and in the final completion request. 

References #2839 
