### PR TITLE
Couchbase: retract supported level

### DIFF
--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -148,6 +148,11 @@ project-info {
     issues.url: ${project-info.labels}"couchbase"
     levels: [
       {
+        readiness: CommunityDriven
+        since: "2022-04-04"
+        since-version: "4.0.0"
+      }
+      {
         readiness: Supported
         since: "2019-04-04"
         since-version: "1.0.0"


### PR DESCRIPTION
The coming Alpakka Couchbase release will not be considered supported.