### PR TITLE
Use testcontainers to setup Rabbitmq docker

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { connector: amqp,                         pre_cmd: 'docker-compose up -d amqp' }
+          - { connector: amqp }
           - { connector: avroparquet }
           - { connector: awslambda }
           - { connector: aws-event-bridge,             pre_cmd: 'docker-compose up -d amazoneventbridge' }

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectionProvidersTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectionProvidersTest.java
@@ -20,8 +20,7 @@ import org.junit.Test;
 
 import java.net.ConnectException;
 
-public class AmqpConnectionProvidersTest {
-
+public class AmqpConnectionProvidersTest extends RabbitMQJUnitTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
@@ -39,8 +39,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-/** Needs a local running AMQP server on the default port with no password. */
-public class AmqpConnectorsTest {
+public class AmqpConnectorsTest extends RabbitMQJUnitTest {
 
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpFlowTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpFlowTest.java
@@ -32,8 +32,7 @@ import akka.stream.testkit.javadsl.TestSink;
 import akka.util.ByteString;
 import scala.collection.JavaConverters;
 
-/** Needs a local running AMQP server on the default port with no password. */
-public class AmqpFlowTest {
+public class AmqpFlowTest extends RabbitMQJUnitTest {
 
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/RabbitMQJUnitTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/RabbitMQJUnitTest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.amqp.javadsl;
+
+import akka.stream.alpakka.amqp.RabbitMqFixedPortContainer;
+import akka.stream.alpakka.amqp.RabbitMQTest$;
+
+// See https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/
+public class RabbitMQJUnitTest {
+  public static final RabbitMqFixedPortContainer CONTAINER;
+
+  static {
+    CONTAINER = RabbitMQTest$.MODULE$.rabbitMQFixedPortContainer();
+    CONTAINER.start();
+  }
+}

--- a/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
+++ b/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
@@ -16,6 +16,7 @@ import akka.stream.alpakka.amqp.javadsl.AmqpFlow;
 import akka.stream.alpakka.amqp.javadsl.AmqpRpcFlow;
 import akka.stream.alpakka.amqp.javadsl.AmqpSink;
 import akka.stream.alpakka.amqp.javadsl.AmqpSource;
+import akka.stream.alpakka.amqp.javadsl.RabbitMQJUnitTest;
 import akka.stream.alpakka.amqp.javadsl.CommittableReadResult;
 import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Flow;
@@ -39,8 +40,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
-/** Needs a local running AMQP server on the default port with no password. */
-public class AmqpDocsTest {
+public class AmqpDocsTest extends RabbitMQJUnitTest {
 
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/AmqpSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/AmqpSpec.scala
@@ -12,7 +12,13 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-abstract class AmqpSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with LogCapturing {
+abstract class AmqpSpec
+    extends AnyWordSpec
+    with RabbitMQTest
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with LogCapturing {
 
   implicit val system = ActorSystem(this.getClass.getSimpleName)
   implicit val executionContext = ExecutionContexts.parasitic

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/RabbitMQTest.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/RabbitMQTest.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.amqp
+
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+// Ideally we would use the provided testcontainers-scala-scalatest
+// ForAllTestContainer however we need to share a global singleton
+// instance of RabbitMqFixedPortContainer with the JUnit tests.
+trait RabbitMQTest extends BeforeAndAfterAll { this: Suite =>
+  import RabbitMQTest._
+  lazy val container: RabbitMqFixedPortContainer = rabbitMQFixedPortContainer
+
+  override def beforeAll(): Unit =
+    rabbitMQFixedPortContainer
+}
+
+object RabbitMQTest {
+  lazy val credentials: AmqpCredentials = AmqpCredentials("user", "password")
+  lazy val rabbitMQFixedPortContainer: RabbitMqFixedPortContainer = {
+    val container = new RabbitMqFixedPortContainer
+    container.start()
+    container
+  }
+}

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/RabbitMqFixedPortContainer.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/RabbitMqFixedPortContainer.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.amqp
+
+import com.dimafeng.testcontainers.FixedHostPortGenericContainer
+
+// The FixedHostPortGenericContainer is needed to test LocalAmqpConnection
+class RabbitMqFixedPortContainer
+    extends FixedHostPortGenericContainer(
+      "rabbitmq:3",
+      exposedPorts = List(5672),
+      exposedHostPort = 5672,
+      exposedContainerPort = 5672
+    )

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -21,9 +21,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.collection.immutable
 
-/**
- * Needs a local running AMQP server on the default port with no password.
- */
 class AmqpConnectorsSpec extends AmqpSpec {
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(10.seconds)

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpGraphStageLogicConnectionShutdownSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpGraphStageLogicConnectionShutdownSpec.scala
@@ -14,7 +14,8 @@ import akka.stream.alpakka.amqp.{
   AmqpConnectionFactoryConnectionProvider,
   AmqpProxyConnection,
   AmqpWriteSettings,
-  QueueDeclaration
+  QueueDeclaration,
+  RabbitMQTest
 }
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.Source
@@ -35,6 +36,7 @@ import org.scalatest.wordspec.AnyWordSpec
  */
 class AmqpGraphStageLogicConnectionShutdownSpec
     extends AnyWordSpec
+    with RabbitMQTest
     with Matchers
     with ScalaFutures
     with BeforeAndAfterEach

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,6 @@ services:
       - "4100:4100"
     volumes:
     - ./sns/src/test/travis/:/conf/
-  amqp:
-    image: rabbitmq:3
-    ports:
-      - "5672:5672"
   cassandra:
     image: cassandra:4.0
     ports:


### PR DESCRIPTION
Replaces manual starting of rabbitmq docker containers in github actions/docker-compose with https://github.com/testcontainers/testcontainers-scala.

Ideally I would have liked to used testcontainers in the idiomatic way (i.e. each test file starting its own docker container with a dynamic IP allowing you to have multiple rabbitmq instances on a single machine). Instead we are forced to use a `FixedPortContainer` that binds a docker container to a static IP (which means you can only have global instance of rabbitmq running), for 2 main reasons

* There appears to be unusual behavior in testing for authentication failed, i.e. https://github.com/akka/alpakka/blob/81580cbc4de9a5f97f6541a0096392e80d9c126f/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala#L52-L70 and https://github.com/akka/alpakka/blob/81580cbc4de9a5f97f6541a0096392e80d9c126f/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java#L92-L120. Basically from what I can tell, when using a Rabbitmq docker container its impossible to test this functionality if rabbitmq is not running on `localhost:5672` because you get a different exception (i.e. `ConnectionRefused` instead of `AuthenticationException`). See https://groups.google.com/g/rabbitmq-users/c/IrcosevMexs for more details

* We have specific tests usually called `LocalAmqpConnection`* which tests the `AmqpLocalConnectionProvider.getInstance()` method. This method creates an Amqp connection provider bound to localhost:5672 which means the only way to test this functionality is to have rabbitmq running on a fixed port (5672)

This means that even if we managed to solve the first point, in order to test `AmqpLocalConnectionProvider.getInstance()` we need a rabbitmq with a fixed port anyways (either that or we would have to disable the tests). There is an argument though that these tests are over compensating, i.e. if you want to test that `AmqpLocalConnectionProvider.getInstance()` points to `localhost:5672` you can just write a unit test that confirms the connection details.

Regarding not stopping the testcontainers docker-container, you don't need to do this since its already handled by https://github.com/testcontainers/moby-ryuk which will automatically close all created docker containers when the JVM process exits

References https://github.com/akka/alpakka/issues/2841
