### PR TITLE
Use testcontainers to setup Mongodb docker

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -107,7 +107,7 @@ jobs:
           - { connector: json-streaming }
           - { connector: kinesis }
           - { connector: kudu,                         pre_cmd: 'docker-compose up -d kudu-master-data kudu-tserver-data kudu-master kudu-tserver' }
-          - { connector: mongodb,                      pre_cmd: 'docker-compose up -d mongo' }
+          - { connector: mongodb }
           - { connector: mqtt,                         pre_cmd: 'docker-compose up -d mqtt' }
           - { connector: mqtt-streaming,               pre_cmd: 'docker-compose up -d mqtt' }
           - { connector: orientdb,                     pre_cmd: 'docker-compose up -d orientdb' }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,10 +197,6 @@ services:
     command: tserver
     links:
       - kudu-master
-  mongo:
-    image: mongo
-    ports:
-      - "27017:27017"
   influxdb:
     image: influxdb:1.8-alpine
     ports:

--- a/docs/src/main/paradox/mongodb.md
+++ b/docs/src/main/paradox/mongodb.md
@@ -38,7 +38,8 @@ The table below shows direct dependencies of this module and the second tab show
 
 In the code examples below we will be using Mongo's support for automatic codec derivation for POJOs.
 For Scala we will be using a case class and a macro based codec derivation.
-For Java a codec for POJO is derived using reflection.
+For Java a codec for POJO is derived using reflection. We assume that you already have an 
+@apidoc[akka.actor.ActorSystem] set up.
 
 Scala
 : @@snip [snip](/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala) { #pojo }
@@ -62,15 +63,6 @@ Scala
 
 Java
 : @@snip [snip](/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java) { #init-connection }
-
-We will also need an @apidoc[akka.actor.ActorSystem].
-
-Scala
-: @@snip [snip](/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala) { #init-system }
-
-Java
-: @@snip [snip](/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java) { #init-system }
-
 
 ## Source
 

--- a/mongodb/src/test/java/docs/javadsl/MongoJUnitTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoJUnitTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.javadsl;
+
+import com.dimafeng.testcontainers.MongoDBContainer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import scala.Option;
+
+@RunWith(Suite.class)
+public class MongoJUnitTest {
+  public static final MongoDBContainer CONTAINER = new MongoDBContainer(Option.empty());
+
+  @BeforeClass
+  public static void startContainer() {
+    CONTAINER.start();
+  }
+
+  @AfterClass
+  public static void stopContainer() {
+    CONTAINER.stop();
+  }
+
+  String getConnectionString() {
+    return "mongodb://"
+        + CONTAINER.container().getContainerIpAddress()
+        + ":"
+        + CONTAINER.container().getMappedPort(27017);
+  }
+}

--- a/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
@@ -16,6 +16,7 @@ import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.testkit.javadsl.StreamTestKit;
+import akka.testkit.javadsl.TestKit;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.model.Updates;
@@ -42,7 +43,7 @@ import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class MongoSinkTest {
+public class MongoSinkTest extends MongoJUnitTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
@@ -64,7 +65,7 @@ public class MongoSinkTest {
     CodecRegistry codecRegistry =
         fromRegistries(fromProviders(codecProvider, new ValueCodecProvider()));
 
-    client = MongoClients.create("mongodb://localhost:27017");
+    client = MongoClients.create(getConnectionString());
     db = client.getDatabase("MongoSinkTest");
     numbersColl = db.getCollection("numbers", Number.class).withCodecRegistry(codecRegistry);
     numbersDocumentColl = db.getCollection("numbers");
@@ -127,7 +128,7 @@ public class MongoSinkTest {
 
   @AfterClass
   public static void terminateActorSystem() {
-    system.terminate();
+    TestKit.shutdownActorSystem(system);
   }
 
   @Test

--- a/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java
@@ -12,6 +12,7 @@ import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
 import akka.stream.javadsl.Source;
 import akka.stream.javadsl.Sink;
 import akka.stream.testkit.javadsl.StreamTestKit;
+import akka.testkit.javadsl.TestKit;
 import com.mongodb.client.result.InsertManyResult;
 import com.mongodb.reactivestreams.client.*;
 import org.bson.Document;
@@ -29,7 +30,7 @@ import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 
-public class MongoSourceTest {
+public class MongoSourceTest extends MongoJUnitTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
@@ -40,9 +41,7 @@ public class MongoSourceTest {
   private final MongoCollection<Number> numbersColl;
 
   public MongoSourceTest() {
-    // #init-system
     system = ActorSystem.create();
-    // #init-system
 
     // #codecs
     PojoCodecProvider codecProvider = PojoCodecProvider.builder().register(Number.class).build();
@@ -50,8 +49,10 @@ public class MongoSourceTest {
         CodecRegistries.fromProviders(codecProvider, new ValueCodecProvider());
     // #codecs
 
+    final String CONNECTION_STRING = getConnectionString();
+
     // #init-connection
-    client = MongoClients.create("mongodb://localhost:27017");
+    client = MongoClients.create(CONNECTION_STRING);
     db = client.getDatabase("MongoSourceTest");
     numbersColl = db.getCollection("numbers", Number.class).withCodecRegistry(codecRegistry);
     // #init-connection
@@ -78,7 +79,7 @@ public class MongoSourceTest {
 
   @AfterClass
   public static void terminateActorSystem() {
-    system.terminate();
+    TestKit.shutdownActorSystem(system);
   }
 
   @Test

--- a/mongodb/src/test/scala/docs/scaladsl/MongoTest.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.scaladsl
+
+import akka.testkit.TestKitBase
+import com.dimafeng.testcontainers.{ForAllTestContainer, MongoDBContainer}
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait MongoTest extends ForAllTestContainer with TestKitBase with BeforeAndAfterAll { self: Suite =>
+  override lazy val container = new MongoDBContainer()
+
+  lazy val ConnectionString: String =
+    s"mongodb://${container.container.getContainerIpAddress}:${container.container.getMappedPort(27017)}"
+
+  override protected def afterAll(): Unit = {
+    shutdown()
+    super.afterAll()
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -356,7 +356,8 @@ object Dependencies {
 
   val MongoDb = Seq(
     libraryDependencies ++= Seq(
-        "org.mongodb.scala" %% "mongo-scala-driver" % "4.4.0" // ApacheV2
+        "org.mongodb.scala" %% "mongo-scala-driver" % "4.4.0", // ApacheV2
+        "com.dimafeng" %% "testcontainers-scala-mongodb" % TestContainersScalaTestVersion % Test
       )
   )
 


### PR DESCRIPTION
Replaces manual starting of mongodb docker containers in github actions/docker-compose with https://github.com/testcontainers/testcontainers-scala.

The only notable thing about the implementation in this PR is that due to the fact that some tests use paradox snippets this will mean some documentation will change, i.e. instead of saying

```scala
private val client = MongoClients.create(s"mongodb://localhost:27017")
```

it will instead say

```scala
private lazy val client = MongoClients.create(connectionString)
```

The `lazy val`s are required because otherwise they will initialize before the container is even started in testcontainers and the `connectionString`/`getConnectionString()` is required because testcontainers doesn't start docker with a global fixed port of 27017.

I am not sure if the change to the docs are a deal breaker but note that if you don't want these changes in the test I will have to use `FixedPortContainer` like in https://github.com/akka/alpakka/pull/2855 which does bring disadvantages, namely the fact that the container will run for the entire lifecycle of the JVM process rather than when only the tests are running (as they are now). This is not going to cause an issue now but as per https://github.com/akka/alpakka/issues/2841#issuecomment-1077380058 ideally once everything is migrated I would like to use a single runner for all of the tests which would only work well if each test starts and shuts down its own docker containers and doing this with both JUnit and ScalaTest tests is problematic.


References https://github.com/akka/alpakka/issues/2841
