### PR TITLE
Use testcontainers to setup OrientDb docker

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -110,7 +110,7 @@ jobs:
           - { connector: mongodb,                      pre_cmd: 'docker-compose up -d mongo' }
           - { connector: mqtt,                         pre_cmd: 'docker-compose up -d mqtt' }
           - { connector: mqtt-streaming,               pre_cmd: 'docker-compose up -d mqtt' }
-          - { connector: orientdb,                     pre_cmd: 'docker-compose up -d orientdb' }
+          - { connector: orientdb }
           - { connector: pravega,                      pre_cmd: 'docker-compose up -d pravega'}
           - { connector: reference }
           - { connector: s3 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,13 +211,6 @@ services:
       - "1883:1883"
     volumes:
       - ./mqtt/src/test/travis:/mqtt/config/conf.d
-  orientdb:
-    image: orientdb:3.1.9
-    ports:
-      - "2424:2424"
-    environment:
-      - "ORIENTDB_ROOT_PASSWORD=root"
-    command: /orientdb/bin/server.sh -Dmemory.chunk.size=268435456
   sftp:
     image: atmoz/sftp
     volumes:

--- a/docs/src/main/paradox/orientdb.md
+++ b/docs/src/main/paradox/orientdb.md
@@ -36,10 +36,10 @@ The table below shows direct dependencies of this module and the second tab show
 Sources, Flows and Sinks provided by this connector need a `OPartitionedDatabasePool` to access to OrientDB. It is your responsibility to close the database connection eg. at actor system termination. **This API has become deprecated in OrientDB, please suggest a Pull Request to use the latest APIs instead.**
 
 Scala
-: @@snip [snip](/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala) { #init-settings }
+: @@snip [snip](/orientdb/src/test/scala/docs/scaladsl/OrientDbBaseSpec.scala) { #init-settings }
 
 Java
-: @@snip [snip](/orientdb/src/test/java/docs/javadsl/OrientDbTest.java) { #init-settings }
+: @@snip [snip](/orientdb/src/test/java/docs/javadsl/OrientDbBaseTest.java) { #init-settings }
 
 
 ## Reading `ODocument` from OrientDB
@@ -48,10 +48,10 @@ Now we can stream messages which contain OrientDB's `ODocument` (in Scala or Jav
 @scala[@scaladoc[OrientDbSource](akka.stream.alpakka.orientdb.scaladsl.OrientDbSource$)]@java[@scaladoc[OrientDbSource](akka.stream.alpakka.orientdb.javadsl.OrientDbSource$)].
 
 Scala
-: @@snip [snip](/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala) { #run-odocument }
+: @@snip [snip](/orientdb/src/test/scala/docs/scaladsl/OrientDbBaseSpec.scala) { #run-odocument }
 
 Java
-: @@snip [snip](/orientdb/src/test/java/docs/javadsl/OrientDbTest.java) { #run-odocument }
+: @@snip [snip](/orientdb/src/test/java/docs/javadsl/OrientDbBaseTest.java) { #run-odocument }
 
 
 ## Typed messages
@@ -59,16 +59,16 @@ Java
 Also, it's possible to stream messages which contains any classes. 
 
 Java
-: @@snip [snip](/orientdb/src/test/java/docs/javadsl/OrientDbTest.java) { #define-class }
+: @@snip [snip](/orientdb/src/test/java/docs/javadsl/OrientDbBaseTest.java) { #define-class }
 
 
 Use `OrientDbSource.typed` and `OrientDbSink.typed` to create source and sink instead.
 
 Scala
-: @@snip [snip](/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala) { #run-typed }
+: @@snip [snip](/orientdb/src/test/scala/docs/scaladsl/OrientDbBaseSpec.scala) { #run-typed }
 
 Java
-: @@snip [snip](/orientdb/src/test/java/docs/javadsl/OrientDbTest.java) { #run-typed }
+: @@snip [snip](/orientdb/src/test/java/docs/javadsl/OrientDbBaseTest.java) { #run-typed }
 
 
 ## Source configuration
@@ -76,10 +76,10 @@ Java
 We can configure the source by `OrientDbSourceSettings`.
 
 Scala
-: @@snip [snip](/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala) { #source-settings }
+: @@snip [snip](/orientdb/src/test/scala/docs/scaladsl/OrientDbBaseSpec.scala) { #source-settings }
 
 Java
-: @@snip [snip](/orientdb/src/test/java/docs/javadsl/OrientDbTest.java) { #source-settings }
+: @@snip [snip](/orientdb/src/test/java/docs/javadsl/OrientDbBaseTest.java) { #source-settings }
 
 
 | Parameter        | Default | Description |
@@ -94,10 +94,10 @@ Java
 You can also build flow stages. The API is similar to creating Sinks.
 
 Scala
-: @@snip [snip](/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala) { #run-flow }
+: @@snip [snip](/orientdb/src/test/scala/docs/scaladsl/OrientDbBaseSpec.scala) { #run-flow }
 
 Java
-: @@snip [snip](/orientdb/src/test/java/docs/javadsl/OrientDbTest.java) { #run-flow }
+: @@snip [snip](/orientdb/src/test/java/docs/javadsl/OrientDbBaseTest.java) { #run-flow }
 
 
 ### Passing data through OrientDBFlow
@@ -105,7 +105,7 @@ Java
 When streaming documents from Kafka, you might want to commit to Kafka **AFTER** the document has been written to OrientDB.
 
 Scala
-: @@snip [snip](/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala) { #kafka-example }
+: @@snip [snip](/orientdb/src/test/scala/docs/scaladsl/OrientDbBaseSpec.scala) { #kafka-example }
 
 Java
-: @@snip [snip](/orientdb/src/test/java/docs/javadsl/OrientDbTest.java) { #kafka-example } 
+: @@snip [snip](/orientdb/src/test/java/docs/javadsl/OrientDbBaseTest.java) { #kafka-example } 

--- a/orientdb/src/test/java/docs/javadsl/OrientDbBaseTest.java
+++ b/orientdb/src/test/java/docs/javadsl/OrientDbBaseTest.java
@@ -42,22 +42,13 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
-public class OrientDbTest {
+public class OrientDbBaseTest extends OrientDbJUnitTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static OServerAdmin oServerAdmin;
   private static OPartitionedDatabasePool oDatabase;
   private static ODatabaseDocumentTx client;
   private static ActorSystem system;
-
-  // #init-settings
-
-  private static String url = "remote:127.0.0.1:2424/";
-  private static String dbName = "GratefulDeadConcertsJava";
-  private static String dbUrl = url + dbName;
-  private static String username = "root";
-  private static String password = "root";
-  // #init-settings
 
   private static String sourceClass = "source1";
   private static String sinkClass1 = "sink1";
@@ -140,18 +131,23 @@ public class OrientDbTest {
 
   @BeforeClass
   public static void setup() throws Exception {
+
     system = ActorSystem.create();
-
-    oServerAdmin = new OServerAdmin(url).connect(username, password);
-    if (!oServerAdmin.existsDatabase(dbName, "plocal")) {
-      oServerAdmin.createDatabase(dbName, "document", "plocal");
-    }
-
+    String ORIENTDB_URL = CONTAINER.url();
     // #init-settings
+    String DB_NAME = "GratefulDeadConcertsJava";
+    String DB_URL = ORIENTDB_URL + DB_NAME;
+    String USERNAME = "root";
+    String PASSWORD = "root";
+
+    oServerAdmin = new OServerAdmin(ORIENTDB_URL).connect(USERNAME, PASSWORD);
+    if (!oServerAdmin.existsDatabase(DB_NAME, "plocal")) {
+      oServerAdmin.createDatabase(DB_NAME, "document", "plocal");
+    }
 
     oDatabase =
         new OPartitionedDatabasePool(
-            dbUrl, username, password, Runtime.getRuntime().availableProcessors(), 10);
+            DB_URL, USERNAME, PASSWORD, Runtime.getRuntime().availableProcessors(), 10);
 
     system.registerOnTermination(() -> oDatabase.close());
     // #init-settings
@@ -176,13 +172,9 @@ public class OrientDbTest {
     unregister(sink3);
     unregister(sink6);
 
-    if (oServerAdmin.existsDatabase(dbName, "plocal")) {
-      oServerAdmin.dropDatabase(dbName, "plocal");
-    }
     oServerAdmin.close();
 
     client.close();
-    oDatabase.close();
     TestKit.shutdownActorSystem(system);
   }
 

--- a/orientdb/src/test/java/docs/javadsl/OrientDbJUnitTest.java
+++ b/orientdb/src/test/java/docs/javadsl/OrientDbJUnitTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.javadsl;
+
+import docs.scaladsl.OrientDbContainer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+public class OrientDbJUnitTest {
+  public static final OrientDbContainer CONTAINER = new OrientDbContainer();
+
+  @BeforeClass
+  public static void startContainer() {
+    CONTAINER.start();
+  }
+
+  @AfterClass
+  public static void stopContainer() {
+    CONTAINER.stop();
+  }
+}

--- a/orientdb/src/test/scala/docs/scaladsl/OrientDbContainer.scala
+++ b/orientdb/src/test/scala/docs/scaladsl/OrientDbContainer.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.scaladsl
+
+import com.dimafeng.testcontainers.GenericContainer
+
+class OrientDbContainer
+    extends GenericContainer(
+      "orientdb:3.1.9",
+      exposedPorts = List(2424),
+      command = List("/orientdb/bin/server.sh", "-Dmemory.chunk.size=268435456"),
+      env = Map(
+        "ORIENTDB_ROOT_PASSWORD" -> "root"
+      )
+    ) {
+  def url: String = {
+    s"remote:${container.getHost}:${container.getMappedPort(2424)}/"
+  }
+}

--- a/orientdb/src/test/scala/docs/scaladsl/OrientDbTest.scala
+++ b/orientdb/src/test/scala/docs/scaladsl/OrientDbTest.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.scaladsl
+
+import akka.testkit.{TestKit, TestKitBase}
+import com.dimafeng.testcontainers.ForAllTestContainer
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait OrientDbTest extends ForAllTestContainer with BeforeAndAfterAll with TestKitBase { self: Suite =>
+  override lazy val container = new OrientDbContainer()
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+}


### PR DESCRIPTION
Replaces manual starting of orientdb docker containers in github actions/docker-compose with https://github.com/testcontainers/testcontainers-scala.

Similar to the other PR's the only notable thing here is that the generated paradox documentation changes slightly, i.e. instead of having

```java
private static String url = "remote:127.0.0.1:2424/";
```
In the `#init-settings` its now removed due to the fact that the url is no longer static but retrieved from the newly created docker container. Instead the example code references `ORIENTDB_URL`/`OrientDbUrl` constant which in a self explanatory manner describes the same thing.

References https://github.com/akka/alpakka/issues/2841
