### PR TITLE
Add S3.getObject and deprecate S3.download

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -212,12 +212,11 @@ import scala.util.{Failure, Success, Try}
         issueRequest(s3Location, rangeOption = range, versionId = versionId, s3Headers = headers)(mat, attr)
           .map(response => response.withEntity(response.entity.withoutSizeLimit))
           .mapAsync(parallelism = 1)(entityForSuccess)
-          .map {
+          .flatMapConcat {
             case (entity, headers) =>
               objectMetadataMat.success(computeMetaData(headers, entity))
               entity.dataBytes
           }
-          .flatMapConcat(identity)
           .mapMaterializedValue(_ => objectMetadataMat.future)
       }
       .mapMaterializedValue(_.flatMap(identity)(ExecutionContexts.parasitic))

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -204,10 +204,10 @@ import scala.util.{Failure, Success, Try}
       s3Headers: S3Headers
   ): Source[ByteString, Future[ObjectMetadata]] = {
     val headers = s3Headers.headersFor(GetObject)
-    val objectMetadataMat = Promise[ObjectMetadata]()
 
     Source
       .fromMaterializer { (mat, attr) =>
+        val objectMetadataMat = Promise[ObjectMetadata]()
         implicit val materializer: Materializer = mat
         issueRequest(s3Location, rangeOption = range, versionId = versionId, s3Headers = headers)(mat, attr)
           .map(response => response.withEntity(response.entity.withoutSizeLimit))

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -217,6 +217,11 @@ import scala.util.{Failure, Success, Try}
               objectMetadataMat.success(computeMetaData(headers, entity))
               entity.dataBytes
           }
+          .mapError {
+            case e: Throwable =>
+              objectMetadataMat.tryFailure(e)
+              e
+          }
           .mapMaterializedValue(_ => objectMetadataMat.future)
       }
       .mapMaterializedValue(_.flatMap(identity)(ExecutionContexts.parasitic))

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
@@ -338,6 +338,7 @@ object S3 {
    * @param key the s3 object key
    * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source Source]] of [[akka.util.ByteString ByteString]], and a [[akka.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
+  @deprecated("Use S3.getObject instead", "4.0.0")
   def download(bucket: String,
                key: String): Source[Optional[JPair[Source[ByteString, NotUsed], ObjectMetadata]], NotUsed] =
     toJava(S3Stream.download(S3Location(bucket, key), None, None, S3Headers.empty))
@@ -350,6 +351,7 @@ object S3 {
    * @param sse the server side encryption to use
    * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source Source]] of [[akka.util.ByteString ByteString]], and a [[akka.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
+  @deprecated("Use S3.getObject instead", "4.0.0")
   def download(
       bucket: String,
       key: String,
@@ -365,6 +367,7 @@ object S3 {
    * @param range the [[akka.http.javadsl.model.headers.ByteRange ByteRange]] you want to download
    * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source Source]] of [[akka.util.ByteString ByteString]], and a [[akka.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
+  @deprecated("Use S3.getObject instead", "4.0.0")
   def download(bucket: String,
                key: String,
                range: ByteRange): Source[Optional[JPair[Source[ByteString, NotUsed], ObjectMetadata]], NotUsed] = {
@@ -381,6 +384,7 @@ object S3 {
    * @param sse the server side encryption to use
    * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source Source]] of [[akka.util.ByteString ByteString]], and a [[akka.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
+  @deprecated("Use S3.getObject instead", "4.0.0")
   def download(
       bucket: String,
       key: String,
@@ -399,6 +403,7 @@ object S3 {
    * @param sse the server side encryption to use
    * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source Source]] of [[akka.util.ByteString ByteString]], and a [[akka.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
+  @deprecated("Use S3.getObject instead", "4.0.0")
   def download(
       bucket: String,
       key: String,
@@ -416,6 +421,7 @@ object S3 {
    * @param s3Headers any headers you want to add
    * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source Source]] of [[akka.util.ByteString ByteString]], and a [[akka.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
+  @deprecated("Use S3.getObject instead", "4.0.0")
   def download(
       bucket: String,
       key: String,
@@ -434,6 +440,7 @@ object S3 {
    * @param s3Headers any headers you want to add
    * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source Source]] of [[akka.util.ByteString ByteString]], and a [[akka.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
+  @deprecated("Use S3.getObject instead", "4.0.0")
   def download(
       bucket: String,
       key: String,
@@ -456,6 +463,7 @@ object S3 {
    * @param s3Headers any headers you want to add
    * @return A [[akka.japi.Pair]] with a [[akka.stream.javadsl.Source Source]] of [[akka.util.ByteString ByteString]], and a [[akka.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
+  @deprecated("Use S3.getObject instead", "4.0.0")
   def download(
       bucket: String,
       key: String,
@@ -466,6 +474,147 @@ object S3 {
     val scalaRange = range.asInstanceOf[ScalaByteRange]
     toJava(
       S3Stream.download(S3Location(bucket, key), Option(scalaRange), Option(versionId.orElse(null)), s3Headers)
+    )
+  }
+
+  /**
+   * Gets a S3 Object
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @return A [[akka.stream.javadsl.Source]] containing the objects data as a [[akka.util.ByteString]] along with a materialized value containing the
+   *         [[akka.stream.alpakka.s3.ObjectMetadata]]
+   */
+  def getObject(bucket: String, key: String): Source[ByteString, CompletionStage[ObjectMetadata]] =
+    new Source(S3Stream.getObject(S3Location(bucket, key), None, None, S3Headers.empty).toCompletionStage())
+
+  /**
+   * Gets a S3 Object
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param sse the server side encryption to use
+   * @return A [[akka.stream.javadsl.Source]] containing the objects data as a [[akka.util.ByteString]] along with a materialized value containing the
+   *         [[akka.stream.alpakka.s3.ObjectMetadata]]
+   */
+  def getObject(
+      bucket: String,
+      key: String,
+      sse: ServerSideEncryption
+  ): Source[ByteString, CompletionStage[ObjectMetadata]] =
+    getObject(bucket, key, S3Headers.empty.withOptionalServerSideEncryption(Option(sse)))
+
+  /**
+   * Gets a specific byte range of a S3 Object
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param range the [[akka.http.javadsl.model.headers.ByteRange ByteRange]] you want to download
+   * @return A [[akka.stream.javadsl.Source]] containing the objects data as a [[akka.util.ByteString]] along with a materialized value containing the
+   *         [[akka.stream.alpakka.s3.ObjectMetadata]]
+   */
+  def getObject(bucket: String, key: String, range: ByteRange): Source[ByteString, CompletionStage[ObjectMetadata]] = {
+    val scalaRange = range.asInstanceOf[ScalaByteRange]
+    new Source(S3Stream.getObject(S3Location(bucket, key), Some(scalaRange), None, S3Headers.empty).toCompletionStage())
+  }
+
+  /**
+   * Gets a specific byte range of a S3 Object
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param range the [[akka.http.javadsl.model.headers.ByteRange ByteRange]] you want to download
+   * @param sse the server side encryption to use
+   * @return A [[akka.stream.javadsl.Source]] containing the objects data as a [[akka.util.ByteString]] along with a materialized value containing the
+   *         [[akka.stream.alpakka.s3.ObjectMetadata]]
+   */
+  def getObject(
+      bucket: String,
+      key: String,
+      range: ByteRange,
+      sse: ServerSideEncryption
+  ): Source[ByteString, CompletionStage[ObjectMetadata]] =
+    getObject(bucket, key, range, S3Headers.empty.withOptionalServerSideEncryption(Option(sse)))
+
+  /**
+   * Gets a specific byte range of a S3 Object
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param range the [[akka.http.javadsl.model.headers.ByteRange ByteRange]] you want to download
+   * @param versionId optional version id of the object
+   * @param sse the server side encryption to use
+   * @return A [[akka.stream.javadsl.Source]] containing the objects data as a [[akka.util.ByteString]] along with a materialized value containing the
+   *         [[akka.stream.alpakka.s3.ObjectMetadata]]
+   */
+  def getObject(
+      bucket: String,
+      key: String,
+      range: ByteRange,
+      versionId: Optional[String],
+      sse: ServerSideEncryption
+  ): Source[ByteString, CompletionStage[ObjectMetadata]] =
+    getObject(bucket, key, range, versionId, S3Headers.empty.withOptionalServerSideEncryption(Option(sse)))
+
+  /**
+   * Gets a S3 Object
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param s3Headers any headers you want to add
+   * @return A [[akka.stream.javadsl.Source]] containing the objects data as a [[akka.util.ByteString]] along with a materialized value containing the
+   *         [[akka.stream.alpakka.s3.ObjectMetadata]]
+   */
+  def getObject(
+      bucket: String,
+      key: String,
+      s3Headers: S3Headers
+  ): Source[ByteString, CompletionStage[ObjectMetadata]] =
+    new Source(S3Stream.getObject(S3Location(bucket, key), None, None, s3Headers).toCompletionStage())
+
+  /**
+   * Gets a specific byte range of a S3 Object
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param range the [[akka.http.javadsl.model.headers.ByteRange ByteRange]] you want to download
+   * @param s3Headers any headers you want to add
+   * @return A [[akka.stream.javadsl.Source]] containing the objects data as a [[akka.util.ByteString]] along with a materialized value containing the
+   *         [[akka.stream.alpakka.s3.ObjectMetadata]]
+   */
+  def getObject(
+      bucket: String,
+      key: String,
+      range: ByteRange,
+      s3Headers: S3Headers
+  ): Source[ByteString, CompletionStage[ObjectMetadata]] = {
+    val scalaRange = range.asInstanceOf[ScalaByteRange]
+    new Source(S3Stream.getObject(S3Location(bucket, key), Some(scalaRange), None, s3Headers).toCompletionStage())
+  }
+
+  /**
+   * Gets a specific byte range of a S3 Object
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param range the [[akka.http.javadsl.model.headers.ByteRange ByteRange]] you want to download
+   * @param versionId optional version id of the object
+   * @param s3Headers any headers you want to add
+   * @return A [[akka.stream.javadsl.Source]] containing the objects data as a [[akka.util.ByteString]] along with a materialized value containing the
+   *         [[akka.stream.alpakka.s3.ObjectMetadata]]
+   */
+  def getObject(
+      bucket: String,
+      key: String,
+      range: ByteRange,
+      versionId: Optional[String],
+      s3Headers: S3Headers
+  ): Source[ByteString, CompletionStage[ObjectMetadata]] = {
+    val scalaRange = range.asInstanceOf[ScalaByteRange]
+    new Source(
+      S3Stream
+        .getObject(S3Location(bucket, key), Option(scalaRange), Option(versionId.orElse(null)), s3Headers)
+        .toCompletionStage()
     )
   }
 

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
@@ -195,6 +195,7 @@ object S3 {
    * @return The source will emit an empty [[scala.Option Option]] if an object can not be found.
    *         Otherwise [[scala.Option Option]] will contain a tuple of object's data and metadata.
    */
+  @deprecated("Use S3.getObject instead", "4.0.0")
   def download(
       bucket: String,
       key: String,
@@ -214,6 +215,7 @@ object S3 {
    * @return The source will emit an empty [[scala.Option Option]] if an object can not be found.
    *         Otherwise [[scala.Option Option]] will contain a tuple of object's data and metadata.
    */
+  @deprecated("Use S3.getObject instead", "4.0.0")
   def download(
       bucket: String,
       key: String,
@@ -222,6 +224,44 @@ object S3 {
       s3Headers: S3Headers
   ): Source[Option[(Source[ByteString, NotUsed], ObjectMetadata)], NotUsed] =
     S3Stream.download(S3Location(bucket, key), range, versionId, s3Headers)
+
+  /**
+   * Gets a S3 Object
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param range [optional] the [[akka.http.scaladsl.model.headers.ByteRange ByteRange]] you want to download
+   * @param sse [optional] the server side encryption used on upload
+   * @return A [[akka.stream.scaladsl.Source]] containing the objects data as a [[akka.util.ByteString]] along with a materialized value containing the
+   *         [[akka.stream.alpakka.s3.ObjectMetadata]]
+   */
+  def getObject(
+      bucket: String,
+      key: String,
+      range: Option[ByteRange] = None,
+      versionId: Option[String] = None,
+      sse: Option[ServerSideEncryption] = None
+  ): Source[ByteString, Future[ObjectMetadata]] =
+    getObject(bucket, key, range, versionId, S3Headers.empty.withOptionalServerSideEncryption(sse))
+
+  /**
+   * Gets a S3 Object
+   *
+   * @param bucket the s3 bucket name
+   * @param key the s3 object key
+   * @param range [optional] the [[akka.http.scaladsl.model.headers.ByteRange ByteRange]] you want to download
+   * @param s3Headers any headers you want to add
+   * @return A [[akka.stream.scaladsl.Source]] containing the objects data as a [[akka.util.ByteString]] along with a materialized value containing the
+   *         [[akka.stream.alpakka.s3.ObjectMetadata]]
+   */
+  def getObject(
+      bucket: String,
+      key: String,
+      range: Option[ByteRange],
+      versionId: Option[String],
+      s3Headers: S3Headers
+  ): Source[ByteString, Future[ObjectMetadata]] =
+    S3Stream.getObject(S3Location(bucket, key), range, versionId, s3Headers)
 
   /**
    * Will return a source of object metadata for a given bucket with optional prefix using version 2 of the List Bucket API.

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -26,7 +26,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.regions.providers._
 
 import java.util.concurrent.ConcurrentLinkedQueue
-import scala.annotation.{nowarn, tailrec}
+import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -188,18 +188,15 @@ trait S3IntegrationSpec
   }
 
   it should "download with real credentials" in {
-    val Some((source, meta)) = S3
-      .download(defaultBucket, objectKey)
+    val (metaFuture, bodyFuture) = S3
+      .getObject(defaultBucket, objectKey)
       .withAttributes(attributes)
-      .runWith(Sink.head)
-      .futureValue: @nowarn("msg=match may not be exhaustive")
-
-    val bodyFuture = source
       .map(_.decodeString("utf8"))
-      .toMat(Sink.head)(Keep.right)
+      .toMat(Sink.head)(Keep.both)
       .run()
 
     bodyFuture.futureValue shouldBe objectValue
+    val meta = metaFuture.futureValue
     meta.eTag should not be empty
     meta.contentType shouldBe Some(ContentTypes.`application/octet-stream`.value)
   }
@@ -238,13 +235,11 @@ trait S3IntegrationSpec
           S3.multipartUpload(defaultBucket, objectKey, metaHeaders = MetaHeaders(metaHeaders))
             .withAttributes(attributes)
         )
-      download <- S3.download(defaultBucket, objectKey).withAttributes(attributes).runWith(Sink.head).flatMap {
-        case Some((downloadSource, _)) =>
-          downloadSource
-            .map(_.decodeString("utf8"))
-            .runWith(Sink.head)
-        case None => Future.successful(None)
-      }
+      download <- S3
+        .getObject(defaultBucket, objectKey)
+        .withAttributes(attributes)
+        .map(_.decodeString("utf8"))
+        .runWith(Sink.head)
     } yield (upload, download)
 
     val (multipartUploadResult, downloaded) = results.futureValue
@@ -270,16 +265,10 @@ trait S3IntegrationSpec
             .withAttributes(attributes)
         )
       download <- S3
-        .download(defaultBucket, objectKey)
+        .getObject(defaultBucket, objectKey)
         .withAttributes(attributes)
+        .map(_.decodeString("utf8"))
         .runWith(Sink.head)
-        .flatMap {
-          case Some((downloadSource, _)) =>
-            downloadSource
-              .map(_.decodeString("utf8"))
-              .runWith(Sink.head)
-          case None => Future.successful(None)
-        }
     } yield (upload, download)
 
     val (multipartUploadResult, downloaded) = results.futureValue
@@ -630,12 +619,7 @@ trait S3IntegrationSpec
       // This delay is here because sometimes there is a delay when you complete a large file and its
       // actually downloadable
       downloaded <- akka.pattern.after(5.seconds)(
-        S3.download(defaultBucket, sourceKey).withAttributes(attributes).runWith(Sink.head).flatMap {
-          case Some((downloadSource, _)) =>
-            downloadSource
-              .runWith(Sink.seq)
-          case None => throw new Exception(s"Expected object in bucket $defaultBucket with key $sourceKey")
-        }
+        S3.getObject(defaultBucket, sourceKey).withAttributes(attributes).runWith(Sink.seq)
       )
 
       _ <- S3.deleteObject(defaultBucket, sourceKey).withAttributes(attributes).runWith(Sink.head)
@@ -684,12 +668,7 @@ trait S3IntegrationSpec
       // This delay is here because sometimes there is a delay when you complete a large file and its
       // actually downloadable
       downloaded <- akka.pattern.after(5.seconds)(
-        S3.download(defaultBucket, sourceKey).withAttributes(attributes).runWith(Sink.head).flatMap {
-          case Some((downloadSource, _)) =>
-            downloadSource
-              .runWith(Sink.seq)
-          case None => throw new Exception(s"Expected object in bucket $defaultBucket with key $sourceKey")
-        }
+        S3.getObject(defaultBucket, sourceKey).withAttributes(attributes).runWith(Sink.seq)
       )
       _ <- S3.deleteObject(defaultBucket, sourceKey).withAttributes(attributes).runWith(Sink.head)
     } yield downloaded
@@ -790,12 +769,7 @@ trait S3IntegrationSpec
       // This delay is here because sometimes there is a delay when you complete a large file and its
       // actually downloadable
       downloaded <- akka.pattern.after(5.seconds)(
-        S3.download(defaultBucket, sourceKey).withAttributes(attributes).runWith(Sink.head).flatMap {
-          case Some((downloadSource, _)) =>
-            downloadSource
-              .runWith(Sink.seq)
-          case None => throw new Exception(s"Expected object in bucket $defaultBucket with key $sourceKey")
-        }
+        S3.getObject(defaultBucket, sourceKey).withAttributes(attributes).runWith(Sink.seq)
       )
       _ <- S3.deleteObject(defaultBucket, sourceKey).withAttributes(attributes).runWith(Sink.head)
 
@@ -964,16 +938,10 @@ trait S3IntegrationSpec
             .withAttributes(otherRegionSettingsPathStyleAccess)
         )
       download <- S3
-        .download(bucketWithDots, objectKey)
+        .getObject(bucketWithDots, objectKey)
         .withAttributes(otherRegionSettingsPathStyleAccess)
+        .map(_.decodeString("utf8"))
         .runWith(Sink.head)
-        .flatMap {
-          case Some((downloadSource, _)) =>
-            downloadSource
-              .map(_.decodeString("utf8"))
-              .runWith(Sink.head)
-          case None => Future.successful(None)
-        }
     } yield (upload, download)
 
     val (multipartUploadResult, downloaded) = results.futureValue
@@ -998,16 +966,10 @@ trait S3IntegrationSpec
         .withAttributes(attributes)
         .run()
       download <- S3
-        .download(defaultBucket, targetKey)
+        .getObject(defaultBucket, targetKey)
         .withAttributes(attributes)
+        .map(_.decodeString("utf8"))
         .runWith(Sink.head)
-        .flatMap {
-          case Some((downloadSource, _)) =>
-            downloadSource
-              .map(_.decodeString("utf8"))
-              .runWith(Sink.head)
-          case None => Future.successful(None)
-        }
     } yield (upload, copy, download)
 
     whenReady(results) {

--- a/s3/src/test/scala/docs/scaladsl/S3SourceSpec.scala
+++ b/s3/src/test/scala/docs/scaladsl/S3SourceSpec.scala
@@ -11,7 +11,7 @@ import akka.stream.alpakka.s3.BucketAccess.{AccessDenied, AccessGranted, NotExis
 import akka.stream.alpakka.s3._
 import akka.stream.alpakka.s3.headers.ServerSideEncryption
 import akka.stream.alpakka.s3.scaladsl.{S3, S3ClientIntegrationSpec, S3WireMockBase}
-import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.util.ByteString
 import akka.{Done, NotUsed}
 import software.amazon.awssdk.regions.Region
@@ -31,17 +31,17 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     mockDownload()
 
     //#download
-    val s3File: Source[Option[(Source[ByteString, NotUsed], ObjectMetadata)], NotUsed] =
-      S3.download(bucket, bucketKey)
+    val s3Source: Source[ByteString, Future[ObjectMetadata]] =
+      S3.getObject(bucket, bucketKey)
 
-    val Some((data: Source[ByteString, _], metadata)) =
-      s3File.runWith(Sink.head).futureValue: @nowarn("msg=match may not be exhaustive")
-
-    val result: Future[String] =
-      data.map(_.utf8String).runWith(Sink.head)
+    val (metadataFuture, dataFuture) =
+      s3Source.toMat(Sink.head)(Keep.both).run()
     //#download
 
-    result.futureValue shouldBe body
+    val data = dataFuture.futureValue
+    val metadata = metadataFuture.futureValue
+
+    data.utf8String shouldBe body
 
     //#downloadToAkkaHttp
     HttpResponse(
@@ -50,7 +50,7 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
           .flatMap(ContentType.parse(_).toOption)
           .getOrElse(ContentTypes.`application/octet-stream`),
         metadata.contentLength,
-        data
+        s3Source
       )
     )
     //#downloadToAkkaHttp
@@ -67,11 +67,9 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
         override def getRegion: Region = region
       })
 
-    val Some((data: Source[ByteString, _], _)) = S3
-      .download(bucket, bucketKey)
+    val data = S3
+      .getObject(bucket, bucketKey)
       .withAttributes(S3Attributes.settings(customRegion))
-      .runWith(Sink.head)
-      .futureValue: @nowarn("msg=match may not be exhaustive")
 
     data.map(_.utf8String).runWith(Sink.head).futureValue shouldBe body
   }
@@ -140,11 +138,9 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     mockRangedDownload()
 
     //#rangedDownload
-    val downloadResult = S3.download(bucket, bucketKey, Some(ByteRange(bytesRangeStart, bytesRangeEnd)))
+    val s3Source = S3.getObject(bucket, bucketKey, Some(ByteRange(bytesRangeStart, bytesRangeEnd)))
     //#rangedDownload
 
-    val Some((s3Source: Source[ByteString, _], _)) =
-      downloadResult.runWith(Sink.head).futureValue: @nowarn("msg=match may not be exhaustive")
     val result: Future[Array[Byte]] = s3Source.map(_.toArray).runWith(Sink.head)
 
     result.futureValue shouldBe rangeOfBody
@@ -154,10 +150,8 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
 
     mockDownloadSSEC()
 
-    val downloadResult = S3.download(bucket, bucketKey, sse = Some(sseCustomerKeys))
+    val s3Source = S3.getObject(bucket, bucketKey, sse = Some(sseCustomerKeys))
 
-    val Some((s3Source: Source[ByteString, _], _)) =
-      downloadResult.runWith(Sink.head).futureValue: @nowarn("msg=match may not be exhaustive")
     val result = s3Source.map(_.utf8String).runWith(Sink.head)
 
     result.futureValue shouldBe bodySSE
@@ -167,29 +161,28 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
     val versionId = "3/L4kqtJlcpXroDTDmJ+rmSpXd3dIbrHY+MTRCxf3vjVBH40Nr8X8gdRQBpUMLUo"
     mockDownloadSSECWithVersion(versionId)
 
-    val downloadResult =
-      S3.download(bucket, bucketKey, versionId = Some(versionId), sse = Some(sseCustomerKeys))
+    val s3Source =
+      S3.getObject(bucket, bucketKey, versionId = Some(versionId), sse = Some(sseCustomerKeys))
 
-    val Some((s3Source: Source[ByteString, _], metadata)) =
-      downloadResult.runWith(Sink.head).futureValue: @nowarn("msg=match may not be exhaustive")
-    val result = s3Source.map(_.utf8String).runWith(Sink.head)
+    val (metadata, result) = s3Source.map(_.utf8String).toMat(Sink.head)(Keep.both).run()
 
     result.futureValue shouldBe bodySSE
-    metadata.versionId.fold(fail("unable to get versionId from S3")) { vId =>
+    metadata.futureValue.versionId.fold(fail("unable to get versionId from S3")) { vId =>
       vId shouldEqual versionId
     }
   }
 
-  it should "fail if request returns 404" in {
+  it should "throw the correct S3Exception if a request returns 404" in {
 
     mock404s()
 
     val download = S3
-      .download("nonexisting-bucket", "nonexisting_file.xml")
+      .getObject("nonexisting-bucket", "nonexisting_file.xml")
       .runWith(Sink.head)
-      .futureValue
 
-    download shouldBe None
+    download.failed.futureValue should matchPattern {
+      case s3Exception: S3Exception if s3Exception.code == "NoSuchKey" =>
+    }
   }
 
   it should "fail for illegal bucket names" in {
@@ -198,7 +191,7 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
       .withEndpointUrl(null)
 
     val download = S3
-      .download("path/../with-dots", "unused")
+      .getObject("path/../with-dots", "unused")
       .withAttributes(S3Attributes.settings(dnsStyleAccess))
       .runWith(Sink.head)
 
@@ -209,20 +202,11 @@ class S3SourceSpec extends S3WireMockBase with S3ClientIntegrationSpec {
 
     mockSSEInvalidRequest()
 
-    import system.dispatcher
-
     val sse = ServerSideEncryption.customerKeys("encoded-key").withMd5("md5-encoded-key")
     val result = S3
-      .download(bucket, bucketKey, sse = Some(sse))
+      .getObject(bucket, bucketKey, sse = Some(sse))
+      .map(_.decodeString("utf8"))
       .runWith(Sink.head)
-      .flatMap {
-        case Some((downloadSource, _)) =>
-          downloadSource
-            .map(_.decodeString("utf8"))
-            .runWith(Sink.head)
-            .map(Some.apply)
-        case None => Future.successful(None)
-      }
 
     whenReady(result.failed) { e =>
       e shouldBe a[S3Exception]


### PR DESCRIPTION
PR adds in the `S3.getObject` method which is an alternative to `S3.download` that has a far simpler/idiomatic API (returns a `Source[ByteString, Future[ObjectMetadata]]` instead of a `Source[Option[(Source[ByteString, NotUsed], ObjectMetadata)], NotUsed]` as well as deprecating `S3.download`. Since no `Option` is returned in `S3.getObject` there is no chance of accidentally creating a leak (with `S3.download` if it returned a `Some` but you didn't consume the underlying `ByteString` `Source` a leak would be created, see referenced issue).

Nothing that fancy in the actual implementation of `Se.getObject`, most changes were mechanical. The materialized value `ObjectMetdata` is propagated by using a `Promise` and all of the tests have been updated to use `S3.getObject`. The old `S3.download` remains completely untouched (apart from depreciation annotation).

One thing to note of is that the documentation generated from the paradox code snippers has changed. While the Scala version essentially the same one of the Java code examples has been changed but for the better since the code sample no longer has blocking `.get` code and instead uses `.thenApply` (which is honestly much better since we shouldn't ever be advocating/documenting blocking code).

References #2866 
