### PR TITLE
Add S3.listBuckets

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/HttpRequests.scala
@@ -29,6 +29,23 @@ import scala.concurrent.{ExecutionContext, Future}
 
   private final val BucketPattern = "{bucket}"
 
+  def listBuckets(headers: Seq[HttpHeader] = Nil)(implicit conf: S3Settings): HttpRequest = {
+    val awsHost = Authority(Uri.Host(s"s3.amazonaws.com"))
+    val (authority, scheme) = conf.endpointUrl match {
+      case Some(endpointUrl) =>
+        val customUri = Uri(endpointUrl)
+        (customUri.authority, customUri.scheme)
+      case None =>
+        (awsHost, "https")
+    }
+
+    val uri = Uri(authority = authority, scheme = scheme)
+
+    HttpRequest(HttpMethods.GET)
+      .withHeaders(Host(awsHost) +: headers)
+      .withUri(uri)
+  }
+
   def listBucket(
       bucket: String,
       prefix: Option[String] = None,

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/Marshalling.scala
@@ -91,6 +91,27 @@ import scala.xml.NodeSeq
     }
   }
 
+  implicit val listBucketsResultUnmarshaller: FromEntityUnmarshaller[ListBucketsResult] = {
+    nodeSeqUnmarshaller(MediaTypes.`application/xml` withCharset HttpCharsets.`UTF-8`).map {
+      case NodeSeq.Empty => throw Unmarshaller.NoContentException
+      case x =>
+        val bucketsRoot = (x \\ "Buckets").headOption
+          .map { br =>
+            (br \\ "Bucket").map { u =>
+              val creationDate = Instant.parse((u \ "CreationDate").text)
+              val name = (u \ "Name").text
+
+              ListBucketsResultContents(
+                creationDate,
+                name
+              )
+            }
+          }
+          .getOrElse(Nil)
+        ListBucketsResult(bucketsRoot)
+    }
+  }
+
   implicit val listMultipartUploadsResultUnmarshaller: FromEntityUnmarshaller[ListMultipartUploadsResult] = {
     nodeSeqUnmarshaller(MediaTypes.`application/xml` withCharset HttpCharsets.`UTF-8`).map {
       case NodeSeq.Empty => throw Unmarshaller.NoContentException

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
@@ -619,6 +619,26 @@ object S3 {
   }
 
   /**
+   * Will return a list containing all of the buckets for the current AWS account
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html
+   * @return [[akka.stream.javadsl.Source Source]] of [[ListBucketsResultContents]]
+   */
+  def listBuckets(): Source[ListBucketsResultContents, NotUsed] =
+    listBuckets(S3Headers.empty)
+
+  /**
+   * Will return a list containing all of the buckets for the current AWS account
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html
+   * @return [[akka.stream.javadsl.Source Source]] of [[ListBucketsResultContents]]
+   */
+  def listBuckets(s3Headers: S3Headers): Source[ListBucketsResultContents, NotUsed] =
+    S3Stream
+      .listBuckets(s3Headers)
+      .asJava
+
+  /**
    * Will return a source of object metadata for a given bucket with optional prefix using version 2 of the List Bucket API.
    * This will automatically page through all keys with the given parameters.
    *

--- a/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
@@ -837,6 +837,64 @@ object FailedUpload {
   def create(reasons: Seq[Throwable]): FailedUpload = FailedUpload(reasons)
 }
 
+final class ListBucketsResultContents private (val creationDate: java.time.Instant, val name: String) {
+
+  /** Java API */
+  def getCreationDate: java.time.Instant = creationDate
+
+  /** Java API */
+  def getName: String = name
+
+  def withCreationDate(value: java.time.Instant): ListBucketsResultContents = copy(creationDate = value)
+
+  def withName(value: String): ListBucketsResultContents = copy(name = value)
+
+  private def copy(
+      name: String = name,
+      creationDate: java.time.Instant = creationDate
+  ): ListBucketsResultContents = new ListBucketsResultContents(
+    name = name,
+    creationDate = creationDate
+  )
+
+  override def toString: String =
+    "ListBucketsResultContents(" +
+    s"creationDate=$creationDate," +
+    s"name=$name" +
+    ")"
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ListBucketsResultContents =>
+      Objects.equals(this.name, that.name) &&
+      Objects.equals(this.creationDate, that.creationDate)
+    case _ => false
+  }
+
+  override def hashCode(): Int =
+    Objects.hash(name, creationDate)
+}
+
+object ListBucketsResultContents {
+
+  /** Scala API */
+  def apply(
+      creationDate: java.time.Instant,
+      name: String
+  ): ListBucketsResultContents = new ListBucketsResultContents(
+    creationDate,
+    name
+  )
+
+  /** Java API */
+  def create(
+      creationDate: java.time.Instant,
+      name: String
+  ): ListBucketsResultContents = apply(
+    creationDate,
+    name
+  )
+}
+
 /**
  * @param bucketName The name of the bucket in which this object is stored
  * @param key The key under which this object is stored

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
@@ -264,6 +264,25 @@ object S3 {
     S3Stream.getObject(S3Location(bucket, key), range, versionId, s3Headers)
 
   /**
+   * Will return a list containing all of the buckets for the current AWS account
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html
+   * @return [[akka.stream.scaladsl.Source Source]] of [[ListBucketsResultContents]]
+   */
+  def listBuckets(): Source[ListBucketsResultContents, NotUsed] =
+    listBuckets(S3Headers.empty)
+
+  /**
+   * Will return a list containing all of the buckets for the current AWS account
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html
+   * @param s3Headers any headers you want to add
+   * @return [[akka.stream.scaladsl.Source Source]] of [[ListBucketsResultContents]]
+   */
+  def listBuckets(s3Headers: S3Headers): Source[ListBucketsResultContents, NotUsed] =
+    S3Stream.listBuckets(s3Headers)
+
+  /**
    * Will return a source of object metadata for a given bucket with optional prefix using version 2 of the List Bucket API.
    * This will automatically page through all keys with the given parameters.
    *

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -98,6 +98,16 @@ trait S3IntegrationSpec
   def defaultRegionContentCount = 4
   def otherRegionContentCount = 5
 
+  it should "list buckets in current aws account" in {
+    val result = for {
+      buckets <- S3.listBuckets().withAttributes(attributes).runWith(Sink.seq)
+    } yield buckets
+
+    val buckets = result.futureValue
+
+    buckets.map(_.name) should contain(defaultBucket)
+  }
+
   it should "list with real credentials" in {
     val result = S3
       .listBucket(defaultBucket, None)


### PR DESCRIPTION
This PR adds the AWS S3 list buckets call (see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html). The call itself is trivial however there are some non conventional differences

* This seems to be one of the few S3 calls that returns a list of entities that is not paginated. Due to this its an open question whether the `S3.listBuckets` method should just return a `Future[Seq[ListBucketsResultContents]]` or the current version which is a `Source[ListBucketsResultContents, NotUsed]`. I opted for the `Source` variant due to consistency with the rest of the S3 API (every single other method in S3 that returns a list of entities is a `Source`) plus there is a chance that AWS may add a paginated `list-buckets` call in the future in which case its trivially easy to use the newly updated version. I don't feel strongly about it either way however, so if you want me to change it to `Future[Seq[ListBucketsResultContents]]` then just let me know
* The base construction of the URI is also very different to any other S3 call, hence why the `listBuckets` call in `HttpRequests.scala` is manually constructing the URI itself, i.e. there isn't any Path/Virtual access style and the authority is hardcoded to `s3.amazonaws.com` (for AWS) since the call is region agnostic. I have tested this both with Minio and a real AWS S3 account so I can confirm its working
