### PR TITLE
Update Jackson dependency to 2.13.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,9 +62,9 @@ object Dependencies {
 
   // Releases https://github.com/FasterXML/jackson-databind/releases
   // CVE issues https://github.com/FasterXML/jackson-databind/issues?utf8=%E2%9C%93&q=+label%3ACVE
-  // This should align with the Jackson minor version used in Akka 2.6.x
-  // https://github.com/akka/akka/blob/master/project/Dependencies.scala#L23
-  val JacksonDatabindVersion = "2.11.4"
+  // This should align with the Jackson minor version used in Akka 2.7.x
+  // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L29
+  val JacksonDatabindVersion = "2.13.4"
   val JacksonDatabindDependencies = Seq(
     "com.fasterxml.jackson.core" % "jackson-core" % JacksonDatabindVersion,
     "com.fasterxml.jackson.core" % "jackson-databind" % JacksonDatabindVersion


### PR DESCRIPTION
* align with Akka 2.7.x
* CVE-2020-36518
