### PR TITLE
Add back Scala 2.12

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectionProvider.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectionProvider.scala
@@ -13,7 +13,7 @@ import javax.net.ssl.{SSLContext, TrustManager}
 
 import scala.annotation.tailrec
 import scala.collection.immutable
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Only for internal implementations
@@ -121,7 +121,7 @@ final class AmqpDetailsConnectionProvider private (
     copy(connectionName = Option(name))
 
   override def get: Connection = {
-    import scala.jdk.CollectionConverters._
+    import scala.collection.JavaConverters._
     val factory = new ConnectionFactory
     credentials.foreach { credentials =>
       factory.setUsername(credentials.username)
@@ -331,7 +331,7 @@ final class AmqpConnectionFactoryConnectionProvider private (val factory: Connec
     copy(hostAndPorts = hostAndPorts.asScala.map(_.toScala).toIndexedSeq)
 
   override def get: Connection = {
-    import scala.jdk.CollectionConverters._
+    import scala.collection.JavaConverters._
     factory.newConnection(hostAndPortList.map(hp => new Address(hp._1, hp._2)).asJava)
   }
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectorSettings.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectorSettings.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.amqp
 import akka.annotation.InternalApi
 import akka.util.JavaDurationConverters._
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.duration._
 

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpConnectorLogic.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpConnectorLogic.scala
@@ -32,7 +32,7 @@ private trait AmqpConnectorLogic { this: GraphStageLogic =>
       connection.addShutdownListener(shutdownListener)
       channel.addShutdownListener(shutdownListener)
 
-      import scala.jdk.CollectionConverters._
+      import scala.collection.JavaConverters._
 
       settings.declarations.foreach {
         case d: QueueDeclaration =>

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/impl/AmqpSourceStage.scala
@@ -50,7 +50,7 @@ private[amqp] final class AmqpSourceStage(settings: AmqpSourceSettings, bufferSi
       private var unackedMessages = 0
 
       override def whenConnected(): Unit = {
-        import scala.jdk.CollectionConverters._
+        import scala.collection.JavaConverters._
         channel.basicQos(bufferSize)
         val consumerCallback = getAsyncCallback(handleDelivery)
 

--- a/azure-storage-queue/src/main/scala/akka/stream/alpakka/azure/storagequeue/impl/AzureQueueSourceStage.scala
+++ b/azure-storage-queue/src/main/scala/akka/stream/alpakka/azure/storagequeue/impl/AzureQueueSourceStage.scala
@@ -35,7 +35,7 @@ import scala.collection.mutable.Queue
       retrieveMessages()
 
     def retrieveMessages(): Unit = {
-      import scala.jdk.CollectionConverters._
+      import scala.collection.JavaConverters._
       val res = cloudQueueBuilt
         .retrieveMessages(settings.batchSize, settings.initialVisibilityTimeout, null, null)
         .asScala

--- a/azure-storage-queue/src/test/scala/docs/scaladsl/AzureQueueSpec.scala
+++ b/azure-storage-queue/src/test/scala/docs/scaladsl/AzureQueueSpec.scala
@@ -15,7 +15,7 @@ import com.microsoft.azure.storage._
 import com.microsoft.azure.storage.queue._
 import org.scalatest._
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.util.Properties

--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ lazy val alpakka = project
         // springWeb triggers an esoteric ScalaDoc bug (from Java code)
         springWeb
       ),
-    licenses := Seq(("BUSL-1.1", url("https://raw.githubusercontent.com/akka/alpakka/master/LICENSE"))), // FIXME change s/main/v4.1.0/ when released
+    licenses := Seq(("BUSL-1.1", url("https://raw.githubusercontent.com/akka/alpakka/master/LICENSE"))), // FIXME change s/master/v4.1.0/ when released
     crossScalaVersions := List() // workaround for https://github.com/sbt/sbt/issues/3465
   )
 
@@ -433,8 +433,9 @@ def alpakkaProject(projectId: String, moduleName: String, additionalSettings: sb
     .disablePlugins(SitePlugin)
     .settings(
       name := s"akka-stream-alpakka-$projectId",
-      licenses := List(License.Apache2),
+      licenses := Seq(("BUSL-1.1", url("https://raw.githubusercontent.com/akka/alpakka/master/LICENSE"))), // FIXME change s/master/v4.1.0/ when released
       AutomaticModuleName.settings(s"akka.stream.alpakka.$moduleName"),
+      scalacOptions += "-Wconf:cat=deprecation&msg=.*JavaConverters.*:s",
       mimaPreviousArtifacts := Set(
           organization.value %% name.value % previousStableVersion.value
             .getOrElse(throw new Error("Unable to determine previous version"))
@@ -454,10 +455,9 @@ def internalProject(projectId: String, additionalSettings: sbt.Def.SettingsDefin
   Project(id = projectId, base = file(projectId))
     .enablePlugins(AutomateHeaderPlugin)
     .disablePlugins(SitePlugin, MimaPlugin)
-    .settings(
-      name := s"akka-stream-alpakka-$projectId",
-      publish / skip := true
-    )
+    .settings(name := s"akka-stream-alpakka-$projectId",
+              publish / skip := true,
+              scalacOptions += "-Wconf:cat=deprecation&msg=.*JavaConverters.*:s")
     .settings(additionalSettings: _*)
 
 Global / onLoad := (Global / onLoad).value.andThen { s =>

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/CassandraMetricsRegistry.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/CassandraMetricsRegistry.scala
@@ -8,7 +8,7 @@ import akka.actor.{ClassicActorSystemProvider, ExtendedActorSystem, Extension, E
 import akka.annotation.InternalApi
 import com.codahale.metrics.MetricRegistry
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Retrieves Cassandra metrics registry for an actor system

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraSession.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraSession.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.{CompletionStage, Executor}
 import java.util.function.{Function => JFunction}
 
 import scala.annotation.varargs
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.ExecutionContext

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraFlow.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraFlow.scala
@@ -10,7 +10,7 @@ import akka.stream.alpakka.cassandra.CassandraWriteSettings
 import akka.stream.scaladsl.{Flow, FlowWithContext}
 import com.datastax.oss.driver.api.core.cql.{BatchStatement, BoundStatement, PreparedStatement}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
 
 /**

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSessionRegistry.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSessionRegistry.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.cassandra.scaladsl
 
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import akka.Done

--- a/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraLifecycle.scala
+++ b/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraLifecycle.scala
@@ -13,7 +13,7 @@ import com.datastax.oss.driver.api.core.cql._
 import org.scalatest._
 import org.scalatest.concurrent.{PatienceConfiguration, ScalaFutures}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}

--- a/cassandra/src/test/scala/docs/javadsl/CassandraSessionSpec.scala
+++ b/cassandra/src/test/scala/docs/javadsl/CassandraSessionSpec.scala
@@ -19,7 +19,7 @@ import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
 import com.datastax.oss.driver.api.core.cql.Row
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._

--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/model.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/model.scala
@@ -13,7 +13,7 @@ import com.couchbase.client.java.env.CouchbaseEnvironment
 import com.couchbase.client.java.{PersistTo, ReplicateTo}
 import com.typesafe.config.Config
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.compat.java8.FutureConverters._

--- a/couchbase/src/test/scala/akka/stream/alpakka/couchbase/testing/CouchbaseSupport.scala
+++ b/couchbase/src/test/scala/akka/stream/alpakka/couchbase/testing/CouchbaseSupport.scala
@@ -17,7 +17,7 @@ import com.couchbase.client.java.document.{BinaryDocument, JsonDocument, RawJson
 import org.slf4j.LoggerFactory
 import play.api.libs.json.Json
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._

--- a/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
@@ -180,7 +180,7 @@ class CsvParsingSpec extends CsvSpec {
           .fromPath(Paths.get("csv/src/test/resources/correctness.csv"))
           .via(CsvParsing.lineScanner())
           .via(CsvToMap.toMap())
-          .map(_.view.mapValues(_.utf8String).toIndexedSeq)
+          .map(_.iterator.map { case (k, v) => k -> v.utf8String }.toIndexedSeq)
           .runWith(Sink.seq)
       val res = fut.futureValue
       res(0) should contain allElementsOf (

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ItemSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ItemSpec.scala
@@ -19,7 +19,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.TableStatus
 
 import scala.annotation.nowarn
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 class ItemSpec extends TestKit(ActorSystem("ItemSpec")) with AsyncWordSpecLike with Matchers with BeforeAndAfterAll {

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TableSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TableSpec.scala
@@ -15,7 +15,7 @@ import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCrede
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpecLike
 

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TestOps.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TestOps.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.dynamodb
 
 import software.amazon.awssdk.services.dynamodb.model._
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 trait TestOps {
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchConnectionSettings.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/ElasticsearchConnectionSettings.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.model.HttpHeader
 import akka.http.scaladsl.model.HttpHeader.ParsingResult
 import akka.japi.Util
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import javax.net.ssl.SSLContext
 import scala.compat.java8.OptionConverters
 

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/WriteMessage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/WriteMessage.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.elasticsearch
 import akka.NotUsed
 import akka.annotation.InternalApi
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
 /**

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchFlow.scala
@@ -9,7 +9,7 @@ import akka.annotation.ApiMayChange
 import akka.stream.alpakka.elasticsearch.{scaladsl, _}
 import com.fasterxml.jackson.databind.ObjectMapper
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Java API to create Elasticsearch flows.

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSource.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/javadsl/ElasticsearchSource.scala
@@ -13,7 +13,7 @@ import akka.stream.{Attributes, Materializer}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.{ArrayNode, NumericNode}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 /**

--- a/file/src/main/scala/akka/stream/alpakka/file/javadsl/LogRotatorSink.scala
+++ b/file/src/main/scala/akka/stream/alpakka/file/javadsl/LogRotatorSink.scala
@@ -15,7 +15,7 @@ import akka.stream.javadsl.Sink
 import akka.util.ByteString
 import akka.japi.function
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
 
 import scala.compat.java8.FutureConverters._

--- a/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
 class ArchiveSpec

--- a/file/src/test/scala/docs/scaladsl/ExecutableUtils.scala
+++ b/file/src/test/scala/docs/scaladsl/ExecutableUtils.scala
@@ -7,8 +7,9 @@ package docs.scaladsl
 import java.io.{BufferedInputStream, InputStream, OutputStream, File => JavaFile}
 import java.nio.file.{Files, Path, Paths}
 
-import akka.util.ByteString
+import scala.annotation.nowarn
 
+import akka.util.ByteString
 import scala.concurrent.Future
 import scala.sys.process.{BasicIO, Process}
 
@@ -48,9 +49,10 @@ object ExecutableUtils {
     finally stream.close()
   }
 
+  @nowarn("msg=deprecated") // Stream => LazyList
   private def readStream(stream: InputStream): ByteString = {
     val reader = new BufferedInputStream(stream)
-    try ByteString(LazyList.continually(reader.read).takeWhile(_ != -1).map(_.toByte).toArray)
+    try ByteString(Stream.continually(reader.read).takeWhile(_ != -1).map(_.toByte).toArray)
     finally reader.close()
   }
 

--- a/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.annotation.nowarn
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
@@ -19,7 +19,7 @@ import net.schmizz.sshj.userauth.password.{PasswordFinder, PasswordUtils, Resour
 import net.schmizz.sshj.xfer.FilePermission
 import org.apache.commons.net.DefaultSocketFactory
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.util.{Failure, Try}
 

--- a/google-cloud-bigquery-storage/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/storage/ProtobufConverters.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/storage/ProtobufConverters.scala
@@ -9,7 +9,7 @@ import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions
 import com.google.cloud.bigquery.storage.v1.stream.ReadSession
 import scalapb.UnknownFieldSet
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Internal API

--- a/google-cloud-bigquery-storage/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/storage/impl/ArrowSource.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/storage/impl/ArrowSource.scala
@@ -18,7 +18,7 @@ import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 object ArrowSource {
 

--- a/google-cloud-bigquery-storage/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/storage/javadsl/BigQueryArrowStorage.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/storage/javadsl/BigQueryArrowStorage.scala
@@ -12,7 +12,7 @@ import akka.stream.alpakka.googlecloud.bigquery.storage.{scaladsl => scstorage}
 import com.google.cloud.bigquery.storage.v1.arrow.{ArrowRecordBatch, ArrowSchema}
 
 import java.util.concurrent.CompletionStage
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters.FutureOps
 
 /**

--- a/google-cloud-bigquery-storage/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/storage/javadsl/BigQueryAvroStorage.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/storage/javadsl/BigQueryAvroStorage.scala
@@ -11,7 +11,7 @@ import com.google.cloud.bigquery.storage.v1.avro.{AvroRows, AvroSchema}
 import com.google.cloud.bigquery.storage.v1.stream.ReadSession.TableReadOptions
 
 import java.util.concurrent.CompletionStage
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters.FutureOps
 
 /**

--- a/google-cloud-bigquery-storage/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/storage/javadsl/BigQueryStorage.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/storage/javadsl/BigQueryStorage.scala
@@ -18,7 +18,7 @@ import com.google.cloud.bigquery.storage.v1.stream.ReadSession
 
 import java.util.concurrent.CompletionStage
 import scala.compat.java8.FutureConverters.FutureOps
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Google BigQuery Storage Api Akka Stream operator factory.

--- a/google-cloud-bigquery-storage/src/test/java/akka/stream/alpakka/googlecloud/bigquery/storage/javadsl/AvroByteStringDecoder.scala
+++ b/google-cloud-bigquery-storage/src/test/java/akka/stream/alpakka/googlecloud/bigquery/storage/javadsl/AvroByteStringDecoder.scala
@@ -16,7 +16,7 @@ import org.apache.avro.io.DecoderFactory
 import java.util
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ExecutionContext, Future}
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class AvroByteStringDecoder(schema: Schema) extends FromByteStringUnmarshaller[java.util.List[BigQueryRecord]] {
 

--- a/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/scaladsl/ArrowByteStringDecoder.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/scaladsl/ArrowByteStringDecoder.scala
@@ -18,7 +18,7 @@ import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ExecutionContext, Future}
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class ArrowByteStringDecoder(val schema: ArrowSchema) extends FromByteStringUnmarshaller[List[BigQueryRecord]] {
 

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/javadsl/BigQuery.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/javadsl/BigQuery.scala
@@ -34,7 +34,7 @@ import java.util.concurrent.CompletionStage
 import java.{lang, util}
 
 import scala.annotation.nowarn
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/DatasetJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/DatasetJsonProtocol.scala
@@ -9,7 +9,7 @@ import akka.stream.alpakka.googlecloud.bigquery.scaladsl.spray.BigQueryRestJsonP
 import spray.json.{JsonFormat, RootJsonFormat}
 
 import java.util
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
 

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/JobJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/JobJsonProtocol.scala
@@ -11,7 +11,7 @@ import spray.json.{JsonFormat, RootJsonFormat}
 import java.util
 
 import scala.annotation.nowarn
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
 

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/QueryJsonProtocol.scala
@@ -16,7 +16,7 @@ import java.{lang, util}
 
 import scala.annotation.nowarn
 import scala.annotation.unchecked.uncheckedVariance
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.FiniteDuration

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/TableDataJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/TableDataJsonProtocol.scala
@@ -15,7 +15,7 @@ import java.{lang, util}
 
 import scala.annotation.nowarn
 import scala.annotation.unchecked.uncheckedVariance
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
 

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/TableJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/model/TableJsonProtocol.scala
@@ -15,7 +15,7 @@ import scala.annotation.nowarn
 import scala.annotation.varargs
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Table resource model

--- a/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/e2e/A.scala
+++ b/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/e2e/A.scala
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 
 import java.time.{Instant, LocalDate, LocalDateTime, LocalTime}
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 @JsonPropertyOrder(alphabetic = true)
 case class A(integer: Int, long: Long, float: Float, double: Double, string: String, boolean: Boolean, record: B) {

--- a/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/e2e/javadsl/EndToEndHelper.scala
+++ b/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/e2e/javadsl/EndToEndHelper.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.googlecloud.bigquery.e2e.javadsl
 
 import akka.stream.alpakka.googlecloud.bigquery.e2e.scaladsl;
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 abstract class EndToEndHelper extends scaladsl.EndToEndHelper {
 

--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/javadsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/javadsl/GooglePubSub.scala
@@ -13,7 +13,7 @@ import akka.{Done, NotUsed}
 import java.util.concurrent.CompletionStage
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Java DSL for Google Pub/Sub

--- a/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/model.scala
+++ b/google-cloud-pub-sub/src/main/scala/akka/stream/alpakka/googlecloud/pubsub/model.scala
@@ -12,7 +12,7 @@ import akka.stream.alpakka.google.auth.ServiceAccountCredentials
 
 import scala.annotation.nowarn
 import scala.collection.immutable
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * @param projectId (deprecated) the project Id in the google account

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/FailedUpload.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/FailedUpload.scala
@@ -5,7 +5,7 @@
 package akka.stream.alpakka.googlecloud.storage
 
 import scala.collection.immutable.Seq
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 final class FailedUpload private (
     val reasons: Seq[Throwable]

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/StorageObject.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/StorageObject.scala
@@ -9,7 +9,7 @@ import java.util.Optional
 
 import akka.http.scaladsl.model.ContentType
 import scala.compat.java8.OptionConverters._
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Represents an object within Google Cloud Storage.

--- a/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/javadsl/GCStorage.scala
+++ b/google-cloud-storage/src/main/scala/akka/stream/alpakka/googlecloud/storage/javadsl/GCStorage.scala
@@ -17,7 +17,7 @@ import akka.stream.{Attributes, Materializer}
 import akka.util.ByteString
 import akka.{Done, NotUsed}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCSExtSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCSExtSpec.scala
@@ -10,7 +10,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class GCSExtSpec extends AnyFlatSpec with Matchers with LogCapturing {
   "GCSExt" should "reuse application config from actor system" in {

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCSSettingsSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCSSettingsSpec.scala
@@ -9,7 +9,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class GCSSettingsSpec extends AnyFlatSpec with Matchers with LogCapturing {
   "GCSSettings" should "create settings from application config" in {

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageExtSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageExtSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.annotation.nowarn
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class GCStorageExtSpec extends AnyFlatSpec with Matchers with LogCapturing {
   "GCStorageExt" should "reuse application config from actor system" in {

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageSettingsSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageSettingsSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.annotation.nowarn
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class GCStorageSettingsSpec extends AnyFlatSpec with Matchers with LogCapturing {
   "GCStorageSettings" should "create settings from application config" in {

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/ServiceAccountCredentials.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/ServiceAccountCredentials.scala
@@ -13,7 +13,7 @@ import spray.json.DefaultJsonProtocol._
 import spray.json.{JsonParser, RootJsonFormat}
 
 import java.time.Clock
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.io.Source
 

--- a/google-common/src/test/scala/docs/scaladsl/GoogleCommonDoc.scala
+++ b/google-common/src/test/scala/docs/scaladsl/GoogleCommonDoc.scala
@@ -11,8 +11,7 @@ import akka.stream.scaladsl.Source
 
 import scala.annotation.nowarn
 
-@nowarn("msg=never used")
-@nowarn("msg=dead code")
+@nowarn
 class GoogleCommonDoc {
 
   implicit val system: ActorSystem = ???

--- a/hbase/src/main/scala/akka/stream/alpakka/hbase/HTableSettings.scala
+++ b/hbase/src/main/scala/akka/stream/alpakka/hbase/HTableSettings.scala
@@ -9,7 +9,7 @@ import org.apache.hadoop.hbase.TableName
 import org.apache.hadoop.hbase.client.Mutation
 
 import scala.collection.immutable
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.FunctionConverters._
 
 final class HTableSettings[T] private (val conf: Configuration,

--- a/hdfs/src/test/scala/akka/stream/alpakka/hdfs/util/TestUtils.scala
+++ b/hdfs/src/test/scala/akka/stream/alpakka/hdfs/util/TestUtils.scala
@@ -178,7 +178,7 @@ object JavaTestUtils extends TestUtils {
 
   import org.junit.Assert._
 
-  import scala.jdk.CollectionConverters._
+  import scala.collection.JavaConverters._
 
   val books: util.List[ByteString] = ScalaTestUtils.books.asJava
 

--- a/influxdb/src/main/scala/akka/stream/alpakka/influxdb/impl/AlpakkaResultMapperHelper.scala
+++ b/influxdb/src/main/scala/akka/stream/alpakka/influxdb/impl/AlpakkaResultMapperHelper.scala
@@ -17,7 +17,7 @@ import akka.annotation.InternalApi
 import org.influxdb.InfluxDBMapperException
 import org.influxdb.dto.Point
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Internal API.

--- a/influxdb/src/main/scala/akka/stream/alpakka/influxdb/impl/InfluxDbSourceStage.scala
+++ b/influxdb/src/main/scala/akka/stream/alpakka/influxdb/impl/InfluxDbSourceStage.scala
@@ -11,7 +11,7 @@ import akka.stream.stage.{GraphStage, GraphStageLogic, OutHandler}
 import org.influxdb.{InfluxDB, InfluxDBException}
 import org.influxdb.dto.{Query, QueryResult}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * INTERNAL API

--- a/influxdb/src/main/scala/akka/stream/alpakka/influxdb/javadsl/InfluxDbFlow.scala
+++ b/influxdb/src/main/scala/akka/stream/alpakka/influxdb/javadsl/InfluxDbFlow.scala
@@ -12,7 +12,7 @@ import akka.stream.javadsl.Flow
 import akka.stream.alpakka.influxdb.scaladsl
 import org.influxdb.dto.Point
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * API may change.

--- a/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpec.scala
@@ -18,7 +18,7 @@ import akka.testkit.TestKit
 import docs.javadsl.TestUtils._
 import akka.stream.scaladsl.Sink
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import docs.javadsl.TestConstants.{INFLUXDB_URL, PASSWORD, USERNAME}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/jms/src/main/scala/akka/stream/alpakka/jms/JmsMessages.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/JmsMessages.scala
@@ -9,7 +9,7 @@ import javax.jms
 import akka.NotUsed
 import akka.stream.alpakka.jms.impl.JmsMessageReader._
 import akka.util.ByteString
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
 /**

--- a/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsMessageReader.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/impl/JmsMessageReader.scala
@@ -10,7 +10,7 @@ import akka.annotation.InternalApi
 import akka.stream.alpakka.jms._
 import akka.util.ByteString
 import scala.annotation.tailrec
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 @InternalApi
 private[jms] object JmsMessageReader {

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsConsumer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsConsumer.scala
@@ -9,7 +9,7 @@ import akka.NotUsed
 import akka.stream.alpakka.jms._
 import akka.stream.javadsl.Source
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Factory methods to create JMS consumers.

--- a/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsProducer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/javadsl/JmsProducer.scala
@@ -12,7 +12,7 @@ import akka.stream.scaladsl.{Flow, Keep}
 import akka.util.ByteString
 import akka.{Done, NotUsed}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters
 
 /**

--- a/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsConsumer.scala
+++ b/jms/src/main/scala/akka/stream/alpakka/jms/scaladsl/JmsConsumer.scala
@@ -10,7 +10,7 @@ import akka.stream.alpakka.jms.impl._
 import akka.stream.scaladsl.Source
 import javax.jms
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Factory methods to create JMS consumers.

--- a/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
@@ -24,7 +24,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 
 import scala.annotation.tailrec
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.collection.mutable
 import scala.concurrent.Future

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/impl/KinesisSourceStage.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/impl/KinesisSourceStage.scala
@@ -15,7 +15,7 @@ import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 import software.amazon.awssdk.services.kinesis.model._
 
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 import scala.compat.java8.FutureConverters._

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/impl/ShardProcessor.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/impl/ShardProcessor.scala
@@ -14,7 +14,7 @@ import software.amazon.kinesis.lifecycle.events._
 import software.amazon.kinesis.processor.{RecordProcessorCheckpointer, ShardRecordProcessor}
 import software.amazon.kinesis.retrieval.KinesisClientRecord
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 @InternalApi
 private[kinesis] class ShardProcessor(

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/javadsl/KinesisSource.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/javadsl/KinesisSource.scala
@@ -10,7 +10,7 @@ import akka.stream.javadsl.Source
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 import software.amazon.awssdk.services.kinesis.model.Record
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 object KinesisSource {
 

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisFlow.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/scaladsl/KinesisFlow.scala
@@ -22,7 +22,7 @@ import software.amazon.awssdk.services.kinesis.model.{
   PutRecordsResultEntry
 }
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable.Queue
 import scala.concurrent.duration._
 import scala.compat.java8.FutureConverters._

--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/scaladsl/KinesisFirehoseFlow.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesisfirehose/scaladsl/KinesisFirehoseFlow.scala
@@ -13,7 +13,7 @@ import akka.stream.scaladsl.Flow
 import software.amazon.awssdk.services.firehose.FirehoseAsyncClient
 import software.amazon.awssdk.services.firehose.model.{PutRecordBatchRequest, PutRecordBatchResponseEntry, Record}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable.Queue
 import scala.concurrent.duration._
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
@@ -6,6 +6,8 @@ package akka.stream.alpakka.kinesis
 
 import java.util.concurrent.CompletableFuture
 
+import scala.annotation.nowarn
+
 import akka.stream.alpakka.kinesis.KinesisErrors.FailurePublishingRecords
 import akka.stream.alpakka.kinesis.scaladsl.KinesisFlow
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
@@ -21,7 +23,6 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.kinesis.model._
-
 import scala.collection.JavaConverters._
 
 class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with LogCapturing {
@@ -92,9 +93,10 @@ class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with Lo
         .run()
   }
 
+  @nowarn("msg=deprecated") // Stream => Stream
   trait KinesisFlowWithContextProbe { self: Settings =>
     val streamName = "stream-name"
-    val recordStream = LazyList
+    val recordStream = Stream
       .from(1)
       .map(
         i =>
@@ -105,7 +107,7 @@ class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with Lo
              .build(),
            i)
       )
-    val resultStream = LazyList
+    val resultStream = Stream
       .from(1)
       .map(i => (PutRecordsResultEntry.builder().build(), i))
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.kinesis.model._
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with LogCapturing {
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSchedulerSourceSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSchedulerSourceSpec.scala
@@ -37,7 +37,7 @@ import software.amazon.kinesis.processor.{
 import software.amazon.kinesis.retrieval.KinesisClientRecord
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Random

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.firehose.model._
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class KinesisFirehoseFlowSpec extends AnyWordSpec with Matchers with KinesisFirehoseMock with LogCapturing {
 

--- a/kudu/src/main/scala/akka/stream/alpakka/kudu/impl/KuduFlowStage.scala
+++ b/kudu/src/main/scala/akka/stream/alpakka/kudu/impl/KuduFlowStage.scala
@@ -12,7 +12,7 @@ import org.apache.kudu.Schema
 import org.apache.kudu.Type._
 import org.apache.kudu.client.{KuduClient, KuduTable, PartialRow}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
 /**

--- a/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala
+++ b/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala
@@ -16,7 +16,7 @@ import org.apache.kudu.{ColumnSchema, Schema, Type}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers

--- a/mongodb/src/main/scala/akka/stream/alpakka/mongodb/javadsl/MongoFlow.scala
+++ b/mongodb/src/main/scala/akka/stream/alpakka/mongodb/javadsl/MongoFlow.scala
@@ -19,7 +19,7 @@ import com.mongodb.client.result.{DeleteResult, UpdateResult}
 import com.mongodb.reactivestreams.client.MongoCollection
 import org.bson.conversions.Bson
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 object MongoFlow {
 

--- a/mongodb/src/main/scala/akka/stream/alpakka/mongodb/scaladsl/MongoFlow.scala
+++ b/mongodb/src/main/scala/akka/stream/alpakka/mongodb/scaladsl/MongoFlow.scala
@@ -13,7 +13,7 @@ import com.mongodb.client.result.{DeleteResult, UpdateResult}
 import com.mongodb.reactivestreams.client.MongoCollection
 import org.bson.conversions.Bson
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 object MongoFlow {
 

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
@@ -19,7 +19,7 @@ import org.mongodb.scala.bson.codecs.Macros._
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
@@ -15,7 +15,7 @@ import org.bson.Document
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent._
 import scala.concurrent.duration._

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/model.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/model.scala
@@ -16,7 +16,7 @@ import akka.util.{ByteIterator, ByteString, ByteStringBuilder}
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.{ExecutionContext, Promise}
 

--- a/mqtt/src/main/scala/akka/stream/alpakka/mqtt/settings.scala
+++ b/mqtt/src/main/scala/akka/stream/alpakka/mqtt/settings.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.mqtt
 import akka.util.JavaDurationConverters._
 import org.eclipse.paho.client.mqttv3.{MqttClientPersistence, MqttConnectOptions}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.collection.immutable.Map
 import scala.concurrent.duration.{FiniteDuration, _}

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/impl/OrientDbSourceStage.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/impl/OrientDbSourceStage.scala
@@ -14,7 +14,7 @@ import com.orientechnologies.orient.`object`.db.OObjectDatabaseTx
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * INTERNAL API

--- a/orientdb/src/main/scala/akka/stream/alpakka/orientdb/javadsl/OrientDbFlow.scala
+++ b/orientdb/src/main/scala/akka/stream/alpakka/orientdb/javadsl/OrientDbFlow.scala
@@ -9,7 +9,7 @@ import akka.stream.alpakka.orientdb._
 import akka.stream.javadsl.Flow
 import com.orientechnologies.orient.core.record.impl.ODocument
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Java API.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,8 @@ object Dependencies {
   val CronBuild = sys.env.get("GITHUB_EVENT_NAME").contains("schedule")
 
   val Scala213 = "2.13.8" // update even in link-validator.conf
-  val ScalaVersions = Seq(Scala213)
+  val Scala212 = "2.12.16"
+  val ScalaVersions = Seq(Scala213, Scala212)
 
   val AkkaVersion = "2.6.19"
   val AkkaBinaryVersion = "2.6"
@@ -125,7 +126,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
         "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-        "com.typesafe.akka" %% "akka-stream-kafka" % "3.0.0" % Test,
+        "com.typesafe.akka" %% "akka-stream-kafka" % "3.1.0-M1" % Test,
         "junit" % "junit" % "4.13.2" % Test, // Eclipse Public License 1.0
         "org.scalatest" %% "scalatest" % "3.2.11" % Test // ApacheV2
       )

--- a/reference/src/main/scala/akka/stream/alpakka/reference/model.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/model.scala
@@ -10,7 +10,7 @@ import akka.annotation.InternalApi
 import akka.util.ByteString
 
 import scala.collection.immutable
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.util.{Success, Try}
 

--- a/reference/src/main/scala/akka/stream/alpakka/reference/model.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/model.scala
@@ -88,7 +88,7 @@ final class ReferenceWriteMessage private (
    * Java setter needs to take Java Long class and convert to Scala Long.
    */
   def withMetrics(metrics: java.util.Map[String, java.lang.Long]): ReferenceWriteMessage =
-    copy(metrics = metrics.asScala.view.mapValues(Long.unbox).toMap)
+    copy(metrics = metrics.asScala.iterator.map { case (k, v) => k -> Long.unbox(v) }.toMap)
 
   /**
    * Java API

--- a/reference/src/main/scala/akka/stream/alpakka/reference/testkit/MessageFactory.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/testkit/MessageFactory.scala
@@ -8,7 +8,7 @@ import akka.stream.alpakka.reference.{ReferenceReadResult, ReferenceWriteMessage
 import akka.util.ByteString
 
 import scala.collection.immutable
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 @ApiMayChange

--- a/reference/src/main/scala/akka/stream/alpakka/reference/testkit/MessageFactory.scala
+++ b/reference/src/main/scala/akka/stream/alpakka/reference/testkit/MessageFactory.scala
@@ -43,6 +43,6 @@ object MessageFactory {
   def createWriteResult(message: ReferenceWriteMessage,
                         metrics: java.util.Map[String, java.lang.Long],
                         status: Int): ReferenceWriteResult =
-    new ReferenceWriteResult(message, metrics.asScala.view.mapValues(Long.unbox).toMap, status)
+    new ReferenceWriteResult(message, metrics.asScala.iterator.map { case (k, v) => k -> Long.unbox(v) }.toMap, status)
 
 }

--- a/s3/src/main/scala/akka/stream/alpakka/s3/S3Headers.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/S3Headers.scala
@@ -13,7 +13,7 @@ import akka.stream.alpakka.s3.headers.{CannedAcl, ServerSideEncryption, StorageC
 import akka.stream.alpakka.s3.impl.S3Request
 
 import scala.collection.immutable.Seq
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 final class MetaHeaders private (val metaHeaders: Map[String, String]) {
 

--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -48,13 +48,15 @@ import scala.util.{Failure, Success, Try}
                                                                           versionId: Option[String] = None)
 
 /** Internal Api */
-@InternalApi private[impl] final case class ListBucketsResult(buckets: Seq[ListBucketsResultContents])
+@InternalApi private[impl] final case class ListBucketsResult(buckets: immutable.Seq[ListBucketsResultContents])
 
 /** Internal Api */
-@InternalApi private[impl] final case class ListBucketResult(isTruncated: Boolean,
-                                                             continuationToken: Option[String],
-                                                             contents: Seq[ListBucketResultContents],
-                                                             commonPrefixes: Seq[ListBucketResultCommonPrefixes])
+@InternalApi private[impl] final case class ListBucketResult(
+    isTruncated: Boolean,
+    continuationToken: Option[String],
+    contents: immutable.Seq[ListBucketResultContents],
+    commonPrefixes: immutable.Seq[ListBucketResultCommonPrefixes]
+)
 
 /** Internal Api */
 @InternalApi private[impl] final case class ListMultipartUploadContinuationToken(nextKeyMarker: Option[String],
@@ -70,8 +72,8 @@ import scala.util.{Failure, Success, Try}
     delimiter: Option[String],
     maxUploads: Int,
     isTruncated: Boolean,
-    uploads: Seq[ListMultipartUploadResultUploads],
-    commonPrefixes: Seq[CommonPrefixes]
+    uploads: immutable.Seq[ListMultipartUploadResultUploads],
+    commonPrefixes: immutable.Seq[CommonPrefixes]
 ) {
 
   /**
@@ -103,9 +105,9 @@ import scala.util.{Failure, Success, Try}
     delimiter: Option[String],
     maxKeys: Int,
     isTruncated: Boolean,
-    versions: Seq[ListObjectVersionsResultVersions],
-    commonPrefixes: Seq[CommonPrefixes],
-    deleteMarkers: Seq[DeleteMarkers]
+    versions: immutable.Seq[ListObjectVersionsResultVersions],
+    commonPrefixes: immutable.Seq[CommonPrefixes],
+    deleteMarkers: immutable.Seq[DeleteMarkers]
 ) {
 
   /**
@@ -128,7 +130,7 @@ import scala.util.{Failure, Success, Try}
                                                             nextPartNumberMarker: Option[Int],
                                                             maxParts: Int,
                                                             isTruncated: Boolean,
-                                                            parts: Seq[ListPartsResultParts],
+                                                            parts: immutable.Seq[ListPartsResultParts],
                                                             initiator: Option[AWSIdentity],
                                                             owner: Option[AWSIdentity],
                                                             storageClass: String) {
@@ -284,7 +286,7 @@ import scala.util.{Failure, Success, Try}
         implicit val materializer: Materializer = mat
         implicit val attributes: Attributes = attr
         Source
-          .unfoldAsync[ListBucketState, Seq[ListBucketResultContents]](Starting()) {
+          .unfoldAsync[ListBucketState, immutable.Seq[ListBucketResultContents]](Starting()) {
             case Finished() => Future.successful(None)
             case Starting() => listBucketCallOnlyContents(None)
             case Running(token) => listBucketCallOnlyContents(Some(token))
@@ -314,7 +316,8 @@ import scala.util.{Failure, Success, Try}
         implicit val materializer: Materializer = mat
         implicit val attributes: Attributes = attr
         Source
-          .unfoldAsync[ListBucketState, (Seq[ListBucketResultContents], Seq[ListBucketResultCommonPrefixes])](
+          .unfoldAsync[ListBucketState,
+                       (immutable.Seq[ListBucketResultContents], immutable.Seq[ListBucketResultCommonPrefixes])](
             Starting()
           ) {
             case Finished() => Future.successful(None)
@@ -391,7 +394,8 @@ import scala.util.{Failure, Success, Try}
         implicit val materializer: Materializer = mat
         implicit val attributes: Attributes = attr
         Source
-          .unfoldAsync[ListMultipartUploadState, (Seq[ListMultipartUploadResultUploads], Seq[CommonPrefixes])](
+          .unfoldAsync[ListMultipartUploadState,
+                       (immutable.Seq[ListMultipartUploadResultUploads], immutable.Seq[CommonPrefixes])](
             Starting()
           ) {
             case Finished() => Future.successful(None)
@@ -416,7 +420,7 @@ import scala.util.{Failure, Success, Try}
         implicit val materializer: Materializer = mat
         implicit val attributes: Attributes = attr
         Source
-          .unfoldAsync[ListMultipartUploadState, Seq[ListMultipartUploadResultUploads]](Starting()) {
+          .unfoldAsync[ListMultipartUploadState, immutable.Seq[ListMultipartUploadResultUploads]](Starting()) {
             case Finished() => Future.successful(None)
             case Starting() => listMultipartUploadCallOnlyUploads(None)
             case Running(token) => listMultipartUploadCallOnlyUploads(Some(token))
@@ -466,7 +470,7 @@ import scala.util.{Failure, Success, Try}
         implicit val materializer: Materializer = mat
         implicit val attributes: Attributes = attr
         Source
-          .unfoldAsync[ListPartsState, Seq[ListPartsResultParts]](Starting()) {
+          .unfoldAsync[ListPartsState, immutable.Seq[ListPartsResultParts]](Starting()) {
             case Finished() => Future.successful(None)
             case Starting() => listMultipartUploadCallOnlyUploads(None)
             case Running(token) => listMultipartUploadCallOnlyUploads(Some(token))
@@ -532,7 +536,9 @@ import scala.util.{Failure, Success, Try}
         implicit val attributes: Attributes = attr
         Source
           .unfoldAsync[ListObjectVersionsState,
-                       (Seq[ListObjectVersionsResultVersions], Seq[DeleteMarkers], Seq[CommonPrefixes])](
+                       (immutable.Seq[ListObjectVersionsResultVersions],
+                        immutable.Seq[DeleteMarkers],
+                        immutable.Seq[CommonPrefixes])](
             Starting()
           ) {
             case Finished() => Future.successful(None)
@@ -566,7 +572,8 @@ import scala.util.{Failure, Success, Try}
         implicit val materializer: Materializer = mat
         implicit val attributes: Attributes = attr
         Source
-          .unfoldAsync[ListObjectVersionsState, (Seq[ListObjectVersionsResultVersions], Seq[DeleteMarkers])](Starting()) {
+          .unfoldAsync[ListObjectVersionsState,
+                       (immutable.Seq[ListObjectVersionsResultVersions], immutable.Seq[DeleteMarkers])](Starting()) {
             case Finished() => Future.successful(None)
             case Starting() => listObjectVersionsCallOnlyVersions(None)
             case Running(token) => listObjectVersionsCallOnlyVersions(Some(token))
@@ -697,7 +704,7 @@ import scala.util.{Failure, Success, Try}
               method: HttpMethod = HttpMethods.GET,
               rangeOption: Option[ByteRange] = None,
               versionId: Option[String] = None,
-              s3Headers: Seq[HttpHeader] = Seq.empty): Source[HttpResponse, NotUsed] =
+              s3Headers: immutable.Seq[HttpHeader] = immutable.Seq.empty): Source[HttpResponse, NotUsed] =
     Source
       .fromMaterializer { (mat, attr) =>
         issueRequest(s3Location, method, rangeOption, versionId, s3Headers)(mat, attr)
@@ -709,7 +716,7 @@ import scala.util.{Failure, Success, Try}
       method: HttpMethod = HttpMethods.GET,
       rangeOption: Option[ByteRange] = None,
       versionId: Option[String],
-      s3Headers: Seq[HttpHeader]
+      s3Headers: immutable.Seq[HttpHeader]
   )(implicit mat: Materializer, attr: Attributes): Source[HttpResponse, NotUsed] = {
     implicit val sys: ActorSystem = mat.system
     implicit val conf: S3Settings = resolveSettings(attr, sys)
@@ -801,7 +808,7 @@ import scala.util.{Failure, Success, Try}
       bucket: String,
       method: HttpMethod,
       httpRequest: (HttpMethod, S3Settings) => HttpRequest,
-      headers: Seq[HttpHeader],
+      headers: immutable.Seq[HttpHeader],
       process: (HttpResponse, Materializer) => Future[T],
       httpEntity: Option[Future[RequestEntity]] = None
   ): Source[T, NotUsed] =
@@ -961,7 +968,7 @@ import scala.util.{Failure, Success, Try}
 
   private def initiateMultipartUpload(s3Location: S3Location,
                                       contentType: ContentType,
-                                      s3Headers: Seq[HttpHeader]): Source[MultipartUpload, NotUsed] =
+                                      s3Headers: immutable.Seq[HttpHeader]): Source[MultipartUpload, NotUsed] =
     Source
       .fromMaterializer { (mat, attr) =>
         implicit val materializer: Materializer = mat
@@ -1011,10 +1018,10 @@ import scala.util.{Failure, Success, Try}
       .toMat(completionSink(targetLocation, s3Headers))(Keep.right)
   }
 
-  private def computeMetaData(headers: Seq[HttpHeader], entity: ResponseEntity): ObjectMetadata =
+  private def computeMetaData(headers: immutable.Seq[HttpHeader], entity: ResponseEntity): ObjectMetadata =
     ObjectMetadata(
       headers ++
-      Seq(
+      immutable.Seq(
         `Content-Length`(entity.contentLengthOption.getOrElse(0)),
         `Content-Type`(entity.contentType),
         CustomContentTypeHeader(entity.contentType)
@@ -1033,12 +1040,14 @@ import scala.util.{Failure, Success, Try}
     override def renderInResponses(): Boolean = true
   }
 
-  private def completeMultipartUpload(s3Location: S3Location, parts: Seq[SuccessfulUploadPart], s3Headers: S3Headers)(
+  private def completeMultipartUpload(s3Location: S3Location,
+                                      parts: immutable.Seq[SuccessfulUploadPart],
+                                      s3Headers: S3Headers)(
       implicit mat: Materializer,
       attr: Attributes
   ): Future[CompleteMultipartUploadResult] = {
     def populateResult(result: CompleteMultipartUploadResult,
-                       headers: Seq[HttpHeader]): CompleteMultipartUploadResult = {
+                       headers: immutable.Seq[HttpHeader]): CompleteMultipartUploadResult = {
       val versionId = headers.find(_.lowercaseName() == "x-amz-version-id").map(_.value())
       result.copy(versionId = versionId)
     }
@@ -1062,7 +1071,7 @@ import scala.util.{Failure, Success, Try}
   @nowarn("msg=deprecated") // Stream => LazyList
   private def initiateUpload(s3Location: S3Location,
                              contentType: ContentType,
-                             s3Headers: Seq[HttpHeader]): Source[(MultipartUpload, Int), NotUsed] =
+                             s3Headers: immutable.Seq[HttpHeader]): Source[(MultipartUpload, Int), NotUsed] =
     Source
       .single(s3Location)
       .flatMapConcat(initiateMultipartUpload(_, contentType, s3Headers))
@@ -1387,9 +1396,9 @@ import scala.util.{Failure, Success, Try}
         import mat.executionContext
         Sink
           .seq[UploadPartResponse]
-          .mapMaterializedValue { responseFuture: Future[Seq[UploadPartResponse]] =>
+          .mapMaterializedValue { responseFuture: Future[immutable.Seq[UploadPartResponse]] =>
             responseFuture
-              .flatMap { responses: Seq[UploadPartResponse] =>
+              .flatMap { responses: immutable.Seq[UploadPartResponse] =>
                 val successes = responses.collect { case r: SuccessfulUploadPart => r }
                 val failures = responses.collect { case r: FailedUploadPart => r }
                 if (responses.isEmpty) {
@@ -1420,7 +1429,7 @@ import scala.util.{Failure, Success, Try}
 
   private def signAndGetAs[T](
       request: HttpRequest,
-      f: (T, Seq[HttpHeader]) => T
+      f: (T, immutable.Seq[HttpHeader]) => T
   )(implicit um: Unmarshaller[ResponseEntity, T], mat: Materializer, attr: Attributes): Source[T, NotUsed] = {
     import mat.executionContext
     implicit val sys: ActorSystem = mat.system
@@ -1466,7 +1475,7 @@ import scala.util.{Failure, Success, Try}
 
   private def entityForSuccess(
       resp: HttpResponse
-  )(implicit mat: Materializer): Future[(ResponseEntity, Seq[HttpHeader])] = {
+  )(implicit mat: Materializer): Future[(ResponseEntity, immutable.Seq[HttpHeader])] = {
     resp match {
       case HttpResponse(status, headers, entity, _) if status.isSuccess() && !status.isRedirection() =>
         Future.successful((entity, headers))

--- a/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/javadsl/S3.scala
@@ -20,7 +20,7 @@ import akka.stream.alpakka.s3.impl._
 import akka.stream.javadsl.{RunnableGraph, Sink, Source}
 import akka.util.ByteString
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.compat.java8.FutureConverters._
 

--- a/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/model.scala
@@ -13,7 +13,7 @@ import akka.stream.alpakka.s3.AccessStyle.PathAccessStyle
 import scala.annotation.nowarn
 import scala.collection.immutable.Seq
 import scala.collection.immutable
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
 final class MultipartUpload private (val bucket: String, val key: String, val uploadId: String) {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ExtSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ExtSpec.scala
@@ -11,7 +11,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class S3ExtSpec extends AnyFlatSpecLike with Matchers {
   it should "reuse application config from actor system" in {

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -30,7 +30,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 trait S3IntegrationSpec
     extends AnyFlatSpecLike

--- a/solr/src/main/scala/akka/stream/alpakka/solr/SolrMessages.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/SolrMessages.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.solr
 import akka.NotUsed
 import akka.annotation.InternalApi
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 object WriteMessage {
   def createUpsertMessage[T](source: T): WriteMessage[T, NotUsed] =

--- a/solr/src/main/scala/akka/stream/alpakka/solr/impl/SolrFlowStage.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/impl/SolrFlowStage.scala
@@ -19,7 +19,7 @@ import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 import scala.collection.immutable
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Internal API

--- a/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/javadsl/SolrFlow.scala
@@ -13,7 +13,7 @@ import akka.stream.scaladsl.Flow
 import org.apache.solr.client.solrj.SolrClient
 import org.apache.solr.common.SolrInputDocument
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable
 
 /**

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/SqsSourceSettings.scala
@@ -9,7 +9,7 @@ import java.time.temporal.ChronoUnit
 import software.amazon.awssdk.services.sqs.model
 
 import scala.collection.immutable
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
 
 final class SqsSourceSettings private (

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsPublishFlow.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsPublishFlow.scala
@@ -18,7 +18,7 @@ import akka.stream.scaladsl.{Flow => SFlow}
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Java API to create SQS flows.

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsPublishSink.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/javadsl/SqsPublishSink.scala
@@ -13,7 +13,7 @@ import akka.stream.scaladsl.{Flow, Keep}
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters.FutureOps
 
 /**

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckFlow.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsAckFlow.scala
@@ -18,7 +18,7 @@ import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition}
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishFlow.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishFlow.scala
@@ -14,7 +14,7 @@ import akka.stream.scaladsl.{Flow, Source}
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
 
 /**

--- a/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
+++ b/sqs/src/main/scala/akka/stream/alpakka/sqs/scaladsl/SqsSource.scala
@@ -12,7 +12,7 @@ import akka.stream.scaladsl.{Flow, Source}
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
 
 /**

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
@@ -22,7 +22,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
 //#init-client
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.util.Random
 

--- a/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
@@ -22,7 +22,7 @@ import org.scalatestplus.mockito.MockitoSugar.mock
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
 class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with LogCapturing {

--- a/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
@@ -16,7 +16,7 @@ import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.{Message, ReceiveMessageRequest, SendMessageRequest}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
 class SqsPublishSpec extends AnyFlatSpec with Matchers with DefaultTestContext with LogCapturing {

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -29,7 +29,7 @@ import software.amazon.awssdk.services.sqs.model.{
   SendMessageRequest
 }
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/testkit/src/main/scala/akka/stream/alpakka/testkit/CapturingAppender.scala
+++ b/testkit/src/main/scala/akka/stream/alpakka/testkit/CapturingAppender.scala
@@ -90,7 +90,7 @@ import org.slf4j.LoggerFactory
    * Also clears the buffer..
    */
   def flush(sourceActorSystem: Option[String]): Unit = synchronized {
-    import scala.jdk.CollectionConverters._
+    import scala.collection.JavaConverters._
     val logbackLogger = getLogbackLogger(classOf[CapturingAppender].getName + "Delegate")
     val appenders = logbackLogger.iteratorForAppenders().asScala.filterNot(_ == this).toList
     for (event <- buffer; appender <- appenders) {

--- a/text/src/test/scala/akka/stream/alpakka/text/scaladsl/CharsetCodingFlowsSpec.scala
+++ b/text/src/test/scala/akka/stream/alpakka/text/scaladsl/CharsetCodingFlowsSpec.scala
@@ -65,7 +65,7 @@ class CharsetCodingFlowsSpec
       import akka.stream.scaladsl.FileIO
 
       // #encoding
-      import scala.jdk.CollectionConverters._
+      import scala.collection.JavaConverters._
       val targetFile = Paths.get("target/outdata.txt")
       val strings = System.getProperties.asScala.map(p => p._1 + " -> " + p._2).toList
       val stringSource: Source[String, _] = Source(strings)

--- a/text/src/test/scala/docs/scaladsl/CharsetCodingFlowsDoc.scala
+++ b/text/src/test/scala/docs/scaladsl/CharsetCodingFlowsDoc.scala
@@ -42,7 +42,7 @@ class CharsetCodingFlowsDoc
       import akka.stream.scaladsl.FileIO
 
       // #encoding
-      import scala.jdk.CollectionConverters._
+      import scala.collection.JavaConverters._
       val targetFile = Paths.get("target/outdata.txt")
       val strings = System.getProperties.asScala.map(p => p._1 + " -> " + p._2).toList
       // #encoding

--- a/xml/src/main/scala/akka/stream/alpakka/xml/javadsl/XmlParsing.scala
+++ b/xml/src/main/scala/akka/stream/alpakka/xml/javadsl/XmlParsing.scala
@@ -13,7 +13,7 @@ import org.w3c.dom.Element
 
 import java.util.function.Consumer
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 object XmlParsing {
 

--- a/xml/src/main/scala/akka/stream/alpakka/xml/model.scala
+++ b/xml/src/main/scala/akka/stream/alpakka/xml/model.scala
@@ -6,7 +6,7 @@ package akka.stream.alpakka.xml
 
 import java.util.Optional
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
 /**


### PR DESCRIPTION
* because it has ripple effect to Alpakka and then Cassandra plugin
* we need to coordinate this decision across all Akka projects, later

This reverts some parts, as little as possible, of https://github.com/akka/alpakka/pull/2777