### PR TITLE
Update solrj dependency to 8.11.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -466,8 +466,8 @@ object Dependencies {
       ) ++ Mockito
   )
 
-  val SolrjVersion = "7.7.3"
-  val SolrVersionForDocs = "7_7"
+  val SolrjVersion = "8.11.1"
+  val SolrVersionForDocs = "8_11"
 
   val Solr = Seq(
     libraryDependencies ++= Seq(

--- a/solr/src/main/scala/akka/stream/alpakka/solr/impl/SolrFlowStage.scala
+++ b/solr/src/main/scala/akka/stream/alpakka/solr/impl/SolrFlowStage.scala
@@ -4,6 +4,8 @@
 
 package akka.stream.alpakka.solr.impl
 
+import scala.annotation.nowarn
+
 import akka.annotation.InternalApi
 import akka.stream.ActorAttributes.SupervisionStrategy
 import akka.stream._
@@ -14,10 +16,8 @@ import org.apache.solr.client.solrj.impl.CloudSolrClient
 import org.apache.solr.client.solrj.request.UpdateRequest
 import org.apache.solr.client.solrj.response.UpdateResponse
 import org.apache.solr.common.SolrInputDocument
-
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
-
 import scala.collection.immutable
 import scala.collection.JavaConverters._
 
@@ -93,6 +93,7 @@ private final class SolrFlowLogic[T, C](
     client.add(collection, docs.asJava, settings.commitWithin)
   }
 
+  @nowarn("msg=deprecated") // FIXME #2917 Deprecated getIdField in Solrj 8.11.x
   private def atomicUpdateBulkToSolr(messages: immutable.Seq[WriteMessage[T, C]]): UpdateResponse = {
     val docs = messages.map { message =>
       val doc = new SolrInputDocument()

--- a/solr/src/test/java/docs/javadsl/SolrTest.java
+++ b/solr/src/test/java/docs/javadsl/SolrTest.java
@@ -45,6 +45,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -830,7 +831,7 @@ public class SolrTest {
 
     File confDir = new File("solr/src/test/resources/conf");
 
-    String zkDir = testWorkingDir.toPath().resolve("zookeeper/server/data").toString();
+    Path zkDir = testWorkingDir.toPath().resolve("zookeeper/server/data");
     zkTestServer = new ZkTestServer(zkDir, zookeeperPort);
     zkTestServer.run();
 

--- a/solr/src/test/java/docs/javadsl/SolrTest.java
+++ b/solr/src/test/java/docs/javadsl/SolrTest.java
@@ -58,6 +58,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("deprecation") // FIXME #2917 Deprecated getIdField in Solrj 8.11.x
 public class SolrTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 


### PR DESCRIPTION
* getIdField in SolrFlowStage.scala:109 is reported as deprecated, but I don't know what it should be replaced with. Create issue https://github.com/akka/alpakka/issues/2917 for this.
