### PR TITLE
Update Akka to 2.7.0-M2

### DIFF
--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
@@ -140,7 +140,7 @@ public class AmqpConnectorsTest {
             .map(WriteMessage::create)
             .viaMat(ampqRpcFlow, Keep.right())
             .mapAsync(1, cm -> cm.ack().thenApply(unused -> cm.message()))
-            .toMat(TestSink.probe(system), Keep.both())
+            .toMat(TestSink.create(system), Keep.both())
             .run(system);
 
     result.first().toCompletableFuture().get(5, TimeUnit.SECONDS);

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpFlowTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpFlowTest.java
@@ -81,7 +81,7 @@ public class AmqpFlowTest {
         Source.from(input)
             .map(s -> WriteMessage.create(ByteString.fromString(s)))
             .via(flow)
-            .toMat(TestSink.probe(system), Keep.right())
+            .toMat(TestSink.create(system), Keep.right())
             .run(system);
 
     result
@@ -115,7 +115,7 @@ public class AmqpFlowTest {
             .map(s -> WriteMessage.create(ByteString.fromString(s)))
             .via(flowWithContext)
             .asSource()
-            .toMat(TestSink.probe(system), Keep.right())
+            .toMat(TestSink.create(system), Keep.right())
             .run(system);
 
     result
@@ -138,7 +138,7 @@ public class AmqpFlowTest {
         Source.from(input)
             .map(s -> Pair.create(WriteMessage.create(ByteString.fromString(s)), s))
             .via(flow)
-            .toMat(TestSink.probe(system), Keep.right())
+            .toMat(TestSink.create(system), Keep.right())
             .run(system);
 
     result

--- a/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
+++ b/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
@@ -136,7 +136,7 @@ public class AmqpDocsTest {
         Source.from(input)
             .map(ByteString::fromString)
             .viaMat(ampqRpcFlow, Keep.right())
-            .toMat(TestSink.probe(system), Keep.both())
+            .toMat(TestSink.create(system), Keep.both())
             .run(system);
     // #create-rpc-flow
     result.first().toCompletableFuture().get(3, TimeUnit.SECONDS);

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -87,7 +87,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
 
       val input = Vector("one", "two", "three", "four", "five")
       val (rpcQueueF, probe) =
-        Source(input).map(s => ByteString(s)).viaMat(amqpRpcFlow)(Keep.right).toMat(TestSink.probe)(Keep.both).run()
+        Source(input).map(s => ByteString(s)).viaMat(amqpRpcFlow)(Keep.right).toMat(TestSink())(Keep.both).run()
       rpcQueueF.futureValue
 
       val amqpSink = AmqpSink.replyTo(
@@ -118,7 +118,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
       Source
         .empty[ByteString]
         .via(AmqpRpcFlow.simple(AmqpWriteSettings(connectionProvider)))
-        .runWith(TestSink.probe)
+        .runWith(TestSink())
         .ensureSubscription()
         .expectComplete()
 
@@ -334,7 +334,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
           .map(bytes => WriteMessage(bytes))
           .viaMat(amqpRpcFlow)(Keep.right)
           .mapAsync(1)(cm => cm.ack().map(_ => cm.message))
-          .toMat(TestSink.probe)(Keep.both)
+          .toMat(TestSink())(Keep.both)
           .run()
       rpcQueueF.futureValue
 

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpFlowSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpFlowSpec.scala
@@ -151,7 +151,7 @@ class AmqpFlowSpec extends AmqpSpec with AmqpMocking with BeforeAndAfterEach {
           .map(s => WriteMessage(ByteString(s)))
           .viaMat(mockedFlowWithContextAndConfirm)(Keep.right)
           .asSource
-          .toMat(TestSink.probe)(Keep.both)
+          .toMat(TestSink())(Keep.both)
           .run()
 
       probe.request(input.size)
@@ -238,7 +238,7 @@ class AmqpFlowSpec extends AmqpSpec with AmqpMocking with BeforeAndAfterEach {
           .map(s => WriteMessage(ByteString(s)))
           .viaMat(mockedUnorderedFlowWithPassThrough)(Keep.right)
           .asSource
-          .toMat(TestSink.probe)(Keep.both)
+          .toMat(TestSink())(Keep.both)
           .run()
 
       probe.request(input.size)
@@ -278,7 +278,7 @@ class AmqpFlowSpec extends AmqpSpec with AmqpMocking with BeforeAndAfterEach {
       Source(input)
         .map(s => WriteMessage(ByteString(s)))
         .viaMat(flow)(Keep.right)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
     val messages = probe.request(input.size).expectNextN(input.size)
@@ -296,7 +296,7 @@ class AmqpFlowSpec extends AmqpSpec with AmqpMocking with BeforeAndAfterEach {
         .asSourceWithContext(identity)
         .map(s => WriteMessage(ByteString(s)))
         .viaMat(flow)(Keep.right)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
     val messages = probe.request(input.size).expectNextN(input.size)
@@ -313,7 +313,7 @@ class AmqpFlowSpec extends AmqpSpec with AmqpMocking with BeforeAndAfterEach {
       Source(input)
         .map(s => (WriteMessage(ByteString(s)), s))
         .viaMat(flow)(Keep.right)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
     val messages = probe.request(input.size).expectNextN(input.size)
@@ -351,7 +351,7 @@ class AmqpFlowSpec extends AmqpSpec with AmqpMocking with BeforeAndAfterEach {
       Source(input)
         .map(s => WriteMessage(ByteString(s)))
         .viaMat(flow)(Keep.right)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
     probe.request(input.size)
@@ -379,7 +379,7 @@ class AmqpFlowSpec extends AmqpSpec with AmqpMocking with BeforeAndAfterEach {
       Source(input)
         .map(s => WriteMessage(ByteString(s)))
         .viaMat(flow)(Keep.right)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
     val messages = probe.request(input.size).expectNextN(input.size)
@@ -398,7 +398,7 @@ class AmqpFlowSpec extends AmqpSpec with AmqpMocking with BeforeAndAfterEach {
       Source(input)
         .map(s => WriteMessage(ByteString(s)))
         .viaMat(flow)(Keep.right)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
     probe.request(input.size)
@@ -437,7 +437,7 @@ class AmqpFlowSpec extends AmqpSpec with AmqpMocking with BeforeAndAfterEach {
       Source(1 to sourceElements)
         .map(s => WriteMessage(ByteString(s)))
         .viaMat(flow)(Keep.right)
-        .toMat(TestSink.probe)(Keep.right)
+        .toMat(TestSink())(Keep.right)
         .run()
 
     probe.request(sourceElements)
@@ -453,11 +453,10 @@ class AmqpFlowSpec extends AmqpSpec with AmqpMocking with BeforeAndAfterEach {
     val input = Vector("one", "two")
 
     val (sourceProbe, sinkProbe) =
-      TestSource
-        .probe[String]
+      TestSource[String]()
         .map(s => WriteMessage(ByteString(s)))
         .viaMat(flow)(Keep.left)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
     sinkProbe.request(input.size)

--- a/amqp/src/test/scala/docs/scaladsl/AmqpDocsSpec.scala
+++ b/amqp/src/test/scala/docs/scaladsl/AmqpDocsSpec.scala
@@ -97,7 +97,7 @@ class AmqpDocsSpec extends AmqpSpec {
       val (rpcQueueF: Future[String], probe: TestSubscriber.Probe[ByteString]) = Source(input)
         .map(s => ByteString(s))
         .viaMat(amqpRpcFlow)(Keep.right)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
       //#create-rpc-flow
       rpcQueueF.futureValue

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
@@ -46,7 +46,7 @@ class AvroParquetSourceSpec
       // #init-source
       val source: Source[GenericRecord, NotUsed] = AvroParquetSource(reader)
       // #init-source
-      val sink = source.runWith(TestSink.probe)
+      val sink = source.runWith(TestSink())
 
       //then
       val result: Seq[GenericRecord] = sink.toStrict(3.seconds)
@@ -70,7 +70,7 @@ class AvroParquetSourceSpec
       // #init-source
       val source: Source[GenericRecord, NotUsed] = AvroParquetSource(reader)
       // #init-source
-      val sink = source.runWith(TestSink.probe)
+      val sink = source.runWith(TestSink())
 
       //then
       val result: Seq[GenericRecord] = sink.toStrict(3.seconds)

--- a/aws-event-bridge/src/test/scala/akka/stream/alpakka/aws/eventbridge/EventBridgePublishMockSpec.scala
+++ b/aws-event-bridge/src/test/scala/akka/stream/alpakka/aws/eventbridge/EventBridgePublishMockSpec.scala
@@ -47,7 +47,7 @@ class EventBridgePublishMockSpec extends AnyFlatSpec with DefaultTestContext wit
     when(eventBridgeClient.putEvents(putRequest)).thenReturn(CompletableFuture.completedFuture(putResult))
 
     val (probe, future) =
-      TestSource.probe[PutEventsRequestEntry].via(EventBridgePublisher.flow()).toMat(Sink.seq)(Keep.both).run()
+      TestSource[PutEventsRequestEntry]().via(EventBridgePublisher.flow()).toMat(Sink.seq)(Keep.both).run()
 
     probe.sendNext(putRequestEntry).sendComplete()
 
@@ -62,7 +62,7 @@ class EventBridgePublishMockSpec extends AnyFlatSpec with DefaultTestContext wit
     when(eventBridgeClient.putEvents(any[PutEventsRequest]())).thenReturn(CompletableFuture.completedFuture(putResult))
 
     val (probe, future) =
-      TestSource.probe[PutEventsRequestEntry].via(EventBridgePublisher.flow()).toMat(Sink.seq)(Keep.both).run()
+      TestSource[PutEventsRequestEntry]().via(EventBridgePublisher.flow()).toMat(Sink.seq)(Keep.both).run()
 
     probe
       .sendNext(entryDetail("eb-message-1"))
@@ -88,7 +88,7 @@ class EventBridgePublishMockSpec extends AnyFlatSpec with DefaultTestContext wit
     when(eventBridgeClient.putEvents(any[PutEventsRequest]())).thenReturn(CompletableFuture.completedFuture(putResult))
 
     val (probe, future) =
-      TestSource.probe[Seq[PutEventsRequestEntry]].via(EventBridgePublisher.flowSeq()).toMat(Sink.seq)(Keep.both).run()
+      TestSource[Seq[PutEventsRequestEntry]]().via(EventBridgePublisher.flowSeq()).toMat(Sink.seq)(Keep.both).run()
     probe
       .sendNext(Seq(entryDetail("eb-message-1"), entryDetail("eb-message-2"), entryDetail("eb-message-3")))
       .sendComplete()
@@ -109,7 +109,7 @@ class EventBridgePublishMockSpec extends AnyFlatSpec with DefaultTestContext wit
     when(eventBridgeClient.putEvents(meq(publishRequest))).thenReturn(promise)
 
     val (probe, future) =
-      TestSource.probe[Seq[PutEventsRequestEntry]].via(EventBridgePublisher.flowSeq()).toMat(Sink.seq)(Keep.both).run()
+      TestSource[Seq[PutEventsRequestEntry]]().via(EventBridgePublisher.flowSeq()).toMat(Sink.seq)(Keep.both).run()
     probe.sendNext(Seq(entryDetail("eb-message"))).sendComplete()
 
     a[RuntimeException] should be thrownBy {
@@ -123,7 +123,7 @@ class EventBridgePublishMockSpec extends AnyFlatSpec with DefaultTestContext wit
     case class MyCustomException(message: String) extends Exception(message)
 
     val (probe, future) =
-      TestSource.probe[Seq[PutEventsRequestEntry]].via(EventBridgePublisher.flowSeq()).toMat(Sink.seq)(Keep.both).run()
+      TestSource[Seq[PutEventsRequestEntry]]().via(EventBridgePublisher.flowSeq()).toMat(Sink.seq)(Keep.both).run()
     probe.sendError(MyCustomException("upstream failure"))
 
     a[MyCustomException] should be thrownBy {

--- a/awslambda/src/test/scala/docs/scaladsl/AwsLambdaFlowSpec.scala
+++ b/awslambda/src/test/scala/docs/scaladsl/AwsLambdaFlowSpec.scala
@@ -69,7 +69,7 @@ class AwsLambdaFlowSpec
           CompletableFuture.completedFuture(invokeResponse)
       })
 
-      val (probe, future) = TestSource.probe[InvokeRequest].via(lambdaFlow).toMat(Sink.seq)(Keep.both).run()
+      val (probe, future) = TestSource[InvokeRequest]().via(lambdaFlow).toMat(Sink.seq)(Keep.both).run()
       probe.sendNext(invokeRequest)
       probe.sendComplete()
 
@@ -91,7 +91,7 @@ class AwsLambdaFlowSpec
         }
       })
 
-      val (probe, future) = TestSource.probe[InvokeRequest].via(lambdaFlow).toMat(Sink.seq)(Keep.both).run()
+      val (probe, future) = TestSource[InvokeRequest]().via(lambdaFlow).toMat(Sink.seq)(Keep.both).run()
 
       probe.sendNext(invokeFailureRequest)
       probe.sendComplete()

--- a/cassandra/src/test/scala/docs/javadsl/CassandraSessionSpec.scala
+++ b/cassandra/src/test/scala/docs/javadsl/CassandraSessionSpec.scala
@@ -103,7 +103,7 @@ final class CassandraSessionSpec extends CassandraSpecBase(ActorSystem("Cassandr
       val stmt = await(session.prepare(s"SELECT count FROM $dataTable WHERE partition = ?"))
       val bound = stmt.bind("A")
       val rows = session.select(bound).asScala
-      val probe = rows.map(_.getLong("count")).runWith(TestSink.probe[Long])
+      val probe = rows.map(_.getLong("count")).runWith(TestSink[Long]())
       probe.within(10.seconds) {
         probe.request(10).expectNextUnordered(1L, 2L, 3L, 4L).expectComplete()
       }
@@ -111,7 +111,7 @@ final class CassandraSessionSpec extends CassandraSpecBase(ActorSystem("Cassandr
 
     "select and bind as Source" in {
       val rows = session.select(s"SELECT count FROM $dataTable WHERE partition = ?", "B").asScala
-      val probe = rows.map(_.getLong("count")).runWith(TestSink.probe[Long])
+      val probe = rows.map(_.getLong("count")).runWith(TestSink[Long]())
       probe.within(10.seconds) {
         probe.request(10).expectNextUnordered(5L, 6L).expectComplete()
       }

--- a/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
@@ -120,11 +120,10 @@ class CsvParsingSpec extends CsvSpec {
     }
 
     "emit completion even without new line at end" in assertAllStagesStopped {
-      val (source, sink) = TestSource
-        .probe[ByteString]
+      val (source, sink) = TestSource[ByteString]()
         .via(CsvParsing.lineScanner())
         .map(_.map(_.utf8String))
-        .toMat(TestSink.probe[List[String]])(Keep.both)
+        .toMat(TestSink[List[String]]())(Keep.both)
         .run()
       source.sendNext(ByteString("eins,zwei,drei\nuno,dos,tres\n1,2,3"))
       sink.request(3)

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStageTest.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStageTest.scala
@@ -54,7 +54,7 @@ class ElasticsearchSimpleFlowStageTest
                 writer
               )
             )
-            .toMat(TestSink.probe)(Keep.both)
+            .toMat(TestSink())(Keep.both)
             .run()
 
         upstream.sendNext(dummyMessages)
@@ -81,7 +81,7 @@ class ElasticsearchSimpleFlowStageTest
                 writer
               )
             )
-            .toMat(TestSink.probe)(Keep.both)
+            .toMat(TestSink())(Keep.both)
             .run()
 
         upstream.sendNext(dummyMessages)

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStageTest.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStageTest.scala
@@ -45,8 +45,7 @@ class ElasticsearchSimpleFlowStageTest
     "stream ends" should {
       "emit element only when downstream requests" in {
         val (upstream, downstream) =
-          TestSource
-            .probe[(immutable.Seq[WriteMessage[String, NotUsed]], immutable.Seq[WriteResult[String, NotUsed]])]
+          TestSource[(immutable.Seq[WriteMessage[String, NotUsed]], immutable.Seq[WriteResult[String, NotUsed]])]()
             .via(
               new impl.ElasticsearchSimpleFlowStage[String, NotUsed](
                 ElasticsearchParams.V7("es-simple-flow-index"),
@@ -72,8 +71,7 @@ class ElasticsearchSimpleFlowStageTest
     "client cannot connect to ES" should {
       "stop the stream" in {
         val (upstream, downstream) =
-          TestSource
-            .probe[(immutable.Seq[WriteMessage[String, NotUsed]], immutable.Seq[WriteResult[String, NotUsed]])]
+          TestSource[(immutable.Seq[WriteMessage[String, NotUsed]], immutable.Seq[WriteResult[String, NotUsed]])]()
             .via(
               new impl.ElasticsearchSimpleFlowStage[String, NotUsed](
                 ElasticsearchParams.V7("es-simple-flow-index"),

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSourcStageTest.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSourcStageTest.scala
@@ -38,7 +38,7 @@ class ElasticsearchSourcStageTest
               (json: String) => ScrollResponse(Some(json), None)
             )
           )
-          .toMat(TestSink.probe)(Keep.right)
+          .toMat(TestSink())(Keep.right)
           .run()
 
         downstream.request(1)

--- a/file/src/test/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlowTest.scala
+++ b/file/src/test/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlowTest.scala
@@ -23,10 +23,9 @@ class ZipArchiveFlowTest
     "stream ends" should {
       "emit element only when downstream requests" in {
         val (upstream, downstream) =
-          TestSource
-            .probe[ByteString]
+          TestSource[ByteString]()
             .via(new ZipArchiveFlow())
-            .toMat(TestSink.probe)(Keep.both)
+            .toMat(TestSink())(Keep.both)
             .run()
 
         upstream.sendNext(FileByteStringSeparators.createStartingByteString("test"))

--- a/file/src/test/scala/docs/scaladsl/FileTailSourceExtrasSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/FileTailSourceExtrasSpec.scala
@@ -58,7 +58,7 @@ class FileTailSourceExtrasSpec
 
       // #shutdown-on-delete
 
-      val probe = stream.toMat(TestSink.probe)(Keep.right).run()
+      val probe = stream.toMat(TestSink())(Keep.right).run()
 
       val result = probe.requestNext()
       result shouldEqual "a"
@@ -84,7 +84,7 @@ class FileTailSourceExtrasSpec
 
       // #shutdown-on-idle-timeout
 
-      val probe = stream.toMat(TestSink.probe)(Keep.right).run()
+      val probe = stream.toMat(TestSink())(Keep.right).run()
 
       val result = probe.requestNext()
       result shouldEqual "a"

--- a/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
@@ -297,7 +297,7 @@ class LogRotatorSinkSpec
     "upstream fail before first file creation" in assertAllStagesStopped {
       val (triggerFunctionCreator, files) = fileLengthTriggerCreator()
       val (probe, completion) =
-        TestSource.probe[ByteString].toMat(LogRotatorSink(triggerFunctionCreator))(Keep.both).run()
+        TestSource[ByteString]().toMat(LogRotatorSink(triggerFunctionCreator))(Keep.both).run()
 
       val ex = new Exception("my-exception")
       probe.sendError(ex)
@@ -308,7 +308,7 @@ class LogRotatorSinkSpec
     "upstream fail after first file creation" in assertAllStagesStopped {
       val (triggerFunctionCreator, files) = fileLengthTriggerCreator()
       val (probe, completion) =
-        TestSource.probe[ByteString].toMat(LogRotatorSink(triggerFunctionCreator))(Keep.both).run()
+        TestSource[ByteString]().toMat(LogRotatorSink(triggerFunctionCreator))(Keep.both).run()
 
       val ex = new Exception("my-exception")
       probe.sendNext(ByteString("test"))
@@ -326,7 +326,7 @@ class LogRotatorSinkSpec
         }
       }
       val (probe, completion) =
-        TestSource.probe[ByteString].toMat(LogRotatorSink(triggerFunctionCreator))(Keep.both).run()
+        TestSource[ByteString]().toMat(LogRotatorSink(triggerFunctionCreator))(Keep.both).run()
       probe.sendNext(ByteString("test"))
       the[Exception] thrownBy Await.result(completion, 3.seconds) shouldBe ex
     }
@@ -339,8 +339,7 @@ class LogRotatorSinkSpec
         }
       }
       val (probe, completion) =
-        TestSource
-          .probe[ByteString]
+        TestSource[ByteString]()
           .toMat(LogRotatorSink(triggerFunctionCreator, Set(StandardOpenOption.READ)))(Keep.both)
           .run()
       probe.sendNext(ByteString("test"))
@@ -368,8 +367,7 @@ class LogRotatorSinkSpec
       }
     }
     val (probe, completion) =
-      TestSource
-        .probe[ByteString]
+      TestSource[ByteString]()
         .toMat(
           LogRotatorSink.withSinkFactory(
             triggerGeneratorCreator = triggerFunctionCreator,

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/CommonFtpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/CommonFtpStageTest.java
@@ -59,7 +59,7 @@ interface CommonFtpStageTest extends BaseSupport, AkkaSupport {
     Source<FtpFile, NotUsed> source = getBrowserSource(basePath);
 
     Pair<NotUsed, TestSubscriber.Probe<FtpFile>> pairResult =
-        source.toMat(TestSink.probe(system), Keep.both()).run(system);
+        source.toMat(TestSink.create(system), Keep.both()).run(system);
     TestSubscriber.Probe<FtpFile> probe = pairResult.second();
     probe.request(demand).expectNextN(numFiles);
     probe.expectComplete();
@@ -73,7 +73,7 @@ interface CommonFtpStageTest extends BaseSupport, AkkaSupport {
 
     Source<ByteString, CompletionStage<IOResult>> source = getIOSource(fileName);
     Pair<CompletionStage<IOResult>, TestSubscriber.Probe<ByteString>> pairResult =
-        source.toMat(TestSink.probe(system), Keep.both()).run(system);
+        source.toMat(TestSink.create(system), Keep.both()).run(system);
     TestSubscriber.Probe<ByteString> probe = pairResult.second();
     probe.request(100).expectNextOrComplete();
 

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -105,7 +105,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
       val basePath = ""
       generateFiles(30, 10, basePath)
       val probe =
-        listFiles(basePath).toMat(TestSink.probe)(Keep.right).run()
+        listFiles(basePath).toMat(TestSink())(Keep.right).run()
       probe.request(40).expectNextN(30)
       probe.expectComplete()
     }
@@ -114,7 +114,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
       val basePath = "/foo"
       generateFiles(30, 10, basePath)
       val probe =
-        listFiles(basePath).toMat(TestSink.probe)(Keep.right).run()
+        listFiles(basePath).toMat(TestSink())(Keep.right).run()
       probe.request(40).expectNextN(30)
       probe.expectComplete()
     }
@@ -123,7 +123,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
       val basePath = "/foo"
       generateFiles(30, 10, basePath)
       val probe =
-        listFilesWithFilter(basePath, f => false).toMat(TestSink.probe)(Keep.right).run()
+        listFilesWithFilter(basePath, f => false).toMat(TestSink())(Keep.right).run()
       probe.request(40).expectNextN(12) // 9 files, 3 directories
       probe.expectComplete()
 
@@ -134,7 +134,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
       generateFiles(30, 10, basePath)
       val probe =
         listFilesWithFilter(basePath, f => f.name.contains("1"))
-          .toMat(TestSink.probe)(Keep.right)
+          .toMat(TestSink())(Keep.right)
           .run()
       probe.request(40).expectNextN(21) // 9 files in root, 2 directories, 10 files in dir_1
       probe.expectComplete()
@@ -144,7 +144,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
     "list all files in sparse directory tree" in assertAllStagesStopped {
       putFileOnFtp("foo/bar/baz/foobar/sample")
       val probe =
-        listFiles("/").toMat(TestSink.probe)(Keep.right).run()
+        listFiles("/").toMat(TestSink())(Keep.right).run()
       probe.request(2).expectNextN(1)
       probe.expectComplete()
     }
@@ -153,7 +153,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
       putFileOnFtp("foo/bar/baz/foobar/sample")
       val probe =
         listFilesWithFilter("/", _ => true, emitTraversedDirectories = true)
-          .toMat(TestSink.probe)(Keep.right)
+          .toMat(TestSink())(Keep.right)
           .run()
       probe.request(10).expectNextN(5) // foo, bar, baz, foobar, and sample_1 = 5 files
       probe.expectComplete()
@@ -187,7 +187,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
       val fileName = "sample_io_" + Instant.now().getNano
       putFileOnFtp(fileName)
       val (result, probe) =
-        retrieveFromPath(s"/$fileName").toMat(TestSink.probe)(Keep.both).run()
+        retrieveFromPath(s"/$fileName").toMat(TestSink())(Keep.both).run()
       probe.request(100).expectNextOrComplete()
 
       val expectedNumOfBytes = getDefaultContent.getBytes().length
@@ -199,7 +199,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
       val offset = 10L
       putFileOnFtp(fileName)
       val (result, probe) =
-        retrieveFromPathWithOffset(s"/$fileName", offset).toMat(TestSink.probe)(Keep.both).run()
+        retrieveFromPathWithOffset(s"/$fileName", offset).toMat(TestSink())(Keep.both).run()
       probe.request(100).expectNextOrComplete()
 
       val expectedNumOfBytes = getDefaultContent.getBytes().length - offset
@@ -211,7 +211,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
       val fileContents = new Array[Byte](2000020)
       Random.nextBytes(fileContents)
       putFileOnFtpWithContents(fileName, fileContents)
-      val (result, probe) = retrieveFromPath(s"/$fileName").toMat(TestSink.probe)(Keep.both).run()
+      val (result, probe) = retrieveFromPath(s"/$fileName").toMat(TestSink())(Keep.both).run()
       probe.request(1000).expectNextOrComplete()
 
       val expectedNumOfBytes = fileContents.length
@@ -225,7 +225,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
       Random.nextBytes(fileContents)
       putFileOnFtpWithContents(fileName, fileContents)
       val (result, probe) =
-        retrieveFromPathWithOffset(s"/$fileName", offset).toMat(TestSink.probe)(Keep.both).run()
+        retrieveFromPathWithOffset(s"/$fileName", offset).toMat(TestSink())(Keep.both).run()
       probe.request(1000).expectNextOrComplete()
 
       val expectedNumOfBytes = fileContents.length - offset
@@ -240,7 +240,7 @@ trait CommonFtpStageSpec extends BaseSpec with Eventually {
       generateFiles(numOfFiles, numOfFiles, basePath)
       val probe = listFiles(basePath)
         .mapAsyncUnordered(1)(file => retrieveFromPath(file.path, fromRoot = true).to(Sink.ignore).run())
-        .toMat(TestSink.probe)(Keep.right)
+        .toMat(TestSink())(Keep.right)
         .run()
       val result = probe.request(numOfFiles + 1).expectNextN(numOfFiles)
       probe.expectComplete()

--- a/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/javadsl/jackson/BigQueryMarshallers.scala
+++ b/google-cloud-bigquery/src/main/scala/akka/stream/alpakka/googlecloud/bigquery/javadsl/jackson/BigQueryMarshallers.scala
@@ -11,12 +11,13 @@ import akka.http.javadsl.unmarshalling.Unmarshaller
 import akka.stream.alpakka.googlecloud.bigquery.model.QueryResponse
 import akka.stream.alpakka.googlecloud.bigquery.model.{TableDataInsertAllRequest, TableDataListResponse}
 import com.fasterxml.jackson.databind.{JavaType, MapperFeature, ObjectMapper}
-
 import java.io.IOException
+
+import com.fasterxml.jackson.databind.json.JsonMapper
 
 object BigQueryMarshallers {
 
-  private val defaultObjectMapper = new ObjectMapper().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+  private val defaultObjectMapper = JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build()
 
   /**
    * [[akka.http.javadsl.unmarshalling.Unmarshaller]] for [[akka.stream.alpakka.googlecloud.bigquery.model.TableDataListResponse]]

--- a/google-cloud-pub-sub/src/test/scala/docs/scaladsl/IntegrationSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/docs/scaladsl/IntegrationSpec.scala
@@ -116,7 +116,7 @@ class IntegrationSpec
       // the acknowledged message should not arrive again
       val (stream, result2) = GooglePubSub
         .subscribe(topic2subscription, config)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
       result2.ensureSubscription()

--- a/google-common/src/test/scala/akka/stream/alpakka/google/util/AnnotateLastSpec.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/util/AnnotateLastSpec.scala
@@ -23,7 +23,7 @@ class AnnotateLastSpec
   "AnnotateLast" should {
 
     "indicate last element" in {
-      val probe = Source(1 to 3).via(AnnotateLast[Int]).runWith(TestSink.probe)
+      val probe = Source(1 to 3).via(AnnotateLast[Int]).runWith(TestSink())
       probe.requestNext(NotLast(1))
       probe.requestNext(NotLast(2))
       probe.requestNext(Last(3))
@@ -31,13 +31,13 @@ class AnnotateLastSpec
     }
 
     "indicate first element is last if only one element" in {
-      val probe = Source.single(1).via(AnnotateLast[Int]).runWith(TestSink.probe)
+      val probe = Source.single(1).via(AnnotateLast[Int]).runWith(TestSink())
       probe.requestNext(Last(1))
       probe.expectComplete()
     }
 
     "do nothing when stream is empty" in {
-      val probe = Source.empty[Nothing].via(AnnotateLast[Nothing]).runWith(TestSink.probe)
+      val probe = Source.empty[Nothing].via(AnnotateLast[Nothing]).runWith(TestSink())
       probe.expectSubscriptionAndComplete()
     }
   }

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
@@ -438,7 +438,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
             case _ => None
           }
         }
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
       probe.requestNext(convertSpanToDuration(patienceConfig.timeout)) shouldBe Some(aMessage)
@@ -451,7 +451,7 @@ class JmsAckConnectorsSpec extends JmsSpec {
       probe.expectComplete()
 
       // Consuming again should give us no elements, as msg was acked and therefore removed from the broker
-      val (emptyConsumerControl, emptySourceProbe) = source.toMat(TestSink.probe)(Keep.both).run()
+      val (emptyConsumerControl, emptySourceProbe) = source.toMat(TestSink())(Keep.both).run()
       emptySourceProbe.ensureSubscription().expectNoMessage()
       emptyConsumerControl.shutdown()
       emptySourceProbe.expectComplete()

--- a/jms/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
@@ -400,7 +400,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSharedServerSpec {
 
           }
         }
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
       probe.requestNext(convertSpanToDuration(patienceConfig.timeout)) shouldBe Some(aMessage)
@@ -413,7 +413,7 @@ class JmsBufferedAckConnectorsSpec extends JmsSharedServerSpec {
       probe.expectComplete()
 
       // Consuming again should give us no elements, as msg was acked and therefore removed from the broker
-      val (emptyConsumerControl, emptySourceProbe) = source.toMat(TestSink.probe)(Keep.both).run()
+      val (emptyConsumerControl, emptySourceProbe) = source.toMat(TestSink())(Keep.both).run()
       emptySourceProbe.ensureSubscription().expectNoMessage()
       emptyConsumerControl.shutdown()
       emptySourceProbe.expectComplete()

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
@@ -89,7 +89,7 @@ class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with Lo
       TestSource
         .probe[PutRecordsRequestEntry]
         .via(KinesisFlow(streamName, settings))
-        .toMat(TestSink.probe[PutRecordsResultEntry])(Keep.both)
+        .toMat(TestSink[PutRecordsResultEntry]())(Keep.both)
         .run()
   }
 
@@ -115,7 +115,7 @@ class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with Lo
       TestSource
         .probe[(PutRecordsRequestEntry, Int)]
         .via(KinesisFlow.withContext(streamName, settings))
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
   }
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
@@ -86,8 +86,7 @@ class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with Lo
         .build()
 
     val (sourceProbe, sinkProbe) =
-      TestSource
-        .probe[PutRecordsRequestEntry]
+      TestSource[PutRecordsRequestEntry]()
         .via(KinesisFlow(streamName, settings))
         .toMat(TestSink[PutRecordsResultEntry]())(Keep.both)
         .run()
@@ -112,8 +111,7 @@ class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with Lo
       .map(i => (PutRecordsResultEntry.builder().build(), i))
 
     val (sourceProbe, sinkProbe) =
-      TestSource
-        .probe[(PutRecordsRequestEntry, Int)]
+      TestSource[(PutRecordsRequestEntry, Int)]()
         .via(KinesisFlow.withContext(streamName, settings))
         .toMat(TestSink())(Keep.both)
         .run()

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSchedulerSourceSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSchedulerSourceSpec.scala
@@ -280,7 +280,7 @@ class KinesisSchedulerSourceSpec
         .viaMat(Valve(switchMode))(Keep.right)
         .viaMat(KillSwitches.single)(Keep.both)
         .watchTermination()(Keep.both)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
     watch.onComplete(_ => lock.release())
@@ -467,7 +467,7 @@ class KinesisSchedulerSourceSpec
               KinesisSchedulerCheckpointSettings(maxBatchSize = 100, maxBatchWait = 500.millis)
             )
         )
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
     val recordProcessor = new ShardProcessor(_ => ())
   }

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSchedulerSourceSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSchedulerSourceSpec.scala
@@ -459,8 +459,7 @@ class KinesisSchedulerSourceSpec
 
   private trait KinesisSchedulerCheckpointContext {
     val (sourceProbe, sinkProbe) =
-      TestSource
-        .probe[CommittableRecord]
+      TestSource[CommittableRecord]()
         .via(
           KinesisSchedulerSource
             .checkpointRecordsFlow(

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSourceSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSourceSpec.scala
@@ -45,7 +45,7 @@ class KinesisSourceSpec extends AnyWordSpec with Matchers with KinesisMock with 
           Record.builder().data(SdkBytes.fromByteBuffer(ByteString("2").toByteBuffer)).build()
         )
 
-        val probe = KinesisSource.basic(shardSettings, amazonKinesisAsync).runWith(TestSink.probe)
+        val probe = KinesisSource.basic(shardSettings, amazonKinesisAsync).runWith(TestSink())
 
         probe.requestNext().utf8String shouldEqual "1"
         probe.requestNext().utf8String shouldEqual "2"
@@ -64,7 +64,7 @@ class KinesisSourceSpec extends AnyWordSpec with Matchers with KinesisMock with 
           Record.builder().data(SdkBytes.fromByteBuffer(ByteString("2").toByteBuffer)).build()
         )
 
-        val probe = KinesisSource.basic(shardSettings, amazonKinesisAsync).runWith(TestSink.probe)
+        val probe = KinesisSource.basic(shardSettings, amazonKinesisAsync).runWith(TestSink())
 
         probe.request(2)
         probe.expectNext().utf8String shouldEqual "1"
@@ -87,7 +87,7 @@ class KinesisSourceSpec extends AnyWordSpec with Matchers with KinesisMock with 
           Record.builder().data(SdkBytes.fromByteBuffer(ByteString("6").toByteBuffer)).build()
         )
 
-        val probe = KinesisSource.basic(shardSettings, amazonKinesisAsync).runWith(TestSink.probe)
+        val probe = KinesisSource.basic(shardSettings, amazonKinesisAsync).runWith(TestSink())
 
         probe.request(1)
         probe.expectNext().utf8String shouldEqual "1"
@@ -119,7 +119,7 @@ class KinesisSourceSpec extends AnyWordSpec with Matchers with KinesisMock with 
         )
 
         val probe =
-          KinesisSource.basicMerge(mergeSettings, amazonKinesisAsync).map(_.utf8String).runWith(TestSink.probe)
+          KinesisSource.basicMerge(mergeSettings, amazonKinesisAsync).map(_.utf8String).runWith(TestSink())
 
         probe.request(6)
         probe.expectNextUnordered("1", "1", "2", "2", "3", "3")
@@ -132,7 +132,7 @@ class KinesisSourceSpec extends AnyWordSpec with Matchers with KinesisMock with 
         override def records =
           util.Arrays.asList(Record.builder().data(SdkBytes.fromByteBuffer(ByteString("1").toByteBuffer)).build())
 
-        val probe = KinesisSource.basic(shardSettings, amazonKinesisAsync).runWith(TestSink.probe)
+        val probe = KinesisSource.basic(shardSettings, amazonKinesisAsync).runWith(TestSink())
 
         probe.requestNext().utf8String shouldEqual "1"
         nextShardIterator.set(null)
@@ -145,7 +145,7 @@ class KinesisSourceSpec extends AnyWordSpec with Matchers with KinesisMock with 
 
     "fail with error when GetStreamRequest fails" in assertAllStagesStopped {
       new KinesisSpecContext with WithGetShardIteratorSuccess with WithGetRecordsFailure {
-        val probe = KinesisSource.basic(shardSettings, amazonKinesisAsync).runWith(TestSink.probe)
+        val probe = KinesisSource.basic(shardSettings, amazonKinesisAsync).runWith(TestSink())
         probe.request(1)
         probe.expectError() shouldBe an[KinesisErrors.GetRecordsError]
         probe.cancel()

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSpec.scala
@@ -74,7 +74,7 @@ class KinesisFirehoseFlowSpec extends AnyWordSpec with Matchers with KinesisFire
       TestSource
         .probe[Record]
         .via(KinesisFirehoseFlow(streamName, settings))
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
   }
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSpec.scala
@@ -71,8 +71,7 @@ class KinesisFirehoseFlowSpec extends AnyWordSpec with Matchers with KinesisFire
     val requestError = new RuntimeException("kinesisfirehose-error")
 
     val (sourceProbe, sinkProbe) =
-      TestSource
-        .probe[Record]
+      TestSource[Record]()
         .via(KinesisFirehoseFlow(streamName, settings))
         .toMat(TestSink())(Keep.both)
         .run()

--- a/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/MqttFrameStageSpec.scala
+++ b/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/MqttFrameStageSpec.scala
@@ -8,7 +8,7 @@ package impl
 import akka.actor.ActorSystem
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Keep, Source}
-import akka.stream.testkit.javadsl.TestSink
+import akka.stream.testkit.scaladsl.TestSink
 import akka.stream.testkit.scaladsl.TestSource
 import akka.testkit.TestKit
 import akka.util.ByteString
@@ -31,7 +31,7 @@ class MqttFrameStageSpec
       Source
         .single(bytes)
         .via(new MqttFrameStage(MaxPacketSize))
-        .runWith(TestSink.probe(system))
+        .runWith(TestSink()(system))
         .request(1)
         .expectNext(bytes)
         .expectComplete()
@@ -42,7 +42,7 @@ class MqttFrameStageSpec
       Source
         .single(bytes)
         .via(new MqttFrameStage(MaxPacketSize))
-        .runWith(TestSink.probe(system))
+        .runWith(TestSink()(system))
         .request(1)
         .expectNext(bytes)
         .expectComplete()
@@ -53,7 +53,7 @@ class MqttFrameStageSpec
       Source
         .single(bytes ++ bytes)
         .via(new MqttFrameStage(MaxPacketSize))
-        .runWith(TestSink.probe(system))
+        .runWith(TestSink()(system))
         .request(2)
         .expectNext(bytes, bytes)
         .expectComplete()
@@ -64,10 +64,9 @@ class MqttFrameStageSpec
       val bytes1 = ByteString.newBuilder.putByte(1).putBytes(Array.ofDim(0x80)).result()
 
       val (pub, sub) =
-        TestSource
-          .probe(system)
+        TestSource()(system)
           .via(new MqttFrameStage(MaxPacketSize * 2))
-          .toMat(TestSink.probe(system))(Keep.both)
+          .toMat(TestSink()(system))(Keep.both)
           .run()
 
       pub.sendNext(bytes0)
@@ -87,7 +86,7 @@ class MqttFrameStageSpec
         Source
           .single(bytes)
           .via(new MqttFrameStage(MaxPacketSize))
-          .runWith(TestSink.probe(system))
+          .runWith(TestSink()(system))
           .request(1)
           .expectError()
       ex.getMessage shouldBe s"Max packet size of $MaxPacketSize exceeded with ${MaxPacketSize + 2}"

--- a/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -305,7 +305,7 @@ public class MqttSourceTest {
         MqttSource.atMostOnce(settings1, subscriptions, bufferSize);
 
     Pair<CompletionStage<Done>, TestSubscriber.Probe<MqttMessage>> result2 =
-        source1.toMat(TestSink.probe(system), Keep.both()).run(system);
+        source1.toMat(TestSink.create(system), Keep.both()).run(system);
 
     // Ensure that the connection made it all the way to the server by waiting until it receives a
     // message

--- a/mqtt/src/test/scala/docs/scaladsl/MqttSourceSpec.scala
+++ b/mqtt/src/test/scala/docs/scaladsl/MqttSourceSpec.scala
@@ -323,7 +323,7 @@ class MqttSourceSpec extends MqttSpecBase("MqttSourceSpec") {
           MqttSubscriptions(topic1, MqttQoS.AtLeastOnce),
           8
         )
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
       // Ensure that the connection made it all the way to the server by waiting until it receives a message
@@ -391,7 +391,7 @@ class MqttSourceSpec extends MqttSpecBase("MqttSourceSpec") {
           )
       )
 
-      val (subscribed, probe) = source1.toMat(TestSink.probe)(Keep.both).run()
+      val (subscribed, probe) = source1.toMat(TestSink())(Keep.both).run()
 
       // Ensure that the connection made it all the way to the server by waiting until it receives a message
       Await.ready(subscribed, timeout)
@@ -443,7 +443,7 @@ class MqttSourceSpec extends MqttSpecBase("MqttSourceSpec") {
           8
         )
         .via(sharedKillSwitch.flow)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
       Await.ready(killSwitch, timeout)
 
@@ -481,7 +481,7 @@ class MqttSourceSpec extends MqttSpecBase("MqttSourceSpec") {
           MqttSubscriptions(topic1, MqttQoS.AtLeastOnce),
           8
         )
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
       // Ensure that the connection made it all the way to the server by waiting until it receives a message

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,17 +9,17 @@ object Dependencies {
   val Scala212 = "2.12.16"
   val ScalaVersions = Seq(Scala213, Scala212)
 
-  val AkkaVersion = "2.6.19"
-  val AkkaBinaryVersion = "2.6"
+  val AkkaVersion = "2.7.0-M2"
+  val AkkaBinaryVersion = "2.7"
 
   val InfluxDBJavaVersion = "2.15"
 
   val AwsSdk2Version = "2.17.113"
   val AwsSpiAkkaHttpVersion = "0.0.11"
   // Sync with plugins.sbt
-  val AkkaGrpcBinaryVersion = "2.1"
-  val AkkaHttpVersion = "10.2.9"
-  val AkkaHttpBinaryVersion = "10.2"
+  val AkkaGrpcBinaryVersion = "2.2"
+  val AkkaHttpVersion = "10.4.0-M1"
+  val AkkaHttpBinaryVersion = "10.4"
   val ScalaTestVersion = "3.2.11"
   val TestContainersScalaTestVersion = "0.40.3"
   val mockitoVersion = "4.8.0" // check even https://github.com/scalatest/scalatestplus-mockito/releases
@@ -42,15 +42,14 @@ object Dependencies {
 
   val testkit = Seq(
     libraryDependencies := Seq(
-        "org.scala-lang.modules" %% "scala-collection-compat" % "2.2.0",
+        "org.scala-lang.modules" %% "scala-collection-compat" % "2.7.0",
         "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
         "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion,
         "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-        "ch.qos.logback" % "logback-classic" % "1.2.3", // Eclipse Public License 1.0
+        "ch.qos.logback" % "logback-classic" % "1.2.11", // Eclipse Public License 1.0
         "org.scalatest" %% "scalatest" % ScalaTestVersion,
         "com.dimafeng" %% "testcontainers-scala-scalatest" % TestContainersScalaTestVersion,
         "com.novocode" % "junit-interface" % "0.11", // BSD-style
-        "ch.qos.logback" % "logback-classic" % "1.2.3", // Eclipse Public License 1.0
         "junit" % "junit" % "4.13" // Eclipse Public License 1.0
       )
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val Scala212 = "2.12.16"
   val ScalaVersions = Seq(Scala213, Scala212)
 
-  val AkkaVersion = "2.7.0-M2"
+  val AkkaVersion = "2.7.0-M3"
   val AkkaBinaryVersion = "2.7"
 
   val InfluxDBJavaVersion = "2.15"

--- a/sns/src/test/scala/akka/stream/alpakka/sns/SnsPublishMockingSpec.scala
+++ b/sns/src/test/scala/akka/stream/alpakka/sns/SnsPublishMockingSpec.scala
@@ -28,7 +28,7 @@ class SnsPublishMockingSpec extends AnyFlatSpec with DefaultTestContext with Mat
     when(snsClient.publish(meq(publishRequest))).thenReturn(CompletableFuture.completedFuture(publishResult))
 
     val (probe, future) =
-      TestSource.probe[PublishRequest].via(SnsPublisher.publishFlow("topic-arn")).toMat(Sink.seq)(Keep.both).run()
+      TestSource[PublishRequest]().via(SnsPublisher.publishFlow("topic-arn")).toMat(Sink.seq)(Keep.both).run()
 
     probe.sendNext(PublishRequest.builder().message("sns-message").build()).sendComplete()
 
@@ -43,7 +43,7 @@ class SnsPublishMockingSpec extends AnyFlatSpec with DefaultTestContext with Mat
     when(snsClient.publish(any[PublishRequest]())).thenReturn(CompletableFuture.completedFuture(publishResult))
 
     val (probe, future) =
-      TestSource.probe[PublishRequest].via(SnsPublisher.publishFlow("topic-arn")).toMat(Sink.seq)(Keep.both).run()
+      TestSource[PublishRequest]().via(SnsPublisher.publishFlow("topic-arn")).toMat(Sink.seq)(Keep.both).run()
 
     probe
       .sendNext(PublishRequest.builder().message("sns-message-1").build())
@@ -69,7 +69,7 @@ class SnsPublishMockingSpec extends AnyFlatSpec with DefaultTestContext with Mat
     when(snsClient.publish(any[PublishRequest]())).thenReturn(CompletableFuture.completedFuture(publishResult))
 
     val (probe, future) =
-      TestSource.probe[PublishRequest].via(SnsPublisher.publishFlow()).toMat(Sink.seq)(Keep.both).run()
+      TestSource[PublishRequest]().via(SnsPublisher.publishFlow()).toMat(Sink.seq)(Keep.both).run()
 
     probe
       .sendNext(PublishRequest.builder().message("sns-message-1").topicArn("topic-arn-1").build())
@@ -95,7 +95,7 @@ class SnsPublishMockingSpec extends AnyFlatSpec with DefaultTestContext with Mat
 
     when(snsClient.publish(meq(publishRequest))).thenReturn(CompletableFuture.completedFuture(publishResult))
 
-    val (probe, future) = TestSource.probe[String].via(SnsPublisher.flow("topic-arn")).toMat(Sink.seq)(Keep.both).run()
+    val (probe, future) = TestSource[String]().via(SnsPublisher.flow("topic-arn")).toMat(Sink.seq)(Keep.both).run()
     probe.sendNext("sns-message").sendComplete()
 
     Await.result(future, 1.second) mustBe publishResult :: Nil
@@ -107,7 +107,7 @@ class SnsPublishMockingSpec extends AnyFlatSpec with DefaultTestContext with Mat
 
     when(snsClient.publish(any[PublishRequest]())).thenReturn(CompletableFuture.completedFuture(publishResult))
 
-    val (probe, future) = TestSource.probe[String].via(SnsPublisher.flow("topic-arn")).toMat(Sink.seq)(Keep.both).run()
+    val (probe, future) = TestSource[String]().via(SnsPublisher.flow("topic-arn")).toMat(Sink.seq)(Keep.both).run()
     probe.sendNext("sns-message-1").sendNext("sns-message-2").sendNext("sns-message-3").sendComplete()
 
     Await.result(future, 1.second) mustBe publishResult :: publishResult :: publishResult :: Nil
@@ -130,7 +130,7 @@ class SnsPublishMockingSpec extends AnyFlatSpec with DefaultTestContext with Mat
 
     when(snsClient.publish(meq(publishRequest))).thenReturn(promise)
 
-    val (probe, future) = TestSource.probe[String].via(SnsPublisher.flow("topic-arn")).toMat(Sink.seq)(Keep.both).run()
+    val (probe, future) = TestSource[String]().via(SnsPublisher.flow("topic-arn")).toMat(Sink.seq)(Keep.both).run()
     probe.sendNext("sns-message").sendComplete()
 
     a[RuntimeException] should be thrownBy {
@@ -143,7 +143,7 @@ class SnsPublishMockingSpec extends AnyFlatSpec with DefaultTestContext with Mat
   it should "fail stage if upstream failure occurs" in {
     case class MyCustomException(message: String) extends Exception(message)
 
-    val (probe, future) = TestSource.probe[String].via(SnsPublisher.flow("topic-arn")).toMat(Sink.seq)(Keep.both).run()
+    val (probe, future) = TestSource[String]().via(SnsPublisher.flow("topic-arn")).toMat(Sink.seq)(Keep.both).run()
     probe.sendError(MyCustomException("upstream failure"))
 
     a[MyCustomException] should be thrownBy {

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
@@ -31,7 +31,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
     when(sqsClient.sendMessage(any[SendMessageRequest]))
       .thenReturn(CompletableFuture.completedFuture(SendMessageResponse.builder().build()))
 
-    val (probe, future) = TestSource.probe[String].toMat(SqsPublishSink("notused"))(Keep.both).run()
+    val (probe, future) = TestSource[String]().toMat(SqsPublishSink("notused"))(Keep.both).run()
     probe.sendNext("notused").sendComplete()
     Await.result(future, 1.second) shouldBe Done
 
@@ -49,7 +49,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
         })
       )
 
-    val (probe, future) = TestSource.probe[String].toMat(SqsPublishSink("notused"))(Keep.both).run()
+    val (probe, future) = TestSource[String]().toMat(SqsPublishSink("notused"))(Keep.both).run()
     probe.sendNext("notused").sendComplete()
 
     a[RuntimeException] should be thrownBy {
@@ -88,7 +88,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
 
   it should "failure the promise on upstream failure" in {
     implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
-    val (probe, future) = TestSource.probe[String].toMat(SqsPublishSink("notused"))(Keep.both).run()
+    val (probe, future) = TestSource[String]().toMat(SqsPublishSink("notused"))(Keep.both).run()
 
     probe.sendError(new RuntimeException("Fake upstream failure"))
 
@@ -103,7 +103,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
     when(sqsClient.sendMessage(any[SendMessageRequest]))
       .thenReturn(CompletableFuture.completedFuture(SendMessageResponse.builder().build()))
 
-    val (probe, future) = TestSource.probe[String].toMat(SqsPublishSink("notused"))(Keep.both).run()
+    val (probe, future) = TestSource[String]().toMat(SqsPublishSink("notused"))(Keep.both).run()
     probe
       .sendNext("test-101")
       .sendNext("test-102")
@@ -132,7 +132,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
         )
       )
 
-    val (probe, future) = TestSource.probe[String].toMat(SqsPublishSink.grouped("notused"))(Keep.both).run()
+    val (probe, future) = TestSource[String]().toMat(SqsPublishSink.grouped("notused"))(Keep.both).run()
     probe.sendNext("notused").sendComplete()
     Await.result(future, 1.second) shouldBe Done
 
@@ -162,7 +162,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
 
     val settings = SqsPublishGroupedSettings.create().withMaxBatchSize(5)
 
-    val (probe, future) = TestSource.probe[String].toMat(SqsPublishSink.grouped("notused", settings))(Keep.both).run()
+    val (probe, future) = TestSource[String]().toMat(SqsPublishSink.grouped("notused", settings))(Keep.both).run()
     probe
       .sendNext("notused - 1")
       .sendNext("notused - 2")
@@ -202,7 +202,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
         )
       )
 
-    val (probe, future) = TestSource.probe[String].toMat(SqsPublishSink.grouped("notused"))(Keep.both).run()
+    val (probe, future) = TestSource[String]().toMat(SqsPublishSink.grouped("notused"))(Keep.both).run()
     probe
       .sendNext("notused - 1")
       .sendNext("notused - 2")
@@ -231,7 +231,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
     )
 
     val settings = SqsPublishGroupedSettings().withMaxBatchSize(5)
-    val (probe, future) = TestSource.probe[String].toMat(SqsPublishSink.grouped("notused", settings))(Keep.both).run()
+    val (probe, future) = TestSource[String]().toMat(SqsPublishSink.grouped("notused", settings))(Keep.both).run()
     probe
       .sendNext("notused - 1")
       .sendNext("notused - 2")
@@ -267,7 +267,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
         )
       )
 
-    val (probe, future) = TestSource.probe[Seq[String]].toMat(SqsPublishSink.batch("notused"))(Keep.both).run()
+    val (probe, future) = TestSource[Seq[String]]().toMat(SqsPublishSink.batch("notused"))(Keep.both).run()
     probe
       .sendNext(
         Seq(

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceMockSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceMockSpec.scala
@@ -46,7 +46,7 @@ class SqsSourceMockSpec extends AnyFlatSpec with Matchers with DefaultTestContex
     val probe = SqsSource(
       "url",
       SqsSourceSettings.Defaults.withMaxBufferSize(10)
-    ).runWith(TestSink.probe[Message])
+    ).runWith(TestSink[Message]())
 
     defaultMessages.foreach(probe.requestNext)
 
@@ -84,7 +84,7 @@ class SqsSourceMockSpec extends AnyFlatSpec with Matchers with DefaultTestContex
     val probe = SqsSource(
       "url",
       SqsSourceSettings.Defaults.withMaxBufferSize(SqsSourceSettings.Defaults.maxBatchSize * bufferToBatchRatio)
-    ).runWith(TestSink.probe[Message])
+    ).runWith(TestSink[Message]())
 
     Thread.sleep(timeout.toMillis * (bufferToBatchRatio + 1))
 
@@ -138,7 +138,7 @@ class SqsSourceMockSpec extends AnyFlatSpec with Matchers with DefaultTestContex
         .withMaxBufferSize(10)
         .withParallelRequests(10)
         .withWaitTime(timeout)
-    ).runWith(TestSink.probe[Message])
+    ).runWith(TestSink[Message]())
 
     (1 to firstWithDataCount * 10).foreach(_ => probe.requestNext())
 

--- a/text/src/test/scala/akka/stream/alpakka/text/scaladsl/CharsetCodingFlowsSpec.scala
+++ b/text/src/test/scala/akka/stream/alpakka/text/scaladsl/CharsetCodingFlowsSpec.scala
@@ -125,8 +125,7 @@ class CharsetCodingFlowsSpec
     }
 
     def verifyByteSends(charsetIn: Charset, charsetOut: Charset, in: String) = {
-      val (source, sink) = TestSource
-        .probe[ByteString]
+      val (source, sink) = TestSource[ByteString]()
         .via(TextFlow.transcoding(charsetIn, charsetOut))
         .map(_.decodeString(charsetOut))
         .toMat(Sink.seq)(Keep.both)
@@ -153,10 +152,9 @@ class CharsetCodingFlowsSpec
     }
 
     "complete" in {
-      val (source, sink) = TestSource
-        .probe[ByteString]
+      val (source, sink) = TestSource[ByteString]()
         .via(TextFlow.transcoding(StandardCharsets.UTF_8, StandardCharsets.UTF_8))
-        .toMat(TestSink.probe[ByteString])(Keep.both)
+        .toMat(TestSink[ByteString]())(Keep.both)
         .run()
       source.sendNext(ByteString("eins,zwei,drei"))
       sink.request(3)

--- a/udp/src/test/java/docs/javadsl/UdpTest.java
+++ b/udp/src/test/java/docs/javadsl/UdpTest.java
@@ -64,9 +64,9 @@ public class UdpTest {
             Pair<TestPublisher.Probe<Datagram>, CompletionStage<InetSocketAddress>>,
             TestSubscriber.Probe<Datagram>>
         materialized =
-            TestSource.<Datagram>probe(system)
+            TestSource.<Datagram>create(system)
                 .viaMat(bindFlow, Keep.both())
-                .toMat(TestSink.probe(system), Keep.both())
+                .toMat(TestSink.create(system), Keep.both())
                 .run(system);
 
     {
@@ -132,9 +132,9 @@ public class UdpTest {
             Pair<TestPublisher.Probe<Datagram>, CompletionStage<InetSocketAddress>>,
             TestSubscriber.Probe<Datagram>>
         materialized =
-            TestSource.<Datagram>probe(system)
+            TestSource.<Datagram>create(system)
                 .viaMat(bindFlow, Keep.both())
-                .toMat(TestSink.probe(system), Keep.both())
+                .toMat(TestSink.create(system), Keep.both())
                 .run(system);
 
     {

--- a/udp/src/test/scala/docs/scaladsl/UdpSpec.scala
+++ b/udp/src/test/scala/docs/scaladsl/UdpSpec.scala
@@ -52,10 +52,9 @@ class UdpSpec
         Udp.bindFlow(bindToLocal)
       // #bind-flow
 
-      val ((pub, bound), sub) = TestSource
-        .probe[Datagram](system)
+      val ((pub, bound), sub) = TestSource[Datagram]()(system)
         .viaMat(bindFlow)(Keep.both)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
       val destination = bound.futureValue
@@ -93,10 +92,9 @@ class UdpSpec
       val bindFlow: Flow[Datagram, Datagram, Future[InetSocketAddress]] =
         Udp.bindFlow(bindToLocal, List(UdpSO.broadcast(true)))
 
-      val ((pub, bound), sub) = TestSource
-        .probe[Datagram](system)
+      val ((pub, bound), sub) = TestSource[Datagram]()(system)
         .viaMat(bindFlow)(Keep.both)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
       val destination = bound.futureValue
@@ -123,16 +121,14 @@ class UdpSpec
     }
 
     "ping-pong messages" in {
-      val ((pub1, bound1), sub1) = TestSource
-        .probe[Datagram](system)
+      val ((pub1, bound1), sub1) = TestSource[Datagram]()(system)
         .viaMat(Udp.bindFlow(bindToLocal))(Keep.both)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
-      val ((pub2, bound2), sub2) = TestSource
-        .probe[Datagram](system)
+      val ((pub2, bound2), sub2) = TestSource[Datagram]()(system)
         .viaMat(Udp.bindFlow(bindToLocal))(Keep.both)
-        .toMat(TestSink.probe)(Keep.both)
+        .toMat(TestSink())(Keep.both)
         .run()
 
       val boundAddress1 = bound1.futureValue


### PR DESCRIPTION
* Akka to 2.7.0-M2
* Akka HTTP 10.4.0-M1
* logback-classic 1.2.11
* Fix deprecation warnings of TestSource and TestSink