### PR TITLE
Cassandra: pick current Jackson version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -108,7 +108,7 @@ object Dependencies {
           .exclude("org.apache.tinkerpop", "*") //https://github.com/akka/alpakka/issues/2200
           .exclude("com.esri.geometry", "esri-geometry-api"), //https://github.com/akka/alpakka/issues/2225
         "com.typesafe.akka" %% "akka-discovery" % AkkaVersion % Provided
-      ) ++ JacksonDatabindDependencies
+      ) ++ JacksonDatabindDependencies // evict Jackson version from "com.datastax.oss" % "java-driver-core"
   )
 
   val Couchbase = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -108,7 +108,7 @@ object Dependencies {
           .exclude("org.apache.tinkerpop", "*") //https://github.com/akka/alpakka/issues/2200
           .exclude("com.esri.geometry", "esri-geometry-api"), //https://github.com/akka/alpakka/issues/2225
         "com.typesafe.akka" %% "akka-discovery" % AkkaVersion % Provided
-      )
+      ) ++ JacksonDatabindDependencies
   )
 
   val Couchbase = Seq(


### PR DESCRIPTION
Ensure Alpakka Cassandra uses the current version of Jackson.
(java-driver-core 4.14.1 brings in 2.13.2)