### PR TITLE
ci: current Ubuntu versions

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   style-compile-mima:
     name: Compile, Code Style, Binary Compatibility
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
@@ -43,7 +43,7 @@ jobs:
 
   documentation:
     name: ScalaDoc, Documentation with Paradox
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
@@ -71,7 +71,7 @@ jobs:
         run: cs launch net.runne::site-link-validator:0.2.2 -- scripts/link-validator.conf
 
   connectors:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validate-links:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'akka/alpakka'
     name: Release
     environment: release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
@@ -45,7 +45,7 @@ jobs:
     if: github.repository == 'akka/alpakka'
     name: Documentation
     environment: release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       # Drafts your next Release notes as Pull Requests are merged
       - uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
Thanks to the brown-out by Github I noticed we had Ubuntu 18.04 still there.