### PR TITLE
XML: Add a contextual version of the parser for XML

### DIFF
--- a/xml/src/main/scala/akka/stream/alpakka/xml/javadsl/XmlParsing.scala
+++ b/xml/src/main/scala/akka/stream/alpakka/xml/javadsl/XmlParsing.scala
@@ -24,8 +24,8 @@ object XmlParsing {
     xml.scaladsl.XmlParsing.parser.asJava
 
   /**
-   * Contextual version of a parser Flow that takes a stream of ByteStrings and parses them to XML events similar to
-   * SAX.
+   * Parser Flow that takes a stream of ByteStrings and parses them to XML events similar to SAX while keeping
+   * a context attached.
    */
   def parserWithContext[Ctx](): akka.stream.javadsl.FlowWithContext[ByteString, Ctx, ParseEvent, Ctx, NotUsed] =
     xml.scaladsl.XmlParsing.parserWithContext().asJava
@@ -37,8 +37,8 @@ object XmlParsing {
     xml.scaladsl.XmlParsing.parser(ignoreInvalidChars).asJava
 
   /**
-   * Contextual version of a parser Flow that takes a stream of ByteStrings and parses them to XML events similar to
-   * SAX.
+   * Parser Flow that takes a stream of ByteStrings and parses them to XML events similar to SAX while keeping
+   * a context attached.
    */
   def parserWithContext[Ctx](
       ignoreInvalidChars: Boolean
@@ -54,8 +54,8 @@ object XmlParsing {
     xml.scaladsl.XmlParsing.parser(false, configureFactory.accept(_)).asJava
 
   /**
-   * Contextual version of a parser Flow that takes a stream of ByteStrings and parses them to XML events similar to
-   * SAX.
+   * Parser Flow that takes a stream of ByteStrings and parses them to XML events similar to SAX while keeping
+   * a context attached.
    */
   def parserWithContext[Ctx](
       configureFactory: Consumer[AsyncXMLInputFactory]
@@ -72,8 +72,8 @@ object XmlParsing {
     xml.scaladsl.XmlParsing.parser(ignoreInvalidChars, configureFactory.accept(_)).asJava
 
   /**
-   * Contextual version of a parser Flow that takes a stream of ByteStrings and parses them to XML events similar to
-   * SAX.
+   * Parser Flow that takes a stream of ByteStrings and parses them to XML events similar to SAX while keeping
+   * a context attached.
    */
   def parserWithContext[Ctx](
       ignoreInvalidChars: Boolean,

--- a/xml/src/main/scala/akka/stream/alpakka/xml/javadsl/XmlParsing.scala
+++ b/xml/src/main/scala/akka/stream/alpakka/xml/javadsl/XmlParsing.scala
@@ -24,10 +24,26 @@ object XmlParsing {
     xml.scaladsl.XmlParsing.parser.asJava
 
   /**
+   * Contextual version of a parser Flow that takes a stream of ByteStrings and parses them to XML events similar to
+   * SAX.
+   */
+  def parserWithContext[Ctx](): akka.stream.javadsl.FlowWithContext[ByteString, Ctx, ParseEvent, Ctx, NotUsed] =
+    xml.scaladsl.XmlParsing.parserWithContext().asJava
+
+  /**
    * Parser Flow that takes a stream of ByteStrings and parses them to XML events similar to SAX.
    */
   def parser(ignoreInvalidChars: Boolean): akka.stream.javadsl.Flow[ByteString, ParseEvent, NotUsed] =
     xml.scaladsl.XmlParsing.parser(ignoreInvalidChars).asJava
+
+  /**
+   * Contextual version of a parser Flow that takes a stream of ByteStrings and parses them to XML events similar to
+   * SAX.
+   */
+  def parserWithContext[Ctx](
+      ignoreInvalidChars: Boolean
+  ): akka.stream.javadsl.FlowWithContext[ByteString, Ctx, ParseEvent, Ctx, NotUsed] =
+    xml.scaladsl.XmlParsing.parserWithContext(ignoreInvalidChars).asJava
 
   /**
    * Parser Flow that takes a stream of ByteStrings and parses them to XML events similar to SAX.
@@ -38,6 +54,15 @@ object XmlParsing {
     xml.scaladsl.XmlParsing.parser(false, configureFactory.accept(_)).asJava
 
   /**
+   * Contextual version of a parser Flow that takes a stream of ByteStrings and parses them to XML events similar to
+   * SAX.
+   */
+  def parserWithContext[Ctx](
+      configureFactory: Consumer[AsyncXMLInputFactory]
+  ): akka.stream.javadsl.FlowWithContext[ByteString, Ctx, ParseEvent, Ctx, NotUsed] =
+    xml.scaladsl.XmlParsing.parserWithContext(false, configureFactory.accept(_)).asJava
+
+  /**
    * Parser Flow that takes a stream of ByteStrings and parses them to XML events similar to SAX.
    */
   def parser(
@@ -45,6 +70,16 @@ object XmlParsing {
       configureFactory: Consumer[AsyncXMLInputFactory]
   ): akka.stream.javadsl.Flow[ByteString, ParseEvent, NotUsed] =
     xml.scaladsl.XmlParsing.parser(ignoreInvalidChars, configureFactory.accept(_)).asJava
+
+  /**
+   * Contextual version of a parser Flow that takes a stream of ByteStrings and parses them to XML events similar to
+   * SAX.
+   */
+  def parserWithContext[Ctx](
+      ignoreInvalidChars: Boolean,
+      configureFactory: Consumer[AsyncXMLInputFactory]
+  ): akka.stream.javadsl.FlowWithContext[ByteString, Ctx, ParseEvent, Ctx, NotUsed] =
+    xml.scaladsl.XmlParsing.parserWithContext(ignoreInvalidChars, configureFactory.accept(_)).asJava
 
   /**
    * A Flow that transforms a stream of XML ParseEvents. This stage coalesces consequitive CData and Characters

--- a/xml/src/main/scala/akka/stream/alpakka/xml/javadsl/XmlParsing.scala
+++ b/xml/src/main/scala/akka/stream/alpakka/xml/javadsl/XmlParsing.scala
@@ -54,15 +54,6 @@ object XmlParsing {
     xml.scaladsl.XmlParsing.parser(false, configureFactory.accept(_)).asJava
 
   /**
-   * Parser Flow that takes a stream of ByteStrings and parses them to XML events similar to SAX while keeping
-   * a context attached.
-   */
-  def parserWithContext[Ctx](
-      configureFactory: Consumer[AsyncXMLInputFactory]
-  ): akka.stream.javadsl.FlowWithContext[ByteString, Ctx, ParseEvent, Ctx, NotUsed] =
-    xml.scaladsl.XmlParsing.parserWithContext(false, configureFactory.accept(_)).asJava
-
-  /**
    * Parser Flow that takes a stream of ByteStrings and parses them to XML events similar to SAX.
    */
   def parser(

--- a/xml/src/main/scala/akka/stream/alpakka/xml/scaladsl/XmlParsing.scala
+++ b/xml/src/main/scala/akka/stream/alpakka/xml/scaladsl/XmlParsing.scala
@@ -7,7 +7,7 @@ package akka.stream.alpakka.xml.scaladsl
 import akka.NotUsed
 import akka.stream.alpakka.xml.ParseEvent
 import akka.stream.alpakka.xml.impl
-import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.{Flow, FlowWithContext}
 import akka.util.ByteString
 import com.fasterxml.aalto.AsyncXMLInputFactory
 import org.w3c.dom.Element
@@ -40,7 +40,20 @@ object XmlParsing {
    */
   def parser(ignoreInvalidChars: Boolean = false,
              configureFactory: AsyncXMLInputFactory => Unit = configureDefault): Flow[ByteString, ParseEvent, NotUsed] =
-    Flow.fromGraph(new impl.StreamingXmlParser(ignoreInvalidChars, configureFactory))
+    Flow[ByteString]
+      .map((_, ()))
+      .via(Flow.fromGraph(new impl.StreamingXmlParser[Unit](ignoreInvalidChars, configureFactory)))
+      .map(_._1)
+
+  /**
+   * Contextual version of a parser Flow that takes a stream of ByteStrings and parses them to XML events similar to
+   * SAX.
+   */
+  def parserWithContext[Ctx](
+      ignoreInvalidChars: Boolean = false,
+      configureFactory: AsyncXMLInputFactory => Unit = configureDefault
+  ): FlowWithContext[ByteString, Ctx, ParseEvent, Ctx, NotUsed] =
+    FlowWithContext.fromTuples(Flow.fromGraph(new impl.StreamingXmlParser[Ctx](ignoreInvalidChars, configureFactory)))
 
   /**
    * A Flow that transforms a stream of XML ParseEvents. This stage coalesces consecutive CData and Characters

--- a/xml/src/main/scala/akka/stream/alpakka/xml/scaladsl/XmlParsing.scala
+++ b/xml/src/main/scala/akka/stream/alpakka/xml/scaladsl/XmlParsing.scala
@@ -44,9 +44,7 @@ object XmlParsing {
       Flow.fromGraph(
         new impl.StreamingXmlParser[ByteString, ParseEvent, Unit](ignoreInvalidChars,
                                                                   configureFactory,
-                                                                  getByteString = identity,
-                                                                  getContext = _ => (),
-                                                                  buildOutput = (parseEvent, _) => parseEvent)
+                                                                  impl.StreamingXmlParser.Transform.uncontextual)
       )
     )
 
@@ -60,11 +58,11 @@ object XmlParsing {
   ): FlowWithContext[ByteString, Ctx, ParseEvent, Ctx, NotUsed] =
     FlowWithContext.fromTuples(
       Flow.fromGraph(
-        new impl.StreamingXmlParser[(ByteString, Ctx), (ParseEvent, Ctx), Ctx](ignoreInvalidChars,
-                                                                               configureFactory,
-                                                                               getByteString = _._1,
-                                                                               getContext = _._2,
-                                                                               buildOutput = (pe, ctx) => (pe, ctx))
+        new impl.StreamingXmlParser[(ByteString, Ctx), (ParseEvent, Ctx), Ctx](
+          ignoreInvalidChars,
+          configureFactory,
+          impl.StreamingXmlParser.Transform.contextual
+        )
       )
     )
 

--- a/xml/src/main/scala/akka/stream/alpakka/xml/scaladsl/XmlParsing.scala
+++ b/xml/src/main/scala/akka/stream/alpakka/xml/scaladsl/XmlParsing.scala
@@ -49,8 +49,8 @@ object XmlParsing {
     )
 
   /**
-   * Contextual version of a parser Flow that takes a stream of ByteStrings and parses them to XML events similar to
-   * SAX.
+   * Parser Flow that takes a stream of ByteStrings and parses them to XML events similar to SAX while keeping
+   * a context attached.
    */
   def parserWithContext[Ctx](
       ignoreInvalidChars: Boolean = false,

--- a/xml/src/main/scala/akka/stream/alpakka/xml/scaladsl/XmlParsing.scala
+++ b/xml/src/main/scala/akka/stream/alpakka/xml/scaladsl/XmlParsing.scala
@@ -44,7 +44,7 @@ object XmlParsing {
       Flow.fromGraph(
         new impl.StreamingXmlParser[ByteString, ParseEvent, Unit](ignoreInvalidChars,
                                                                   configureFactory,
-                                                                  impl.StreamingXmlParser.Transform.uncontextual)
+                                                                  impl.StreamingXmlParser.ContextHandler.uncontextual)
       )
     )
 
@@ -61,7 +61,7 @@ object XmlParsing {
         new impl.StreamingXmlParser[(ByteString, Ctx), (ParseEvent, Ctx), Ctx](
           ignoreInvalidChars,
           configureFactory,
-          impl.StreamingXmlParser.Transform.contextual
+          impl.StreamingXmlParser.ContextHandler.contextual
         )
       )
     )

--- a/xml/src/test/scala/docs/scaladsl/XmlProcessingSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlProcessingSpec.scala
@@ -356,7 +356,7 @@ class XmlProcessingSpec extends AnyWordSpec with Matchers with ScalaFutures with
       configWasCalled shouldBe true
     }
 
-    "properly parse XML contextually" in {
+    "parse XML and attach line numbers as context" in {
       val doc = """|<doc>
                    |  <elem>
                    |    elem1

--- a/xml/src/test/scala/docs/scaladsl/XmlProcessingSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlProcessingSpec.scala
@@ -8,7 +8,7 @@ import akka.actor.ActorSystem
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.alpakka.xml._
 import akka.stream.alpakka.xml.scaladsl.XmlParsing
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.scaladsl.{Flow, Framing, Keep, Sink, Source}
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
@@ -354,6 +354,45 @@ class XmlProcessingSpec extends AnyWordSpec with Matchers with ScalaFutures with
         )
       )
       configWasCalled shouldBe true
+    }
+
+    "properly parse XML contextually" in {
+      val doc = """|<doc>
+                   |  <elem>
+                   |    elem1
+                   |  </elem>
+                   |  <elem>
+                   |    elem2
+                   |  </elem>
+                   |</doc>""".stripMargin
+      val resultFuture = Source
+        .single(ByteString(doc))
+        .via(
+          Framing.delimiter(delimiter = ByteString(System.lineSeparator),
+                            maximumFrameLength = 65536,
+                            allowTruncation = true)
+        )
+        .zipWithIndex
+        .runWith(XmlParsing.parserWithContext[Long]().asFlow.toMat(Sink.seq)(Keep.right))
+
+      resultFuture.futureValue should ===(
+        List(
+          (StartDocument, 0L),
+          (StartElement("doc"), 0L),
+          (Characters("  "), 1L),
+          (StartElement("elem"), 1L),
+          (Characters("    elem1"), 2L),
+          (Characters("  "), 3L),
+          (EndElement("elem"), 3L),
+          (Characters("  "), 4L),
+          (StartElement("elem"), 4L),
+          (Characters("    elem2"), 5L),
+          (Characters("  "), 6L),
+          (EndElement("elem"), 6L),
+          (EndElement("doc"), 7L),
+          (EndDocument, 7L)
+        )
+      )
     }
 
   }


### PR DESCRIPTION
This pull request adds a contextual version of the parser provided by `XmlParsing`. 

API-wise, I was not entirely sure how to set this up, since different modules seem to follow different conventions. For example, the Cassandra module provides a `withContext` method directly in the `CassandraFlow` object (https://github.com/akka/alpakka/blob/4f77c8b6b7e443acb39fa3164613c19a626e530f/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraFlow.scala), but the AMQP module provides its own `AmqpFlowWithContext` object with contextual variants (https://github.com/akka/alpakka/blob/4f77c8b6b7e443acb39fa3164613c19a626e530f/amqp/src/main/scala/akka/stream/alpakka/amqp/scaladsl/AmqpFlowWithContext.scala).