### PR TITLE
chore: current GH actions; coursier/setup-action; Fossa install

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with: # https://github.com/olafurpg/setup-scala#faster-checkout-of-big-repos
           fetch-depth: 100
 
@@ -31,12 +31,12 @@ jobs:
         run: git fetch --depth=100 origin +refs/tags/*:refs/tags/*
 
       - name: Set up JDK 8
-        uses: coursier/setup-action@v1.2.1
+        uses: coursier/setup-action@v1.3.0
         with:
           jvm: adopt:8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.3.3
+        uses: coursier/cache-action@v6.4.0
 
       - name: "Code style, compile tests, MiMa. Run locally with: sbt +~2.13 \"verifyCodeStyle; Test/compile; mimaReportBinaryIssues\""
         run: sbt +~2.13 "verifyCodeStyle; Test/compile; mimaReportBinaryIssues"
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with: # https://github.com/olafurpg/setup-scala#faster-checkout-of-big-repos
           fetch-depth: 100
 
@@ -57,12 +57,12 @@ jobs:
         run: git fetch --depth=100 origin +refs/tags/*:refs/tags/*
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1.2.1
+        uses: coursier/setup-action@v1.3.0
         with:
           jvm: adopt:11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.3.3
+        uses: coursier/cache-action@v6.4.0
 
       - name: "Create all API docs and create site with Paradox"
         run: sbt docs/makeSite
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with: # gh-detect-changes.sh compares with the target branch
           fetch-depth: 0
 
@@ -142,13 +142,13 @@ jobs:
 
       - name: Set up JDK 8
         if: env.execute_build == 'true'
-        uses: coursier/setup-action@v1.2.1
+        uses: coursier/setup-action@v1.3.0
         with:
           jvm: adopt:8
 
       - name: Cache Coursier cache
         if: env.execute_build == 'true'
-        uses: coursier/cache-action@v6.3.3
+        uses: coursier/cache-action@v6.4.0
 
       - name: ${{ matrix.connector }}
         if: env.execute_build == 'true'

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -9,6 +9,9 @@ on:
     tags-ignore:
       - v*
 
+permissions:
+  contents: read
+
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.
   group: ci-${{ github.ref }}

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Fetch tags
         run: git fetch --depth=100 origin +refs/tags/*:refs/tags/*
 
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:8
+          jvm: temurin:1.11
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
@@ -59,7 +59,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:11
+          jvm: temurin:1.11
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
@@ -68,7 +68,7 @@ jobs:
         run: sbt docs/makeSite
 
       - name: Run Link Validator
-        run: cs launch net.runne::site-link-validator:0.2.2 -- scripts/link-validator.conf
+        run: cs launch net.runne::site-link-validator:0.2.3 -- scripts/link-validator.conf
 
   connectors:
     runs-on: ubuntu-22.04
@@ -144,7 +144,7 @@ jobs:
         if: env.execute_build == 'true'
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:8
+          jvm: temurin:1.8
 
       - name: Cache Coursier cache
         if: env.execute_build == 'true'

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with: # https://github.com/olafurpg/setup-scala#faster-checkout-of-big-repos
           fetch-depth: 100
 
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with: # https://github.com/olafurpg/setup-scala#faster-checkout-of-big-repos
           fetch-depth: 100
 
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with: # gh-detect-changes.sh compares with the target branch
           fetch-depth: 0
 

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -8,20 +8,20 @@ on:
 jobs:
   fossa:
     name: Fossa
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/alpakka'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.0
         with:
           jvm: adopt:11
 

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * 0' # At 00:00 on Sunday
 
+permissions:
+  contents: read
+
 jobs:
   fossa:
     name: Fossa

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:11
+          jvm: temurin:1.17
 
       - name: FOSSA policy check
         run: |-

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -12,22 +12,22 @@ jobs:
     if: github.repository == 'akka/alpakka'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v13
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.2
 
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1
+        with:
+          jvm: adopt:11
+
       - name: FOSSA policy check
         run: |-
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
           fossa analyze && fossa test
         env:
           FOSSA_API_KEY: "${{secrets.FOSSA_API_KEY}}"

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with: # https://github.com/olafurpg/setup-scala#faster-checkout-of-big-repos
           fetch-depth: 100
 
@@ -18,10 +18,10 @@ jobs:
         run: git fetch --depth=100 origin +refs/tags/*:refs/tags/*
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.0
         with:
           jvm: adopt:11
           apps: cs

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron:  '0 6 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   validate-links:
     runs-on: ubuntu-22.04

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -1,6 +1,7 @@
 name: Link Validator
 
 on:
+  workflow_dispatch:
   schedule:
     - cron:  '0 6 * * 1'
 
@@ -9,23 +10,24 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with: # https://github.com/olafurpg/setup-scala#faster-checkout-of-big-repos
           fetch-depth: 100
 
       - name: Fetch tags
         run: git fetch --depth=100 origin +refs/tags/*:refs/tags/*
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v13
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.2
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1
+        with:
+          jvm: adopt:11
+          apps: cs
 
       - name: sbt site
         run: sbt docs/makeSite
 
       - name: Run Link Validator
-        run: cs launch net.runne::site-link-validator:0.2.2 -- scripts/link-validator.conf
+        run: cs launch net.runne::site-link-validator:0.2.3 -- scripts/link-validator.conf

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:11
+          jvm: temurin:1.17
           apps: cs
 
       - name: sbt site

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,18 +19,18 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Setup Scala with JDK 8
-        uses: olafurpg/setup-scala@v13
-        with:
-          java-version: adopt@1.8.0-275
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v6.2
+
+      - name: Set up JDK 8
+        uses: coursier/setup-action@v1
+        with:
+          jvm: adopt:8
 
       - name: Publish artifacts for all Scala versions
         env:
@@ -50,15 +50,18 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 8
-        uses: coursier/setup-action@v1.2.1
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6.2
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1
         with:
-          java-version: adopt@1.11.0-9
+          jvm: adopt:11
 
       - name: Publish API and reference documentation
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,16 +19,16 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK 8
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.0
         with:
           jvm: adopt:8
 
@@ -50,16 +50,16 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.0
         with:
           jvm: adopt:11
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:8
+          jvm: temurin:1.11.0.17
 
       - name: Publish artifacts for all Scala versions
         env:
@@ -61,7 +61,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:11
+          jvm: temurin:1.11
 
       - name: Publish API and reference documentation
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
       - release-*
     tags: ["v*"]
 
+permissions:
+  contents: read
+
 jobs:
   release:
     # runs on main repo only

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       # Drafts your next Release notes as Pull Requests are merged
-      - uses: release-drafter/release-drafter@v5
+      # https://github.com/release-drafter/release-drafter/releases
+      # v5.21.1
+      - uses: release-drafter/release-drafter@6df64e4ba4842c203c604c1f45246c5863410adb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,9 +7,14 @@ on:
     - main
     - release-*
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       # Drafts your next Release notes as Pull Requests are merged
       # https://github.com/release-drafter/release-drafter/releases

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -26,6 +26,8 @@ site-link-validator {
     "https://github.com/"
     # MVN repository forbids access after a few requests
     "https://mvnrepository.com/artifact/"
+    # in api/alpakka/snapshot/akka/stream/alpakka/google/scaladsl/X$minusUpload$minusContent$minusType.html
+    "https://doc.akka.io/api/akka-http/10.4.0/akka/http/impl/"
   ]
 
   non-https-whitelist = [


### PR DESCRIPTION
Current Fossa CLI install URL.

GitHub workflow housekeeping (to not hit Node 12 EOL):
- checkout v3
- coursier/setup-action instead of olafurpg/setup-scala

References https://github.com/akka/alpakka-kafka/pull/1574