### PR TITLE
Adding some basic development setup information.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,9 @@ Ensure to install the following dependencies:
 - Java JDK
 - [Scala 2.x](https://scala-lang.org/)
 
-When cloning the repository, make sure to clone in a way which pulls the tags such as a regular `git clone` (not a shallow clone). This is needed because the MiMa plugin checks the git history and tags when loading the sbt project. If you have already done a shallow clone of the project, do a regular `git fetch` or `git pull` to pull the tag information.
+When cloning or updating the repository, make sure to clone/fetch/pull in a way which gets the git tags (such as a regular `git clone`, `git fetch` or `git pull`).
+This is needed because the MiMa plugin checks the git history and tags when loading the sbt project.
+Doing a shallow clone/fetch/pull will not get the tag information and will interfere with the project loading process.
 
 ## General Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ You may also check out these [other resources](https://akka.io/get-involved/).
 Ensure to install the following dependencies:
 
 - [Git](https://git-scm.com/) (Make sure the `git` executable is referenced in the `PATH` environment variable)
+  - Having `git` in the `PATH` is important because it is used by the MiMa plugin when loading the sbt project.
 - Java JDK
 - [Scala 2.x](https://scala-lang.org/)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,14 @@ You may also check out these [other resources](https://akka.io/get-involved/).
 
 # Contributing to Alpakka
 
+## Development Setup
+
+Ensure to install the following dependencies:
+
+- [Git](https://git-scm.com/) (Make sure the `git` executable is referenced in the `PATH` environment variable)
+- Java JDK
+- [Scala 2.x](https://scala-lang.org/)
+
 ## General Workflow
 
 This is the process for committing code into master.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Ensure to install the following dependencies:
 - [Git](https://git-scm.com/) (Make sure the `git` executable is referenced in the `PATH` environment variable)
   - Having `git` in the `PATH` is important because it is used by the MiMa plugin when loading the sbt project.
 - Java JDK
-- [Scala 2.x](https://scala-lang.org/)
+- [SBT](https://www.scala-sbt.org/) which can be installed standalone, or bundled with [Scala](https://scala-lang.org/) or IDEs such as [IntelliJ IDEA](https://www.jetbrains.com/idea/).
 
 When cloning or updating the repository, make sure to clone/fetch/pull in a way which gets the git tags (such as a regular `git clone`, `git fetch` or `git pull`).
 This is needed because the MiMa plugin checks the git history and tags when loading the sbt project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ Ensure to install the following dependencies:
 - Java JDK
 - [Scala 2.x](https://scala-lang.org/)
 
+When cloning the repository, make sure to clone in a way which pulls the tags such as a regular `git clone` (not a shallow clone). This is needed because the MiMa plugin checks the git history and tags when loading the sbt project. If you have already done a shallow clone of the project, do a regular `git fetch` or `git pull` to pull the tag information.
+
 ## General Workflow
 
 This is the process for committing code into master.


### PR DESCRIPTION
Mentioning explicit step of making sure the `git` executable is in the system's `PATH` environment variable to resolve issue #2893.
