### PR TITLE
ftp(test): use ubuntu/squid Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,7 +238,7 @@ services:
     command: username:userpass:${FTP_USER_UID:-2000}:${FTP_USER_GID:-2000}
   squid:
     network_mode: host # required for route back to localhost
-    image: datadog/squid
+    image: ubuntu/squid
     volumes:
       - ./ftp/src/test/resources/squid.conf:/etc/squid/squid.conf
   pravega:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
   val AkkaHttpBinaryVersion = "10.4"
   val AlpakkaKafkaVersion = "4.0.0"
   val ScalaTestVersion = "3.2.11"
-  val TestContainersScalaTestVersion = "0.40.3"
+  val TestContainersScalaTestVersion = "0.40.3" // pulls Testcontainers 1.16.2
   val mockitoVersion = "4.8.0" // check even https://github.com/scalatest/scalatestplus-mockito/releases
   val hoverflyVersion = "0.14.1"
 


### PR DESCRIPTION
FTP tests have been failing on CI as the `datadog/squid` image is not available anymore.