### PR TITLE
docs(pravega): remove broken Slack link

### DIFF
--- a/docs/src/main/paradox/pravega.md
+++ b/docs/src/main/paradox/pravega.md
@@ -181,4 +181,4 @@ Scala
 
 ## Support
 
-In addition to our regular Alpakka community support on [![gitter: akka/akka](https://img.shields.io/badge/gitter%3A-akka%2Fakka-blue.svg?style=flat-square)](https://gitter.im/akka/akka) and Lightbend's [discuss.lightbend.com](https://discuss.lightbend.com/c/akka/streams-and-alpakka), you can also visit the `#akka-streams-connector` channel on the [Pravega slack](https://pravega-slack-invite.herokuapp.com) for assistance with Pravega integration itself.
+In addition to our regular Alpakka community support on [![gitter: akka/akka](https://img.shields.io/badge/gitter%3A-akka%2Fakka-blue.svg?style=flat-square)](https://gitter.im/akka/akka) and Lightbend's [discuss.lightbend.com](https://discuss.lightbend.com/c/akka/streams-and-alpakka).


### PR DESCRIPTION
Most likely due to Heroku's new pricing, the Slack invite page has been taken down.