### PR TITLE
bump: Google cloud SDK/emulator 416; Pub/Sub gRPC 1.123.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,7 +130,8 @@ services:
       - ./geode/scripts/:/scripts/
     command: /scripts/geode.sh
   gcloud-pubsub-emulator:
-    image: google/cloud-sdk:311.0.0
+    # https://hub.docker.com/r/google/cloud-sdk/tags
+    image: google/cloud-sdk:416.0.0
     ports:
       - "8538:8538"
     command: gcloud beta emulators pubsub start --project=alpakka --host-port=0.0.0.0:8538

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -248,7 +248,7 @@ object Dependencies {
     // see Akka gRPC version in plugins.sbt
     libraryDependencies ++= Seq(
         // https://github.com/googleapis/java-pubsub/tree/master/proto-google-cloud-pubsub-v1/
-        "com.google.cloud" % "google-cloud-pubsub" % "1.112.5" % "protobuf-src", // ApacheV2
+        "com.google.cloud" % "google-cloud-pubsub" % "1.123.1" % "protobuf-src", // ApacheV2
         "io.grpc" % "grpc-auth" % akka.grpc.gen.BuildInfo.grpcVersion,
         // https://github.com/googleapis/google-auth-library-java
         "com.google.auth" % "google-auth-library-oauth2-http" % GoogleAuthVersion,


### PR DESCRIPTION
- Google cloud SDK/emulator 416 (was 311); 
- Pub/Sub gRPC protobuf 1.123.1 (was 1.112.5)

References 
- #2454
