### PR TITLE
Ensure to only pass sse headers to completeMultipartUpload

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/S3Stream.scala
@@ -1055,7 +1055,7 @@ import scala.util.{Failure, Success, Try}
     import mat.executionContext
     implicit val conf: S3Settings = resolveSettings(attr, mat.system)
 
-    val headers = s3Headers.headersFor(UploadPart)
+    val headers = s3Headers.serverSideEncryption.toIndexedSeq.flatMap(_.headersFor(UploadPart))
 
     Source
       .future(

--- a/s3/src/test/scala/docs/scaladsl/S3SinkSpec.scala
+++ b/s3/src/test/scala/docs/scaladsl/S3SinkSpec.scala
@@ -285,7 +285,6 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec with Option
       .withHeader(sseCKeyHeaderMd5, new EqualToPattern(sseCKeyHeaderMd5Value))
       .withoutHeader(requestPayerHeader)
 
-
   }
 
   it should "copy a file from source bucket to target bucket when expected content length is greater then chunk size" in {

--- a/s3/src/test/scala/docs/scaladsl/S3SinkSpec.scala
+++ b/s3/src/test/scala/docs/scaladsl/S3SinkSpec.scala
@@ -235,6 +235,8 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec with Option
     val sseCAlgorithmHeader = "x-amz-server-side-encryption-customer-algorithm"
     val sseCAlgorithmHeaderValue = "AES256"
     val sseCKeyHeader = "x-amz-server-side-encryption-customer-key"
+    val sseCKeyHeaderMd5 = "x-amz-server-side-encryption-customer-key-MD5"
+    val sseCKeyHeaderMd5Value = "md5"
     val sseCKeyHeaderValue = sseCustomerKey
     val sseCSourceAlgorithmHeader = "x-amz-copy-source-server-side-encryption-customer-algorithm"
     val sseCSourceAlgorithmHeaderValue = "AES256"
@@ -275,10 +277,14 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec with Option
       .withHeader(sseCSourceKeyHeader, new EqualToPattern(sseCSourceKeyHeaderValue))
       .withHeader(requestPayerHeader, new EqualToPattern(requestPayerHeaderValue))
 
-    // No SSE-C headers required for CompleteMultipartUpload
+    // Only SSE headers possible, no other headers
     mock verifyThat
     postRequestedFor(urlEqualTo(s"/$targetBucketKey?uploadId=$uploadId"))
-      .withHeader(requestPayerHeader, new EqualToPattern(requestPayerHeaderValue))
+      .withHeader(sseCAlgorithmHeader, new EqualToPattern(sseCAlgorithmHeaderValue))
+      .withHeader(sseCKeyHeader, new EqualToPattern(sseCKeyHeaderValue))
+      .withHeader(sseCKeyHeaderMd5, new EqualToPattern(sseCKeyHeaderMd5Value))
+      .withoutHeader(requestPayerHeader)
+
 
   }
 


### PR DESCRIPTION
Not very explicit in the [docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html#API_CompleteMultipartUpload_Examples), but other headers beside the sse headers are not allowed for this particular request (`completeMultipartUpload`).

Fixes https://github.com/akka/alpakka/issues/2906 and reverts a small part from https://github.com/akka/alpakka/pull/2844.