### PR TITLE
chore: run link checking on JDK 11

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 17
+      - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: temurin:1.17
+          jvm: temurin:1.11
           apps: cs
 
       - name: sbt site


### PR DESCRIPTION
Publishing docs runs on JDK 11 and thus JavaDoc 11, the regular link checker should use the same version as URLs are affected.

https://github.com/akka/alpakka/blob/3d8b41ffe8c5904b8d2d197d642939d26a84d4ee/.github/workflows/publish.yml#L64-L67
