### PR TITLE
fix(mqtt-streaming): Separate MQTT QoS by message type (#2969

### DIFF
--- a/mqtt-streaming/src/main/mima-filters/5.1.0-M1.backwards.excludes/mqtt-streaming
+++ b/mqtt-streaming/src/main/mima-filters/5.1.0-M1.backwards.excludes/mqtt-streaming
@@ -1,0 +1,7 @@
+# Values removed to fix different QoS encoding in MQTT streaming Publish and Subscribe
+# https://github.com/akka/alpakka/pull/2969
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.ControlPacketFlags.QoSFailure")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.ControlPacketFlags.QoSReserved")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.ControlPacketFlags.QoSExactlyOnceDelivery")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.ControlPacketFlags.QoSAtLeastOnceDelivery")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.mqtt.streaming.ControlPacketFlags.QoSAtMostOnceDelivery")

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ClientState.scala
@@ -440,7 +440,7 @@ import scala.util.{Either, Failure, Success}
             serverConnected(data, resetPingReqTimer = true)
 
           case (_, PublishReceivedFromRemote(_, publish, local))
-              if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 =>
+              if (publish.flags & PublishQoSFlags.QoSReserved).underlying == 0 =>
             local.success(Consumer.ForwardPublish)
             serverConnected(data, resetPingReqTimer = false)
 
@@ -495,7 +495,7 @@ import scala.util.{Either, Failure, Success}
             }
 
           case (context, PublishReceivedLocally(publish, _))
-              if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 =>
+              if (publish.flags & PublishQoSFlags.QoSReserved).underlying == 0 =>
             QueueOfferState.waitForQueueOfferCompleted(
               data.remote.offer(ForwardPublish(publish, None)),
               result => QueueOfferCompleted(ByteString.empty, result.toEither),

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/RequestState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/RequestState.scala
@@ -134,12 +134,12 @@ import scala.util.{Either, Failure, Success}
       Behaviors
         .receive[Event] {
           case (_, PubAckReceivedFromRemote(local))
-              if data.publish.flags.contains(ControlPacketFlags.QoSAtLeastOnceDelivery) =>
+              if data.publish.flags.contains(PublishQoSFlags.QoSAtLeastOnceDelivery) =>
             local.success(ForwardPubAck(data.publishData))
             Behaviors.stopped
 
           case (_, PubRecReceivedFromRemote(local))
-              if data.publish.flags.contains(ControlPacketFlags.QoSAtMostOnceDelivery) =>
+              if data.publish.flags.contains(PublishQoSFlags.QoSAtMostOnceDelivery) =>
             local.success(ForwardPubRec(data.publishData))
             timer.cancel(ReceivePubackrec)
             publishAcknowledged(data)
@@ -296,10 +296,10 @@ import scala.util.{Either, Failure, Success}
     timer.startSingleTimer(ReceivePubackrel, ReceivePubAckRecTimeout, data.settings.consumerPubAckRecTimeout)
     Behaviors
       .receiveMessagePartial[Event] {
-        case PubAckReceivedLocally(remote) if data.publish.flags.contains(ControlPacketFlags.QoSAtLeastOnceDelivery) =>
+        case PubAckReceivedLocally(remote) if data.publish.flags.contains(PublishQoSFlags.QoSAtLeastOnceDelivery) =>
           remote.success(ForwardPubAck)
           Behaviors.stopped
-        case PubRecReceivedLocally(remote) if data.publish.flags.contains(ControlPacketFlags.QoSExactlyOnceDelivery) =>
+        case PubRecReceivedLocally(remote) if data.publish.flags.contains(PublishQoSFlags.QoSExactlyOnceDelivery) =>
           remote.success(ForwardPubRec)
           timer.cancel(ReceivePubackrel)
           consumeReceived(data)

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/impl/ServerState.scala
@@ -521,7 +521,7 @@ import scala.util.{Failure, Success}
           case (_, Unsubscribed(unsubscribe)) =>
             clientConnected(data.copy(publishers = data.publishers -- unsubscribe.topicFilters))
           case (_, PublishReceivedFromRemote(publish, local))
-              if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 =>
+              if (publish.flags & PublishQoSFlags.QoSReserved).underlying == 0 =>
             local.success(Consumer.ForwardPublish)
             clientConnected(data)
           case (context, prfr @ PublishReceivedFromRemote(publish @ Publish(_, topicName, Some(packetId), _), local)) =>
@@ -572,7 +572,7 @@ import scala.util.{Failure, Success}
               clientConnected(data.copy(activeConsumers = data.activeConsumers - topicName))
             }
           case (context, PublishReceivedLocally(publish, _))
-              if (publish.flags & ControlPacketFlags.QoSReserved).underlying == 0 &&
+              if (publish.flags & PublishQoSFlags.QoSReserved).underlying == 0 &&
               data.publishers.exists(Topics.filter(_, publish.topicName)) =>
             QueueOfferState.waitForQueueOfferCompleted(
               data.remote

--- a/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/model.scala
+++ b/mqtt-streaming/src/main/scala/akka/stream/alpakka/mqtt/streaming/model.scala
@@ -22,7 +22,7 @@ import scala.concurrent.{ExecutionContext, Promise}
 
 /**
  * 2.2.1 MQTT Control Packet type
- * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
+ * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Table_2.1_-
  */
 object ControlPacketType {
   val Reserved1 = ControlPacketType(0)
@@ -46,7 +46,8 @@ final case class ControlPacketType private (underlying: Int) extends AnyVal
 
 /**
  * 2.2.2 Flags
- * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
+ * 3.3.1 Publish message header flags
+ * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718038
  */
 object ControlPacketFlags {
   val None = ControlPacketFlags(0)
@@ -56,12 +57,30 @@ object ControlPacketFlags {
   val ReservedUnsubscribe = ControlPacketFlags(1 << 1)
   val ReservedUnsubAck = ControlPacketFlags(1 << 1)
   val DUP = ControlPacketFlags(1 << 3)
+  val RETAIN = ControlPacketFlags(1)
+}
+
+/**
+ * 3.3.1 Publish QoS flags
+ * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Table_3.11_-
+ */
+object PublishQoSFlags {
   val QoSAtMostOnceDelivery = ControlPacketFlags(0)
   val QoSAtLeastOnceDelivery = ControlPacketFlags(1 << 1)
   val QoSExactlyOnceDelivery = ControlPacketFlags(2 << 1)
   val QoSReserved = ControlPacketFlags(3 << 1)
-  val QoSFailure = ControlPacketFlags(1 << 7)
-  val RETAIN = ControlPacketFlags(1)
+}
+
+/**
+ * 3.8.3 Subscribe payload QoS
+ * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Figure_3.26_-
+ */
+object SubscribeQoSFlags {
+  val QoSAtMostOnceDelivery = ControlPacketFlags(0)
+  val QoSAtLeastOnceDelivery = ControlPacketFlags(1)
+  val QoSExactlyOnceDelivery = ControlPacketFlags(2)
+  val QoSReserved = ControlPacketFlags(3)
+  val QoSFailure = ControlPacketFlags(0x80)
 }
 
 final case class ControlPacketFlags private (underlying: Int) extends AnyVal {
@@ -293,7 +312,7 @@ final case class Publish @InternalApi private[streaming] (override val flags: Co
    * Conveniently create a publish message with at least once delivery
    */
   def this(topicName: String, payload: ByteString) =
-    this(ControlPacketFlags.QoSAtLeastOnceDelivery, topicName, Some(PacketId(0)), payload)
+    this(PublishQoSFlags.QoSAtLeastOnceDelivery, topicName, Some(PacketId(0)), payload)
 
   override def toString: String =
     s"""Publish(flags:$flags,topicName:$topicName,packetId:$packetId,payload:${payload.size}b)"""
@@ -371,7 +390,7 @@ final case class Subscribe @InternalApi private[streaming] (packetId: PacketId,
    * A convenience for subscribing to a single topic with at-least-once semantics
    */
   def this(topicFilter: String) =
-    this(PacketId(0), List(topicFilter -> ControlPacketFlags.QoSAtLeastOnceDelivery))
+    this(PacketId(0), List(topicFilter -> SubscribeQoSFlags.QoSAtLeastOnceDelivery))
 }
 
 /**
@@ -894,12 +913,12 @@ object MqttCodec {
     // 3.3 PUBLISH – Publish message
     def decodePublish(l: Int, flags: ControlPacketFlags): Either[DecodeError, Publish] =
       try {
-        if (!flags.contains(ControlPacketFlags.QoSReserved)) {
+        if (!flags.contains(PublishQoSFlags.QoSReserved)) {
           val packetLen = v.len
           val topicName = v.decodeString()
           val packetId =
-            if (flags.contains(ControlPacketFlags.QoSAtLeastOnceDelivery) ||
-                flags.contains(ControlPacketFlags.QoSExactlyOnceDelivery))
+            if (flags.contains(PublishQoSFlags.QoSAtLeastOnceDelivery) ||
+                flags.contains(PublishQoSFlags.QoSExactlyOnceDelivery))
               Some(PacketId(v.getShort & 0xffff))
             else None
           val payload = v.getByteString(l - (packetLen - v.len))
@@ -971,7 +990,7 @@ object MqttCodec {
           }
         val topicFilters = decodeTopicFilters(l - (packetLen - v.len), Vector.empty)
         val topicFiltersValid = topicFilters.nonEmpty && topicFilters.foldLeft(true) {
-            case (true, (Right(_), tff)) if tff.underlying < ControlPacketFlags.QoSReserved.underlying => true
+            case (true, (Right(_), tff)) if tff.underlying < SubscribeQoSFlags.QoSReserved.underlying => true
             case _ => false
           }
         if (topicFiltersValid) {

--- a/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -13,21 +13,7 @@ import akka.stream.KillSwitches;
 import akka.stream.OverflowStrategy;
 import akka.stream.SystemMaterializer;
 import akka.stream.UniqueKillSwitch;
-import akka.stream.alpakka.mqtt.streaming.Command;
-import akka.stream.alpakka.mqtt.streaming.ConnAck;
-import akka.stream.alpakka.mqtt.streaming.ConnAckFlags;
-import akka.stream.alpakka.mqtt.streaming.ConnAckReturnCode;
-import akka.stream.alpakka.mqtt.streaming.Connect;
-import akka.stream.alpakka.mqtt.streaming.ConnectFlags;
-import akka.stream.alpakka.mqtt.streaming.ControlPacket;
-import akka.stream.alpakka.mqtt.streaming.ControlPacketFlags;
-import akka.stream.alpakka.mqtt.streaming.DecodeErrorOrEvent;
-import akka.stream.alpakka.mqtt.streaming.Event;
-import akka.stream.alpakka.mqtt.streaming.MqttSessionSettings;
-import akka.stream.alpakka.mqtt.streaming.PubAck;
-import akka.stream.alpakka.mqtt.streaming.Publish;
-import akka.stream.alpakka.mqtt.streaming.SubAck;
-import akka.stream.alpakka.mqtt.streaming.Subscribe;
+import akka.stream.alpakka.mqtt.streaming.*;
 import akka.stream.alpakka.mqtt.streaming.javadsl.ActorMqttClientSession;
 import akka.stream.alpakka.mqtt.streaming.javadsl.ActorMqttServerSession;
 import akka.stream.alpakka.mqtt.streaming.javadsl.Mqtt;
@@ -127,7 +113,7 @@ public class MqttFlowTest {
     session.tell(
         new Command<>(
             new Publish(
-                ControlPacketFlags.RETAIN() | ControlPacketFlags.QoSAtLeastOnceDelivery(),
+                ControlPacketFlags.RETAIN() | PublishQoSFlags.QoSAtLeastOnceDelivery(),
                 topic,
                 ByteString.fromString("ohi"))));
     // #run-streaming-flow
@@ -265,7 +251,7 @@ public class MqttFlowTest {
     clientSession.tell(
         new Command<>(
             new Publish(
-                ControlPacketFlags.RETAIN() | ControlPacketFlags.QoSAtLeastOnceDelivery(),
+                ControlPacketFlags.RETAIN() | PublishQoSFlags.QoSAtLeastOnceDelivery(),
                 topic,
                 ByteString.fromString("ohi"))));
 

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -80,7 +80,7 @@ trait MqttFlowSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll 
       commands.offer(Command(Connect(clientId, ConnectFlags.CleanSession)))
       commands.offer(Command(Subscribe(topic)))
       session ! Command(
-        Publish(ControlPacketFlags.RETAIN | ControlPacketFlags.QoSAtLeastOnceDelivery, topic, ByteString("ohi"))
+        Publish(ControlPacketFlags.RETAIN | PublishQoSFlags.QoSAtLeastOnceDelivery, topic, ByteString("ohi"))
       )
       //#run-streaming-flow
 
@@ -173,7 +173,7 @@ trait MqttFlowSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll 
       commands.offer(Command(Connect(clientId, ConnectFlags.None)))
       commands.offer(Command(Subscribe(topic)))
       clientSession ! Command(
-        Publish(ControlPacketFlags.RETAIN | ControlPacketFlags.QoSAtLeastOnceDelivery, topic, ByteString("ohi"))
+        Publish(ControlPacketFlags.RETAIN | PublishQoSFlags.QoSAtLeastOnceDelivery, topic, ByteString("ohi"))
       )
 
       events.futureValue match {
@@ -191,9 +191,9 @@ trait MqttFlowSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll 
   }
 
   "mqtt client" should {
-    Seq(ControlPacketFlags.QoSAtMostOnceDelivery,
-        ControlPacketFlags.QoSAtLeastOnceDelivery,
-        ControlPacketFlags.QoSExactlyOnceDelivery).foreach { qos =>
+    Seq(SubscribeQoSFlags.QoSAtMostOnceDelivery,
+        SubscribeQoSFlags.QoSAtLeastOnceDelivery,
+        SubscribeQoSFlags.QoSExactlyOnceDelivery).foreach { qos =>
       s"subscribe at QoS ${qos.underlying.toString} level" in assertAllStagesStopped {
         val id = qos.underlying.toString
 

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -99,9 +99,7 @@ trait MqttFlowSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll 
   }
 
   "mqtt server flow" should {
-    // Ignored due to ://github.com/akka/alpakka/issues/1549, possibly
-    // fixed with https://github.com/akka/alpakka/pull/2189
-    "receive a bidirectional connection and a subscription to a topic" ignore {
+    "receive a bidirectional connection and a subscription to a topic" {
 
       val host = "localhost"
 

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -99,7 +99,7 @@ trait MqttFlowSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll 
   }
 
   "mqtt server flow" should {
-    "receive a bidirectional connection and a subscription to a topic" {
+    "receive a bidirectional connection and a subscription to a topic" in assertAllStagesStopped {
 
       val host = "localhost"
 

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -74,7 +74,7 @@ class MqttSessionSpec
 
       val subscribe = Subscribe("some-topic")
       val subscribeBytes = subscribe.encode(ByteString.newBuilder, PacketId(1)).result()
-      val subAck = SubAck(PacketId(1), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val subAck = SubAck(PacketId(1), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val subAckBytes = subAck.encode(ByteString.newBuilder).result()
 
       val publish = Publish("some-topic", ByteString("some-payload"))
@@ -162,7 +162,7 @@ class MqttSessionSpec
       val connAckBytes = connAck.encode(ByteString.newBuilder).result()
 
       val subscribeBytes = subscribe.encode(ByteString.newBuilder, PacketId(1)).result()
-      val subAck = SubAck(PacketId(1), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val subAck = SubAck(PacketId(1), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val subAckBytes = subAck.encode(ByteString.newBuilder).result()
 
       client.offer(Command(connect))
@@ -440,10 +440,10 @@ class MqttSessionSpec
 
       val subscribe = Subscribe("some-topic")
       val subscribeBytes = subscribe.encode(ByteString.newBuilder, PacketId(1)).result()
-      val subAck = SubAck(PacketId(1), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val subAck = SubAck(PacketId(1), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val subAckBytes = subAck.encode(ByteString.newBuilder).result()
 
-      val publish = Publish(ControlPacketFlags.QoSAtMostOnceDelivery, "some-topic", ByteString("some-payload"))
+      val publish = Publish(PublishQoSFlags.QoSAtMostOnceDelivery, "some-topic", ByteString("some-payload"))
       val publishBytes = publish.encode(ByteString.newBuilder, None).result()
 
       client.offer(Command(connect))
@@ -491,10 +491,10 @@ class MqttSessionSpec
 
       val subscribe = Subscribe("some-topic")
       val subscribeBytes = subscribe.encode(ByteString.newBuilder, PacketId(1)).result()
-      val subAck = SubAck(PacketId(1), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val subAck = SubAck(PacketId(1), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val subAckBytes = subAck.encode(ByteString.newBuilder).result()
 
-      val publish = Publish(ControlPacketFlags.QoSAtLeastOnceDelivery, "some-topic", ByteString("some-payload"))
+      val publish = Publish(PublishQoSFlags.QoSAtLeastOnceDelivery, "some-topic", ByteString("some-payload"))
       val publishBytes = publish.encode(ByteString.newBuilder, Some(PacketId(1))).result()
       val pubAck = PubAck(PacketId(1))
       val pubAckBytes = pubAck.encode(ByteString.newBuilder).result()
@@ -552,10 +552,10 @@ class MqttSessionSpec
 
       val subscribe = Subscribe("some-topic")
       val subscribeBytes = subscribe.encode(ByteString.newBuilder, PacketId(1)).result()
-      val subAck = SubAck(PacketId(1), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val subAck = SubAck(PacketId(1), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val subAckBytes = subAck.encode(ByteString.newBuilder).result()
 
-      val publish = Publish(ControlPacketFlags.QoSAtLeastOnceDelivery, "some-topic", ByteString("some-payload"))
+      val publish = Publish(PublishQoSFlags.QoSAtLeastOnceDelivery, "some-topic", ByteString("some-payload"))
       val publishBytes = publish.encode(ByteString.newBuilder, Some(PacketId(1))).result()
       val pubAck = PubAck(PacketId(1))
       val pubAckBytes = pubAck.encode(ByteString.newBuilder).result()
@@ -630,13 +630,13 @@ class MqttSessionSpec
 
       val subscribe = Subscribe("some-topic")
       val subscribe1Bytes = subscribe.encode(ByteString.newBuilder, PacketId(1)).result()
-      val subAck1 = SubAck(PacketId(1), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val subAck1 = SubAck(PacketId(1), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val subAck1Bytes = subAck1.encode(ByteString.newBuilder).result()
       val subscribe2Bytes = subscribe.encode(ByteString.newBuilder, PacketId(2)).result()
-      val subAck2 = SubAck(PacketId(2), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val subAck2 = SubAck(PacketId(2), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val subAck2Bytes = subAck2.encode(ByteString.newBuilder).result()
 
-      val publish = Publish(ControlPacketFlags.QoSAtLeastOnceDelivery, "some-topic", ByteString("some-payload"))
+      val publish = Publish(PublishQoSFlags.QoSAtLeastOnceDelivery, "some-topic", ByteString("some-payload"))
       val publishBytes = publish.encode(ByteString.newBuilder, Some(PacketId(1))).result()
       val pubAck = PubAck(PacketId(1))
 
@@ -702,7 +702,7 @@ class MqttSessionSpec
       val connAck = ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)
       val connAckBytes = connAck.encode(ByteString.newBuilder).result()
 
-      val publish = Publish(ControlPacketFlags.QoSAtLeastOnceDelivery | ControlPacketFlags.DUP,
+      val publish = Publish(PublishQoSFlags.QoSAtLeastOnceDelivery | ControlPacketFlags.DUP,
                             "some-topic",
                             ByteString("some-payload"))
       val publishBytes = publish.encode(ByteString.newBuilder, Some(PacketId(1))).result()
@@ -755,10 +755,10 @@ class MqttSessionSpec
 
       val subscribe = Subscribe("some-topic")
       val subscribeBytes = subscribe.encode(ByteString.newBuilder, PacketId(1)).result()
-      val subAck = SubAck(PacketId(1), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val subAck = SubAck(PacketId(1), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val subAckBytes = subAck.encode(ByteString.newBuilder).result()
 
-      val publish = Publish(ControlPacketFlags.QoSExactlyOnceDelivery, "some-topic", ByteString("some-payload"))
+      val publish = Publish(PublishQoSFlags.QoSExactlyOnceDelivery, "some-topic", ByteString("some-payload"))
       val publishBytes = publish.encode(ByteString.newBuilder, Some(PacketId(1))).result()
       val pubRec = PubRec(PacketId(1))
       val pubRecBytes = pubRec.encode(ByteString.newBuilder).result()
@@ -815,7 +815,7 @@ class MqttSessionSpec
       val connAck = ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)
       val connAckBytes = connAck.encode(ByteString.newBuilder).result()
 
-      val publish = Publish(ControlPacketFlags.QoSAtMostOnceDelivery, "some-topic", ByteString("some-payload"))
+      val publish = Publish(PublishQoSFlags.QoSAtMostOnceDelivery, "some-topic", ByteString("some-payload"))
       val publishBytes = publish.encode(ByteString.newBuilder, None).result()
 
       client.offer(Command(connect))
@@ -1067,7 +1067,7 @@ class MqttSessionSpec
       val connAck = ConnAck(ConnAckFlags.None, ConnAckReturnCode.ConnectionAccepted)
       val connAckBytes = connAck.encode(ByteString.newBuilder).result()
 
-      val publish = Publish(ControlPacketFlags.QoSExactlyOnceDelivery, "some-topic", ByteString("some-payload"))
+      val publish = Publish(PublishQoSFlags.QoSExactlyOnceDelivery, "some-topic", ByteString("some-payload"))
       val publishBytes = publish.encode(ByteString.newBuilder, Some(PacketId(1))).result()
       val carry = "some-carry"
       val pubRec = PubRec(PacketId(1))
@@ -1215,7 +1215,7 @@ class MqttSessionSpec
 
       val subscribe = Subscribe("some-topic")
       val subscribeBytes = subscribe.encode(ByteString.newBuilder, PacketId(1)).result()
-      val subAck = SubAck(PacketId(1), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val subAck = SubAck(PacketId(1), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val subAckBytes = subAck.encode(ByteString.newBuilder).result()
 
       val unsubscribe = Unsubscribe("some-topic")
@@ -1344,7 +1344,7 @@ class MqttSessionSpec
       val connAckBytes = connAck.encode(ByteString.newBuilder).result()
 
       val subscribeBytes = subscribe.encode(ByteString.newBuilder, PacketId(1)).result()
-      val subAck = SubAck(PacketId(1), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val subAck = SubAck(PacketId(1), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val subAckBytes = subAck.encode(ByteString.newBuilder).result()
 
       val publishBytes = publish.encode(ByteString.newBuilder, Some(PacketId(1))).result()
@@ -1443,11 +1443,11 @@ class MqttSessionSpec
       val connAckBytes = connAck.encode(ByteString.newBuilder).result()
 
       val subscribe1Bytes = subscribe.encode(ByteString.newBuilder, PacketId(1)).result()
-      val sub1Ack = SubAck(PacketId(1), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val sub1Ack = SubAck(PacketId(1), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val sub1AckBytes = sub1Ack.encode(ByteString.newBuilder).result()
 
       val subscribe2Bytes = subscribe.encode(ByteString.newBuilder, PacketId(2)).result()
-      val sub2Ack = SubAck(PacketId(2), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val sub2Ack = SubAck(PacketId(2), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val sub2AckBytes = sub2Ack.encode(ByteString.newBuilder).result()
 
       fromClientQueue.offer(connectBytes)
@@ -1521,7 +1521,7 @@ class MqttSessionSpec
       val connAckBytes = connAck.encode(ByteString.newBuilder).result()
 
       val subscribeBytes = subscribe.encode(ByteString.newBuilder, PacketId(1)).result()
-      val subAck = SubAck(PacketId(1), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val subAck = SubAck(PacketId(1), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val subAckBytes = subAck.encode(ByteString.newBuilder).result()
 
       val publish = Publish("some-topic", ByteString("some-payload"))
@@ -1794,7 +1794,7 @@ class MqttSessionSpec
       val connAckBytes = connAck.encode(ByteString.newBuilder).result()
 
       val subscribeBytes = subscribe.encode(ByteString.newBuilder, PacketId(1)).result()
-      val subAck = SubAck(PacketId(1), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val subAck = SubAck(PacketId(1), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val subAckBytes = subAck.encode(ByteString.newBuilder).result()
 
       val disconnectBytes = disconnect.encode(ByteString.newBuilder).result()
@@ -2002,7 +2002,7 @@ class MqttSessionSpec
       val connAckBytes = connAck.encode(ByteString.newBuilder).result()
 
       val subscribeBytes = subscribe.encode(ByteString.newBuilder, PacketId(1)).result()
-      val subAck = SubAck(PacketId(1), List(ControlPacketFlags.QoSAtLeastOnceDelivery))
+      val subAck = SubAck(PacketId(1), List(SubscribeQoSFlags.QoSAtLeastOnceDelivery))
       val subAckBytes = subAck.encode(ByteString.newBuilder).result()
 
       val publish = Publish("some-topic", ByteString("some-payload"))


### PR DESCRIPTION
As @ohze pointed out a long while ago, when subscribing Alpakka MQTT streaming sent the Quality of Service uncorrectly.

With the details @sbmpost added it became apparent that the code made the wrong assumption the QoS was encoded the same for Subscribe and Publish, but it is not.

The first commit contains the test case suggested by @ohze.
The second commit changes the API slightly to separate QoS encoding for the two message types.
The third commit re-enables a test case that was ignored due to regular failure. Which seems related.

Fixes
- #2731 
- #1549