### PR TITLE
bump: ScalaTest 2.3.15 (was 2.3.11) + drop ScalaTest+ Mockito

### DIFF
--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpMocking.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpMocking.scala
@@ -6,17 +6,17 @@ package akka.stream.alpakka.amqp.scaladsl
 
 import com.rabbitmq.client.{Address, Channel, ConfirmCallback, ConfirmListener, Connection, ConnectionFactory}
 import org.mockito.ArgumentMatchers._
-import org.scalatestplus.mockito.MockitoSugar
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.when
 
-trait AmqpMocking extends MockitoSugar {
+trait AmqpMocking {
 
-  val channelMock: Channel = mock[Channel]
+  val channelMock: Channel = mock(classOf[Channel])
 
-  val connectionMock: Connection = mock[Connection]
+  val connectionMock: Connection = mock(classOf[Connection])
 
   def connectionFactoryMock: ConnectionFactory = {
-    val connectionFactory = mock[ConnectionFactory]
+    val connectionFactory = mock(classOf[ConnectionFactory])
 
     when(connectionFactory.newConnection(any[java.util.List[Address]]))
       .thenReturn(connectionMock)
@@ -25,7 +25,7 @@ trait AmqpMocking extends MockitoSugar {
       .thenReturn(channelMock)
 
     when(channelMock.addConfirmListener(any[ConfirmCallback](), any[ConfirmCallback]()))
-      .thenReturn(mock[ConfirmListener])
+      .thenReturn(mock(classOf[ConfirmListener]))
 
     connectionFactory
   }

--- a/aws-event-bridge/src/test/scala/akka/stream/alpakka/aws/eventbridge/DefaultTestContext.scala
+++ b/aws-event-bridge/src/test/scala/akka/stream/alpakka/aws/eventbridge/DefaultTestContext.scala
@@ -6,17 +6,17 @@ package akka.stream.alpakka.aws.eventbridge
 
 import akka.actor.ActorSystem
 import org.mockito.Mockito.reset
+import org.mockito.Mockito.mock
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
-import org.scalatestplus.mockito.MockitoSugar
 import software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-trait DefaultTestContext extends BeforeAndAfterAll with BeforeAndAfterEach with MockitoSugar { this: Suite =>
+trait DefaultTestContext extends BeforeAndAfterAll with BeforeAndAfterEach { this: Suite =>
 
   implicit protected val system: ActorSystem = ActorSystem()
-  implicit protected val eventBridgeClient: EventBridgeAsyncClient = mock[EventBridgeAsyncClient]
+  implicit protected val eventBridgeClient: EventBridgeAsyncClient = mock(classOf[EventBridgeAsyncClient])
 
   override protected def beforeEach(): Unit =
     reset(eventBridgeClient)

--- a/awslambda/src/test/scala/docs/scaladsl/AwsLambdaFlowSpec.scala
+++ b/awslambda/src/test/scala/docs/scaladsl/AwsLambdaFlowSpec.scala
@@ -21,7 +21,6 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import org.scalatestplus.mockito.MockitoSugar
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.lambda.LambdaAsyncClient
 import software.amazon.awssdk.services.lambda.model.{InvokeRequest, InvokeResponse}
@@ -36,12 +35,11 @@ class AwsLambdaFlowSpec
     with BeforeAndAfterEach
     with ScalaFutures
     with Matchers
-    with MockitoSugar
     with LogCapturing {
 
   implicit val ec = system.dispatcher
 
-  implicit val awsLambdaClient = mock[LambdaAsyncClient]
+  implicit val awsLambdaClient = mock(classOf[LambdaAsyncClient])
 
   override protected def afterEach(): Unit = {
     reset(awsLambdaClient)

--- a/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
@@ -52,7 +52,7 @@ public class CassandraFlowTest {
 
   @AfterClass
   public static void afterAll() {
-    helper.shutdown();
+    if (helper != null) helper.shutdown();
   }
 
   ActorSystem system = helper.system;

--- a/cassandra/src/test/java/docs/javadsl/CassandraTestHelper.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraTestHelper.java
@@ -55,7 +55,7 @@ public class CassandraTestHelper {
   }
 
   public static <T> T await(Future<T> future) {
-    int seconds = 10;
+    int seconds = 15;
     try {
       return Await.result(future, FiniteDuration.create(seconds, TimeUnit.SECONDS));
     } catch (InterruptedException e) {

--- a/google-cloud-bigquery-storage/src/test/scala/docs/scaladsl/ExampleReader.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/docs/scaladsl/ExampleReader.scala
@@ -7,13 +7,8 @@ package docs.scaladsl
 import akka.actor.ActorSystem
 import akka.http.scaladsl.unmarshalling.FromByteStringUnmarshaller
 import akka.stream.alpakka.googlecloud.bigquery.storage.{BigQueryRecord, BigQueryStorageSettings}
-import akka.stream.alpakka.googlecloud.bigquery.storage.scaladsl.{
-  BigQueryArrowStorage,
-  BigQueryAvroStorage,
-  BigQueryStorageAttributes,
-  GrpcBigQueryStorageReader
-}
-import org.scalatestplus.mockito.MockitoSugar.mock
+import akka.stream.alpakka.googlecloud.bigquery.storage.scaladsl.{BigQueryArrowStorage, BigQueryAvroStorage, BigQueryStorageAttributes, GrpcBigQueryStorageReader}
+import org.mockito.Mockito
 
 //#read-all
 import akka.NotUsed
@@ -45,7 +40,7 @@ class ExampleReader {
 
   //#read-merged
   implicit val unmarshaller: FromByteStringUnmarshaller[List[BigQueryRecord]] =
-    mock[FromByteStringUnmarshaller[List[BigQueryRecord]]]
+    Mockito.mock(classOf[FromByteStringUnmarshaller[List[BigQueryRecord]]])
   val sequentialSource: Source[List[BigQueryRecord], Future[NotUsed]] =
     BigQueryStorage.createMergedStreams("projectId", "datasetId", "tableId", DataFormat.AVRO)
   //#read-merged

--- a/google-cloud-bigquery-storage/src/test/scala/docs/scaladsl/ExampleReader.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/docs/scaladsl/ExampleReader.scala
@@ -13,7 +13,7 @@ import akka.stream.alpakka.googlecloud.bigquery.storage.scaladsl.{
   BigQueryStorageAttributes,
   GrpcBigQueryStorageReader
 }
-import org.mockito.Mockito
+import org.mockito.Mockito.mock
 
 //#read-all
 import akka.NotUsed
@@ -45,7 +45,7 @@ class ExampleReader {
 
   //#read-merged
   implicit val unmarshaller: FromByteStringUnmarshaller[List[BigQueryRecord]] =
-    Mockito.mock(classOf[FromByteStringUnmarshaller[List[BigQueryRecord]]])
+    mock(classOf[FromByteStringUnmarshaller[List[BigQueryRecord]]])
   val sequentialSource: Source[List[BigQueryRecord], Future[NotUsed]] =
     BigQueryStorage.createMergedStreams("projectId", "datasetId", "tableId", DataFormat.AVRO)
   //#read-merged

--- a/google-cloud-bigquery-storage/src/test/scala/docs/scaladsl/ExampleReader.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/docs/scaladsl/ExampleReader.scala
@@ -7,7 +7,12 @@ package docs.scaladsl
 import akka.actor.ActorSystem
 import akka.http.scaladsl.unmarshalling.FromByteStringUnmarshaller
 import akka.stream.alpakka.googlecloud.bigquery.storage.{BigQueryRecord, BigQueryStorageSettings}
-import akka.stream.alpakka.googlecloud.bigquery.storage.scaladsl.{BigQueryArrowStorage, BigQueryAvroStorage, BigQueryStorageAttributes, GrpcBigQueryStorageReader}
+import akka.stream.alpakka.googlecloud.bigquery.storage.scaladsl.{
+  BigQueryArrowStorage,
+  BigQueryAvroStorage,
+  BigQueryStorageAttributes,
+  GrpcBigQueryStorageReader
+}
 import org.mockito.Mockito
 
 //#read-all

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
@@ -23,12 +23,7 @@ import org.scalatest.matchers.should.Matchers
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
-class GooglePubSubSpec
-    extends AnyFlatSpec
-    with ScalaFutures
-    with Matchers
-    with LogCapturing
-    with BeforeAndAfterAll {
+class GooglePubSubSpec extends AnyFlatSpec with ScalaFutures with Matchers with LogCapturing with BeforeAndAfterAll {
 
   implicit val defaultPatience =
     PatienceConfig(timeout = 5.seconds, interval = 100.millis)

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
@@ -19,14 +19,12 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.mockito.MockitoSugar
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
 class GooglePubSubSpec
     extends AnyFlatSpec
-    with MockitoSugar
     with ScalaFutures
     with Matchers
     with LogCapturing
@@ -42,7 +40,7 @@ class GooglePubSubSpec
   }
 
   private trait Fixtures {
-    lazy val mockHttpApi = mock[PubSubApi]
+    lazy val mockHttpApi = mock(classOf[PubSubApi])
     lazy val googlePubSub = new GooglePubSub {
       override val httpApi = mockHttpApi
     }
@@ -52,7 +50,7 @@ class GooglePubSubSpec
     def tokenFlow[T]: Flow[T, (T, Option[String]), NotUsed] =
       Flow[T].map(request => (request, Some("ok")))
 
-    val http: HttpExt = mock[HttpExt]
+    val http: HttpExt = mock(classOf[HttpExt])
     val config = PubSubConfig()
   }
 

--- a/google-common/src/test/scala/akka/stream/alpakka/google/http/GoogleHttpSpec.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/http/GoogleHttpSpec.scala
@@ -21,7 +21,7 @@ import akka.stream.alpakka.google.{GoogleHttpException, GoogleSettings, RequestS
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.testkit.TestKit
 import org.mockito.ArgumentMatchers.{any, anyInt, argThat}
-import org.mockito.Mockito.{when, mock}
+import org.mockito.Mockito.{mock, when}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers

--- a/google-common/src/test/scala/akka/stream/alpakka/google/http/GoogleHttpSpec.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/http/GoogleHttpSpec.scala
@@ -21,12 +21,11 @@ import akka.stream.alpakka.google.{GoogleHttpException, GoogleSettings, RequestS
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.testkit.TestKit
 import org.mockito.ArgumentMatchers.{any, anyInt, argThat}
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{when, mock}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import org.scalatestplus.mockito.MockitoSugar
 import spray.json.{JsObject, JsValue}
 
 import scala.annotation.nowarn
@@ -38,13 +37,12 @@ class GoogleHttpSpec
     with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures
-    with MockitoSugar {
+    with ScalaFutures {
 
   override def afterAll(): Unit = TestKit.shutdownActorSystem(system)
 
   def mockHttp: HttpExt = {
-    val http = mock[HttpExt]
+    val http = mock(classOf[HttpExt])
     when(http.system) thenReturn system.asInstanceOf[ExtendedActorSystem]
     http
   }
@@ -62,8 +60,8 @@ class GoogleHttpSpec
     ).thenReturn(Flow[Any]
                    .zipWith(response)(Keep.right)
                    .map(Try(_))
-                   .map((_, mock[Nothing]))
-                   .mapMaterializedValue(_ => mock[HostConnectionPool]),
+                   .map((_, mock(classOf[Nothing])))
+                   .mapMaterializedValue(_ => mock(classOf[HostConnectionPool])),
                  Nil: _*): @nowarn("msg=dead code")
     http
   }
@@ -157,7 +155,7 @@ class GoogleHttpSpec
 
       final class AnotherException extends RuntimeException
 
-      val credentials = mock[Credentials]
+      val credentials = mock(classOf[Credentials])
       when(credentials.get()(any[ExecutionContext], any[RequestSettings])).thenReturn(
         Future.failed(GoogleOAuth2Exception(ErrorInfo())),
         Future.failed(new AnotherException)

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/v1/impl/FcmSenderSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/v1/impl/FcmSenderSpec.scala
@@ -17,7 +17,7 @@ import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{doReturn, verify, when, mock}
+import org.mockito.Mockito.{doReturn, mock, verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpecLike

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/v1/impl/FcmSenderSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/v1/impl/FcmSenderSpec.scala
@@ -17,9 +17,8 @@ import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{doReturn, verify, when}
+import org.mockito.Mockito.{doReturn, verify, when, mock}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -33,7 +32,6 @@ class FcmSenderSpec
     with AnyWordSpecLike
     with Matchers
     with ScalaFutures
-    with MockitoSugar
     with BeforeAndAfterAll
     with LogCapturing {
 
@@ -54,7 +52,7 @@ class FcmSenderSpec
 
     "call the api as the docs want to" in {
       val sender = new FcmSender
-      val http = mock[HttpExt]
+      val http = mock(classOf[HttpExt])
       when(
         http.singleRequest(any[HttpRequest](),
                            any[HttpsConnectionContext](),
@@ -81,7 +79,7 @@ class FcmSenderSpec
 
     "parse the success response correctly" in {
       val sender = new FcmSender
-      val http = mock[HttpExt]
+      val http = mock(classOf[HttpExt])
       when(
         http.singleRequest(any[HttpRequest](),
                            any[HttpsConnectionContext](),
@@ -99,7 +97,7 @@ class FcmSenderSpec
 
     "parse the error response correctly" in {
       val sender = new FcmSender
-      val http = mock[HttpExt]
+      val http = mock(classOf[HttpExt])
       when(
         http.singleRequest(any[HttpRequest](),
                            any[HttpsConnectionContext](),

--- a/huawei-push-kit/src/test/scala/akka/stream/alpakka/huawei/pushkit/impl/HmsTokenApiSpec.scala
+++ b/huawei-push-kit/src/test/scala/akka/stream/alpakka/huawei/pushkit/impl/HmsTokenApiSpec.scala
@@ -16,12 +16,11 @@ import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito.{mock, verify, when}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.DurationInt
@@ -31,7 +30,6 @@ class HmsTokenApiSpec
     with AnyWordSpecLike
     with Matchers
     with ScalaFutures
-    with MockitoSugar
     with BeforeAndAfterAll
     with LogCapturing {
 
@@ -49,7 +47,7 @@ class HmsTokenApiSpec
 
     "call the api as the docs want to" in {
 
-      val http = mock[HttpExt]
+      val http = mock(classOf[HttpExt])
       when(
         http.singleRequest(any[HttpRequest](),
                            any[HttpsConnectionContext](),
@@ -82,7 +80,7 @@ class HmsTokenApiSpec
     }
 
     "return the token" in {
-      val http = mock[HttpExt]
+      val http = mock(classOf[HttpExt])
       when(
         http.singleRequest(any[HttpRequest](),
                            any[HttpsConnectionContext](),

--- a/huawei-push-kit/src/test/scala/akka/stream/alpakka/huawei/pushkit/impl/PushKitSenderSpec.scala
+++ b/huawei-push-kit/src/test/scala/akka/stream/alpakka/huawei/pushkit/impl/PushKitSenderSpec.scala
@@ -16,13 +16,12 @@ import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito.{verify, mock, when}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 import org.scalatest.wordspec.AnyWordSpecLike
-import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.{Await, ExecutionContext, Future}
 
@@ -31,7 +30,6 @@ class PushKitSenderSpec
     with AnyWordSpecLike
     with Matchers
     with ScalaFutures
-    with MockitoSugar
     with BeforeAndAfterAll
     with LogCapturing {
 
@@ -51,7 +49,7 @@ class PushKitSenderSpec
 
     "call the api as the docs want to" in {
       val sender = new PushKitSender
-      val http = mock[HttpExt]
+      val http = mock(classOf[HttpExt])
       when(
         http.singleRequest(any[HttpRequest](),
                            any[HttpsConnectionContext](),
@@ -83,7 +81,7 @@ class PushKitSenderSpec
 
     "parse the success response correctly" in {
       val sender = new PushKitSender
-      val http = mock[HttpExt]
+      val http = mock(classOf[HttpExt])
       when(
         http.singleRequest(any[HttpRequest](),
                            any[HttpsConnectionContext](),
@@ -105,7 +103,7 @@ class PushKitSenderSpec
 
     "parse the error response correctly" in {
       val sender = new PushKitSender
-      val http = mock[HttpExt]
+      val http = mock(classOf[HttpExt])
       when(
         http.singleRequest(any[HttpRequest](),
                            any[HttpsConnectionContext](),

--- a/huawei-push-kit/src/test/scala/akka/stream/alpakka/huawei/pushkit/impl/PushKitSenderSpec.scala
+++ b/huawei-push-kit/src/test/scala/akka/stream/alpakka/huawei/pushkit/impl/PushKitSenderSpec.scala
@@ -16,7 +16,7 @@ import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{verify, mock, when}
+import org.mockito.Mockito.{mock, verify, when}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsProducerRetrySpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsProducerRetrySpec.scala
@@ -11,7 +11,7 @@ import akka.stream.alpakka.jms.scaladsl.{JmsConsumer, JmsProducer}
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import javax.jms.{JMSException, Message, TextMessage}
 import org.mockito.ArgumentMatchers.{any, anyInt, anyLong}
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{mock, when}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 
@@ -173,7 +173,7 @@ class JmsProducerRetrySpec extends JmsSpec {
     "retry send as often as configured" in withMockedProducer { ctx =>
       import ctx._
       val sendAttempts = new AtomicInteger()
-      val message = mock[TextMessage]
+      val message = mock(classOf[TextMessage])
 
       when(session.createTextMessage(any[String])).thenReturn(message)
 
@@ -202,7 +202,7 @@ class JmsProducerRetrySpec extends JmsSpec {
     "fail send on first attempt if retry is disabled" in withMockedProducer { ctx =>
       import ctx._
       val sendAttempts = new AtomicInteger()
-      val message = mock[TextMessage]
+      val message = mock(classOf[TextMessage])
 
       when(session.createTextMessage(any[String])).thenReturn(message)
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsSpec.scala
@@ -7,15 +7,15 @@ package akka.stream.alpakka.jms
 import akka.actor.ActorSystem
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.testkit.TestKit
-import javax.jms._
 import jmstestkit.JmsBroker
 import org.mockito.ArgumentMatchers.{any, anyBoolean, anyInt}
-import org.mockito.Mockito.when
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.mockito.Mockito.{mock, when}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+
+import javax.jms._
 
 abstract class JmsSpec
     extends AnyWordSpec
@@ -24,7 +24,6 @@ abstract class JmsSpec
     with BeforeAndAfterEach
     with ScalaFutures
     with Eventually
-    with MockitoSugar
     with LogCapturing {
 
   implicit val system = ActorSystem(this.getClass.getSimpleName)
@@ -55,22 +54,22 @@ abstract class JmsSpec
 
   def withMockedProducer(test: ProducerMock => Unit): Unit = test(ProducerMock())
 
-  case class ProducerMock(factory: ConnectionFactory = mock[ConnectionFactory],
-                          connection: Connection = mock[Connection],
-                          session: Session = mock[Session],
-                          producer: MessageProducer = mock[MessageProducer],
-                          queue: javax.jms.Queue = mock[javax.jms.Queue]) {
+  case class ProducerMock(factory: ConnectionFactory = mock(classOf[ConnectionFactory]),
+                          connection: Connection = mock(classOf[Connection]),
+                          session: Session = mock(classOf[Session]),
+                          producer: MessageProducer = mock(classOf[MessageProducer]),
+                          queue: javax.jms.Queue = mock(classOf[javax.jms.Queue])) {
     when(factory.createConnection()).thenReturn(connection)
     when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session)
     when(session.createProducer(any[javax.jms.Destination])).thenReturn(producer)
     when(session.createQueue(any[String])).thenReturn(queue)
   }
 
-  case class ConsumerMock(factory: ConnectionFactory = mock[ConnectionFactory],
-                          connection: Connection = mock[Connection],
-                          session: Session = mock[Session],
-                          consumer: MessageConsumer = mock[MessageConsumer],
-                          queue: javax.jms.Queue = mock[javax.jms.Queue]) {
+  case class ConsumerMock(factory: ConnectionFactory = mock(classOf[ConnectionFactory]),
+                          connection: Connection = mock(classOf[Connection]),
+                          session: Session = mock(classOf[Session]),
+                          consumer: MessageConsumer = mock(classOf[MessageConsumer]),
+                          queue: javax.jms.Queue = mock(classOf[javax.jms.Queue])) {
     when(factory.createConnection()).thenReturn(connection)
     when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session)
     when(session.createConsumer(any[javax.jms.Destination])).thenReturn(consumer)

--- a/jms/src/test/scala/akka/stream/alpakka/jms/impl/JmsMessageProducerSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/impl/JmsMessageProducerSpec.scala
@@ -8,19 +8,18 @@ import akka.stream.alpakka.jms.{Destination, _}
 import javax.jms.{Destination => JmsDestination, _}
 import org.mockito.ArgumentMatchers.{any, anyBoolean, anyInt, anyString}
 import org.mockito.Mockito._
-import org.scalatestplus.mockito.MockitoSugar
 
-class JmsMessageProducerSpec extends JmsSpec with MockitoSugar {
+class JmsMessageProducerSpec extends JmsSpec {
 
   trait Setup {
-    val factory: ConnectionFactory = mock[ConnectionFactory]
-    val connection: Connection = mock[Connection]
-    val session: Session = mock[Session]
-    val destination: JmsDestination = mock[JmsDestination]
-    val producer: MessageProducer = mock[MessageProducer]
-    val textMessage: TextMessage = mock[TextMessage]
-    val mapMessage: MapMessage = mock[MapMessage]
-    val settingsDestination: Destination = mock[Destination]
+    val factory: ConnectionFactory = mock(classOf[ConnectionFactory])
+    val connection: Connection = mock(classOf[Connection])
+    val session: Session = mock(classOf[Session])
+    val destination: JmsDestination = mock(classOf[JmsDestination])
+    val producer: MessageProducer = mock(classOf[MessageProducer])
+    val textMessage: TextMessage = mock(classOf[TextMessage])
+    val mapMessage: MapMessage = mock(classOf[MapMessage])
+    val settingsDestination: Destination = mock(classOf[Destination])
 
     when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session)
     when(session.createProducer(any[javax.jms.Destination])).thenReturn(producer)

--- a/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
@@ -866,7 +866,7 @@ class JmsConnectorsSpec extends JmsSpec {
     "produce elements in order" in withMockedProducer { ctx =>
       import ctx._
       val delays = new AtomicInteger()
-      val textMessage = mock[TextMessage]
+      val textMessage = mock(classOf[TextMessage])
 
       val delayedSend = new Answer[Unit] {
         override def answer(invocation: InvocationOnMock): Unit = {
@@ -895,7 +895,7 @@ class JmsConnectorsSpec extends JmsSpec {
       val sendLatch = new CountDownLatch(3)
       val receiveLatch = new CountDownLatch(3)
 
-      val messages = (1 to 10).map(i => mock[TextMessage] -> i).toMap
+      val messages = (1 to 10).map(i => mock(classOf[TextMessage]) -> i).toMap
       messages.foreach {
         case (msg, i) => when(session.createTextMessage(i.toString)).thenReturn(msg)
       }
@@ -939,7 +939,7 @@ class JmsConnectorsSpec extends JmsSpec {
     "put back JmsProducer to the pool when send fails" in withMockedProducer { ctx =>
       import ctx._
 
-      val messages = (1 to 10).map(i => mock[TextMessage] -> i).toMap
+      val messages = (1 to 10).map(i => mock(classOf[TextMessage]) -> i).toMap
       messages.foreach {
         case (msg, i) => when(session.createTextMessage(i.toString)).thenReturn(msg)
       }
@@ -974,7 +974,7 @@ class JmsConnectorsSpec extends JmsSpec {
       override def answer(invocation: InvocationOnMock): Unit = {
         val listener = invocation.getArgument[MessageListener](0)
         mockMessages.foreach { s =>
-          val message = mock[TextMessage]
+          val message = mock(classOf[TextMessage])
           when(message.getText).thenReturn(s)
           listener.onMessage(message)
         }
@@ -982,10 +982,10 @@ class JmsConnectorsSpec extends JmsSpec {
     }
 
     "reconnect when timing out establishing a connection" in {
-      val factory = mock[ConnectionFactory]
-      val connection = mock[Connection]
-      val session = mock[Session]
-      val consumer = mock[MessageConsumer]
+      val factory = mock(classOf[ConnectionFactory])
+      val connection = mock(classOf[Connection])
+      val session = mock(classOf[Session])
+      val consumer = mock(classOf[MessageConsumer])
       @volatile var connectCount = 0
       val connectTimeout = 2.seconds
       val connectDelay = 10.seconds
@@ -1020,10 +1020,10 @@ class JmsConnectorsSpec extends JmsSpec {
     }
 
     "reconnect when timing out starting a connection" in {
-      val factory = mock[ConnectionFactory]
-      val connection = mock[Connection]
-      val session = mock[Session]
-      val consumer = mock[MessageConsumer]
+      val factory = mock(classOf[ConnectionFactory])
+      val connection = mock(classOf[Connection])
+      val session = mock(classOf[Session])
+      val consumer = mock(classOf[MessageConsumer])
       @volatile var connectStartCount = 0
       val connectTimeout = 2.seconds
       val connectStartDelay = 10.seconds
@@ -1059,10 +1059,10 @@ class JmsConnectorsSpec extends JmsSpec {
     }
 
     "reconnect when runtime connection exception occurs" in {
-      val factory = mock[ConnectionFactory]
-      val connection = mock[Connection]
-      val session = mock[Session]
-      val consumer = mock[MessageConsumer]
+      val factory = mock(classOf[ConnectionFactory])
+      val connection = mock(classOf[Connection])
+      val session = mock(classOf[Session])
+      val consumer = mock(classOf[MessageConsumer])
       @volatile var connectCount = 0
       @volatile var exceptionListener: Option[ExceptionListener] = None
       val messageGroups = mockMessages.grouped(3)
@@ -1088,7 +1088,7 @@ class JmsConnectorsSpec extends JmsSpec {
           val listener = invocation.getArgument[MessageListener](0)
           val thisMessageGroup = messageGroups.next()
           thisMessageGroup.foreach { s =>
-            val message = mock[TextMessage]
+            val message = mock(classOf[TextMessage])
             when(message.getText).thenReturn(s)
             listener.onMessage(message)
           }
@@ -1140,11 +1140,11 @@ class JmsConnectorsSpec extends JmsSpec {
     }
 
     "pass through empty envelopes" in {
-      val connectionFactory = mock[ConnectionFactory]
-      val connection = mock[Connection]
-      val session = mock[Session]
-      val producer = mock[MessageProducer]
-      val message = mock[TextMessage]
+      val connectionFactory = mock(classOf[ConnectionFactory])
+      val connection = mock(classOf[Connection])
+      val session = mock(classOf[Session])
+      val producer = mock(classOf[MessageProducer])
+      val message = mock(classOf[TextMessage])
 
       when(connectionFactory.createConnection()).thenReturn(connection)
       when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session)

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/DefaultTestContext.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/DefaultTestContext.scala
@@ -8,13 +8,12 @@ import java.util.concurrent.{Executors, TimeoutException}
 
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 
 import scala.concurrent.duration._
 import scala.concurrent.{blocking, Await, ExecutionContext, ExecutionContextExecutor}
 
-trait DefaultTestContext extends BeforeAndAfterAll with BeforeAndAfterEach with MockitoSugar { this: Suite =>
+trait DefaultTestContext extends BeforeAndAfterAll with BeforeAndAfterEach { this: Suite =>
 
   implicit protected val system: ActorSystem = ActorSystem(
     "KinesisTests",

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisMock.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisMock.scala
@@ -5,18 +5,17 @@
 package akka.stream.alpakka.kinesis
 
 import akka.actor.ActorSystem
-import org.mockito.Mockito.reset
+import org.mockito.Mockito.{mock, reset}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
-import org.scalatestplus.mockito.MockitoSugar
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-trait KinesisMock extends BeforeAndAfterAll with BeforeAndAfterEach with MockitoSugar { this: Suite =>
+trait KinesisMock extends BeforeAndAfterAll with BeforeAndAfterEach { this: Suite =>
 
   implicit protected val system: ActorSystem = ActorSystem()
-  implicit protected val amazonKinesisAsync: KinesisAsyncClient = mock[KinesisAsyncClient]
+  implicit protected val amazonKinesisAsync: KinesisAsyncClient = mock(classOf[KinesisAsyncClient])
 
   override protected def beforeEach(): Unit =
     reset(amazonKinesisAsync)

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseMock.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseMock.scala
@@ -5,18 +5,17 @@
 package akka.stream.alpakka.kinesisfirehose
 
 import akka.actor.ActorSystem
-import org.mockito.Mockito.reset
+import org.mockito.Mockito.{mock, reset}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
-import org.scalatestplus.mockito.MockitoSugar
 import software.amazon.awssdk.services.firehose.FirehoseAsyncClient
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-trait KinesisFirehoseMock extends BeforeAndAfterAll with BeforeAndAfterEach with MockitoSugar { this: Suite =>
+trait KinesisFirehoseMock extends BeforeAndAfterAll with BeforeAndAfterEach { this: Suite =>
 
   implicit protected val system: ActorSystem = ActorSystem()
-  implicit protected val amazonKinesisFirehoseAsync: FirehoseAsyncClient = mock[FirehoseAsyncClient]
+  implicit protected val amazonKinesisFirehoseAsync: FirehoseAsyncClient = mock(classOf[FirehoseAsyncClient])
 
   override protected def beforeEach(): Unit =
     reset(amazonKinesisFirehoseAsync)

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
@@ -41,6 +41,9 @@ class MongoSinkSpec
 
   implicit val system = ActorSystem()
 
+  override implicit val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = 10.seconds, interval = 100.millis)
+
   override protected def beforeAll(): Unit =
     Source.fromPublisher(db.drop()).runWith(Sink.headOption).futureValue
 
@@ -52,9 +55,6 @@ class MongoSinkSpec
   private val domainObjectsColl: MongoCollection[DomainObject] =
     db.getCollection("domainObjectsSink", classOf[DomainObject]).withCodecRegistry(codecRegistry)
   private val domainObjectsDocumentColl = db.getCollection("domainObjectsSink")
-
-  implicit val defaultPatience =
-    PatienceConfig(timeout = 10.seconds, interval = 100.millis)
 
   override def afterEach(): Unit = {
     Source.fromPublisher(numbersDocumentColl.deleteMany(new Document())).runWith(Sink.head).futureValue

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
@@ -34,6 +34,9 @@ class MongoSourceSpec
   implicit val system = ActorSystem()
   // #init-system
 
+  override implicit val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = 5.seconds, interval = 50.millis)
+
   override protected def beforeAll(): Unit =
     Source.fromPublisher(db.drop()).runWith(Sink.headOption).futureValue
 
@@ -61,9 +64,6 @@ class MongoSourceSpec
   // #init-connection
 
   private val numbersDocumentColl = db.getCollection("numbers")
-
-  implicit val defaultPatience =
-    PatienceConfig(timeout = 5.seconds, interval = 50.millis)
 
   override def afterEach(): Unit =
     Source.fromPublisher(numbersDocumentColl.deleteMany(new Document())).runWith(Sink.head).futureValue

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
   val AkkaHttpVersion = "10.5.0-M1"
   val AkkaHttpBinaryVersion = "10.5"
   val AlpakkaKafkaVersion = "4.0.2"
-  val ScalaTestVersion = "3.2.11"
+  val ScalaTestVersion = "3.2.15"
   val TestContainersScalaTestVersion = "0.40.3" // pulls Testcontainers 1.16.2
   val mockitoVersion = "4.8.1" // check even https://github.com/scalatest/scalatestplus-mockito/releases
   val hoverflyVersion = "0.14.1"
@@ -58,11 +58,7 @@ object Dependencies {
       )
   )
 
-  val Mockito = Seq(
-    "org.mockito" % "mockito-core" % mockitoVersion % Test,
-    // https://github.com/scalatest/scalatestplus-mockito/releases
-    "org.scalatestplus" %% "mockito-4-2" % (ScalaTestVersion + ".0") % Test
-  )
+  val Mockito = Seq("org.mockito" % "mockito-core" % mockitoVersion % Test)
 
   // Releases https://github.com/FasterXML/jackson-databind/releases
   // CVE issues https://github.com/FasterXML/jackson-databind/issues?utf8=%E2%9C%93&q=+label%3ACVE

--- a/sns/src/test/scala/akka/stream/alpakka/sns/DefaultTestContext.scala
+++ b/sns/src/test/scala/akka/stream/alpakka/sns/DefaultTestContext.scala
@@ -5,18 +5,17 @@
 package akka.stream.alpakka.sns
 
 import akka.actor.ActorSystem
-import org.mockito.Mockito.reset
-import org.scalatestplus.mockito.MockitoSugar
+import org.mockito.Mockito.{mock, reset}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 import software.amazon.awssdk.services.sns.SnsAsyncClient
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-trait DefaultTestContext extends BeforeAndAfterAll with BeforeAndAfterEach with MockitoSugar { this: Suite =>
+trait DefaultTestContext extends BeforeAndAfterAll with BeforeAndAfterEach { this: Suite =>
 
   implicit protected val system: ActorSystem = ActorSystem()
-  implicit protected val snsClient: SnsAsyncClient = mock[SnsAsyncClient]
+  implicit protected val snsClient: SnsAsyncClient = mock(classOf[SnsAsyncClient])
 
   override protected def beforeEach(): Unit =
     reset(snsClient)

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
@@ -17,7 +17,6 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.mockito.MockitoSugar.mock
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
@@ -27,7 +26,7 @@ import scala.concurrent.duration._
 class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestContext with LogCapturing {
 
   "SqsPublishSink" should "send a message" in {
-    implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
+    implicit val sqsClient: SqsAsyncClient = mock(classOf[SqsAsyncClient])
     when(sqsClient.sendMessage(any[SendMessageRequest]))
       .thenReturn(CompletableFuture.completedFuture(SendMessageResponse.builder().build()))
 
@@ -40,7 +39,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
   }
 
   it should "fail stage on client failure and fail the promise" in {
-    implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
+    implicit val sqsClient: SqsAsyncClient = mock(classOf[SqsAsyncClient])
 
     when(sqsClient.sendMessage(any[SendMessageRequest]()))
       .thenReturn(
@@ -87,7 +86,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
   }
 
   it should "failure the promise on upstream failure" in {
-    implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
+    implicit val sqsClient: SqsAsyncClient = mock(classOf[SqsAsyncClient])
     val (probe, future) = TestSource[String]().toMat(SqsPublishSink("notused"))(Keep.both).run()
 
     probe.sendError(new RuntimeException("Fake upstream failure"))
@@ -98,7 +97,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
   }
 
   it should "complete promise after all messages have been sent" in {
-    implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
+    implicit val sqsClient: SqsAsyncClient = mock(classOf[SqsAsyncClient])
 
     when(sqsClient.sendMessage(any[SendMessageRequest]))
       .thenReturn(CompletableFuture.completedFuture(SendMessageResponse.builder().build()))
@@ -118,7 +117,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
   }
 
   it should "send batch of messages" in {
-    implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
+    implicit val sqsClient: SqsAsyncClient = mock(classOf[SqsAsyncClient])
 
     when(sqsClient.sendMessageBatch(any[SendMessageBatchRequest]))
       .thenReturn(
@@ -142,7 +141,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
   }
 
   it should "send all messages in batches of given size" in {
-    implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
+    implicit val sqsClient: SqsAsyncClient = mock(classOf[SqsAsyncClient])
 
     when(sqsClient.sendMessageBatch(any[SendMessageBatchRequest]))
       .thenReturn(
@@ -184,7 +183,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
   }
 
   it should "fail if any of the messages in batch failed" in {
-    implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
+    implicit val sqsClient: SqsAsyncClient = mock(classOf[SqsAsyncClient])
 
     when(sqsClient.sendMessageBatch(any[SendMessageBatchRequest]))
       .thenReturn(
@@ -221,7 +220,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
   }
 
   it should "fail if whole batch is failed" in {
-    implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
+    implicit val sqsClient: SqsAsyncClient = mock(classOf[SqsAsyncClient])
     when(
       sqsClient.sendMessageBatch(any[SendMessageBatchRequest]())
     ).thenReturn(
@@ -250,7 +249,7 @@ class SqsPublishSinkSpec extends AnyFlatSpec with Matchers with DefaultTestConte
   }
 
   it should "send all batches of messages" in {
-    implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
+    implicit val sqsClient: SqsAsyncClient = mock(classOf[SqsAsyncClient])
 
     when(sqsClient.sendMessageBatch(any[SendMessageBatchRequest]))
       .thenReturn(

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceMockSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceMockSpec.scala
@@ -15,7 +15,6 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.mockito.MockitoSugar.mock
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.{Message, ReceiveMessageRequest, ReceiveMessageResponse}
 
@@ -32,7 +31,7 @@ class SqsSourceMockSpec extends AnyFlatSpec with Matchers with DefaultTestContex
   }
 
   "SqsSource" should "send a request and unwrap the response" in {
-    implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
+    implicit val sqsClient: SqsAsyncClient = mock(classOf[SqsAsyncClient])
     when(sqsClient.receiveMessage(any[ReceiveMessageRequest]))
       .thenReturn(
         CompletableFuture.completedFuture(
@@ -61,7 +60,7 @@ class SqsSourceMockSpec extends AnyFlatSpec with Matchers with DefaultTestContex
   }
 
   it should "buffer messages and acquire them fast with slow sqs" in {
-    implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
+    implicit val sqsClient: SqsAsyncClient = mock(classOf[SqsAsyncClient])
     val timeout = 1.second
     val bufferToBatchRatio = 5
 
@@ -98,7 +97,7 @@ class SqsSourceMockSpec extends AnyFlatSpec with Matchers with DefaultTestContex
   }
 
   it should "enable throttling on emptyReceives and disable throttling when a new message arrives" in {
-    implicit val sqsClient: SqsAsyncClient = mock[SqsAsyncClient]
+    implicit val sqsClient: SqsAsyncClient = mock(classOf[SqsAsyncClient])
     val firstWithDataCount = 30
     val thenEmptyCount = 15
     val parallelism = 10

--- a/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
@@ -15,10 +15,9 @@ import akka.stream.alpakka.sqs.SqsAckResultEntry._
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import akka.stream.scaladsl.{Sink, Source}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{spy, times, verify, when}
+import org.mockito.Mockito.{mock, spy, times, verify, when}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.mockito.MockitoSugar.mock
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
@@ -242,7 +241,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
   it should "fail if any of the messages in the batch request failed" in {
     val messages = for (i <- 0 until 10) yield Message.builder().body(s"Message - $i").build()
 
-    implicit val mockAwsSqsClient = mock[SqsAsyncClient]
+    implicit val mockAwsSqsClient = mock(classOf[SqsAsyncClient])
 
     when(mockAwsSqsClient.deleteMessageBatch(any[DeleteMessageBatchRequest]))
       .thenReturn(CompletableFuture.completedFuture {
@@ -263,7 +262,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
   it should "fail if the batch request failed" in {
     val messages = for (i <- 0 until 10) yield Message.builder().body(s"Message - $i").build()
 
-    implicit val mockAwsSqsClient = mock[SqsAsyncClient]
+    implicit val mockAwsSqsClient = mock(classOf[SqsAsyncClient])
 
     when(mockAwsSqsClient.deleteMessageBatch(any[DeleteMessageBatchRequest]))
       .thenReturn(
@@ -284,7 +283,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
   it should "fail if the client invocation failed" in {
     val messages = for (i <- 0 until 10) yield Message.builder().body(s"Message - $i").build()
 
-    implicit val mockAwsSqsClient = mock[SqsAsyncClient]
+    implicit val mockAwsSqsClient = mock(classOf[SqsAsyncClient])
 
     when(
       mockAwsSqsClient.deleteMessageBatch(any[DeleteMessageBatchRequest])
@@ -354,7 +353,7 @@ class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with 
   it should "ignore batch of messages" in {
     val messages = for (i <- 0 until 10) yield Message.builder().body(s"Message - $i").build()
 
-    implicit val mockAwsSqsClient = mock[SqsAsyncClient]
+    implicit val mockAwsSqsClient = mock(classOf[SqsAsyncClient])
 
     val future =
       //#batch-ignore


### PR DESCRIPTION
Dropping the not too useful ScalaTest+ Mockito dependency which is not published for Scala 2.12 for this ScalaTest version.

Fixed some implicit resolution issue in Mongo tests.