### PR TITLE
AWS S3: Add getObjectByRanges to S3 API

### DIFF
--- a/s3/src/main/scala/akka/stream/alpakka/s3/impl/MergeOrderedN.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/impl/MergeOrderedN.scala
@@ -1,0 +1,128 @@
+package akka.stream.alpakka.s3.impl
+
+import akka.annotation.InternalApi
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.stream.{Attributes, Inlet, Outlet, UniformFanInShape}
+
+import scala.collection.{immutable, mutable}
+
+@InternalApi private[impl] object MergeOrderedN {
+  /** @see [[MergeOrderedN]] */
+  def apply[T](inputPorts: Int, breadth: Int) =
+    new MergeOrderedN[T](inputPorts, breadth)
+}
+
+/**
+  * Takes multiple streams (in ascending order of input ports) whose elements will be pushed only if all elements from the
+  * previous stream(s) are already pushed downstream.
+  *
+  * The `breadth` controls how many upstream are pulled in parallel.
+  * That means elements might be received in any order, but will be buffered (if necessary) until their time comes.
+  *
+  * '''Emits when''' the next element from upstream (in ascending order of input ports) is available
+  *
+  * '''Backpressures when''' downstream backpressures
+  *
+  * '''Completes when''' all upstreams complete and there are no more buffered elements
+  *
+  * '''Cancels when''' downstream cancels
+  */
+@InternalApi private[impl] final class MergeOrderedN[T](val inputPorts: Int, val breadth: Int) extends GraphStage[UniformFanInShape[T, T]] {
+  require(inputPorts > 1, "input ports must be > 1")
+  require(breadth > 0, "breadth must be > 0")
+
+  val in: immutable.IndexedSeq[Inlet[T]] = Vector.tabulate(inputPorts)(i => Inlet[T]("MergeOrderedN.in" + i))
+  val out: Outlet[T] = Outlet[T]("MergeOrderedN.out")
+  override val shape: UniformFanInShape[T, T] = UniformFanInShape(out, in: _*)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with OutHandler {
+    private val bufferByInPort = mutable.Map.empty[Int, mutable.Queue[T]] // Queue must not be empty, if so entry should be removed
+    private var currentHeadInPortIdx = 0
+    private var currentLastInPortIdx = 0
+    private val overallLastInPortIdx = inputPorts - 1
+
+    setHandler(out, this)
+
+    in.zipWithIndex.foreach { case (inPort, idx) =>
+      setHandler(inPort, new InHandler {
+        override def onPush(): Unit = {
+          val elem = grab(inPort)
+          if (currentHeadInPortIdx != idx || !isAvailable(out)) {
+            bufferByInPort.updateWith(idx) {
+              case Some(inPortBuffer) =>
+                Some(inPortBuffer.enqueue(elem))
+              case None =>
+                val inPortBuffer = mutable.Queue.empty[T]
+                inPortBuffer.enqueue(elem)
+                Some(inPortBuffer)
+            }
+          } else {
+            pushUsingQueue(Some(elem))
+          }
+          tryPull(inPort)
+        }
+
+        override def onUpstreamFinish(): Unit = {
+          if (canCompleteStage)
+            completeStage()
+          else if (canSlideFrame)
+            slideFrame()
+        }
+      })
+    }
+
+    override def onPull(): Unit = pushUsingQueue()
+
+    private def pushUsingQueue(next: Option[T] = None): Unit = {
+      val maybeBuffer = bufferByInPort.get(currentHeadInPortIdx)
+      if (maybeBuffer.forall(_.isEmpty) && next.nonEmpty) {
+        push(out, next.get)
+      } else if (maybeBuffer.exists(_.nonEmpty) && next.nonEmpty) {
+        maybeBuffer.get.enqueue(next.get)
+        push(out, maybeBuffer.get.dequeue())
+      } else if (maybeBuffer.exists(_.nonEmpty) && next.isEmpty) {
+        push(out, maybeBuffer.get.dequeue())
+      } else {
+        // Both empty
+      }
+
+      if (maybeBuffer.exists(_.isEmpty))
+        bufferByInPort.remove(currentHeadInPortIdx)
+
+      if (canCompleteStage)
+        completeStage()
+      else if (canSlideFrame)
+        slideFrame()
+    }
+
+    override def preStart(): Unit = {
+      if (breadth >= inputPorts) {
+        in.foreach(pull)
+        currentLastInPortIdx = overallLastInPortIdx
+      } else {
+        in.slice(0, breadth).foreach(pull)
+        currentLastInPortIdx = breadth - 1
+      }
+    }
+
+    private def canSlideFrame: Boolean =
+      (!bufferByInPort.contains(currentHeadInPortIdx) || bufferByInPort(currentHeadInPortIdx).isEmpty) &&
+        isClosed(in(currentHeadInPortIdx))
+
+    private def canCompleteStage: Boolean =
+      canSlideFrame && currentHeadInPortIdx == overallLastInPortIdx
+
+    private def slideFrame(): Unit = {
+      currentHeadInPortIdx += 1
+
+      if (isAvailable(out))
+        pushUsingQueue()
+
+      if (currentLastInPortIdx != overallLastInPortIdx)
+        currentLastInPortIdx += 1
+
+      if (!hasBeenPulled(in(currentLastInPortIdx)))
+        tryPull(in(currentLastInPortIdx))
+    }
+  }
+}

--- a/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
+++ b/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala
@@ -264,6 +264,55 @@ object S3 {
     S3Stream.getObject(S3Location(bucket, key), range, versionId, s3Headers)
 
   /**
+   * Gets a S3 Object using `Byte-Range Fetches`
+   *
+   * @param bucket      the s3 bucket name
+   * @param key         the s3 object key
+   * @param sse [optional] the server side encryption used on upload
+   * @param rangeSize   size of each range to request
+   * @param parallelism number of range to request in parallel
+   *
+   * @return A [[akka.stream.scaladsl.Source]] containing the objects data as a [[akka.util.ByteString]] along with a materialized value containing the
+   *         [[akka.stream.alpakka.s3.ObjectMetadata]]
+   */
+  def getObjectByRanges(
+                 bucket: String,
+                 key: String,
+                 versionId: Option[String] = None,
+                 sse: Option[ServerSideEncryption] = None,
+                 rangeSize: Long = MinChunkSize,
+                 parallelism: Int = 4
+               ): Source[ByteString, Future[ObjectMetadata]] =
+    S3Stream.getObjectByRanges(S3Location(bucket, key),
+      versionId,
+      S3Headers.empty.withOptionalServerSideEncryption(sse),
+      rangeSize,
+      parallelism
+    )
+
+  /**
+   * Gets a S3 Object using `Byte-Range Fetches`
+   *
+   * @param bucket    the s3 bucket name
+   * @param key       the s3 object key
+   * @param s3Headers any headers you want to add
+   * @param rangeSize size of each range to request
+   * @param parallelism number of range to request in parallel
+   *
+   * @return A [[akka.stream.scaladsl.Source]] containing the objects data as a [[akka.util.ByteString]] along with a materialized value containing the
+   *         [[akka.stream.alpakka.s3.ObjectMetadata]]
+   */
+  def getObjectByRanges(
+                 bucket: String,
+                 key: String,
+                 versionId: Option[String],
+                 s3Headers: S3Headers,
+                 rangeSize: Long,
+                 parallelism: Int
+               ): Source[ByteString, Future[ObjectMetadata]] =
+    S3Stream.getObjectByRanges(S3Location(bucket, key), versionId, s3Headers, rangeSize, parallelism)
+
+  /**
    * Will return a list containing all of the buckets for the current AWS account
    *
    * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -5,6 +5,7 @@
 package akka.stream.alpakka.s3.scaladsl
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.model.headers.ByteRange
 import akka.stream.alpakka.s3.S3Settings
 import akka.stream.alpakka.s3.headers.ServerSideEncryption
 import akka.stream.alpakka.s3.impl.S3Stream
@@ -174,6 +175,19 @@ abstract class S3WireMockBase(_system: ActorSystem, val _wireMockServer: WireMoc
           .withHeader("x-amz-server-side-encryption-customer-key-MD5", new EqualToPattern(sseCustomerMd5Key))
           .willReturn(
             aResponse().withStatus(200).withHeader("ETag", s""""$etagSSE"""").withHeader("Content-Length", "8")
+          )
+      )
+
+  def mockRangedDownload(byteRange: ByteRange, range: String): Unit =
+    mock
+      .register(
+        get(urlEqualTo(s"/$bucketKey"))
+          .withHeader("Range", new EqualToPattern(s"bytes=$byteRange"))
+          .willReturn(
+            aResponse()
+              .withStatus(200)
+              .withHeader("ETag", """"fba9dede5f27731c9771645a39863328"""")
+              .withBody(range)
           )
       )
 


### PR DESCRIPTION
Fixes #2981 

Note I created a `MergeOrderedN` flow graph, because I didn't find a way to do the same using existing ones.
Happy to remove it if there's a way.
