### PR TITLE
docs: fix multiple examples for commit after write to elasticsearch

### DIFF
--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV5Spec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV5Spec.scala
@@ -241,9 +241,8 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
 
     "kafka-example - store documents and pass Responses with passThrough in bulk" in {
 
-      //#kafka-example
       // We're going to pretend we got messages from kafka.
-      // After we've written them to Elastic, we want
+      // After we've written them to Elastic in bulk, we want
       // to commit the offset to Kafka
 
       case class KafkaOffset(offset: Int)
@@ -284,7 +283,6 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
         .runWith(Sink.ignore)
 
       kafkaToEs.futureValue shouldBe Done
-      //#kafka-example
       flushAndRefresh(connectionSettings, indexName)
 
       // Make sure all messages was committed to kafka
@@ -295,9 +293,8 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
 
     "kafka-example - store documents and pass Responses with passThrough skipping some w/ NOP" in {
 
-      //#kafka-example
       // We're going to pretend we got messages from kafka.
-      // After we've written them to Elastic, we want
+      // Of those, only some will be written to Elastic, we want
       // to commit the offset to Kafka
 
       case class KafkaOffset(offset: Int)
@@ -343,7 +340,6 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
         .runWith(Sink.ignore)
 
       kafkaToEs.futureValue shouldBe Done
-      //#kafka-example
       flushAndRefresh(connectionSettings, indexName)
 
       // Make sure all messages was committed to kafka
@@ -355,9 +351,8 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
 
     "kafka-example - skip all NOP documents and pass Responses with passThrough" in {
 
-      //#kafka-example
       // We're going to pretend we got messages from kafka.
-      // After we've written them to Elastic, we want
+      // After we skip all NOP docs, we want
       // to commit the offset to Kafka
 
       case class KafkaOffset(offset: Int)
@@ -402,7 +397,6 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
         .runWith(Sink.ignore)
 
       kafkaToEs.futureValue shouldBe Done
-      //#kafka-example
       flushAndRefresh(connectionSettings, indexName)
 
       // Make sure all messages was committed to kafka


### PR DESCRIPTION
Noticed that [here](https://doc.akka.io/docs/alpakka/current/elasticsearch.html#passing-data-through-elasticsearchflow), in Scala sample, multiple code snippets are being included while the java sample only has one. I think this was due to copy/paste of the tags when creating new tests. Thus, removing the tags so only one example is shown as with the Java counterpart.
