### PR TITLE
fix: Release with JDK 8, #2994

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -43,6 +43,32 @@ jobs:
       - name: "Code style, compile tests, MiMa. Run locally with: sbt \"verifyCodeStyle; +Test/compile; mimaReportBinaryIssues\""
         run: sbt "verifyCodeStyle; +Test/compile; mimaReportBinaryIssues"
 
+  compile-jdk-8:
+    name: Compile with JDK 8
+    runs-on: ubuntu-22.04
+    env:
+      JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.1.0
+        with: # https://github.com/olafurpg/setup-scala#faster-checkout-of-big-repos
+          fetch-depth: 100
+
+      - name: Fetch tags
+        run: git fetch --depth=100 origin +refs/tags/*:refs/tags/*
+
+      - name: Set up JDK 8
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.8.0-275
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6.4.0
+
+      - name: "Compile JDK 8"
+        run: sbt compile
+
   documentation:
     name: ScalaDoc, Documentation with Paradox
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,10 +29,11 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 11
+      # Release must be with JDK 8 because --release 8 flag prevents access to com.sun.nio.file.SensitivityWatchEventModifier
+      - name: Set up JDK 8
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: temurin:1.11.0.17
+          jvm: adopt:1.8.0-275
 
       - name: Publish artifacts for all Scala versions
         env:

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -114,8 +114,9 @@ object Common extends AutoPlugin {
           "-Xlint:try",
           "-Xlint:unchecked",
           "-Xlint:varargs",
-          "--release",
-          "8"
+          // Release must be with JDK 8 because this flag prevents access to com.sun.nio.file.SensitivityWatchEventModifier
+          // "--release",
+          // "8"
         ),
       compile / javacOptions ++= (scalaVersion.value match {
           case Dependencies.Scala213 if insideCI.value && fatalWarnings.value && !Dependencies.CronBuild =>

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -113,7 +113,9 @@ object Common extends AutoPlugin {
           "-Xlint:static",
           "-Xlint:try",
           "-Xlint:unchecked",
-          "-Xlint:varargs"
+          "-Xlint:varargs",
+          "--release",
+          "8"
         ),
       compile / javacOptions ++= (scalaVersion.value match {
           case Dependencies.Scala213 if insideCI.value && fatalWarnings.value && !Dependencies.CronBuild =>

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -113,7 +113,7 @@ object Common extends AutoPlugin {
           "-Xlint:static",
           "-Xlint:try",
           "-Xlint:unchecked",
-          "-Xlint:varargs",
+          "-Xlint:varargs"
           // Release must be with JDK 8 because this flag prevents access to com.sun.nio.file.SensitivityWatchEventModifier
           // "--release",
           // "8"


### PR DESCRIPTION
--release 8 was not defined in javacOptions 
However, --release 8 flag prevents access to com.sun.nio.file.SensitivityWatchEventModifier so instead we have to use JDK 8 in the release CI job.

References #2994
