### PR TITLE
FTP: Add a setting to enable automatic server encoding detection

### DIFF
--- a/ftp/src/main/mima-filters/6.0.3.backwards.excludes
+++ b/ftp/src/main/mima-filters/6.0.3.backwards.excludes
@@ -1,0 +1,3 @@
+# Allow change to FtpSettings and FtpsSettings
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.ftp.FtpSettings.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.alpakka.ftp.FtpsSettings.this")

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
@@ -19,6 +19,10 @@ private[ftp] trait FtpOperations extends CommonFtpOperations { _: FtpLike[FTPCli
   def connect(connectionSettings: FtpSettings)(implicit ftpClient: FTPClient): Try[Handler] = Try {
     connectionSettings.proxy.foreach(ftpClient.setProxy)
 
+    if (ftpClient.getAutodetectUTF8() != connectionSettings.autodetectUTF8) {
+      ftpClient.setAutodetectUTF8(connectionSettings.autodetectUTF8)
+    }
+
     try {
       ftpClient.connect(connectionSettings.host, connectionSettings.port)
     } catch {

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
@@ -21,6 +21,10 @@ private[ftp] trait FtpsOperations extends CommonFtpOperations {
     Try {
       connectionSettings.proxy.foreach(ftpClient.setProxy)
 
+      if (ftpClient.getAutodetectUTF8() != connectionSettings.autodetectUTF8) {
+        ftpClient.setAutodetectUTF8(connectionSettings.autodetectUTF8)
+      }
+
       ftpClient.connect(connectionSettings.host, connectionSettings.port)
 
       connectionSettings.configureConnection(ftpClient)

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -130,7 +130,7 @@ final class FtpSettings private (
     s"credentials=$credentials," +
     s"binary=$binary," +
     s"passiveMode=$passiveMode," +
-    s"autodetectUTF8=$autodetectUTF8" +
+    s"autodetectUTF8=$autodetectUTF8," +
     s"configureConnection=$configureConnection," +
     s"proxy=$proxy)"
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -60,6 +60,8 @@ abstract sealed class FtpFileSettings extends RemoteFileSettings {
  * @param credentials credentials (username and password)
  * @param binary specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false)
  * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
+ * @param autodetectUTF8 enables or disables automatic server encoding detection (only UTF-8 supported).
+ *                       Disabled by default (false).
  * @param configureConnection A function which will be called after connecting to the server. Use this for
  *                            any custom configuration required by the server you are connecting to.
  * @param proxy An optional proxy to use when connecting with these settings
@@ -70,6 +72,7 @@ final class FtpSettings private (
     val credentials: FtpCredentials,
     val binary: Boolean,
     val passiveMode: Boolean,
+    val autodetectUTF8: Boolean,
     val configureConnection: FTPClient => Unit,
     val proxy: Option[Proxy]
 ) extends FtpFileSettings {
@@ -80,6 +83,8 @@ final class FtpSettings private (
   def withBinary(value: Boolean): FtpSettings = if (binary == value) this else copy(binary = value)
   def withPassiveMode(value: Boolean): FtpSettings =
     if (passiveMode == value) this else copy(passiveMode = value)
+  def withAutodetectUTF8(value: Boolean): FtpSettings =
+    if (autodetectUTF8 == value) this else copy(autodetectUTF8 = value)
   def withProxy(value: Proxy): FtpSettings = copy(proxy = Some(value))
 
   /**
@@ -104,6 +109,7 @@ final class FtpSettings private (
       credentials: FtpCredentials = credentials,
       binary: Boolean = binary,
       passiveMode: Boolean = passiveMode,
+      autodetectUTF8: Boolean = autodetectUTF8,
       configureConnection: FTPClient => Unit = configureConnection,
       proxy: Option[Proxy] = proxy
   ): FtpSettings = new FtpSettings(
@@ -112,6 +118,7 @@ final class FtpSettings private (
     credentials = credentials,
     binary = binary,
     passiveMode = passiveMode,
+    autodetectUTF8 = autodetectUTF8,
     configureConnection = configureConnection,
     proxy = proxy
   )
@@ -123,6 +130,7 @@ final class FtpSettings private (
     s"credentials=$credentials," +
     s"binary=$binary," +
     s"passiveMode=$passiveMode," +
+    s"autodetectUTF8=$autodetectUTF8" +
     s"configureConnection=$configureConnection," +
     s"proxy=$proxy)"
 }
@@ -142,6 +150,7 @@ object FtpSettings {
     credentials = FtpCredentials.AnonFtpCredentials,
     binary = false,
     passiveMode = false,
+    autodetectUTF8 = false,
     configureConnection = _ => (),
     proxy = None
   )
@@ -160,6 +169,8 @@ object FtpSettings {
  * @param credentials credentials (username and password)
  * @param binary specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false)
  * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
+ * @param autodetectUTF8 enables or disables automatic server encoding detection (only UTF-8 supported).
+ *                       Disabled by default (false).
  * @param configureConnection A function which will be called after connecting to the server. Use this for
  *                            any custom configuration required by the server you are connecting to.
  * @param proxy An optional proxy to use when connecting with these settings
@@ -170,6 +181,7 @@ final class FtpsSettings private (
     val credentials: FtpCredentials,
     val binary: Boolean,
     val passiveMode: Boolean,
+    val autodetectUTF8: Boolean,
     val configureConnection: FTPSClient => Unit,
     val proxy: Option[Proxy]
 ) extends FtpFileSettings {
@@ -180,6 +192,8 @@ final class FtpsSettings private (
   def withBinary(value: Boolean): FtpsSettings = if (binary == value) this else copy(binary = value)
   def withPassiveMode(value: Boolean): FtpsSettings =
     if (passiveMode == value) this else copy(passiveMode = value)
+  def withAutodetectUTF8(value: Boolean): FtpsSettings =
+    if (autodetectUTF8 == value) this else copy(autodetectUTF8 = value)
   def withProxy(value: Proxy): FtpsSettings = copy(proxy = Some(value))
 
   /**
@@ -204,6 +218,7 @@ final class FtpsSettings private (
       credentials: FtpCredentials = credentials,
       binary: Boolean = binary,
       passiveMode: Boolean = passiveMode,
+      autodetectUTF8: Boolean = autodetectUTF8,
       configureConnection: FTPSClient => Unit = configureConnection,
       proxy: Option[Proxy] = proxy
   ): FtpsSettings = new FtpsSettings(
@@ -212,6 +227,7 @@ final class FtpsSettings private (
     credentials = credentials,
     binary = binary,
     passiveMode = passiveMode,
+    autodetectUTF8 = autodetectUTF8,
     configureConnection = configureConnection,
     proxy = proxy
   )
@@ -223,6 +239,7 @@ final class FtpsSettings private (
     s"credentials=$credentials," +
     s"binary=$binary," +
     s"passiveMode=$passiveMode," +
+    s"autodetectUTF8=$autodetectUTF8" +
     s"configureConnection=$configureConnection," +
     s"proxy=$proxy)"
 }
@@ -242,6 +259,7 @@ object FtpsSettings {
     FtpCredentials.AnonFtpCredentials,
     binary = false,
     passiveMode = false,
+    autodetectUTF8 = false,
     configureConnection = _ => (),
     proxy = None
   )

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/model.scala
@@ -239,7 +239,7 @@ final class FtpsSettings private (
     s"credentials=$credentials," +
     s"binary=$binary," +
     s"passiveMode=$passiveMode," +
-    s"autodetectUTF8=$autodetectUTF8" +
+    s"autodetectUTF8=$autodetectUTF8," +
     s"configureConnection=$configureConnection," +
     s"proxy=$proxy)"
 }


### PR DESCRIPTION
References #2998

I've added a method to FtpSettings and FtpsSettings to enable or disable automatic server encoding detection.