### PR TITLE
bump: Akka HTTP AWS SPI 1.0.1 (was 0.0.11)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val InfluxDBJavaVersion = "2.15"
 
   val AwsSdk2Version = "2.17.113"
-  val AwsSpiAkkaHttpVersion = "0.0.11"
+  val AwsSpiAkkaHttpVersion = "1.0.1"
   // Sync with plugins.sbt
   val AkkaGrpcBinaryVersion = "2.3"
   // sync ignore prefix in scripts/link-validator.conf#L30


### PR DESCRIPTION
This opens the chance to enable Scala 3 builds for some AWS modules.

References 
- https://github.com/matsluni/aws-spi-akka-http/releases
