### PR TITLE
bump: Jackson 2.15.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,9 +62,9 @@ object Dependencies {
 
   // Releases https://github.com/FasterXML/jackson-databind/releases
   // CVE issues https://github.com/FasterXML/jackson-databind/issues?utf8=%E2%9C%93&q=+label%3ACVE
-  // This should align with the Jackson minor version used in Akka 2.7.x
+  // This should align with the Jackson minor version used in Akka
   // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L29
-  val JacksonVersion = "2.13.5"
+  val JacksonVersion = "2.15.2"
   val JacksonDatabindVersion = JacksonVersion
   val JacksonDatabindDependencies = Seq(
     "com.fasterxml.jackson.core" % "jackson-core" % JacksonVersion,


### PR DESCRIPTION
Use same Jackson version as in upcoming Akka 2.9. Targeting next minor release.