### PR TITLE
bump: Cassandra java-driver-core 4.17.0

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,5 @@
 commits.message = "bump: ${artifactName} ${nextVersion} (was ${currentVersion})"
 
 updates.pin  = [
-  { groupId = "com.fasterxml.jackson.core", version = "2.11." }
+  { groupId = "com.fasterxml.jackson.core", version = "2.15." }
 ]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -99,8 +99,8 @@ object Dependencies {
   )
 
   val CassandraVersionInDocs = "4.0"
-  val CassandraDriverVersion = "4.14.1"
-  val CassandraDriverVersionInDocs = "4.14"
+  val CassandraDriverVersion = "4.17.0"
+  val CassandraDriverVersionInDocs = "4.17"
 
   val Cassandra = Seq(
     libraryDependencies ++= Seq(


### PR DESCRIPTION
in sync with https://github.com/akka/akka-persistence-cassandra/pull/1048