### PR TITLE
AMQP Fix #3023

### DIFF
--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectionProvider.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectionProvider.scala
@@ -367,13 +367,12 @@ final class AmqpCachedConnectionProvider private (val provider: AmqpConnectionPr
   def withAutomaticRelease(automaticRelease: Boolean): AmqpCachedConnectionProvider =
     copy(automaticRelease = automaticRelease)
 
-  private lazy val connection = provider.get
-
   @tailrec
   override def get: Connection = state.get match {
     case Empty =>
       if (state.compareAndSet(Empty, Connecting)) {
         try {
+          val connection = provider.get
           if (!state.compareAndSet(Connecting, Connected(connection, 1)))
             throw new ConcurrentModificationException(
               "Unexpected concurrent modification while creating the connection."

--- a/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectionProvider.scala
+++ b/amqp/src/main/scala/akka/stream/alpakka/amqp/AmqpConnectionProvider.scala
@@ -367,12 +367,14 @@ final class AmqpCachedConnectionProvider private (val provider: AmqpConnectionPr
   def withAutomaticRelease(automaticRelease: Boolean): AmqpCachedConnectionProvider =
     copy(automaticRelease = automaticRelease)
 
+  private def getConnection = provider.get
+
   @tailrec
   override def get: Connection = state.get match {
     case Empty =>
       if (state.compareAndSet(Empty, Connecting)) {
         try {
-          val connection = provider.get
+          val connection = getConnection
           if (!state.compareAndSet(Connecting, Connected(connection, 1)))
             throw new ConcurrentModificationException(
               "Unexpected concurrent modification while creating the connection."

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectionProvidersSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectionProvidersSpec.scala
@@ -211,6 +211,8 @@ class AmqpConnectionProvidersSpec extends AmqpSpec {
 
       val newConnection = reusableConnectionProvider.get
       newConnection should not be (originalConnection)
+      newConnection.isOpen shouldBe true
+      originalConnection.isOpen should not be true
     }
   }
 }


### PR DESCRIPTION
Offer new cached connection when previous one has been closed and released

References #3023

ℹ️ I'm not sure whether `abort` is the best way to simulate connection closed by the server. Hopefully, for the purpose of unit test, this is good enough