### PR TITLE
ftp: Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,6 +166,7 @@ lazy val ftp = alpakkaProject(
   "ftp",
   "ftp",
   Dependencies.Ftp,
+  Scala3.settings,
   Test / fork := true,
   // To avoid potential blocking in machines with low entropy (default is `/dev/random`)
   Test / javaOptions += "-Djava.security.egd=file:/dev/./urandom"

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpLike.scala
@@ -45,7 +45,7 @@ protected[ftp] trait FtpLike[FtpClient, S <: RemoteFileSettings] {
  * INTERNAL API
  */
 @InternalApi
-protected[ftp] trait RetrieveOffset { _: FtpLike[_, _] =>
+protected[ftp] trait RetrieveOffset { ftpLike: FtpLike[_, _] =>
 
   def retrieveFileInputStream(name: String, handler: Handler, offset: Long): Try[InputStream]
 
@@ -55,7 +55,7 @@ protected[ftp] trait RetrieveOffset { _: FtpLike[_, _] =>
  * INTERNAL API
  */
 @InternalApi
-protected[ftp] trait UnconfirmedReads { _: FtpLike[_, _] =>
+protected[ftp] trait UnconfirmedReads { ftpLike: FtpLike[_, _] =>
 
   def retrieveFileInputStream(name: String, handler: Handler, offset: Long, maxUnconfirmedReads: Int): Try[InputStream]
 

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpOperations.scala
@@ -14,7 +14,7 @@ import scala.util.Try
  * INTERNAL API
  */
 @InternalApi
-private[ftp] trait FtpOperations extends CommonFtpOperations { _: FtpLike[FTPClient, FtpSettings] =>
+private[ftp] trait FtpOperations extends CommonFtpOperations { ftpLike: FtpLike[FTPClient, FtpSettings] =>
 
   def connect(connectionSettings: FtpSettings)(implicit ftpClient: FTPClient): Try[Handler] = Try {
     connectionSettings.proxy.foreach(ftpClient.setProxy)

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/FtpsOperations.scala
@@ -15,7 +15,7 @@ import scala.util.Try
  */
 @InternalApi
 private[ftp] trait FtpsOperations extends CommonFtpOperations {
-  _: FtpLike[FTPSClient, FtpsSettings] =>
+  ftpLike: FtpLike[FTPSClient, FtpsSettings] =>
 
   def connect(connectionSettings: FtpsSettings)(implicit ftpClient: FTPSClient): Try[Handler] =
     Try {

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/impl/SftpOperations.scala
@@ -27,7 +27,7 @@ import scala.util.{Failure, Try}
  * INTERNAL API
  */
 @InternalApi
-private[ftp] trait SftpOperations { _: FtpLike[SSHClient, SftpSettings] =>
+private[ftp] trait SftpOperations { ftpLike: FtpLike[SSHClient, SftpSettings] =>
 
   type Handler = SFTPClient
 

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/javadsl/FtpApi.scala
@@ -21,7 +21,7 @@ import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
 import scala.compat.java8.FunctionConverters._
 
 @DoNotInherit
-sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[FtpClient, S] =>
+sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { factory: FtpSourceFactory[FtpClient, S] =>
 
   /**
    * Java API: creates a [[akka.stream.javadsl.Source Source]] of [[FtpFile]]s from the remote user `root` directory.
@@ -584,6 +584,6 @@ object Sftp extends SftpApi {
    */
   def create(customSshClient: SSHClient): SftpApi =
     new SftpApi {
-      override val sshClient: SSHClient = customSshClient
+      override def sshClient(): SSHClient = customSshClient
     }
 }

--- a/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/akka/stream/alpakka/ftp/scaladsl/FtpApi.scala
@@ -18,7 +18,7 @@ import org.apache.commons.net.ftp.{FTPClient, FTPSClient}
 import scala.concurrent.Future
 
 @DoNotInherit
-sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[FtpClient, S] =>
+sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { factory: FtpSourceFactory[FtpClient, S] =>
 
   /**
    * Scala API: creates a [[akka.stream.scaladsl.Source Source]] of [[FtpFile]]s from the remote user `root` directory.
@@ -398,6 +398,6 @@ object Sftp extends SftpApi {
    */
   def apply(customSshClient: SSHClient): SftpApi =
     new SftpApi {
-      override val sshClient: SSHClient = customSshClient
+      override def sshClient(): SSHClient = customSshClient
     }
 }

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
@@ -70,7 +70,7 @@ trait BaseSpec
   // Allows to run tests n times in a row with a command line argument, useful for debugging sporadic failures
   // e.g. ftp/testOnly *.FtpsStageSpec -- -Dtimes=20
   // https://gist.github.com/dwickern/6ba9c5c505d2325d3737ace059302922
-  override abstract protected def runTest(testName: String, args: Args): Status = {
+  override protected def runTest(testName: String, args: Args): Status = {
     def run0(times: Int): Status = {
       val status = super.runTest(testName, args)
       if (times <= 1) status else status.thenRun(run0(times - 1))

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -67,6 +67,8 @@ object Common extends AutoPlugin {
           case Dependencies.Scala213
               if insideCI.value && fatalWarnings.value && !Dependencies.CronBuild && scalaVersion.value != Dependencies.Scala3 =>
             Seq("-Werror")
+          case Dependencies.Scala3 if insideCI.value =>
+            Seq("-explain")
           case _ => Seq.empty[String]
         }),
       Compile / doc / scalacOptions := scalacOptions.value ++ Seq(


### PR DESCRIPTION
- Enable Scala 3 for Alpakka FTP.
- Syntax changes for the mixin traits.
- Use `-explain` for Scala 3 in CI.