### PR TITLE
Replace Spray JWT dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -186,7 +186,8 @@ lazy val googleCommon = alpakkaProject(
   "google-common",
   "google.common",
   Dependencies.GoogleCommon,
-  Test / fork := true
+  Test / fork := true,
+  headerSources / excludeFilter := HiddenFileFilter || "JwtSprayJsonParser.scala"
 )
 
 lazy val googleCloudBigQuery = alpakkaProject(

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/GoogleOAuth2.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/GoogleOAuth2.scala
@@ -13,7 +13,7 @@ import akka.stream.Materializer
 import akka.stream.alpakka.google.http.GoogleHttp
 import akka.stream.alpakka.google.{implicits, RequestSettings}
 import pdi.jwt.JwtAlgorithm.RS256
-import pdi.jwt.{JwtClaim, JwtSprayJson}
+import pdi.jwt.JwtClaim
 import spray.json.DefaultJsonProtocol._
 import spray.json.JsonFormat
 

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/JwtSprayJsonParser.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/JwtSprayJsonParser.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+/*
+ * This software is licensed under the Apache 2 license.
+ * Copyright 2021 JWT-Scala Contributors.
+ */
+
+package akka.stream.alpakka.google.auth
+
+import pdi.jwt.{JwtAlgorithm, JwtClaim, JwtHeader, JwtJsonCommon}
+
+import java.time.Clock
+import pdi.jwt.exceptions.JwtNonStringException
+import spray.json._
+
+/**
+ * Implementation of `JwtCore` using `JsObject` from spray-json.
+ *
+ * This class originally came from jwt-spray-json,
+ * but was removed in https://github.com/jwt-scala/jwt-scala/commit/bf1131ce02480103c0b953b97da001105a3ee038
+ */
+trait JwtSprayJsonParser[H, C] extends JwtJsonCommon[JsObject, H, C] {
+  protected def parse(value: String): JsObject = value.parseJson.asJsObject
+
+  protected def stringify(value: JsObject): String = value.compactPrint
+
+  protected def getAlgorithm(header: JsObject): Option[JwtAlgorithm] =
+    header.fields.get("alg").flatMap {
+      case JsString("none") => None
+      case JsString(algo) => Option(JwtAlgorithm.fromString(algo))
+      case JsNull => None
+      case _ => throw new JwtNonStringException("alg")
+    }
+
+}
+
+object JwtSprayJson extends JwtSprayJson(Clock.systemUTC) {
+  def apply(clock: Clock): JwtSprayJson = new JwtSprayJson(clock)
+}
+
+class JwtSprayJson(override val clock: Clock) extends JwtSprayJsonParser[JwtHeader, JwtClaim] {
+
+  import DefaultJsonProtocol._
+  override def parseHeader(header: String): JwtHeader = {
+    val jsObj = parse(header)
+    JwtHeader(
+      algorithm = getAlgorithm(jsObj),
+      typ = safeGetField[String](jsObj, "typ"),
+      contentType = safeGetField[String](jsObj, "cty"),
+      keyId = safeGetField[String](jsObj, "kid")
+    )
+  }
+
+  override def parseClaim(claim: String): JwtClaim = {
+    val jsObj = parse(claim)
+    val content = JsObject(jsObj.fields - "iss" - "sub" - "aud" - "exp" - "nbf" - "iat" - "jti")
+    JwtClaim(
+      content = stringify(content),
+      issuer = safeGetField[String](jsObj, "iss"),
+      subject = safeGetField[String](jsObj, "sub"),
+      audience = safeGetField[Set[String]](jsObj, "aud")
+        .orElse(safeGetField[String](jsObj, "aud").map(s => Set(s))),
+      expiration = safeGetField[Long](jsObj, "exp"),
+      notBefore = safeGetField[Long](jsObj, "nbf"),
+      issuedAt = safeGetField[Long](jsObj, "iat"),
+      jwtId = safeGetField[String](jsObj, "jti")
+    )
+  }
+
+  private[this] def safeRead[A: JsonReader](js: JsValue) =
+    safeReader[A].read(js).fold(_ => None, a => Option(a))
+
+  private[this] def safeGetField[A: JsonReader](js: JsObject, name: String) =
+    js.fields.get(name).flatMap(safeRead[A])
+}

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/JwtSprayJsonParser.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/JwtSprayJsonParser.scala
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
- */
-
-/*
  * This software is licensed under the Apache 2 license.
  * Copyright 2021 JWT-Scala Contributors.
+ *
+ * Copyright (C) since 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.stream.alpakka.google.auth

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/JwtSprayJsonParser.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/JwtSprayJsonParser.scala
@@ -9,6 +9,7 @@
 
 package akka.stream.alpakka.google.auth
 
+import akka.annotation.InternalApi
 import pdi.jwt.{JwtAlgorithm, JwtClaim, JwtHeader, JwtJsonCommon}
 
 import java.time.Clock
@@ -21,7 +22,8 @@ import spray.json._
  * This class originally came from jwt-spray-json,
  * but was removed in https://github.com/jwt-scala/jwt-scala/commit/bf1131ce02480103c0b953b97da001105a3ee038
  */
-trait JwtSprayJsonParser[H, C] extends JwtJsonCommon[JsObject, H, C] {
+@InternalApi
+private[auth] trait JwtSprayJsonParser[H, C] extends JwtJsonCommon[JsObject, H, C] {
   protected def parse(value: String): JsObject = value.parseJson.asJsObject
 
   protected def stringify(value: JsObject): String = value.compactPrint
@@ -36,11 +38,13 @@ trait JwtSprayJsonParser[H, C] extends JwtJsonCommon[JsObject, H, C] {
 
 }
 
-object JwtSprayJson extends JwtSprayJson(Clock.systemUTC) {
+@InternalApi
+private[auth] object JwtSprayJson extends JwtSprayJson(Clock.systemUTC) {
   def apply(clock: Clock): JwtSprayJson = new JwtSprayJson(clock)
 }
 
-class JwtSprayJson(override val clock: Clock) extends JwtSprayJsonParser[JwtHeader, JwtClaim] {
+@InternalApi
+private[auth] class JwtSprayJson(override val clock: Clock) extends JwtSprayJsonParser[JwtHeader, JwtClaim] {
 
   import DefaultJsonProtocol._
   override def parseHeader(header: String): JwtHeader = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,8 @@ object Dependencies {
   val CouchbaseVersion = "2.7.16"
   val CouchbaseVersionForDocs = "2.7"
 
-  val JwtCoreVersion = "3.0.1"
+  // https://github.com/jwt-scala/jwt-scala/releases
+  val JwtScalaVersion = "9.4.4"
 
   val log4jOverSlf4jVersion = "1.7.36"
   val jclOverSlf4jVersion = "1.7.36"
@@ -204,7 +205,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "com.github.jwt-scala" %% "jwt-spray-json" % "9.0.2", // ApacheV2
+        "com.github.jwt-scala" %% "jwt-json-common" % JwtScalaVersion,
         // https://github.com/googleapis/google-auth-library-java
         "com.google.auth" % "google-auth-library-credentials" % GoogleAuthVersion,
         "io.specto" % "hoverfly-java" % hoverflyVersion % Test // ApacheV2
@@ -304,7 +305,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "com.github.jwt-scala" %% "jwt-spray-json" % "7.1.4" // ApacheV2
+        "com.github.jwt-scala" %% "jwt-json-common" % JwtScalaVersion
       ) ++ Mockito
   )
 


### PR DESCRIPTION
Remove the dependency on `com.github.jwt-scala` `jwt-spray-json` which was discontinued.

Add the relevant sources from that library into google-common which was the only Alpakka part relying in this.

References
- https://github.com/jwt-scala/jwt-scala/pull/318
