### PR TITLE
chore: avoid broken and outdated links

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,6 @@ jobs:
           echo $AKKA_RSYNC_GUSTAV | base64 -d > .github/id_rsa
           chmod 600 .github/id_rsa
           ssh-add .github/id_rsa
-          sbt publishRsync
+          sbt docs/publishRsync
         env:
           AKKA_RSYNC_GUSTAV: ${{ secrets.AKKA_RSYNC_GUSTAV }}

--- a/docs/src/main/paradox/other-docs/webinars-presentations-articles.md
+++ b/docs/src/main/paradox/other-docs/webinars-presentations-articles.md
@@ -74,9 +74,6 @@ blog by Abhishek Srivastava, October 2017
 [Using cats with reactive-kafka](https://iravid.com/posts/using-cats-with-reactive-kafka.html)
 blog by Itamar Ravid, July 2017
 
-[Exploring Reactive Integrations in Java 8 With Akka Streams, Alpakka, and Kafka](https://dzone.com/articles/exploring-reactive-integrations-in-java-8-with-akka-streams-alpakka-and-kafka)
-Webinar by Konrad Malawski, Lightbend, Janary 2017
-
 ## 2016
 
 [Akka Streams Integration, codename Alpakka](https://akka.io/blog/article/2016/08/23/intro-alpakka)

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -27,7 +27,7 @@ site-link-validator {
     # MVN repository forbids access after a few requests
     "https://mvnrepository.com/artifact/"
     # in api/alpakka/snapshot/akka/stream/alpakka/google/scaladsl/X$minusUpload$minusContent$minusType.html
-    "https://doc.akka.io/api/akka-http/10.5.1/akka/http/impl/",
+    "https://doc.akka.io/api/akka-http/10.6.0/akka/http/impl/",
     "https://repo.akka.io/"
   ]
 


### PR DESCRIPTION
The DZone article was archived.
Links to Akka HTTP internals fail the link checker.