### PR TITLE
Elasticsearch: keep path from base URI

### DIFF
--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
@@ -6,7 +6,6 @@ package akka.stream.alpakka.elasticsearch.impl
 
 import akka.annotation.InternalApi
 import akka.http.scaladsl.HttpExt
-import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.alpakka.elasticsearch._

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
@@ -71,8 +71,8 @@ private[elasticsearch] final class ElasticsearchSimpleFlowStage[T, C](
 
     override def onPush(): Unit = {
       val endpoint =
-        if (settings.allowExplicitIndex) baseUri.path / "_bulk"
-        else baseUri.path / elasticsearchParams.indexName / "_bulk"
+        if (settings.allowExplicitIndex) baseUri.path ?/ "_bulk"
+        else baseUri.path ?/ elasticsearchParams.indexName / "_bulk"
       val (messages, resultsPassthrough) = grab(in)
       inflight = true
       val json: String = restApi.toJson(messages)

--- a/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
+++ b/elasticsearch/src/main/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStage.scala
@@ -79,7 +79,7 @@ private[elasticsearch] final class ElasticsearchSimpleFlowStage[T, C](
       log.debug("Posting data to Elasticsearch: {}", json)
 
       if (json.nonEmpty) {
-        val uri = baseUri.withPath(Path(endpoint))
+        val uri = baseUri.withPath(baseUri.path / endpoint)
         val request = HttpRequest(HttpMethods.POST)
           .withUri(uri)
           .withEntity(HttpEntity(NDJsonProtocol.`application/x-ndjson`, json))


### PR DESCRIPTION
The current implementation drops any path that is present in the baseUri.

References
- #3019 
