### PR TITLE
bump: Rollback sbt to 1.9.6

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.7

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.9.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.6


### PR DESCRIPTION
Strange issues in main on 1.9.9 where javax.jms cannot be found. We did not manage to reproduce that locally, but consistently happens in ghactions.