### PR TITLE
revert: logback may not pull slf4j 2.x

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,8 +34,14 @@ object Dependencies {
   // https://github.com/jwt-scala/jwt-scala/releases
   val JwtScalaVersion = "9.4.4"
 
-  val log4jOverSlf4jVersion = "1.7.36"
-  val jclOverSlf4jVersion = "1.7.36"
+  // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L20
+  val slf4jVersion = "1.7.36"
+  val log4jOverSlf4jVersion = slf4jVersion
+  val jclOverSlf4jVersion = slf4jVersion
+
+  // Later versions bump slf4j-api past 2.x
+  // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L28
+  val LogbackClassicVersion = "1.2.13"
 
   val Common = Seq(
     // These libraries are added to all modules via the `Common` AutoPlugin
@@ -50,7 +56,7 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
         "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion,
         "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-        "ch.qos.logback" % "logback-classic" % "1.4.14",
+        "ch.qos.logback" % "logback-classic" % LogbackClassicVersion,
         "org.scalatest" %% "scalatest" % ScalaTestVersion,
         "com.dimafeng" %% "testcontainers-scala-scalatest" % TestContainersScalaTestVersion,
         "com.novocode" % "junit-interface" % "0.11", // BSD-style

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,9 +39,10 @@ object Dependencies {
   val log4jOverSlf4jVersion = slf4jVersion
   val jclOverSlf4jVersion = slf4jVersion
 
-  // Later versions bump slf4j-api past 2.x
+  // Akka 2.9 expects Slf4j 1.x
   // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L28
-  val LogbackClassicVersion = "1.2.13"
+  val LogbackWithSlf4jV1 = "1.2.13"
+  val LogbackWithSlf4jV2 = "1.5.3"
 
   val Common = Seq(
     // These libraries are added to all modules via the `Common` AutoPlugin
@@ -56,7 +57,7 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
         "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion,
         "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-        "ch.qos.logback" % "logback-classic" % LogbackClassicVersion,
+        "ch.qos.logback" % "logback-classic" % LogbackWithSlf4jV1,
         "org.scalatest" %% "scalatest" % ScalaTestVersion,
         "com.dimafeng" %% "testcontainers-scala-scalatest" % TestContainersScalaTestVersion,
         "com.novocode" % "junit-interface" % "0.11", // BSD-style
@@ -255,7 +256,8 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "com.github.tomakehurst" % "wiremock" % "3.0.1" % Test // ApacheV2
+        "com.github.tomakehurst" % "wiremock" % "3.0.1" % Test,
+        "ch.qos.logback" % "logback-classic" % LogbackWithSlf4jV2 % Test
       ) ++ Mockito
   )
 
@@ -339,8 +341,7 @@ object Dependencies {
         "jakarta.jms" % "jakarta.jms-api" % "3.1.0", // Eclipse Public License 2.0 + + GPLv2
         "org.apache.activemq" % "artemis-jakarta-server" % "2.33.0" % Test, // ApacheV2
         "org.apache.activemq" % "artemis-jakarta-client" % "2.33.0" % Test, // ApacheV2
-        // slf4j-api 2.0.9 via activemq-client
-        "ch.qos.logback" % "logback-classic" % "1.4.14" % Test
+        "ch.qos.logback" % "logback-classic" % LogbackWithSlf4jV2 % Test
       ) ++ Mockito
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,7 +42,7 @@ object Dependencies {
   // Akka 2.9 expects Slf4j 1.x
   // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L28
   val LogbackWithSlf4jV1 = "1.2.13"
-  val LogbackWithSlf4jV2 = "1.5.3"
+  val wiremock = ("com.github.tomakehurst" % "wiremock" % "3.0.1" % Test).exclude("org.slf4j", "slf4j-api")
 
   val Common = Seq(
     // These libraries are added to all modules via the `Common` AutoPlugin
@@ -256,8 +256,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "com.github.tomakehurst" % "wiremock" % "3.0.1" % Test,
-        "ch.qos.logback" % "logback-classic" % LogbackWithSlf4jV2 % Test
+        wiremock
       ) ++ Mockito
   )
 
@@ -339,9 +338,8 @@ object Dependencies {
   val JakartaJms = Seq(
     libraryDependencies ++= Seq(
         "jakarta.jms" % "jakarta.jms-api" % "3.1.0", // Eclipse Public License 2.0 + + GPLv2
-        "org.apache.activemq" % "artemis-jakarta-server" % "2.33.0" % Test, // ApacheV2
-        "org.apache.activemq" % "artemis-jakarta-client" % "2.33.0" % Test, // ApacheV2
-        "ch.qos.logback" % "logback-classic" % LogbackWithSlf4jV2 % Test
+        ("org.apache.activemq" % "artemis-jakarta-server" % "2.33.0" % Test).exclude("org.slf4j", "slf4j-api"),
+        ("org.apache.activemq" % "artemis-jakarta-client" % "2.33.0" % Test).exclude("org.slf4j", "slf4j-api")
       ) ++ Mockito
   )
 
@@ -445,7 +443,7 @@ object Dependencies {
         "software.amazon.awssdk" % "auth" % AwsSdk2Version,
         // in-memory filesystem for file related tests
         "com.google.jimfs" % "jimfs" % "1.3.0" % Test, // ApacheV2
-        "com.github.tomakehurst" % "wiremock-jre8" % "3.0.1" % Test // ApacheV2
+        wiremock
       )
   )
 
@@ -467,8 +465,8 @@ object Dependencies {
   val SlickVersion = "3.5.0"
   val Slick = Seq(
     libraryDependencies ++= Seq(
-        "com.typesafe.slick" %% "slick" % SlickVersion, // BSD 2-clause "Simplified" License
-        "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion, // BSD 2-clause "Simplified" License
+        ("com.typesafe.slick" %% "slick" % SlickVersion).exclude("org.slf4j", "slf4j-api"),
+        ("com.typesafe.slick" %% "slick-hikaricp" % SlickVersion).exclude("org.slf4j", "slf4j-api"),
         "com.h2database" % "h2" % "2.1.214" % Test // Eclipse Public License 1.0
       )
   )

--- a/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
+++ b/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
@@ -8,6 +8,8 @@ import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.{Arrays, Optional}
 
+import scala.annotation.nowarn
+
 import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.alpakka.solr._
@@ -746,6 +748,7 @@ class SolrSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with Sca
     TestKit.shutdownActorSystem(system)
   }
 
+  @nowarn("msg=deprecated") // FIXME #2917 Deprecated getIdField in Solrj 8.11.x
   private def setupCluster(): Unit = {
     val targetDir = new File("solr/target")
     val testWorkingDir =
@@ -769,6 +772,7 @@ class SolrSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with Sca
     solrClient.getClusterStateProvider
       .asInstanceOf[ZkClientClusterStateProvider]
       .uploadConfig(confDir.toPath, "conf")
+    solrClient.setIdField("router")
 
     assertTrue(!solrClient.getZkStateReader.getClusterState.getLiveNodes.isEmpty)
   }

--- a/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
+++ b/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
@@ -742,13 +742,12 @@ class SolrSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with Sca
   }
 
   override def afterAll(): Unit = {
-    solrClient.close()
-    cluster.shutdown()
-    zkTestServer.shutdown()
+    if (solrClient != null) solrClient.close()
+    if (cluster != null) cluster.shutdown()
+    if (zkTestServer != null) zkTestServer.shutdown()
     TestKit.shutdownActorSystem(system)
   }
 
-  @nowarn("msg=deprecated") // FIXME #2917 Deprecated getIdField in Solrj 8.11.x
   private def setupCluster(): Unit = {
     val targetDir = new File("solr/target")
     val testWorkingDir =
@@ -772,7 +771,6 @@ class SolrSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with Sca
     solrClient.getClusterStateProvider
       .asInstanceOf[ZkClientClusterStateProvider]
       .uploadConfig(confDir.toPath, "conf")
-    solrClient.setIdField("router")
 
     assertTrue(!solrClient.getZkStateReader.getClusterState.getLiveNodes.isEmpty)
   }

--- a/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
+++ b/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
@@ -8,8 +8,6 @@ import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.{Arrays, Optional}
 
-import scala.annotation.nowarn
-
 import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.alpakka.solr._


### PR DESCRIPTION
Revert
- #3051 

and review all places to stay on Slf4j V1. Some places pulled in V2 in hideous ways.
