### PR TITLE
bump(sqs test): ElasticMQ image 1.5.8 (was 1.3.4)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
           cbq -c Administrator:password -e http://couchbase:8093
       "
   elasticmq:
-    image: softwaremill/elasticmq-native:1.3.4
+    image: softwaremill/elasticmq-native:1.5.8
     ports:
       - "9324:9324"
   dynamodb:


### PR DESCRIPTION
Bumping the ElasticMQ image for testing should make the test succeed.

Refs
- https://github.com/softwaremill/elasticmq/releases/tag/v1.5.8