### PR TITLE
bump (Hbase, Hadoop): Hadoop 3.4, Hbase 2.6) fixes CVE-2021-37137

### DIFF
--- a/hbase/src/main/scala/akka/stream/alpakka/hbase/impl/HBaseCapabilities.scala
+++ b/hbase/src/main/scala/akka/stream/alpakka/hbase/impl/HBaseCapabilities.scala
@@ -7,8 +7,8 @@ package akka.stream.alpakka.hbase.impl
 import java.io.Closeable
 
 import akka.stream.stage.StageLogging
-import org.apache.hadoop.hbase.{HColumnDescriptor, HTableDescriptor, TableName}
-import org.apache.hadoop.hbase.client.{Connection, ConnectionFactory, Table}
+import org.apache.hadoop.hbase.TableName
+import org.apache.hadoop.hbase.client.{ColumnFamilyDescriptorBuilder, Connection, ConnectionFactory, Table, TableDescriptorBuilder}
 import org.apache.hadoop.conf.Configuration
 
 import scala.concurrent.duration.DurationInt
@@ -18,6 +18,8 @@ import scala.util.{Failure, Success, Try}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 import scala.language.postfixOps
+
+import org.apache.hadoop.hbase.util.Bytes
 
 private[impl] trait HBaseCapabilities { this: StageLogging =>
 
@@ -53,11 +55,11 @@ private[impl] trait HBaseCapabilities { this: StageLogging =>
       if (admin.isTableAvailable(tableName))
         connection.getTable(tableName)
       else {
-        val tableDescriptor: HTableDescriptor = new HTableDescriptor(tableName)
+        val tableDescriptor = TableDescriptorBuilder.newBuilder(tableName)
         columnFamilies.foreach { cf =>
-          tableDescriptor.addFamily(new HColumnDescriptor(cf))
+          tableDescriptor.setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(Bytes.toBytes(cf)).build())
         }
-        admin.createTable(tableDescriptor)
+        admin.createTable(tableDescriptor.build())
         log.info(s"Table $tableName created with cfs: $columnFamilies.")
         connection.getTable(tableName)
       }

--- a/hbase/src/main/scala/akka/stream/alpakka/hbase/impl/HBaseCapabilities.scala
+++ b/hbase/src/main/scala/akka/stream/alpakka/hbase/impl/HBaseCapabilities.scala
@@ -8,7 +8,13 @@ import java.io.Closeable
 
 import akka.stream.stage.StageLogging
 import org.apache.hadoop.hbase.TableName
-import org.apache.hadoop.hbase.client.{ColumnFamilyDescriptorBuilder, Connection, ConnectionFactory, Table, TableDescriptorBuilder}
+import org.apache.hadoop.hbase.client.{
+  ColumnFamilyDescriptorBuilder,
+  Connection,
+  ConnectionFactory,
+  Table,
+  TableDescriptorBuilder
+}
 import org.apache.hadoop.conf.Configuration
 
 import scala.concurrent.duration.DurationInt

--- a/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
+++ b/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
@@ -72,7 +72,7 @@ public class HBaseStageTest {
       person -> {
         try {
           Append append = new Append(String.format("id_%d", person.id).getBytes("UTF-8"));
-          append.add(
+          append.addColumn(
               "info".getBytes("UTF-8"), "aliases".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
 
           return Collections.singletonList(append);

--- a/hbase/src/test/scala/docs/scaladsl/HBaseStageSpec.scala
+++ b/hbase/src/test/scala/docs/scaladsl/HBaseStageSpec.scala
@@ -49,7 +49,7 @@ class HBaseStageSpec
   val appendHBaseConverter: Person => immutable.Seq[Mutation] = { person =>
     // Append to a cell
     val append = new Append(s"id_${person.id}")
-    append.add("info", "aliases", person.name)
+    append.addColumn("info", "aliases", person.name)
     List(append)
   }
   //#create-converter-append

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -290,8 +290,8 @@ object Dependencies {
   )
 
   val HBase = {
-    val hbaseVersion = "1.4.14"
-    val hadoopVersion = "3.3.6"
+    val hbaseVersion = "2.6.0"
+    val hadoopVersion = "3.4.0"
     Seq(
       libraryDependencies ++= Seq(
           "org.apache.hbase" % "hbase-shaded-client" % hbaseVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2,
@@ -303,7 +303,7 @@ object Dependencies {
     )
   }
 
-  val HadoopVersion = "3.3.6"
+  val HadoopVersion = "3.4.0"
   val Hdfs = Seq(
     libraryDependencies ++= Seq(
         "org.apache.hadoop" % "hadoop-client" % HadoopVersion exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"), // ApacheV2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,3 +18,5 @@ addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.5.0")
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.4.3")
 // templating
 addSbtPlugin("com.github.sbt" % "sbt-boilerplate" % "0.7.0")
+
+addDependencyTreePlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,5 +18,3 @@ addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.5.0")
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.4.3")
 // templating
 addSbtPlugin("com.github.sbt" % "sbt-boilerplate" % "0.7.0")
-
-addDependencyTreePlugin


### PR DESCRIPTION
Note: hbase is currently not tested due to mentioned issue.