### PR TITLE
fix(couchbase): cli args in the same line

### DIFF
--- a/couchbase/src/main/scala/akka/stream/alpakka/couchbase/scaladsl/CouchbaseFlow.scala
+++ b/couchbase/src/main/scala/akka/stream/alpakka/couchbase/scaladsl/CouchbaseFlow.scala
@@ -14,7 +14,8 @@ import com.couchbase.client.java.document.{Document, JsonDocument}
 object CouchbaseFlow {
 
   /**
-   * Create a flow to query Couchbase for by `id` and emit [[com.couchbase.client.java.document.JsonDocument JsonDocument]]s.
+   * Create a flow to query Couchbase for by `id` and
+   * emit [[com.couchbase.client.java.document.JsonDocument JsonDocument]]s.
    */
   def fromId(sessionSettings: CouchbaseSessionSettings, bucketName: String): Flow[String, JsonDocument, NotUsed] =
     Flow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,28 +42,11 @@ services:
             printf '.'
             sleep 2
         done
-        couchbase-cli cluster-init -c couchbase \
-          --cluster-username Administrator --cluster-password password \
-          --cluster-ramsize 300 \
-          --cluster-index-ramsize 256 \
-          --services data,index,query,fts
-        couchbase-cli bucket-create -c couchbase \
-          -u Administrator -p password \
-          --bucket akka \
-          --bucket-type couchbase \
-          --bucket-ramsize 100 \
-          --bucket-replica 1 \
-          --wait
-        couchbase-cli bucket-create -c couchbase \
-          -u Administrator -p password \
-          --bucket akkaquery \
-          --bucket-type couchbase \
-          --bucket-ramsize 100 \
-          --bucket-replica 1 \
-          --wait
+        couchbase-cli cluster-init -c couchbase --cluster-username Administrator --cluster-password password --cluster-ramsize 300 --cluster-index-ramsize 256 --services data,index,query,fts
+        couchbase-cli bucket-create -c couchbase -u Administrator -p password --bucket akka --bucket-type couchbase --bucket-ramsize 100 --bucket-replica 1 --wait
+        couchbase-cli bucket-create -c couchbase -u Administrator -p password --bucket akkaquery --bucket-type couchbase --bucket-ramsize 100 --bucket-replica 1 --wait
         sleep 2 # just wait a tiny bit more after creating the bucket
-        echo 'CREATE PRIMARY INDEX ON akkaquery USING GSI;' | \
-          cbq -c Administrator:password -e http://couchbase:8093
+        echo 'CREATE PRIMARY INDEX ON akkaquery USING GSI;' | cbq -c Administrator:password -e http://couchbase:8093
       "
   elasticmq:
     image: softwaremill/elasticmq-native:1.5.8


### PR DESCRIPTION
Avoid failing `couchbase_prep`. Could only test it locally with a newer version of the docker image, but bumping that would have required to bump the java client, which I am trying to avoid for now.