### PR TITLE
Mark Couchbase and Kudu connectors as EOL

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -37,4 +37,4 @@ jobs:
         run: sbt docs/makeSite
 
       - name: Run Link Validator
-        run: cs launch net.runne::site-link-validator:0.2.4 -- scripts/link-validator.conf
+        run: cs launch net.runne::site-link-validator:0.2.5 -- scripts/link-validator.conf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,6 @@ We follow the standard GitHub [fork & pull](https://help.github.com/articles/usi
 
 You're always welcome to submit your PR straight away and start the discussion (without reading the rest of this wonderful doc, or the README.md). The goal of these notes is to make your experience contributing to Alpakka as smooth and pleasant as possible. We're happy to guide you through the process once you've submitted your PR.
 
-# The Akka Community
-
-In case of questions about the contribution process or for discussion of specific issues please visit the [akka/dev gitter chat](https://gitter.im/akka/dev).
-
-You may also check out these [other resources](https://akka.io/get-involved/).
-
 # Contributing to Alpakka
 
 ## Development Setup
@@ -43,8 +37,6 @@ This is the process for committing code into main.
 1. After the review you should fix the issues (review comments, CI failures, compiler warnings) by pushing a new commit for new review, iterating until the reviewers give their thumbs up and CI tests pass.
 
 1. If the branch merge conflicts with its target, rebase your branch onto the target branch.
-
-In case of questions about the contribution process or for discussion of specific issues please visit the [akka/dev gitter chat](https://gitter.im/akka/dev).
 
 
 ## Alpakka specific advice

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you find an issue that you'd like to see fixed, the quickest way to make that
 
 Refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file for more details about the workflow, and general hints on how to prepare your pull request. If you're planning to implement a new module within Alpakka, look at our [contributor advice](contributor-advice.md).
 
-You can also ask for clarifications or guidance in GitHub issues directly, or in the [akka/dev](https://gitter.im/akka/dev) chat if a more real time communication would be of benefit.
+You can also ask for clarifications or guidance in GitHub issues directly.
 
 Caveat Emptor
 -------------

--- a/build.sbt
+++ b/build.sbt
@@ -417,7 +417,7 @@ lazy val docs = project
         "extref.geode.base_url" -> s"https://geode.apache.org/docs/guide/${Dependencies.GeodeVersionForDocs}/%s",
         "extref.javaee-api.base_url" -> "https://docs.oracle.com/javaee/7/api/index.html?%s.html",
         "extref.paho-api.base_url" -> "https://www.eclipse.org/paho/files/javadoc/index.html?%s.html",
-        "extref.pravega.base_url" -> s"https://cncf.pravega.io/docs/${Dependencies.PravegaVersionForDocs}/%s",
+        "extref.pravega.base_url" -> s"https://cncf.pravega.io/docs/latest/%s",
         "extref.slick.base_url" -> s"https://scala-slick.org/doc/${Dependencies.SlickVersion}/%s",
         // Cassandra
         "extref.cassandra.base_url" -> s"https://cassandra.apache.org/doc/${Dependencies.CassandraVersionInDocs}/%s",
@@ -434,7 +434,6 @@ lazy val docs = project
         "javadoc.jakarta.jms.base_url" -> "https://jakarta.ee/specifications/messaging/3.1/apidocs/jakarta.messaging/",
         "javadoc.jakarta.jms.link_style" -> "direct",
         "javadoc.com.couchbase.base_url" -> s"https://docs.couchbase.com/sdk-api/couchbase-java-client-${Dependencies.CouchbaseVersion}/",
-        "javadoc.io.pravega.base_url" -> s"http://pravega.io/docs/${Dependencies.PravegaVersionForDocs}/javadoc/clients/",
         "javadoc.org.apache.kudu.base_url" -> s"https://kudu.apache.org/releases/${Dependencies.KuduVersion}/apidocs/",
         "javadoc.org.apache.hadoop.base_url" -> s"https://hadoop.apache.org/docs/r${Dependencies.HadoopVersion}/api/",
         "javadoc.software.amazon.awssdk.base_url" -> "https://sdk.amazonaws.com/java/api/latest/",

--- a/docs/release-train-issue-template.md
+++ b/docs/release-train-issue-template.md
@@ -51,7 +51,6 @@ For important patch releases, and only if critical issues have been fixed:
 
 - [ ] Send a release notification to [Lightbend discuss](https://discuss.akka.io)
 - [ ] Tweet using the [@akkateam](https://twitter.com/akkateam/) account (or ask someone to) about the new release
-- [ ] Announce on [Gitter akka/akka](https://gitter.im/akka/akka)
 - [ ] Announce internally (with links to Tweet, discuss)
 
 For minor or major releases:

--- a/docs/src/main/paradox/couchbase.md
+++ b/docs/src/main/paradox/couchbase.md
@@ -1,5 +1,11 @@
 # Couchbase
 
+@@@ warning { title="End of life" }
+
+The Couchbase connector has not been updated for too long and is now considered End of Life. It will be removed with the next release of Alpakka.
+
+@@@
+
 @@@ note { title="Couchbase"}
 
 Couchbase is an open-source, distributed (shared-nothing architecture) multi-model NoSQL document-oriented database software package that is optimized for interactive applications. These applications may serve many concurrent users by creating, storing, retrieving, aggregating, manipulating and presenting data. In support of these kinds of application needs, Couchbase Server is designed to provide easy-to-scale key-value or JSON document access with low latency and high sustained throughput. It is designed to be clustered from a single machine to very large-scale deployments spanning many machines. 

--- a/docs/src/main/paradox/external/db2-event-store.md
+++ b/docs/src/main/paradox/external/db2-event-store.md
@@ -1,9 +1,0 @@
-# IBM Db2 Event Store
-
-This adapter provides an Akka Streams interface for [IBM Db2 Event Store](https://www.ibm.com/support/knowledgecenter/en/SSGNPV_1.1.2/eos?origURL=SSGNPV_1.1.2/eventstore/welcome.html). 
-
-
-## External library
-
-This library is not maintained in the Alpakka repository.
-Learn more about it in the [sample application with Db2 EventStore](https://github.com/IBM/db2-event-store-akka-streams).

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -43,7 +43,6 @@ The [Alpakka project](https://doc.akka.io/docs/alpakka/current/) is an initiativ
 * [Huawei Push Kit](huawei-push-kit.md)
 * [HTTP](external/http.md)
 * [IBM Bluemix Cloud Object storage](bluemix-cos.md)
-* [IBM DB2 Event Store](external/db2-event-store.md)
 * [InfluxDB](influxdb.md)
 * [IronMQ](ironmq.md)
 * [Jakarta Messaging](jakarta-jms/index.md)

--- a/docs/src/main/paradox/kudu.md
+++ b/docs/src/main/paradox/kudu.md
@@ -1,5 +1,11 @@
 # Apache Kudu
 
+@@@warning { title="End of life" }
+
+The Kudu connector has not been updated for too long and is now considered End of Life. It will be removed with the next release of Alpakka.
+
+@@@
+
 The Alpakka Kudu connector supports writing to [Apache Kudu](https://kudu.apache.org) tables.
 
 Apache Kudu is a free and open source column-oriented data store in the Apache Hadoop ecosystem.

--- a/docs/src/main/paradox/pravega.md
+++ b/docs/src/main/paradox/pravega.md
@@ -187,8 +187,3 @@ Or a Flow
 
 Scala
 :   @@snip[snip](/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaStreamAndTableSpec.scala) { #table-reading-flow }
-
-
-## Support
-
-In addition to our regular Alpakka community support on [![gitter: akka/akka](https://img.shields.io/badge/gitter%3A-akka%2Fakka-blue.svg?style=flat-square)](https://gitter.im/akka/akka) and Lightbend's [discuss.lightbend.com](https://discuss.lightbend.com/c/akka/streams-and-alpakka).

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -61,7 +61,7 @@ project-info {
     ]
   }
   aws-event-bridge: ${project-info.shared-info} {
-    title: "Alpakka AWS EventBriged"
+    title: "Alpakka AWS EventBridge"
     jpms-name: "akka.stream.alpakka.aws.eventbrigde"
     issues.url: ${project-info.labels}"aws-eventbrigde"
     levels: [
@@ -147,6 +147,11 @@ project-info {
     jpms-name: "akka.stream.alpakka.couchbase"
     issues.url: ${project-info.labels}"couchbase"
     levels: [
+      {
+        readiness: EndOfLife
+        since: "2024-10-14"
+        since-version: "9.0.0-M1"
+      }
       {
         readiness: CommunityDriven
         since: "2022-04-04"
@@ -583,6 +588,11 @@ project-info {
     jpms-name: "akka.stream.alpakka.kudu"
     issues.url: ${project-info.labels}"kudu"
     levels: [
+      {
+        readiness: EndOfLife
+        since: "2024-10-14"
+        since-version: "9.0.0-M1"
+      }
       {
         readiness: CommunityDriven
         since: "2018-05-09"

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -33,7 +33,9 @@ site-link-validator {
     # Datastax seem to be blocking bot requests
     "https://docs.datastax.com/en/developer/java-driver/",
     "https://docs.datastax.com/en/drivers/java/4.17/",
-    "https://docs.datastax.com/en/dse/6.7/"
+    "https://docs.datastax.com/en/dse/6.7/",
+    # PKIX path validation failed
+    "https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/"
   ]
 
   ignore-files = []


### PR DESCRIPTION
Mark End of life for
- Apache Kudu connector
- Couchbase connector

Also
- remove links to Gitter
- improve links for Pravega