### PR TITLE
Revert "bump: activemq-broker, activemq-client 5.18.5 (was 5.16.7) (#3241)"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -353,8 +353,8 @@ object Dependencies {
     libraryDependencies ++= Seq(
         "javax.jms" % "jms" % "1.1" % Provided, // CDDL + GPLv2
         "com.ibm.mq" % "com.ibm.mq.allclient" % "9.3.5.1" % Test, // IBM International Program License Agreement https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/maven/licenses/L-APIG-AZYF2E/LI_en.html
-        "org.apache.activemq" % "activemq-broker" % "5.18.5" % Test, // ApacheV2
-        "org.apache.activemq" % "activemq-client" % "5.18.5" % Test, // ApacheV2
+        "org.apache.activemq" % "activemq-broker" % "5.16.7" % Test, // ApacheV2
+        "org.apache.activemq" % "activemq-client" % "5.16.7" % Test, // ApacheV2
         "io.github.sullis" %% "jms-testkit" % "1.0.4" % Test // ApacheV2
       ) ++ Mockito,
     // Having JBoss as a first resolver is a workaround for https://github.com/coursier/coursier/issues/200


### PR DESCRIPTION
This reverts commit 847fafb2cb93ca0b300dd49268686abcbc3077c0.

Showed [here](https://github.com/akka/alpakka/pull/3260) as a red herring, was introduced [here](https://github.com/akka/alpakka/pull/3241).