### PR TITLE
bump: Slick 3.5.2 (was 3.5.1)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -474,12 +474,12 @@ object Dependencies {
     )
   }
 
-  val SlickVersion = "3.5.1"
+  val SlickVersion = "3.5.2"
   val Slick = Seq(
     libraryDependencies ++= Seq(
-        ("com.typesafe.slick" %% "slick" % SlickVersion).exclude("org.slf4j", "slf4j-api"),
-        ("com.typesafe.slick" %% "slick-hikaricp" % SlickVersion).exclude("org.slf4j", "slf4j-api"),
-        "com.h2database" % "h2" % "2.3.232" % Test // Eclipse Public License 1.0
+        "com.typesafe.slick" %% "slick" % SlickVersion,
+        "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion,
+        "com.h2database" % "h2" % "2.3.232" % Test
       )
   )
   val Eventbridge = Seq(


### PR DESCRIPTION
and drop slf4j exclusions as we bumped the version.

References
- https://github.com/slick/slick/releases/tag/v3.5.2