### PR TITLE
docs: show template's Akka logo

### DIFF
--- a/docs/src/main/paradox/_template/logo.st
+++ b/docs/src/main/paradox/_template/logo.st
@@ -1,1 +1,0 @@
-<a href="https://akka.io"><img class="logo" src="$page.base$images/akka-alpakka-reverse.svg"/></a>


### PR DESCRIPTION
The site currently uses the original Alpakka logo.