### PR TITLE
Delete docs/src/main/paradox/_template/logo.st

### DIFF
--- a/docs/src/main/paradox/_template/logo.st
+++ b/docs/src/main/paradox/_template/logo.st
@@ -1,1 +1,0 @@
-<a href="https://akka.io"><img class="logo" src="$page.base$images/akka-alpakka-reverse.svg"/></a>


### PR DESCRIPTION
Delete the Alpakka logo so that it uses the new Akka logo

@ennru can we this repo just use the Akka logo, as the Alpakka logo uses the old Akka brand?
