### PR TITLE
chore: link validator in separate workflow

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -47,39 +47,6 @@ jobs:
       - name: "Code style, compile tests, MiMa. Run locally with: sbt \"verifyCodeStyle; +Test/compile; mimaReportBinaryIssues\""
         run: sbt "verifyCodeStyle; +Test/compile; mimaReportBinaryIssues"
 
-  documentation:
-    name: ScalaDoc, Documentation with Paradox
-    runs-on: ubuntu-22.04
-    env:
-      JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
-
-    steps:
-      - name: Checkout
-        # https://github.com/actions/checkout/releases
-        # v4.1.1
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-        with: # https://github.com/olafurpg/setup-scala#faster-checkout-of-big-repos
-          fetch-depth: 100
-          fetch-tags: true
-
-      - name: Cache Coursier cache
-        # https://github.com/coursier/cache-action/releases
-        # v6.4.5
-        uses: coursier/cache-action@1ff273bff02a8787bc9f1877d347948af647956d
-
-      - name: Set up JDK 11
-        # https://github.com/coursier/setup-action/releases
-        # v1.3.5
-        uses: coursier/setup-action@7bde40eee928896f074dbb76d22dd772eed5c65f
-        with:
-          jvm: temurin:1.11
-
-      - name: "Create all API docs and create site with Paradox"
-        run: sbt docs/makeSite
-
-      - name: Run Link Validator
-        run: cs launch net.runne::site-link-validator:0.2.3 -- scripts/link-validator.conf
-
   connectors:
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -31,12 +31,12 @@ jobs:
         # v6.4.5
         uses: coursier/cache-action@1ff273bff02a8787bc9f1877d347948af647956d
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         # https://github.com/coursier/setup-action/releases
         # v1.3.5
         uses: coursier/setup-action@7bde40eee928896f074dbb76d22dd772eed5c65f
         with:
-          jvm: temurin:1.11
+          jvm: temurin:1.17
           apps: cs
 
       - name: sbt site

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -1,6 +1,12 @@
 name: Link Validator
 
 on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags-ignore:
+      - v*
   workflow_dispatch:
   schedule:
     - cron:  '0 6 * * 1'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,11 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     # runs on main repo only

--- a/docs/src/main/paradox/azure-storage-queue.md
+++ b/docs/src/main/paradox/azure-storage-queue.md
@@ -2,7 +2,7 @@
 
 The Azure Storage Queue connector provides an Akka Stream Source and Sinks for Azure Storage Queue integration.
 
-Azure Storage Queue is a queuing service similar to Amazon's SQS. It is designed mostly for long-running and non-time-critical tasks. For more information on Azure Storage Queue see the [Azure docs](https://azure.microsoft.com/en-us/services/storage/queues/).
+Azure Storage Queue is a queuing service similar to Amazon's SQS. It is designed mostly for long-running and non-time-critical tasks. For more information on Azure Storage Queue see the [Azure docs](https://azure.microsoft.com/en-us/products/storage/queues/).
 
 @@project-info{ projectId="azure-storage-queue" }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import Keys._
 object Dependencies {
 
   // Java Platform version for JavaDoc creation
-  // sync with Java version in .github/workflows/publish.yml#documentation
+  // sync with Java version in .github/workflows/link-validator.yml
   lazy val JavaDocLinkVersion = 17
 
   val CronBuild = sys.env.get("GITHUB_EVENT_NAME").contains("schedule")

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -38,6 +38,10 @@ site-link-validator {
     "https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/"
     # REMOVE some day: The Slick 3.5.2 docs are not published, 2024-12-06
     "https://scala-slick.org/doc/3.5.2/"
+    # Ignore links to docs of non-base Java modules
+    "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/sql/"
+    "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/xml/stream/"
+    "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/org/w3c/"
   ]
 
   ignore-files = []


### PR DESCRIPTION
- Run the link validator workflow on PRs and merges instead of the "Documentation" part in the main CI workflow
- Cancel the Publish workflow in case another merge happens while it is running