### PR TITLE
FTP (test): Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -216,7 +216,7 @@ object Dependencies {
         "commons-net" % "commons-net" % "3.11.1",
         // Versions after sshj 0.35.0 depend on SLF4J 2.x
         "com.hierynomus" % "sshj" % "0.39.0",
-        ("io.github.hakky54" % "sslcontext-kickstart-for-pem" % "8.3.7" % Test)
+        ("io.github.hakky54" % "ayza-for-pem" % "10.0.0" % Test)
       )
   )
 


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience