### PR TITLE
chore: Reduce link validator schedule

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -9,7 +9,7 @@ on:
       - v*
   workflow_dispatch:
   schedule:
-    - cron:  '0 6 * * 1'
+    - cron:  '0 6 1 * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
Once a month is enough.