### PR TITLE
Drop unused compatibility libraries

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,7 +60,6 @@ object Dependencies {
 
   val testkit = Seq(
     libraryDependencies := Seq(
-        "org.scala-lang.modules" %% "scala-collection-compat" % "2.7.0",
         "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
         "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion,
         "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
@@ -166,7 +165,6 @@ object Dependencies {
         (
           ExclusionRule(organization = "com.typesafe.akka")
         ),
-        "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2",
         "software.amazon.awssdk" % "dynamodb" % AwsSdk2Version excludeAll // ApacheV2
         (
           ExclusionRule("software.amazon.awssdk", "apache-client"),
@@ -504,8 +502,7 @@ object Dependencies {
           ExclusionRule("software.amazon.awssdk", "netty-nio-client")
         ),
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-        "com.typesafe.akka" %% "akka-pki" % AkkaVersion,
-        "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2"
+        "com.typesafe.akka" %% "akka-pki" % AkkaVersion
       ) ++ Mockito
   )
 
@@ -515,7 +512,6 @@ object Dependencies {
         (
           ExclusionRule(organization = "com.typesafe.akka")
         ),
-        "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2",
         "software.amazon.awssdk" % "sns" % AwsSdk2Version excludeAll // ApacheV2
         (
           ExclusionRule("software.amazon.awssdk", "apache-client"),
@@ -543,7 +539,6 @@ object Dependencies {
         (
           ExclusionRule(organization = "com.typesafe.akka")
         ),
-        "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2",
         "software.amazon.awssdk" % "sqs" % AwsSdk2Version excludeAll // ApacheV2
         (
           ExclusionRule("software.amazon.awssdk", "apache-client"),


### PR DESCRIPTION
The Java 8 compat library should have been dropped when we dropped Java 8 compilation.

The Scala Collections library even when we dropped Scala 2.12.