### PR TITLE
chore: drop Scala collection compat

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,7 +62,6 @@ object Dependencies {
 
   val testkit = Seq(
     libraryDependencies := Seq(
-        "org.scala-lang.modules" %% "scala-collection-compat" % "2.7.0",
         "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
         "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion,
         "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,


### PR DESCRIPTION
...which was still a testkit dependency but not needed anymore since everything is Scala 2.13+