### PR TITLE
bump: Cassandra Java driver 4.19.1 (was 4.17.0)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -424,8 +424,8 @@ lazy val docs = project
         "extref.slick.base_url" -> s"https://scala-slick.org/doc/${Dependencies.SlickVersion}/%s",
         // Cassandra
         "extref.cassandra.base_url" -> s"https://cassandra.apache.org/doc/${Dependencies.CassandraVersionInDocs}/%s",
-        "extref.cassandra-driver.base_url" -> s"https://docs.datastax.com/en/developer/java-driver/${Dependencies.CassandraDriverVersionInDocs}/%s",
-        "javadoc.com.datastax.oss.base_url" -> s"https://docs.datastax.com/en/drivers/java/${Dependencies.CassandraDriverVersionInDocs}/",
+        "extref.cassandra-driver.base_url" -> s"https://apache.github.io/cassandra-java-driver/${Dependencies.CassandraDriverVersionInDocs}/%s",
+        "javadoc.com.datastax.oss.base_url" -> s"https://apache.github.io/cassandra-java-driver/${Dependencies.CassandraDriverVersionInDocs}/api/",
         // Solr
         "extref.solr.base_url" -> s"https://solr.apache.org/guide/${Dependencies.SolrVersionForDocs}/%s",
         "javadoc.org.apache.solr.base_url" -> s"https://solr.apache.org/docs/${Dependencies.SolrVersionForDocs}_0/solr-solrj/",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -127,11 +127,11 @@ object Dependencies {
 
   val CassandraVersionInDocs = "4.0"
   val CassandraDriverVersion = "4.19.1"
-  val CassandraDriverVersionInDocs = "4.19"
+  val CassandraDriverVersionInDocs = CassandraDriverVersion
 
   val Cassandra = Seq(
     libraryDependencies ++= Seq(
-        ("com.datastax.oss" % "java-driver-core" % CassandraDriverVersion)
+        ("org.apache.cassandra" % "java-driver-core" % CassandraDriverVersion)
           .exclude("com.github.spotbugs", "spotbugs-annotations")
           .exclude("org.apache.tinkerpop", "*") //https://github.com/akka/alpakka/issues/2200
           .exclude("com.esri.geometry", "esri-geometry-api"), //https://github.com/akka/alpakka/issues/2225


### PR DESCRIPTION
References
- https://github.com/apache/cassandra-java-driver/releases/tag/4.19.1
- https://mvnrepository.com/artifact/org.apache.cassandra/java-driver-core/4.19.1
- https://github.com/akka/alpakka/pull/3015
