### PR TITLE
fix(kinesis): Fix shard end coordination race condition

### DIFF
--- a/kinesis/src/main/scala/akka/stream/alpakka/kinesis/impl/ShardProcessor.scala
+++ b/kinesis/src/main/scala/akka/stream/alpakka/kinesis/impl/ShardProcessor.scala
@@ -21,23 +21,16 @@ private[kinesis] class ShardProcessor(
     processRecord: CommittableRecord => Unit
 ) extends ShardRecordProcessor {
 
-  // We need extra coordination in the event of a Shard End (for example, when we double
-  // the number of shards, the old shards are ended and the new shards take their place).
-  //
-  // When a shard needs to be ended, the "shardEnded" method is invoked. We block that
-  // invocation until all records (actually we only care about the latest record)
-  // are checkpointed using the asynchronous stream mechanism.
-  //
-  // When all records are checkpointed, the "shardEnded" method can safely acknowledge
-  // that the shard can be ended.
-  //
-  // If we were not to do this extra work, the shard would be ended before we made sure
-  // that all the records have been successfully consumed by the stream.
-  //
-  // To do the coordination we use a Semaphore instance in every ShardProcessor
-  // instance. Both the ShardProcessor and its Semaphore will live in a thread spawned
-  // by the AWS KCL Scheduler after the Scheduler run() method has been invoked.
-  private val lastRecordSemaphore = new Semaphore(1)
+  // Coordination for shard end: we must not call checkpointer.checkpoint() in shardEnded until
+  // the last record we handed out has been checkpointed. Otherwise, when the final batch has
+  // no records (isAtShardEnd was never true in the previous batch), shardEnded would complete
+  // immediately and later checkpoint attempts for in-flight records would fail because the
+  // shard is already checkpointed with SHARD_END. We tie a semaphore to the last record of
+  // each batch; that record releases it on checkpoint. shardEnded waits on it before
+  // checkpointing the shard. If the last batch is empty, lastRecordSemaphore still refers to
+  // the previous batch's last record, so we correctly wait for it.
+  @volatile
+  private var lastRecordSemaphore: Option[Semaphore] = None
 
   private var shardData: ShardProcessorData = _
   private var checkpointer: RecordProcessorCheckpointer = _
@@ -56,20 +49,19 @@ private[kinesis] class ShardProcessor(
                                   processRecordsInput.isAtShardEnd,
                                   processRecordsInput.millisBehindLatest)
 
-    if (batchData.isAtShardEnd) {
-      lastRecordSemaphore.acquire()
-    }
-
     val numberOfRecords = processRecordsInput.records().size()
     processRecordsInput.records().asScala.zipWithIndex.foreach {
       case (record, index) =>
-        processRecord(
-          new InternalCommittableRecord(
-            record,
-            batchData,
-            lastRecord = processRecordsInput.isAtShardEnd && index + 1 == numberOfRecords
-          )
-        )
+        // Only the last record in the batch gets a semaphore; when it is checkpointed it
+        // releases it so shardEnded can proceed. Non-last records pass None.
+        val committableRecord =
+          if (index + 1 == numberOfRecords) {
+            lastRecordSemaphore = Some(new Semaphore(0))
+            new InternalCommittableRecord(record, batchData, checkpointed = lastRecordSemaphore)
+          } else {
+            new InternalCommittableRecord(record, batchData, None)
+          }
+        processRecord(committableRecord)
     }
   }
 
@@ -80,10 +72,11 @@ private[kinesis] class ShardProcessor(
 
   override def shardEnded(shardEndedInput: ShardEndedInput): Unit = {
     checkpointer = shardEndedInput.checkpointer()
-    // We must checkpoint to finish the shard, but we wait
-    // until all records in flight have been processed
+    // We must checkpoint to finish the shard, but we wait until the last record we handed
+    // out has been checkpointed (releases the semaphore). If no records were ever created,
+    // lastRecordSemaphore is None and we proceed without waiting.
     shutdown = Some(ShutdownReason.SHARD_END)
-    lastRecordSemaphore.acquire()
+    lastRecordSemaphore.foreach(_.acquire())
     checkpointer.checkpoint()
   }
 
@@ -94,11 +87,15 @@ private[kinesis] class ShardProcessor(
     shutdown = Some(ShutdownReason.REQUESTED)
   }
 
-  final class InternalCommittableRecord(record: KinesisClientRecord, batchData: BatchData, lastRecord: Boolean)
-      extends CommittableRecord(record, batchData, shardData) {
+  final class InternalCommittableRecord(
+      record: KinesisClientRecord,
+      batchData: BatchData,
+      checkpointed: Option[Semaphore]
+  ) extends CommittableRecord(record, batchData, shardData) {
     private def checkpoint(): Unit = {
       checkpointer.checkpoint(sequenceNumber, subSequenceNumber)
-      if (lastRecord) lastRecordSemaphore.release()
+      // Signal shardEnded that this (last) record is done so it can safely checkpoint the shard.
+      checkpointed.foreach(_.release())
     }
     override def shutdownReason: Option[ShutdownReason] = shutdown
     override def forceCheckpoint(): Unit =

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/impl/ShardProcessorSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/impl/ShardProcessorSpec.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.stream.alpakka.kinesis.impl
+
+import java.util.Collections
+
+import akka.stream.alpakka.kinesis.{CommittableRecord, DefaultTestContext}
+import org.mockito.Mockito.{verify, when}
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar.mock
+import software.amazon.kinesis.lifecycle.events.{InitializationInput, ProcessRecordsInput, ShardEndedInput}
+import software.amazon.kinesis.processor.RecordProcessorCheckpointer
+import software.amazon.kinesis.retrieval.KinesisClientRecord
+
+class ShardProcessorSpec extends AnyWordSpec with Matchers with DefaultTestContext with IntegrationPatience {
+
+  private def mockKinesisRecord(sequenceNumber: String, subSequenceNumber: Long): KinesisClientRecord = {
+    val r = mock[KinesisClientRecord]
+    when(r.sequenceNumber()).thenReturn(sequenceNumber)
+    when(r.subSequenceNumber()).thenReturn(subSequenceNumber)
+    r
+  }
+
+  private def mockInitInput(shardId: String): InitializationInput = {
+    val input = mock[InitializationInput]
+    when(input.shardId()).thenReturn(shardId)
+    when(input.extendedSequenceNumber()).thenReturn(null)
+    when(input.pendingCheckpointSequenceNumber()).thenReturn(null)
+    input
+  }
+
+  private def mockProcessRecordsInput(
+      records: java.util.List[KinesisClientRecord],
+      checkpointer: RecordProcessorCheckpointer,
+      isAtShardEnd: Boolean
+  ): ProcessRecordsInput = {
+    val input = mock[ProcessRecordsInput]
+    when(input.records()).thenReturn(records)
+    when(input.checkpointer()).thenReturn(checkpointer)
+    when(input.cacheEntryTime()).thenReturn(java.time.Instant.now())
+    when(input.cacheExitTime()).thenReturn(java.time.Instant.now())
+    when(input.isAtShardEnd()).thenReturn(isAtShardEnd)
+    when(input.millisBehindLatest()).thenReturn(0L)
+    input
+  }
+
+  private def mockShardEndedInput(checkpointer: RecordProcessorCheckpointer): ShardEndedInput = {
+    val input = mock[ShardEndedInput]
+    when(input.checkpointer()).thenReturn(checkpointer)
+    input
+  }
+
+  "ShardProcessor" should {
+
+    "block shardEnded until the last record in the batch is checkpointed" in {
+      val records = Collections.singletonList(mockKinesisRecord("seq-1", 0L))
+      val checkpointer = mock[RecordProcessorCheckpointer]
+      var capturedRecord: Option[CommittableRecord] = None
+
+      val processor = new ShardProcessor(r => capturedRecord = Some(r))
+      processor.initialize(mockInitInput("shard-1"))
+      processor.processRecords(mockProcessRecordsInput(records, checkpointer, isAtShardEnd = true))
+
+      val shardEndedDone = new java.util.concurrent.atomic.AtomicBoolean(false)
+      val shardEndedThread = new Thread(
+        () => {
+          processor.shardEnded(mockShardEndedInput(checkpointer))
+          shardEndedDone.set(true)
+        }
+      )
+      shardEndedThread.start()
+
+      // shardEnded should block because the record has not been checkpointed yet
+      Thread.sleep(100)
+      shardEndedDone.get() shouldBe false
+
+      // checkpoint the last record; this should release the semaphore and let shardEnded proceed
+      capturedRecord.get.forceCheckpoint()
+      shardEndedThread.join(2000)
+      shardEndedDone.get() shouldBe true
+
+      verify(checkpointer).checkpoint("seq-1", 0L)
+      verify(checkpointer).checkpoint()
+    }
+
+    "when the last batch is empty, block shardEnded until the previous batch's last record is checkpointed" in {
+      val checkpointer = mock[RecordProcessorCheckpointer]
+      var lastSeenRecord: Option[CommittableRecord] = None
+
+      val processor = new ShardProcessor(r => lastSeenRecord = Some(r))
+      processor.initialize(mockInitInput("shard-1"))
+
+      // First batch: one record, not at shard end (simulates that the final batch will be empty)
+      val firstBatchRecords = Collections.singletonList(mockKinesisRecord("seq-1", 0L))
+      processor.processRecords(mockProcessRecordsInput(firstBatchRecords, checkpointer, isAtShardEnd = false))
+      val recordFromFirstBatch = lastSeenRecord.get
+
+      // Second batch: empty, at shard end (KCL can call processRecords with 0 records)
+      processor.processRecords(mockProcessRecordsInput(Collections.emptyList(), checkpointer, isAtShardEnd = true))
+
+      val shardEndedDone = new java.util.concurrent.atomic.AtomicBoolean(false)
+      val shardEndedThread = new Thread(
+        () => {
+          processor.shardEnded(mockShardEndedInput(checkpointer))
+          shardEndedDone.set(true)
+        }
+      )
+      shardEndedThread.start()
+
+      // shardEnded must wait for the previous batch's last record, not complete immediately
+      Thread.sleep(100)
+      shardEndedDone.get() shouldBe false
+
+      recordFromFirstBatch.forceCheckpoint()
+      shardEndedThread.join(2000)
+      shardEndedDone.get() shouldBe true
+
+      verify(checkpointer).checkpoint("seq-1", 0L)
+      verify(checkpointer).checkpoint()
+    }
+
+    "complete shardEnded immediately when no records were ever processed" in {
+      val checkpointer = mock[RecordProcessorCheckpointer]
+      val processor = new ShardProcessor(_ => ())
+
+      processor.initialize(mockInitInput("shard-1"))
+      // processRecords never called with any records (or only empty batches)
+      processor.processRecords(mockProcessRecordsInput(Collections.emptyList(), checkpointer, isAtShardEnd = true))
+
+      processor.shardEnded(mockShardEndedInput(checkpointer))
+
+      verify(checkpointer).checkpoint()
+    }
+  }
+}

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/impl/ShardProcessorSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/impl/ShardProcessorSpec.scala
@@ -6,7 +6,8 @@ package akka.stream.alpakka.kinesis.impl
 
 import java.util.Collections
 
-import akka.stream.alpakka.kinesis.{CommittableRecord, DefaultTestContext}
+import akka.stream.alpakka.kinesis.CommittableRecord
+import akka.stream.alpakka.testkit.scaladsl.LogCapturing
 import org.mockito.Mockito.{mock => jMock, verify, when}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -14,7 +15,7 @@ import software.amazon.kinesis.lifecycle.events.{InitializationInput, ProcessRec
 import software.amazon.kinesis.processor.RecordProcessorCheckpointer
 import software.amazon.kinesis.retrieval.KinesisClientRecord
 
-class ShardProcessorSpec extends AnyWordSpec with Matchers with DefaultTestContext {
+class ShardProcessorSpec extends AnyWordSpec with Matchers with LogCapturing {
 
   private def mock[T](implicit ct: scala.reflect.ClassTag[T]): T =
     jMock(ct.runtimeClass.asInstanceOf[Class[T]])

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/impl/ShardProcessorSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/impl/ShardProcessorSpec.scala
@@ -7,16 +7,17 @@ package akka.stream.alpakka.kinesis.impl
 import java.util.Collections
 
 import akka.stream.alpakka.kinesis.{CommittableRecord, DefaultTestContext}
-import org.mockito.Mockito.{verify, when}
-import org.scalatest.concurrent.IntegrationPatience
+import org.mockito.Mockito.{mock => jMock, verify, when}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.mockito.MockitoSugar.mock
 import software.amazon.kinesis.lifecycle.events.{InitializationInput, ProcessRecordsInput, ShardEndedInput}
 import software.amazon.kinesis.processor.RecordProcessorCheckpointer
 import software.amazon.kinesis.retrieval.KinesisClientRecord
 
-class ShardProcessorSpec extends AnyWordSpec with Matchers with DefaultTestContext with IntegrationPatience {
+class ShardProcessorSpec extends AnyWordSpec with Matchers with DefaultTestContext {
+
+  private def mock[T](implicit ct: scala.reflect.ClassTag[T]): T =
+    jMock(ct.runtimeClass.asInstanceOf[Class[T]])
 
   private def mockKinesisRecord(sequenceNumber: String, subSequenceNumber: Long): KinesisClientRecord = {
     val r = mock[KinesisClientRecord]


### PR DESCRIPTION
## Summary
- Fix race condition in `ShardProcessor` where premature shard checkpoint occurs when KCL delivers an empty final batch
- Replace single semaphore coordination with per-batch last-record tracking
- Add `ShardProcessorSpec` with comprehensive test coverage for the coordination scenarios

## Problem
The original implementation used a single `Semaphore(1)` that was acquired when `isAtShardEnd` was true. This created a race condition:

1. When KCL delivers a batch with records where `isAtShardEnd=false`, the records are processed normally
2. KCL then delivers an empty final batch with `isAtShardEnd=true` (this is valid KCL behavior)
3. The `shardEnded` method is called, but since no records were in the final batch, no semaphore coordination happened
4. `shardEnded` immediately checkpoints the shard with `SHARD_END`
5. In-flight records from the previous batch fail to checkpoint because the shard is already marked as ended

## Solution
Replace the single semaphore approach with a per-batch tracking mechanism:

- Create a new `Semaphore(0)` for the **last record of each batch** (empty batches create no semaphore)
- Store it in `Option[Semaphore]` (volatile) so it persists across batches
- When `shardEnded` is called, wait on the most recent semaphore (which correctly points to the previous batch's last record if the final batch is empty)
- If no records were ever processed, proceed without waiting

## Test Coverage
Added `ShardProcessorSpec` with three test scenarios:
1. **Normal case**: Block `shardEnded` until the last record is checkpointed
2. **Empty final batch**: Block `shardEnded` until the previous batch's last record is checkpointed (the critical bug fix)
3. **No records**: Complete `shardEnded` immediately when no records were ever processed

## Related
This bug was discovered and fixed in https://github.com/adRise/hyades/pull/3668 and has been ported to alpakka.

🤖 Generated with [Claude Code](https://claude.com/claude-code)