### PR TITLE
feat: Azure identity for azure storage auth

### DIFF
--- a/azure-storage/src/main/resources/reference.conf
+++ b/azure-storage/src/main/resources/reference.conf
@@ -9,7 +9,8 @@ alpakka {
 
     #azure-credentials
     credentials {
-      # valid values are anon (annonymous), SharedKey, SharedKeyLite, and sas
+      # valid values are anon (anonymous), SharedKey, SharedKeyLite, sas, and BearerToken
+      # BearerToken uses Azure AD OAuth2 via azure-identity (supports managed identity, workload identity, etc.)
       authorization-type = anon
       authorization-type = ${?AZURE_STORAGE_AUTHORIZATION_TYPE}
 

--- a/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/Settings.scala
+++ b/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/Settings.scala
@@ -47,7 +47,10 @@ final class StorageSettings(val apiVersion: String,
   /** Java API */
   def getAlgorithm: String = algorithm
 
-  def witApiVersion(apiVersion: String): StorageSettings = copy(apiVersion = apiVersion)
+  def withApiVersion(apiVersion: String): StorageSettings = copy(apiVersion = apiVersion)
+
+  @deprecated("Use withApiVersion instead", "azure-storage 10.0.0")
+  def witApiVersion(apiVersion: String): StorageSettings = withApiVersion(apiVersion)
 
   def withAuthorizationType(authorizationType: String): StorageSettings = copy(authorizationType = authorizationType)
 
@@ -97,6 +100,7 @@ final class StorageSettings(val apiVersion: String,
   override def hashCode(): Int =
     Objects.hash(apiVersion,
                  authorizationType,
+                 endPointUrl,
                  azureNameKeyCredential,
                  sasToken,
                  retrySettings,

--- a/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/Settings.scala
+++ b/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/Settings.scala
@@ -47,29 +47,21 @@ final class StorageSettings(val apiVersion: String,
   /** Java API */
   def getAlgorithm: String = algorithm
 
-  /** Java API */
   def witApiVersion(apiVersion: String): StorageSettings = copy(apiVersion = apiVersion)
 
-  /** Java API */
   def withAuthorizationType(authorizationType: String): StorageSettings = copy(authorizationType = authorizationType)
 
-  /** Java API */
   def withSasToken(sasToken: String): StorageSettings = copy(sasToken = emptyStringToOption(sasToken))
 
-  /** Java API */
   def withAzureNameKeyCredential(azureNameKeyCredential: AzureNameKeyCredential): StorageSettings =
     copy(azureNameKeyCredential = azureNameKeyCredential)
 
-  /** Java API */
   def withEndPointUrl(endPointUrl: String): StorageSettings = copy(endPointUrl = emptyStringToOption(endPointUrl))
 
-  /** Java API */
   def withRetrySettings(retrySettings: RetrySettings): StorageSettings = copy(retrySettings = retrySettings)
 
-  /** Java API */
   def withAlgorithm(algorithm: String): StorageSettings = copy(algorithm = algorithm)
 
-  /** Java API */
   def withTokenCredential(tokenCredential: TokenCredential): StorageSettings =
     copy(authorizationType = BearerTokenAuthorizationType, tokenCredential = Some(tokenCredential))
 
@@ -103,7 +95,13 @@ final class StorageSettings(val apiVersion: String,
   }
 
   override def hashCode(): Int =
-    Objects.hash(apiVersion, authorizationType, azureNameKeyCredential, sasToken, retrySettings, algorithm, tokenCredential)
+    Objects.hash(apiVersion,
+                 authorizationType,
+                 azureNameKeyCredential,
+                 sasToken,
+                 retrySettings,
+                 algorithm,
+                 tokenCredential)
 
   private def copy(
       apiVersion: String = apiVersion,

--- a/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/Settings.scala
+++ b/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/Settings.scala
@@ -7,6 +7,8 @@ package azure
 package storage
 
 import akka.actor.ClassicActorSystemProvider
+import com.azure.core.credential.TokenCredential
+import com.azure.identity.DefaultAzureCredentialBuilder
 import com.typesafe.config.Config
 
 import java.time.{Duration => JavaDuration}
@@ -22,7 +24,8 @@ final class StorageSettings(val apiVersion: String,
                             val azureNameKeyCredential: AzureNameKeyCredential,
                             val sasToken: Option[String],
                             val retrySettings: RetrySettings,
-                            val algorithm: String) {
+                            val algorithm: String,
+                            val tokenCredential: Option[TokenCredential] = None) {
 
   /** Java API */
   def getApiVersion: String = apiVersion
@@ -67,15 +70,22 @@ final class StorageSettings(val apiVersion: String,
   /** Java API */
   def withAlgorithm(algorithm: String): StorageSettings = copy(algorithm = algorithm)
 
+  def withTokenCredential(tokenCredential: TokenCredential): StorageSettings =
+    copy(authorizationType = BearerTokenAuthorizationType, tokenCredential = Some(tokenCredential))
+
+  /** Java API */
+  def getTokenCredential: Optional[TokenCredential] = tokenCredential.toJava
+
   override def toString: String =
     s"""StorageSettings(
        | apiVersion=$apiVersion,
        | authorizationType=$authorizationType,
        | endPointUrl=$endPointUrl,
        | azureNameKeyCredential=$azureNameKeyCredential,
-       | sasToken=$sasToken
+       | sasToken=$sasToken,
        | retrySettings=$retrySettings,
-       | algorithm=$algorithm
+       | algorithm=$algorithm,
+       | tokenCredential=${tokenCredential.map(_ => "<provided>").getOrElse("<none>")}
        |)""".stripMargin.replaceAll(System.lineSeparator(), "")
 
   override def equals(other: Any): Boolean = other match {
@@ -86,7 +96,8 @@ final class StorageSettings(val apiVersion: String,
       Objects.equals(azureNameKeyCredential, that.azureNameKeyCredential) &&
       sasToken == that.sasToken &&
       Objects.equals(retrySettings, that.retrySettings) &&
-      algorithm == that.algorithm
+      algorithm == that.algorithm &&
+      tokenCredential == that.tokenCredential
 
     case _ => false
   }
@@ -101,21 +112,24 @@ final class StorageSettings(val apiVersion: String,
       azureNameKeyCredential: AzureNameKeyCredential = azureNameKeyCredential,
       sasToken: Option[String] = sasToken,
       retrySettings: RetrySettings = retrySettings,
-      algorithm: String = algorithm
+      algorithm: String = algorithm,
+      tokenCredential: Option[TokenCredential] = tokenCredential
   ) =
-    StorageSettings(apiVersion,
-                    authorizationType,
-                    endPointUrl,
-                    azureNameKeyCredential,
-                    sasToken,
-                    retrySettings,
-                    algorithm)
+    new StorageSettings(apiVersion,
+                        authorizationType,
+                        endPointUrl,
+                        azureNameKeyCredential,
+                        sasToken,
+                        retrySettings,
+                        algorithm,
+                        tokenCredential)
 }
 
 object StorageSettings {
   private[storage] val ConfigPath = "alpakka.azure-storage"
   private val AuthorizationTypes =
-    Seq(AnonymousAuthorizationType, SharedKeyAuthorizationType, SharedKeyLiteAuthorizationType, SasAuthorizationType)
+    Seq(AnonymousAuthorizationType, SharedKeyAuthorizationType, SharedKeyLiteAuthorizationType, SasAuthorizationType,
+      BearerTokenAuthorizationType)
 
   def apply(
       apiVersion: String,
@@ -167,14 +181,19 @@ object StorageSettings {
     val retrySettings =
       if (config.hasPath("retry-settings")) RetrySettings(config.getConfig("retry-settings")) else RetrySettings.Default
 
-    StorageSettings(
+    val tokenCredential =
+      if (authorizationType == BearerTokenAuthorizationType) Some(new DefaultAzureCredentialBuilder().build())
+      else None
+
+    new StorageSettings(
       apiVersion = apiVersion,
       authorizationType = authorizationType,
       endPointUrl = config.getOptionalString("endpoint-url"),
       azureNameKeyCredential = AzureNameKeyCredential(credentials),
       sasToken = credentials.getOptionalString("sas-token"),
       retrySettings = retrySettings,
-      algorithm = config.getString("signing-algorithm", "HmacSHA256")
+      algorithm = config.getString("signing-algorithm", "HmacSHA256"),
+      tokenCredential = tokenCredential
     )
   }
 

--- a/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/Settings.scala
+++ b/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/Settings.scala
@@ -128,8 +128,11 @@ final class StorageSettings(val apiVersion: String,
 object StorageSettings {
   private[storage] val ConfigPath = "alpakka.azure-storage"
   private val AuthorizationTypes =
-    Seq(AnonymousAuthorizationType, SharedKeyAuthorizationType, SharedKeyLiteAuthorizationType, SasAuthorizationType,
-      BearerTokenAuthorizationType)
+    Seq(AnonymousAuthorizationType,
+        SharedKeyAuthorizationType,
+        SharedKeyLiteAuthorizationType,
+        SasAuthorizationType,
+        BearerTokenAuthorizationType)
 
   def apply(
       apiVersion: String,

--- a/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/Settings.scala
+++ b/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/Settings.scala
@@ -69,6 +69,7 @@ final class StorageSettings(val apiVersion: String,
   /** Java API */
   def withAlgorithm(algorithm: String): StorageSettings = copy(algorithm = algorithm)
 
+  /** Java API */
   def withTokenCredential(tokenCredential: TokenCredential): StorageSettings =
     copy(authorizationType = BearerTokenAuthorizationType, tokenCredential = Some(tokenCredential))
 

--- a/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/Settings.scala
+++ b/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/Settings.scala
@@ -8,7 +8,6 @@ package storage
 
 import akka.actor.ClassicActorSystemProvider
 import com.azure.core.credential.TokenCredential
-import com.azure.identity.DefaultAzureCredentialBuilder
 import com.typesafe.config.Config
 
 import java.time.{Duration => JavaDuration}
@@ -103,7 +102,7 @@ final class StorageSettings(val apiVersion: String,
   }
 
   override def hashCode(): Int =
-    Objects.hash(apiVersion, authorizationType, azureNameKeyCredential, sasToken, retrySettings, algorithm)
+    Objects.hash(apiVersion, authorizationType, azureNameKeyCredential, sasToken, retrySettings, algorithm, tokenCredential)
 
   private def copy(
       apiVersion: String = apiVersion,
@@ -127,6 +126,20 @@ final class StorageSettings(val apiVersion: String,
 
 object StorageSettings {
   private[storage] val ConfigPath = "alpakka.azure-storage"
+
+  private def buildDefaultAzureCredential(): TokenCredential =
+    try {
+      val clazz = Class.forName("com.azure.identity.DefaultAzureCredentialBuilder")
+      val builder = clazz.getDeclaredConstructor().newInstance()
+      clazz.getMethod("build").invoke(builder).asInstanceOf[TokenCredential]
+    } catch {
+      case _: ClassNotFoundException =>
+        throw new RuntimeException(
+          "BearerToken authorization type requires the 'com.azure:azure-identity' library on the classpath. " +
+          "Add it as a dependency to your project."
+        )
+    }
+
   private val AuthorizationTypes =
     Seq(AnonymousAuthorizationType,
         SharedKeyAuthorizationType,
@@ -185,7 +198,7 @@ object StorageSettings {
       if (config.hasPath("retry-settings")) RetrySettings(config.getConfig("retry-settings")) else RetrySettings.Default
 
     val tokenCredential =
-      if (authorizationType == BearerTokenAuthorizationType) Some(new DefaultAzureCredentialBuilder().build())
+      if (authorizationType == BearerTokenAuthorizationType) Some(buildDefaultAzureCredential())
       else None
 
     new StorageSettings(

--- a/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/impl/auth/Signer.scala
+++ b/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/impl/auth/Signer.scala
@@ -11,11 +11,13 @@ import akka.NotUsed
 import akka.http.scaladsl.model.{HttpRequest, Uri}
 import akka.http.scaladsl.model.headers._
 import akka.stream.scaladsl.Source
+import com.azure.core.credential.TokenRequestContext
 
 import java.time.Clock
 import java.util.Base64
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
+import scala.jdk.FutureConverters._
 
 /** Takes initial request and add signed `Authorization` header and essential XMS headers.
  *
@@ -42,7 +44,19 @@ final case class Signer(initialRequest: HttpRequest, settings: StorageSettings)(
     val authorizationType = settings.authorizationType
     if (authorizationType == AnonymousAuthorizationType || authorizationType == SasAuthorizationType)
       Source.single(requestWithHeaders)
-    else
+    else if (authorizationType == BearerTokenAuthorizationType) {
+      val credential = settings.tokenCredential.getOrElse(
+        throw new IllegalStateException("TokenCredential must be provided for BearerToken authorization type")
+      )
+      val context = new TokenRequestContext().addScopes(Signer.StorageScope)
+      Source
+        .future(credential.getToken(context).toFuture.asScala)
+        .map { accessToken =>
+          requestWithHeaders.addHeader(
+            RawHeader(AuthorizationHeaderKey, s"Bearer ${accessToken.getToken}")
+          )
+        }
+    } else
       Source.single(
         requestWithHeaders.addHeader(
           RawHeader(AuthorizationHeaderKey, generateAuthorizationHeader)
@@ -133,6 +147,7 @@ final case class Signer(initialRequest: HttpRequest, settings: StorageSettings)(
 }
 
 object Signer {
+  private val StorageScope = "https://storage.azure.com/.default"
   private val SharedKeyHeaders =
     Seq(
       `Content-Encoding`.name,

--- a/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/package.scala
+++ b/azure-storage/src/main/scala/akka/stream/alpakka/azure/storage/package.scala
@@ -29,6 +29,7 @@ package object storage {
   private[storage] val SharedKeyAuthorizationType = "SharedKey"
   private[storage] val SharedKeyLiteAuthorizationType = "SharedKeyLite"
   private[storage] val SasAuthorizationType = "sas"
+  private[storage] val BearerTokenAuthorizationType = "BearerToken"
   private[storage] val BlobType = "blob"
   private[storage] val FileType = "file"
   private[storage] val BlockBlobType = "BlockBlob"

--- a/azure-storage/src/test/java/docs/javadsl/RequestBuilderTest.java
+++ b/azure-storage/src/test/java/docs/javadsl/RequestBuilderTest.java
@@ -7,7 +7,12 @@ package docs.javadsl;
 import akka.http.javadsl.model.ContentTypes;
 import akka.http.javadsl.model.headers.ByteRange;
 import akka.http.scaladsl.model.headers.RawHeader;
+import akka.stream.alpakka.azure.storage.AzureNameKeyCredential;
+import akka.stream.alpakka.azure.storage.RetrySettings;
+import akka.stream.alpakka.azure.storage.StorageSettings;
 import akka.stream.alpakka.azure.storage.headers.ServerSideEncryption;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
 import akka.stream.alpakka.azure.storage.requests.CreateFile;
 import akka.stream.alpakka.azure.storage.requests.GetBlob;
 import akka.stream.alpakka.azure.storage.requests.PutBlockBlob;
@@ -82,5 +87,51 @@ public class RequestBuilderTest {
     Assert.assertEquals(1, requestBuilder.additionalHeaders().size());
     Assert.assertEquals(
         new RawHeader("If-Match", "foobar"), requestBuilder.additionalHeaders().head());
+  }
+
+  @Test
+  public void createSettingsWithDefaultAzureCredential() {
+    // #bearer-token-default
+    var credential = new DefaultAzureCredentialBuilder().build();
+
+    var settings =
+        StorageSettings.create(
+                "2024-11-04",
+                "anon",
+                java.util.Optional.empty(),
+                AzureNameKeyCredential.create("myaccount", ""),
+                java.util.Optional.empty(),
+                RetrySettings.Default(),
+                "HmacSHA256")
+            .withTokenCredential(credential);
+    // #bearer-token-default
+
+    Assert.assertEquals("BearerToken", settings.authorizationType());
+    Assert.assertTrue(settings.getTokenCredential().isPresent());
+  }
+
+  @Test
+  public void createSettingsWithManagedIdentityCredential() {
+    // #bearer-token-managed-identity
+    // User Assigned Managed Identity
+    var credential =
+        new ManagedIdentityCredentialBuilder()
+            .clientId("<managed-identity-client-id>")
+            .build();
+
+    var settings =
+        StorageSettings.create(
+                "2024-11-04",
+                "anon",
+                java.util.Optional.empty(),
+                AzureNameKeyCredential.create("myaccount", ""),
+                java.util.Optional.empty(),
+                RetrySettings.Default(),
+                "HmacSHA256")
+            .withTokenCredential(credential);
+    // #bearer-token-managed-identity
+
+    Assert.assertEquals("BearerToken", settings.authorizationType());
+    Assert.assertTrue(settings.getTokenCredential().isPresent());
   }
 }

--- a/azure-storage/src/test/java/docs/javadsl/RequestBuilderTest.java
+++ b/azure-storage/src/test/java/docs/javadsl/RequestBuilderTest.java
@@ -11,12 +11,12 @@ import akka.stream.alpakka.azure.storage.AzureNameKeyCredential;
 import akka.stream.alpakka.azure.storage.RetrySettings;
 import akka.stream.alpakka.azure.storage.StorageSettings;
 import akka.stream.alpakka.azure.storage.headers.ServerSideEncryption;
-import com.azure.identity.DefaultAzureCredentialBuilder;
-import com.azure.identity.ManagedIdentityCredentialBuilder;
 import akka.stream.alpakka.azure.storage.requests.CreateFile;
 import akka.stream.alpakka.azure.storage.requests.GetBlob;
 import akka.stream.alpakka.azure.storage.requests.PutBlockBlob;
 import akka.stream.alpakka.testkit.javadsl.LogCapturingJunit4;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -115,9 +115,7 @@ public class RequestBuilderTest {
     // #bearer-token-managed-identity
     // User Assigned Managed Identity
     var credential =
-        new ManagedIdentityCredentialBuilder()
-            .clientId("<managed-identity-client-id>")
-            .build();
+        new ManagedIdentityCredentialBuilder().clientId("<managed-identity-client-id>").build();
 
     var settings =
         StorageSettings.create(

--- a/azure-storage/src/test/scala/akka/stream/alpakka/azure/storage/scaladsl/AzuriteOAuthIntegrationSpec.scala
+++ b/azure-storage/src/test/scala/akka/stream/alpakka/azure/storage/scaladsl/AzuriteOAuthIntegrationSpec.scala
@@ -42,21 +42,51 @@ class AzuriteOAuthIntegrationSpec extends StorageIntegrationSpec with ForAllTest
 
     import scala.sys.process._
     Seq(
-      "keytool", "-genkeypair", "-alias", "azurite", "-keyalg", "RSA", "-keysize", "2048",
-      "-storetype", "PKCS12", "-keystore", keystore.getAbsolutePath,
-      "-storepass", "password", "-validity", "1",
-      "-dname", "CN=localhost", "-ext", "san=dns:localhost,ip:127.0.0.1"
+      "keytool",
+      "-genkeypair",
+      "-alias",
+      "azurite",
+      "-keyalg",
+      "RSA",
+      "-keysize",
+      "2048",
+      "-storetype",
+      "PKCS12",
+      "-keystore",
+      keystore.getAbsolutePath,
+      "-storepass",
+      "password",
+      "-validity",
+      "1",
+      "-dname",
+      "CN=localhost",
+      "-ext",
+      "san=dns:localhost,ip:127.0.0.1"
     ).!!
 
     Seq(
-      "openssl", "pkcs12", "-in", keystore.getAbsolutePath,
-      "-out", certFile.getAbsolutePath, "-clcerts", "-nokeys",
-      "-passin", "pass:password"
+      "openssl",
+      "pkcs12",
+      "-in",
+      keystore.getAbsolutePath,
+      "-out",
+      certFile.getAbsolutePath,
+      "-clcerts",
+      "-nokeys",
+      "-passin",
+      "pass:password"
     ).!!
     Seq(
-      "openssl", "pkcs12", "-in", keystore.getAbsolutePath,
-      "-out", keyFile.getAbsolutePath, "-nocerts", "-nodes",
-      "-passin", "pass:password"
+      "openssl",
+      "pkcs12",
+      "-in",
+      keystore.getAbsolutePath,
+      "-out",
+      keyFile.getAbsolutePath,
+      "-nocerts",
+      "-nodes",
+      "-passin",
+      "pass:password"
     ).!!
 
     certFile.deleteOnExit()
@@ -72,15 +102,24 @@ class AzuriteOAuthIntegrationSpec extends StorageIntegrationSpec with ForAllTest
       exposedPorts = Seq(10000, 10001, 10002),
       command = Seq(
         "azurite",
-        "--blobHost", "0.0.0.0", "--queueHost", "0.0.0.0", "--tableHost", "0.0.0.0",
-        "--oauth", "basic",
-        "--cert", "/certs/cert.pem", "--key", "/certs/key.pem"
+        "--blobHost",
+        "0.0.0.0",
+        "--queueHost",
+        "0.0.0.0",
+        "--tableHost",
+        "0.0.0.0",
+        "--oauth",
+        "basic",
+        "--cert",
+        "/certs/cert.pem",
+        "--key",
+        "/certs/key.pem"
       )
     )
-    c.container.withCopyFileToContainer(
-      MountableFile.forHostPath(new File(certDir, "cert.pem").getAbsolutePath), "/certs/cert.pem")
-    c.container.withCopyFileToContainer(
-      MountableFile.forHostPath(new File(certDir, "key.pem").getAbsolutePath), "/certs/key.pem")
+    c.container.withCopyFileToContainer(MountableFile.forHostPath(new File(certDir, "cert.pem").getAbsolutePath),
+                                        "/certs/cert.pem")
+    c.container.withCopyFileToContainer(MountableFile.forHostPath(new File(certDir, "key.pem").getAbsolutePath),
+                                        "/certs/key.pem")
     c
   }
 

--- a/azure-storage/src/test/scala/akka/stream/alpakka/azure/storage/scaladsl/AzuriteOAuthIntegrationSpec.scala
+++ b/azure-storage/src/test/scala/akka/stream/alpakka/azure/storage/scaladsl/AzuriteOAuthIntegrationSpec.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.stream.alpakka
+package azure
+package storage
+package scaladsl
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.{ConnectionContext, Http}
+import akka.stream.Attributes
+import com.azure.core.credential.{AccessToken, TokenCredential, TokenRequestContext}
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import reactor.core.publisher.Mono
+
+import org.testcontainers.utility.MountableFile
+
+import java.io.{File, FileInputStream}
+import java.nio.file.Files
+import java.security.KeyStore
+import java.time.OffsetDateTime
+import java.util.Base64
+import javax.net.ssl.{SSLContext, TrustManagerFactory}
+
+/**
+ * Runs the blob integration tests against Azurite with OAuth enabled (`--oauth basic`),
+ * exercising the BearerToken / azure-identity authorization path.
+ *
+ * Azurite requires HTTPS for Bearer token auth, so we generate a self-signed cert
+ * and configure both Azurite and Akka HTTP to use it.
+ */
+class AzuriteOAuthIntegrationSpec extends StorageIntegrationSpec with ForAllTestContainer {
+
+  private lazy val certDir: File = {
+    val dir = Files.createTempDirectory("azurite-certs").toFile
+    dir.deleteOnExit()
+
+    val keystore = new File(dir, "keystore.p12")
+    val certFile = new File(dir, "cert.pem")
+    val keyFile = new File(dir, "key.pem")
+
+    import scala.sys.process._
+    Seq(
+      "keytool", "-genkeypair", "-alias", "azurite", "-keyalg", "RSA", "-keysize", "2048",
+      "-storetype", "PKCS12", "-keystore", keystore.getAbsolutePath,
+      "-storepass", "password", "-validity", "1",
+      "-dname", "CN=localhost", "-ext", "san=dns:localhost,ip:127.0.0.1"
+    ).!!
+
+    Seq(
+      "openssl", "pkcs12", "-in", keystore.getAbsolutePath,
+      "-out", certFile.getAbsolutePath, "-clcerts", "-nokeys",
+      "-passin", "pass:password"
+    ).!!
+    Seq(
+      "openssl", "pkcs12", "-in", keystore.getAbsolutePath,
+      "-out", keyFile.getAbsolutePath, "-nocerts", "-nodes",
+      "-passin", "pass:password"
+    ).!!
+
+    certFile.deleteOnExit()
+    keyFile.deleteOnExit()
+    keystore.deleteOnExit()
+
+    dir
+  }
+
+  override lazy val container: GenericContainer = {
+    val c = new GenericContainer(
+      dockerImage = "mcr.microsoft.com/azure-storage/azurite:latest",
+      exposedPorts = Seq(10000, 10001, 10002),
+      command = Seq(
+        "azurite",
+        "--blobHost", "0.0.0.0", "--queueHost", "0.0.0.0", "--tableHost", "0.0.0.0",
+        "--oauth", "basic",
+        "--cert", "/certs/cert.pem", "--key", "/certs/key.pem"
+      )
+    )
+    c.container.withCopyFileToContainer(
+      MountableFile.forHostPath(new File(certDir, "cert.pem").getAbsolutePath), "/certs/cert.pem")
+    c.container.withCopyFileToContainer(
+      MountableFile.forHostPath(new File(certDir, "key.pem").getAbsolutePath), "/certs/key.pem")
+    c
+  }
+
+  private def blobHostAddress: String =
+    s"https://${container.container.getHost}:${container.container.getMappedPort(10000)}"
+
+  override protected implicit val system: ActorSystem = ActorSystem("AzuriteOAuthIntegrationSpec")
+
+  // Set up Akka HTTP to trust the self-signed cert after the container starts
+  override def afterStart(): Unit = {
+    super.afterStart()
+    val keystoreFile = new File(certDir, "keystore.p12")
+    val ks = KeyStore.getInstance("PKCS12")
+    val fis = new FileInputStream(keystoreFile)
+    try ks.load(fis, "password".toCharArray)
+    finally fis.close()
+
+    val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+    tmf.init(ks)
+
+    val sslContext = SSLContext.getInstance("TLS")
+    sslContext.init(null, tmf.getTrustManagers, null)
+
+    Http(system).setDefaultClientHttpsContext(ConnectionContext.httpsClient(sslContext))
+  }
+
+  private def fakeJwt: String = {
+    val encoder = Base64.getUrlEncoder.withoutPadding()
+    val header = encoder.encodeToString("""{"alg":"none","typ":"JWT"}""".getBytes)
+    val now = System.currentTimeMillis() / 1000
+    val payload = encoder.encodeToString(
+      s"""{"aud":"https://storage.azure.com","iss":"https://sts.windows.net/fake/","iat":$now,"nbf":$now,"exp":${now + 3600}}""".getBytes
+    )
+    s"$header.$payload."
+  }
+
+  private val fakeTokenCredential: TokenCredential = new TokenCredential {
+    override def getToken(request: TokenRequestContext): Mono[AccessToken] =
+      Mono.just(new AccessToken(fakeJwt, OffsetDateTime.now().plusHours(1)))
+  }
+
+  protected lazy val blobSettings: StorageSettings =
+    StorageExt(system)
+      .settings("azurite")
+      .withEndPointUrl(blobHostAddress)
+      .withTokenCredential(fakeTokenCredential)
+
+  override protected def getDefaultAttributes: Attributes = StorageAttributes.settings(blobSettings)
+}

--- a/azure-storage/src/test/scala/docs/scaladsl/RequestBuilderSpec.scala
+++ b/azure-storage/src/test/scala/docs/scaladsl/RequestBuilderSpec.scala
@@ -6,6 +6,7 @@ package docs.scaladsl
 
 import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.model.headers.{ByteRange, RawHeader}
+import akka.stream.alpakka.azure.storage.{AzureNameKeyCredential, StorageSettings}
 import akka.stream.alpakka.azure.storage.headers.ServerSideEncryption
 import akka.stream.alpakka.azure.storage.requests.{CreateFile, GetBlob, PutBlockBlob}
 import akka.stream.alpakka.testkit.scaladsl.LogCapturing
@@ -66,5 +67,50 @@ class RequestBuilderSpec extends AnyFlatSpec with Matchers with LogCapturing {
     //#request-builder-with-additional-headers
 
     requestBuilder.additionalHeaders shouldBe Seq(RawHeader("If-Match", "foobar"))
+  }
+
+  it should "create settings with default Azure credential" in {
+    //#bearer-token-default
+    import com.azure.identity.DefaultAzureCredentialBuilder
+
+    val credential = new DefaultAzureCredentialBuilder().build()
+
+    val settings = StorageSettings(
+      apiVersion = "2024-11-04",
+      authorizationType = "anon",
+      endPointUrl = None,
+      azureNameKeyCredential = AzureNameKeyCredential("myaccount", Array.empty[Byte]),
+      sasToken = None,
+      retrySettings = akka.stream.alpakka.azure.storage.RetrySettings.Default,
+      algorithm = "HmacSHA256"
+    ).withTokenCredential(credential)
+    //#bearer-token-default
+
+    settings.authorizationType shouldBe "BearerToken"
+    settings.tokenCredential shouldBe defined
+  }
+
+  it should "create settings with managed identity credential" in {
+    //#bearer-token-managed-identity
+    import com.azure.identity.ManagedIdentityCredentialBuilder
+
+    // User Assigned Managed Identity
+    val credential = new ManagedIdentityCredentialBuilder()
+      .clientId("<managed-identity-client-id>")
+      .build()
+
+    val settings = StorageSettings(
+      apiVersion = "2024-11-04",
+      authorizationType = "anon",
+      endPointUrl = None,
+      azureNameKeyCredential = AzureNameKeyCredential("myaccount", Array.empty[Byte]),
+      sasToken = None,
+      retrySettings = akka.stream.alpakka.azure.storage.RetrySettings.Default,
+      algorithm = "HmacSHA256"
+    ).withTokenCredential(credential)
+    //#bearer-token-managed-identity
+
+    settings.authorizationType shouldBe "BearerToken"
+    settings.tokenCredential shouldBe defined
   }
 }

--- a/docs/src/main/paradox/azure-storage.md
+++ b/docs/src/main/paradox/azure-storage.md
@@ -56,6 +56,14 @@ At minimum following configurations needs to be set:
 
 For environments where shared keys or SAS tokens are not desirable, the connector supports OAuth2 bearer token authentication via the [Azure Identity](https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme?view=azure-java-stable) library. This enables authentication using Managed Identity (system or user-assigned), workload identity, environment credentials, and other mechanisms supported by `DefaultAzureCredential`.
 
+The `azure-identity` library is an optional dependency. To use bearer token authentication, add it to your project:
+
+@@dependency [sbt,Maven,Gradle] {
+group=com.azure
+artifact=azure-identity
+version=1.15.4
+}
+
 To use bearer token authentication via configuration, set `authorization-type` to `BearerToken`. This will automatically use `DefaultAzureCredential` which tries multiple credential sources in order:
 
 ```

--- a/docs/src/main/paradox/azure-storage.md
+++ b/docs/src/main/paradox/azure-storage.md
@@ -52,6 +52,37 @@ At minimum following configurations needs to be set:
 * `account-key`, Account key to use to create authorization signature, mandatory for `SharedKey` or `SharedKeyLite` authorization types, as described [here](https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key). Environment variable `AZURE_STORAGE_ACCOUNT_KEY` can be set to override this configuration.
 * `sas-token` if authorization type is `sas`. Environment variable `AZURE_STORAGE_SAS_TOKEN` can be set to override this configuration.
 
+### Azure AD authentication (BearerToken)
+
+For environments where shared keys or SAS tokens are not desirable, the connector supports OAuth2 bearer token authentication via the [Azure Identity](https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme?view=azure-java-stable) library. This enables authentication using Managed Identity (system or user-assigned), workload identity, environment credentials, and other mechanisms supported by `DefaultAzureCredential`.
+
+To use bearer token authentication via configuration, set `authorization-type` to `BearerToken`. This will automatically use `DefaultAzureCredential` which tries multiple credential sources in order:
+
+```
+alpakka.azure-storage.credentials {
+  authorization-type = BearerToken
+  account-name = "myaccount"
+}
+```
+
+To use `DefaultAzureCredential` programmatically:
+
+Scala
+: @@snip [snip](/azure-storage/src/test/scala/docs/scaladsl/RequestBuilderSpec.scala) { #bearer-token-default }
+
+Java
+: @@snip [snip](/azure-storage/src/test/java/docs/javadsl/RequestBuilderTest.java) { #bearer-token-default }
+
+For User Assigned Managed Identity (UAMI), provide the client ID of the managed identity:
+
+Scala
+: @@snip [snip](/azure-storage/src/test/scala/docs/scaladsl/RequestBuilderSpec.scala) { #bearer-token-managed-identity }
+
+Java
+: @@snip [snip](/azure-storage/src/test/java/docs/javadsl/RequestBuilderTest.java) { #bearer-token-managed-identity }
+
+Any `com.azure.core.credential.TokenCredential` implementation can be used with `withTokenCredential`, including `ClientSecretCredential`, `ClientCertificateCredential`, `WorkloadIdentityCredential`, and others from the `azure-identity` library.
+
 ## Building request
 
 Each function takes two parameters `objectPath` and `requestBuilder`. The `objectPath` is a `/` separated string of the path of the blob

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -116,13 +116,15 @@ object Dependencies {
       )
   )
 
+  val AzureCoreVersion = "1.55.3"
   val AzureIdentityVersion = "1.15.4"
 
   val AzureStorage = Seq(
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-xml" % AkkaHttpVersion,
-        "com.azure" % "azure-identity" % AzureIdentityVersion, // MIT
+        "com.azure" % "azure-core" % AzureCoreVersion, // MIT - TokenCredential API
+        "com.azure" % "azure-identity" % AzureIdentityVersion % "provided,test", // MIT - optional, needed for DefaultAzureCredential
         // for testing authorization signature
         "com.azure" % "azure-storage-common" % "12.29.1" % Test,
         wiremock

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -116,10 +116,13 @@ object Dependencies {
       )
   )
 
+  val AzureIdentityVersion = "1.15.4"
+
   val AzureStorage = Seq(
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-xml" % AkkaHttpVersion,
+        "com.azure" % "azure-identity" % AzureIdentityVersion, // MIT
         // for testing authorization signature
         "com.azure" % "azure-storage-common" % "12.29.1" % Test,
         wiremock


### PR DESCRIPTION
Ammend the azure-storage auth options with azure-identity, enabling OAuth2 bearer token authentication.

 * Opt in dependency on azure-identity to not bring in the entire dependency graph by default, users opt in with an explicit dependency to actually use it
 * When authorization-type is set to BearerToken in config, DefaultAzureCredential is used automatically, supporting managed identity, workload identity, environment credentials, etc.
 * Users can also provide any custom TokenCredential programmatically via StorageSettings.withTokenCredential(credential), e.g. for User Assigned Managed Identity
  with a specific client ID
 * Token acquisition is async (bridges the Azure SDK Mono<AccessToken> into the Akka Stream via Source.future), token caching/refresh handled by the Azure SDK internally