### PR TITLE
build: Only publish artifacts on release tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,6 @@ name: Publish
 on:
   push:
     branches:
-      - main
-      - release-*
     tags: ["v*"]
 
 permissions:


### PR DESCRIPTION
Takes forever, and nobody uses those snapshots anyway