### PR TITLE
bump: AWS SDK 2.46.20

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val InfluxDBJavaVersion = "2.15"
 
   // https://github.com/aws/aws-sdk-java-v2
-  val AwsSdk2Version = "2.36.3"
+  val AwsSdk2Version = "2.46.20"
   val AwsSpiAkkaHttpVersion = "1.0.1"
   // Sync with plugins.sbt
   val AkkaGrpcBinaryVersion = "2.5"


### PR DESCRIPTION
Primarily for upstream netty bump (see https://github.com/aws/aws-sdk-java-v2/pull/7016)... among the CVEs fixed in this version are: https://github.com/advisories/GHSA-5pvg-856g-cp85 and https://github.com/advisories/GHSA-676x-f7gg-47vc.
