### PR TITLE
Replace hardcoded repo.akka.io/maven references

### DIFF
--- a/docs/release-train-issue-template.md
+++ b/docs/release-train-issue-template.md
@@ -25,15 +25,15 @@ Key links:
 - [ ] Update the revision in Fossa in the Akka Group for the Akka umbrella version, e.g. `22.10`. Note that the revisions for the release is udpated by Akka Group > Projects > Edit. For recent dependency updates the Fossa validation can be triggered from the GitHub actions "Dependency License Scanning".
 - [ ] Wait until [main build finished](https://github.com/akka/alpakka/actions) after merging the latest PR
 - [ ] Update the [draft release](https://github.com/akka/alpakka/releases) with the next tag version `v$VERSION$`, title and release description. Use the `Publish release` button, which will create the tag.
-- [ ] Check that GitHub Actions release build has executed successfully (GitHub Actions will start a [CI build](https://github.com/akka/alpakka/actions) for the new tag and publish artifacts to https://repo.akka.io/maven)
+- [ ] Check that GitHub Actions release build has executed successfully (GitHub Actions will start a [CI build](https://github.com/akka/alpakka/actions) for the new tag and publish artifacts to the Akka repository)
 
 ### Check availability
 
 - [ ] Check [API](https://doc.akka.io/api/alpakka/$VERSION$/) documentation
 - [ ] Check [reference](https://doc.akka.io/libraries/alpakka/$VERSION$/) documentation. Check that the reference docs were deployed and show a version warning (see section below on how to fix the version warning).
-- [ ] Check the release `mvn dependency:get -Dartifact=com.lightbend.akka:akka-stream-alpakka-xml_2.13:$VERSION$`
+- [ ] Check the release using your token resolver URL from https://account.akka.io/token: `mvn dependency:get -Dartifact=com.lightbend.akka:akka-stream-alpakka-xml_2.13:$VERSION$ -Dmaven.repo.remote=<token url>`
 
-### When everything is on https://repo.akka.io/maven
+### When everything is available in the Akka repository
   - [ ] Log into `gustav.akka.io` as `akkarepo` 
     - [ ] If this updates the `current` version, run `./update-alpakka-current-version.sh $VERSION$`
     - [ ] otherwise check changes and commit the new version to the local git repository

--- a/docs/src/main/paradox/other-docs/versioning.md
+++ b/docs/src/main/paradox/other-docs/versioning.md
@@ -10,8 +10,8 @@ As all Alpakka modules (excluding Alpakka Kafka) share a single version number, 
 
 Alpakka publishes 
 
-* regular releases to https://repo.akka.io/maven
-* milestone and release candidates (of major versions) to https://repo.akka.io/maven
+* regular releases to the Akka repository (access via token from https://account.akka.io/token)
+* milestone and release candidates (of major versions) to the Akka repository
 * @ref:[snapshots](snapshots.md) to https://repo.akka.io/snapshots
 
 ### Compatibility


### PR DESCRIPTION
## Summary

The bare `https://repo.akka.io/maven` URL requires token-based access (obtained from https://account.akka.io/token) and is no longer usable as-is for links or verification steps.

**`docs/release-train-issue-template.md`**
- "publish artifacts to `https://repo.akka.io/maven`" → "publish artifacts to the Akka repository"
- `mvn dependency:get` check updated to use `-Dmaven.repo.remote=<token url>` from https://account.akka.io/token
- Section heading updated to match

**`docs/src/main/paradox/other-docs/versioning.md`**
- Publish destination bullet points updated to "the Akka repository" with a note pointing to https://account.akka.io/token for access

`CONTRIBUTING.md` already documents the correct local build setup via `~/.sbt/1.0/akka-commercial.sbt` and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)