### PR TITLE
chore: Harden GCP object storage access

### DIFF
--- a/docs/src/main/paradox/google-common.md
+++ b/docs/src/main/paradox/google-common.md
@@ -35,12 +35,37 @@ If you use a non-standard configuration path or need multiple different configur
 
 ## Credentials
 
-Credentials will be loaded automatically:
+The `alpakka.google.credentials.provider` setting selects where credentials come from:
+
+| `provider`                      | Credentials |
+|---------------------------------|-------------|
+| `application-default` (default) | Tries `service-account`, then `compute-engine` |
+| `service-account`               | A service account key, from your configuration file or a credentials file |
+| `compute-engine`                | The service account of the [Compute Engine](https://cloud.google.com/compute) instance, read from the metadata server |
+| `user-access`                   | A user refresh token, from your configuration file or a credentials file |
+| `none`                          | No credentials; requests are sent unauthenticated |
+
+With the default `application-default` provider, credentials will be loaded automatically:
 
 1. From the file path specified by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or another [“well-known” location](https://medium.com/google-cloud/use-google-cloud-user-credentials-when-testing-containers-locally-acb57cd4e4da); or
-2. When running in a [Compute Engine](https://cloud.google.com/compute) instance.
+2. When running in a [Compute Engine](https://cloud.google.com/compute) instance, from the metadata server at `metadata.google.internal`.
 
 Credentials can also be specified manually in your configuration file.
+
+@@@ warning
+
+If neither source yields credentials, `application-default` does not fail: it logs a warning and falls back to
+the `none` provider. Requests are then sent without valid credentials and are rejected by Google APIs, typically
+with `401 Unauthorized` or `403 Forbidden`, which looks like a permissions problem rather than a configuration
+problem. Set `provider` explicitly if this fallback is not what you want.
+
+Reading credentials from the Compute Engine metadata server blocks during settings initialization for at most
+`alpakka.google.credentials.compute-engine.timeout`. A timeout means the metadata server
+could not be reached — because the application is not running on Google Cloud, or because the request was
+intercepted or blocked by a proxy or service mesh — and leads to the same fallback. The warning names both the
+service account and the Compute Engine failure, so check it before investigating IAM.
+
+@@@
 
 ## Accessing settings
 

--- a/google-common/src/main/resources/reference.conf
+++ b/google-common/src/main/resources/reference.conf
@@ -17,8 +17,10 @@ alpakka.google {
     # Override to specify custom scopes
     scopes = ${alpakka.google.credentials.default-scopes}
 
-    # Options: application-default, service-account, compute-engine, none
-    # application-default first tries service-account then compute-engine
+    # Options: application-default, service-account, compute-engine, user-access, none
+    # application-default first tries service-account then compute-engine. If neither is available it logs a
+    # warning and falls back to none, which means that requests are sent without valid credentials and are
+    # rejected by Google APIs. Set this explicitly if that fallback is not wanted.
     provider = application-default
 
     application-default {
@@ -52,8 +54,10 @@ alpakka.google {
       scopes = ${alpakka.google.credentials.scopes}
     }
 
-    # Timeout for blocking call during settings initialization to compute engine metadata server
-    compute-engine.timeout = 1s
+    # Timeout for blocking call during settings initialization to compute engine metadata server.
+    # Exceeding it is treated as a failure to obtain compute engine credentials, and usually means that the
+    # metadata server is not reachable rather than that the credentials are wrong.
+    compute-engine.timeout = 3s
 
     user-access {
       project-id = ""

--- a/google-common/src/main/scala/akka/stream/alpakka/google/ResumableUpload.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/ResumableUpload.scala
@@ -30,6 +30,8 @@ private[alpakka] object ResumableUpload {
   final case class UploadFailedException() extends Exception
   private final case class Chunk(bytes: ByteString, position: Long)
 
+  private val maxErrorBodyLength = 512
+
   /**
    * Initializes and runs a resumable upload to a media endpoint.
    *
@@ -92,8 +94,20 @@ private[alpakka] object ResumableUpload {
 
     implicit val um: FromResponseUnmarshaller[Uri] = Unmarshaller.withMaterializer {
       implicit ec => implicit mat => (response: HttpResponse) =>
-        response.discardEntityBytes().future.map { _ =>
-          response.header[Location].fold(throw InvalidResponseException(ErrorInfo("No Location header")))(_.uri)
+        response.header[Location] match {
+          case Some(location) =>
+            response.discardEntityBytes().future.map(_ => location.uri)
+          case None =>
+            // Report the status and whatever the response said, rather than only the missing header: the header is
+            // absent for every failed response, and the entity is where the API (or an intercepting proxy) explains why
+            Unmarshal(response.entity).to[String].recover { case _ => "<unavailable>" }.map { body =>
+              throw InvalidResponseException(
+                ErrorInfo(
+                  s"Resumable upload could not be initiated, no Location header in ${response.status.value} response",
+                  s"Response body: [${body.take(maxErrorBodyLength)}]"
+                )
+              )
+            }
         }
     }.withDefaultRetry
 

--- a/google-common/src/main/scala/akka/stream/alpakka/google/ResumableUpload.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/ResumableUpload.scala
@@ -30,7 +30,10 @@ private[alpakka] object ResumableUpload {
   final case class UploadFailedException() extends Exception
   private final case class Chunk(bytes: ByteString, position: Long)
 
-  private val maxErrorBodyLength = 512
+  private val MaxErrorBodyLength = 512
+
+  private def truncate(body: String) =
+    if (body.length > MaxErrorBodyLength) body.take(MaxErrorBodyLength) + "..." else body
 
   /**
    * Initializes and runs a resumable upload to a media endpoint.
@@ -104,7 +107,7 @@ private[alpakka] object ResumableUpload {
               throw InvalidResponseException(
                 ErrorInfo(
                   s"Resumable upload could not be initiated, no Location header in ${response.status.value} response",
-                  s"Response body: [${body.take(maxErrorBodyLength)}]"
+                  s"Response body: [${truncate(body)}]"
                 )
               )
             }

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/Credentials.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/Credentials.scala
@@ -13,6 +13,7 @@ import com.google.auth.{Credentials => GoogleCredentials}
 import com.typesafe.config.Config
 
 import java.util.concurrent.Executor
+import scala.annotation.tailrec
 import scala.collection.immutable.ListMap
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
@@ -40,9 +41,20 @@ object Credentials {
             creds
           } catch {
             case NonFatal(ex2) =>
-              log.warning("Unable to find Application Default Credentials for Google APIs")
-              log.warning("Application default: {}", ex1.getMessage)
-              log.warning("Compute Engine: {}", ex2.getMessage)
+              log.warning(
+                "Unable to find Application Default Credentials for Google APIs. Falling back to the `none` " +
+                "credentials provider: requests to Google APIs will be made without valid credentials and will be " +
+                "rejected (typically with 401 or 403) unless the resource is publicly accessible. Configure " +
+                "`alpakka.google.credentials.provider` explicitly if this fallback is not intended. " +
+                "Application default credentials failed with [{}]. " +
+                "Compute Engine credentials failed with [{}]; a timeout here means the metadata server at [{}] " +
+                "did not respond within `alpakka.google.credentials.compute-engine.timeout`, which indicates a " +
+                "connectivity problem (not running on Google Cloud, or the request being intercepted or blocked by " +
+                "a proxy or service mesh) rather than a problem with the credentials themselves.",
+                describe(ex1),
+                describe(ex2),
+                GoogleComputeMetadata.metadataUrl
+              )
               parseNone(c) // TODO Once credentials are guaranteed to be managed centrally we can throw an error instead
           }
       }
@@ -67,6 +79,17 @@ object Credentials {
   }
 
   private def parseNone(c: Config) = NoCredentials(c.getConfig("none"))
+
+  /**
+   * Renders the message of `ex` together with the messages of its causes, since the cause chain often carries the
+   * actual reason (e.g. a connection timeout) while the outermost message is generic.
+   */
+  private def describe(ex: Throwable): String = {
+    @tailrec def loop(ex: Throwable, depth: Int, acc: List[String]): List[String] =
+      if ((ex eq null) || depth == 0) acc
+      else loop(ex.getCause, depth - 1, s"${ex.getClass.getName}: ${ex.getMessage}" :: acc)
+    loop(ex, 5, Nil).reverse.mkString(", caused by ")
+  }
 
   private var _cache: Map[Any, Credentials] = ListMap.empty
   @deprecated("Intended only to help with migration", "3.0.0")

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/Credentials.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/Credentials.scala
@@ -12,13 +12,14 @@ import akka.stream.alpakka.google.RequestSettings
 import com.google.auth.{Credentials => GoogleCredentials}
 import com.typesafe.config.Config
 
-import java.util.concurrent.Executor
+import java.util.concurrent.{Executor, TimeoutException}
 import scala.annotation.tailrec
 import scala.collection.immutable.ListMap
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.jdk.DurationConverters._
 import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
 
 object Credentials {
 
@@ -28,7 +29,6 @@ object Credentials {
    */
   def apply(c: Config)(implicit system: ClassicActorSystemProvider): Credentials = c.getString("provider") match {
     case "application-default" =>
-      val log = Logging(system.classicSystem, classOf[Credentials])
       try {
         val creds = parseApplicationDefault(c)
         log.info("Using service account credentials")
@@ -67,8 +67,26 @@ object Credentials {
   private def parseServiceAccount(c: Config)(implicit system: ClassicActorSystemProvider) =
     ServiceAccountCredentials(c.getConfig("service-account"))
 
-  private def parseComputeEngine(c: Config)(implicit system: ClassicActorSystemProvider) =
-    Await.result(ComputeEngineCredentials(), c.getDuration("compute-engine.timeout").toScala)
+  private def parseComputeEngine(c: Config)(implicit system: ClassicActorSystemProvider) = {
+    val credentials = ComputeEngineCredentials()
+    val timeout = c.getDuration("compute-engine.timeout").toScala
+    try Await.result(credentials, timeout)
+    catch {
+      case ex: TimeoutException =>
+        // The request can fail long after we have stopped waiting for it, for example when connecting to the metadata
+        // server times out. That failure is the actual reason, so log it once it arrives instead of discarding it.
+        credentials.onComplete {
+          case Failure(cause) =>
+            log.warning("Compute Engine credentials request failed after the [{}] timeout had elapsed: {}",
+                        timeout,
+                        describe(cause))
+          case Success(late) =>
+            // Nothing can reach these credentials any more, so release the resources they hold
+            late.close()
+        }(system.classicSystem.dispatcher)
+        throw ex
+    }
+  }
 
   private def parseUserAccess(c: Config)(implicit system: ClassicActorSystemProvider) =
     UserAccessCredentials(c.getConfig("user-access"))
@@ -80,15 +98,20 @@ object Credentials {
 
   private def parseNone(c: Config) = NoCredentials(c.getConfig("none"))
 
+  private def log(implicit system: ClassicActorSystemProvider) = Logging(system.classicSystem, classOf[Credentials])
+
+  private val MaxCauseDepth = 5
+
   /**
    * Renders the message of `ex` together with the messages of its causes, since the cause chain often carries the
    * actual reason (e.g. a connection timeout) while the outermost message is generic.
    */
   private def describe(ex: Throwable): String = {
     @tailrec def loop(ex: Throwable, depth: Int, acc: List[String]): List[String] =
-      if ((ex eq null) || depth == 0) acc
+      if (ex eq null) acc
+      else if (depth == 0) "..." :: acc
       else loop(ex.getCause, depth - 1, s"${ex.getClass.getName}: ${ex.getMessage}" :: acc)
-    loop(ex, 5, Nil).reverse.mkString(", caused by ")
+    loop(ex, MaxCauseDepth, Nil).reverse.mkString(", caused by ")
   }
 
   private var _cache: Map[Any, Credentials] = ListMap.empty

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/GoogleComputeMetadata.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/GoogleComputeMetadata.scala
@@ -11,7 +11,6 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.HttpMethods.GET
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
 
 import java.time.Clock
@@ -20,7 +19,7 @@ import scala.concurrent.Future
 @InternalApi
 private[auth] object GoogleComputeMetadata {
 
-  private val metadataUrl = "http://metadata.google.internal/computeMetadata/v1"
+  private[auth] val metadataUrl = "http://metadata.google.internal/computeMetadata/v1"
   private val tokenUrl = s"$metadataUrl/instance/service-accounts/default/token"
   private val projectIdUrl = s"$metadataUrl/project/project-id"
   private val `Metadata-Flavor` = RawHeader("Metadata-Flavor", "Google")
@@ -37,7 +36,7 @@ private[auth] object GoogleComputeMetadata {
     implicit val system: ActorSystem = mat.system
     for {
       response <- Http().singleRequest(tokenRequest)
-      token <- Unmarshal(response.entity).to[AccessToken]
+      token <- GoogleOAuth2Exception.unmarshalOrFail[AccessToken](tokenUrl, response)
     } yield token
   }
 
@@ -48,7 +47,7 @@ private[auth] object GoogleComputeMetadata {
     implicit val system: ActorSystem = mat.system
     for {
       response <- Http().singleRequest(projectIdRequest)
-      projectId <- Unmarshal(response.entity).to[String]
+      projectId <- GoogleOAuth2Exception.unmarshalOrFail[String](projectIdUrl, response)
     } yield projectId
   }
 }

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/GoogleOAuth2Exception.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/GoogleOAuth2Exception.scala
@@ -5,12 +5,21 @@
 package akka.stream.alpakka.google.auth
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import akka.http.scaladsl.model.{ErrorInfo, ExceptionWithErrorInfo, HttpResponse}
-import akka.http.scaladsl.unmarshalling.{FromResponseUnmarshaller, PredefinedFromEntityUnmarshallers, Unmarshaller}
+import akka.http.scaladsl.model.{ErrorInfo, ExceptionWithErrorInfo, HttpResponse, Uri}
+import akka.http.scaladsl.unmarshalling.{
+  FromEntityUnmarshaller,
+  FromResponseUnmarshaller,
+  PredefinedFromEntityUnmarshallers,
+  Unmarshal,
+  Unmarshaller
+}
+import akka.stream.Materializer
 import akka.stream.alpakka.google.implicits._
 import akka.stream.alpakka.google.util.Retry
 import spray.json.DefaultJsonProtocol._
 import spray.json.RootJsonFormat
+
+import scala.concurrent.{ExecutionContext, Future}
 
 final case class GoogleOAuth2Exception private[akka] (override val info: ErrorInfo) extends ExceptionWithErrorInfo(info)
 
@@ -45,4 +54,35 @@ private[google] object GoogleOAuth2Exception {
             ex
       }
       .withDefaultRetry
+
+  private val maxErrorBodyLength = 512
+
+  /**
+   * Unmarshals a successful response, or fails with a [[GoogleOAuth2Exception]] describing the status and body of an
+   * unsuccessful one. Without the status check an error response is unmarshalled as if it were a token, which reports
+   * an unrelated parsing failure (e.g. `Unexpected end-of-input` for an empty body) and hides both the status and any
+   * explanation the endpoint gave. Intended for the credentials endpoints that are requested directly, without the
+   * [[akka.stream.alpakka.google.http.GoogleHttp]] unmarshalling and retry machinery.
+   */
+  private[auth] def unmarshalOrFail[T](uri: Uri, response: HttpResponse)(
+      implicit um: FromEntityUnmarshaller[T],
+      ec: ExecutionContext,
+      mat: Materializer
+  ): Future[T] =
+    if (response.status.isSuccess())
+      Unmarshal(response.entity).to[T]
+    else
+      Unmarshal(response.entity)
+        .to[String]
+        .recover { case _ => "<unavailable>" }
+        .flatMap { body =>
+          Future.failed(
+            GoogleOAuth2Exception(
+              ErrorInfo(
+                s"Unexpected ${response.status.value} response from [$uri]",
+                s"Response body: [${body.take(maxErrorBodyLength)}]"
+              )
+            )
+          )
+        }
 }

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/GoogleOAuth2Exception.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/GoogleOAuth2Exception.scala
@@ -55,7 +55,10 @@ private[google] object GoogleOAuth2Exception {
       }
       .withDefaultRetry
 
-  private val maxErrorBodyLength = 512
+  private val MaxErrorBodyLength = 512
+
+  private def truncate(body: String) =
+    if (body.length > MaxErrorBodyLength) body.take(MaxErrorBodyLength) + "..." else body
 
   /**
    * Unmarshals a successful response, or fails with a [[GoogleOAuth2Exception]] describing the status and body of an
@@ -80,7 +83,7 @@ private[google] object GoogleOAuth2Exception {
             GoogleOAuth2Exception(
               ErrorInfo(
                 s"Unexpected ${response.status.value} response from [$uri]",
-                s"Response body: [${body.take(maxErrorBodyLength)}]"
+                s"Response body: [${truncate(body)}]"
               )
             )
           )

--- a/google-common/src/main/scala/akka/stream/alpakka/google/auth/UserAccessMetadata.scala
+++ b/google-common/src/main/scala/akka/stream/alpakka/google/auth/UserAccessMetadata.scala
@@ -11,7 +11,6 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.HttpMethods.POST
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{FormData, HttpRequest}
-import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
 
 import java.time.Clock
@@ -41,7 +40,7 @@ private[auth] object UserAccessMetadata {
     implicit val system: ActorSystem = mat.system
     for {
       response <- Http().singleRequest(tokenRequest(clientId, clientSecret, refreshToken))
-      token <- Unmarshal(response.entity).to[AccessToken]
+      token <- GoogleOAuth2Exception.unmarshalOrFail[AccessToken](tokenUrl, response)
     } yield token
   }
 }

--- a/google-common/src/test/scala/akka/stream/alpakka/google/ResumableUploadSpec.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/ResumableUploadSpec.scala
@@ -15,7 +15,7 @@ import akka.testkit.TestKit
 import akka.util.ByteString
 import io.specto.hoverfly.junit.core.SimulationSource.dsl
 import io.specto.hoverfly.junit.dsl.HoverflyDsl.service
-import io.specto.hoverfly.junit.dsl.ResponseCreators.{created, serverError, success}
+import io.specto.hoverfly.junit.dsl.ResponseCreators.{created, forbidden, serverError, success}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
@@ -85,6 +85,44 @@ class ResumableUploadSpec
         )
 
       result.futureValue shouldEqual JsObject.empty
+    }
+
+    "report the status and body of a failed session initiation" in {
+
+      hoverfly.simulate(
+        dsl(
+          service("example.com")
+            .post("/")
+            .queryParam("uploadType", "resumable")
+            .queryParam("prettyPrint", "false")
+            .header("Authorization", "Bearer yyyy.c.an-access-token")
+            .header("X-Upload-Content-Type", "application/octet-stream")
+            .willReturn(
+              forbidden()
+                .header("Content-Type", "application/json")
+                .body("""{"error":{"message":"Caller does not have permission"}}""")
+            )
+        )
+      )
+
+      import implicits._
+      implicit val um: FromResponseUnmarshaller[JsValue] =
+        Unmarshaller.messageUnmarshallerFromEntityUnmarshaller(sprayJsValueUnmarshaller).withDefaultRetry
+
+      val result = Source
+        .single(ByteString("helloworld"))
+        .runWith(
+          ResumableUpload[JsValue](
+            HttpRequest(POST,
+                        Uri("https://example.com?uploadType=resumable"),
+                        List(`X-Upload-Content-Type`(ContentTypes.`application/octet-stream`)))
+          )
+        )
+
+      val ex = result.failed.futureValue
+      ex shouldBe a[ResumableUpload.InvalidResponseException]
+      ex.getMessage should include("403 Forbidden")
+      ex.getMessage should include("Caller does not have permission")
     }
 
   }

--- a/google-common/src/test/scala/akka/stream/alpakka/google/auth/GoogleOAuth2ExceptionSpec.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/auth/GoogleOAuth2ExceptionSpec.scala
@@ -64,5 +64,13 @@ class GoogleOAuth2ExceptionSpec
       ex.getMessage should include("403 Forbidden")
       ex.getMessage should include("service account not enabled")
     }
+
+    "mark a truncated error body" in {
+      val response = HttpResponse(StatusCodes.BadGateway, entity = HttpEntity("x" * 1000))
+
+      val ex = GoogleOAuth2Exception.unmarshalOrFail[AccessToken](uri, response).failed.futureValue
+      ex.getMessage should include("x" * 512 + "...")
+      ex.getMessage should not include ("x" * 513)
+    }
   }
 }

--- a/google-common/src/test/scala/akka/stream/alpakka/google/auth/GoogleOAuth2ExceptionSpec.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/auth/GoogleOAuth2ExceptionSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.stream.alpakka.google.auth
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse, StatusCodes}
+import akka.testkit.TestKit
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import java.time.Clock
+import scala.concurrent.ExecutionContext
+
+class GoogleOAuth2ExceptionSpec
+    extends TestKit(ActorSystem())
+    with AnyWordSpecLike
+    with Matchers
+    with ScalaFutures
+    with BeforeAndAfterAll {
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(remainingOrDefault)
+  implicit val executionContext: ExecutionContext = system.dispatcher
+  implicit val clock: Clock = Clock.systemUTC()
+
+  private val uri = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
+
+  "unmarshalOrFail" should {
+
+    "unmarshal a successful response" in {
+      val response = HttpResponse(
+        entity = HttpEntity(ContentTypes.`application/json`,
+                            """{"access_token": "token", "token_type": "String", "expires_in": 3600}""")
+      )
+
+      GoogleOAuth2Exception.unmarshalOrFail[AccessToken](uri, response).futureValue should matchPattern {
+        case AccessToken("token", _) =>
+      }
+    }
+
+    "report the status of an error response with an empty body" in {
+      val response = HttpResponse(StatusCodes.ServiceUnavailable, entity = HttpEntity.Empty)
+
+      val ex = GoogleOAuth2Exception.unmarshalOrFail[AccessToken](uri, response).failed.futureValue
+      ex shouldBe a[GoogleOAuth2Exception]
+      ex.getMessage should include("503 Service Unavailable")
+      ex.getMessage should include(uri)
+    }
+
+    "report the body of an error response" in {
+      val response = HttpResponse(StatusCodes.Forbidden, entity = HttpEntity("service account not enabled"))
+
+      val ex = GoogleOAuth2Exception.unmarshalOrFail[AccessToken](uri, response).failed.futureValue
+      ex shouldBe a[GoogleOAuth2Exception]
+      ex.getMessage should include("403 Forbidden")
+      ex.getMessage should include("service account not enabled")
+    }
+  }
+}


### PR DESCRIPTION
Diagnosing a failure to reach the GCE metadata server took far longer than it should have: every layer reported a symptom rather than the failure, and the credential path degraded silently, so the trail pointed at IAM instead of the network.

**Credentials**
- `Credentials.apply` logged three warnings that never said what the fallback does. Now one warning stating the consequence (falls back to the `none` provider, so requests are rejected with 401/403), with cause chains and a pointer at the metadata server as the likely cause of a timeout.
- `GoogleComputeMetadata` and `UserAccessMetadata` ignored the response status and unmarshalled errors as tokens, turning an empty-bodied 5xx into `Unexpected end-of-input at input index 0`. They now fail with the status, URL and body. `getProjectId` was worse than a bad message — it accepted an error page (or `""`) as the project ID.
- `compute-engine.timeout` 1s → 3s. A false negative is permanent for the ActorSystem's lifetime (settings are cached, `NoCredentials` never retries), so degrading costs more than waiting.

**Uploads**
- `ResumableUpload.initiateSession` threw `No Location header` for any response lacking one, discarding the entity first. The header is absent from every failed response, so that described the least interesting part; it now reports the status and keeps the API's own error message.

**Docs**
- `google-common.md` presented credential loading as automatic and infallible. Added the `provider` options and a warning covering the silent fallback and the blocking metadata read. `reference.conf` was missing `user-access` from its options list and said nothing about the fallback.

Behaviour is unchanged apart from the timeout default, and errors that previously surfaced as parse failures — or, for `getProjectId`, not at all. Tests added for the metadata status check and failed upload initiation.

